### PR TITLE
[TP 147318] - fix crash that occurs in the test app

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -229,7 +229,7 @@ public class Klaviyo : NSObject {
         assertPropertyTypes(properties: propertiesDict)
         
         guard let apiKey = apiKey else {
-            environment.logger.error("Track event called before API was set.")
+            environment.logger.error("Track event called before API key was set.")
             //TODO: store pending event for when api key is set.
             return
         }
@@ -294,8 +294,8 @@ public class Klaviyo : NSObject {
         }
         
         guard let apiKey = apiKey else {
-            environment.logger.error("Track person called before setting the API Key.")
-            //TODO: store pending event for when api key is set.
+            environment.logger.error("Track person called before API key was set.")
+            //TODO: store pending data for when api key is set.
             return
         }
         

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -43,7 +43,7 @@ public class Klaviyo : NSObject {
     public let KLMessageDimension = "$message"
     
     // KL Definitions File: API URL Constants
-    let KlaviyoServerURLString = "https://934e-76-152-202-190.ngrok.io/api"
+    let KlaviyoServerURLString = "https://a.klaviyo.com/api"
     let KlaviyoServerTrackEventEndpoint = "/track"
     let KlaviyoServerTrackPersonEndpoint = "/identify"
     
@@ -229,7 +229,7 @@ public class Klaviyo : NSObject {
         assertPropertyTypes(properties: propertiesDict)
         
         guard let apiKey = apiKey else {
-            print("track event called before apikey was set!")
+            environment.logger.error("Track event called before API was set.")
             //TODO: store pending event for when api key is set.
             return
         }
@@ -292,6 +292,13 @@ public class Klaviyo : NSObject {
         if personDictionary.allKeys.count == 0 {
             return
         }
+        
+        guard let apiKey = apiKey else {
+            environment.logger.error("Track person called before setting the API Key.")
+            //TODO: store pending event for when api key is set.
+            return
+        }
+        
         // Update properties for JSON encoding
         let personInfoDictionary = updatePropertiesDictionary(propDictionary: personDictionary)
         assertPropertyTypes(properties: personInfoDictionary)
@@ -299,11 +306,7 @@ public class Klaviyo : NSObject {
         serialQueue.async(execute: {
             let event = NSMutableDictionary()
             
-            if self.apiKey!.count > 0 {
-                event[self.KLPersonTrackTokenJSONKey] = self.apiKey
-            } else {
-                event[self.KLPersonTrackTokenJSONKey] = ""
-            }
+            event[self.KLPersonTrackTokenJSONKey] = apiKey
             
             event[self.KLPersonPropertiesJSONKey] = personInfoDictionary
             self.peopleQueue!.add(_: event)

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -43,7 +43,7 @@ public class Klaviyo : NSObject {
     public let KLMessageDimension = "$message"
     
     // KL Definitions File: API URL Constants
-    let KlaviyoServerURLString = "https://a.klaviyo.com/api"
+    let KlaviyoServerURLString = "https://934e-76-152-202-190.ngrok.io/api"
     let KlaviyoServerTrackEventEndpoint = "/track"
     let KlaviyoServerTrackPersonEndpoint = "/identify"
     

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -228,15 +228,15 @@ public class Klaviyo : NSObject {
         let customerPropertiesDict = updatePropertiesDictionary(propDictionary: customerProperties)
         assertPropertyTypes(properties: propertiesDict)
         
+        guard let apiKey = apiKey else {
+            print("track event called before apikey was set!")
+            //TODO: store pending event for when api key is set.
+            return
+        }
+        
         serialQueue.async(execute: {
             let event = NSMutableDictionary()
-            
-            // Set the apiKey for the event
-            if (self.apiKey!.count > 0) {
-                event[self.KLEventTrackTokenJSONKey] = self.apiKey
-            } else {
-                event[self.KLEventTrackTokenJSONKey] = ""
-            }
+            event[self.KLEventTrackTokenJSONKey] = apiKey
             
             // If it's a push event, set a service key to Klaviyo
             var service: String = "api"

--- a/Sources/KlaviyoSwift/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEnvironment.swift
@@ -13,10 +13,12 @@ struct KlaviyoEnvironment {
     var archiverClient: ArchiverClient
     var fileClient: FileClient
     var data: (URL) throws -> Data
+    var logger: LoggerClient
     static let production = KlaviyoEnvironment(
         archiverClient: ArchiverClient.production,
         fileClient: FileClient.production,
-        data: { url in try Data(contentsOf: url) }
+        data: { url in try Data(contentsOf: url) },
+        logger: LoggerClient.production
     )
 
 }

--- a/Sources/KlaviyoSwift/LoggerClient.swift
+++ b/Sources/KlaviyoSwift/LoggerClient.swift
@@ -1,0 +1,14 @@
+//
+//  LoggerClient.swift
+//  KlaviyoSwift
+//
+//  Created by Noah Durell on 10/21/22.
+//
+
+import Foundation
+import os
+
+struct LoggerClient {
+    var error: (String) -> ()
+    static let production = Self(error: { message in os_log("%{public}@", type: .error) })
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -30,10 +30,12 @@ extension ArchiverClient {
 
 extension KlaviyoEnvironment {
     static var testURL = { (_:String) in TEST_URL }
+    static var lastLog: String?
     static let test = KlaviyoEnvironment(
         archiverClient: ArchiverClient.test,
         fileClient: FileClient.test,
-        data: { _ in TEST_RETURN_DATA }
+        data: { _ in TEST_RETURN_DATA },
+        logger: LoggerClient.test
     )
 }
 
@@ -44,5 +46,12 @@ extension FileClient {
         removeItem: { _ in },
         libraryDirectory: { TEST_URL }
     )
+}
+
+extension LoggerClient {
+    static var lastLoggedMessage: String?
+    static let test = LoggerClient { message in
+        lastLoggedMessage = message
+    }
 }
 

--- a/Tests/KlaviyoSwiftTests/Tests.swift
+++ b/Tests/KlaviyoSwiftTests/Tests.swift
@@ -10,11 +10,13 @@ class Tests: XCTestCase {
         super.setUp()
         Klaviyo.setupWithPublicAPIKey(apiKey: "wbg7GT")
         klaviyo = Klaviyo.sharedInstance
+        environment = KlaviyoEnvironment.test
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+        LoggerClient.lastLoggedMessage = nil
     }
     
     func testAPIKeyExists() {
@@ -88,6 +90,26 @@ class Tests: XCTestCase {
         } else {
             XCTAssertNotNil(klaviyo.apnDeviceToken, "push token should exist if registered")
         }
+    }
+    
+    func testTrackEventWithNoApiKey() {
+        klaviyo.apiKey = nil
+        
+        klaviyo.trackEvent(eventName: "foo")
+        
+        XCTAssertEqual(LoggerClient.lastLoggedMessage, "Track event called before API was set.")
+        
+    }
+    
+    func testTrackPersonWithNoApiKey() {
+        klaviyo.apiKey = nil
+        
+        let emailDict: NSMutableDictionary = [klaviyo.KLPersonEmailDictKey: "testemail@gmail.com"]
+        
+        klaviyo.trackPersonWithInfo(personDictionary: emailDict)
+        
+        XCTAssertEqual(LoggerClient.lastLoggedMessage, "Track person called before setting the API Key.")
+        
     }
     
 }

--- a/klaviyo-swift-sdk.xcodeproj/project.pbxproj
+++ b/klaviyo-swift-sdk.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		7C375BC028E77149008605B3 /* KlaviyoTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C375BBF28E77149008605B3 /* KlaviyoTestUtils.swift */; };
+		7C54A46F2902F01E00611E4E /* LoggerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C54A46E2902F01E00611E4E /* LoggerClient.swift */; };
 		OBJ_33 /* ArchivalUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* ArchivalUtils.swift */; };
 		OBJ_34 /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* FileUtils.swift */; };
 		OBJ_35 /* Klaviyo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Klaviyo.swift */; };
@@ -53,6 +54,7 @@
 
 /* Begin PBXFileReference section */
 		7C375BBF28E77149008605B3 /* KlaviyoTestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlaviyoTestUtils.swift; sourceTree = "<group>"; };
+		7C54A46E2902F01E00611E4E /* LoggerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerClient.swift; sourceTree = "<group>"; };
 		OBJ_10 /* FileUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
 		OBJ_11 /* Klaviyo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Klaviyo.swift; sourceTree = "<group>"; };
 		OBJ_12 /* KlaviyoEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlaviyoEnvironment.swift; sourceTree = "<group>"; };
@@ -120,7 +122,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -134,7 +136,6 @@
 				OBJ_26 /* Gemfile */,
 				OBJ_27 /* Gemfile.lock */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -153,6 +154,7 @@
 				OBJ_11 /* Klaviyo.swift */,
 				OBJ_12 /* KlaviyoEnvironment.swift */,
 				OBJ_13 /* ReachabilitySwift.swift */,
+				7C54A46E2902F01E00611E4E /* LoggerClient.swift */,
 			);
 			name = KlaviyoSwift;
 			path = Sources/KlaviyoSwift;
@@ -224,7 +226,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_19 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -246,6 +248,7 @@
 				OBJ_34 /* FileUtils.swift in Sources */,
 				OBJ_35 /* Klaviyo.swift in Sources */,
 				OBJ_36 /* KlaviyoEnvironment.swift in Sources */,
+				7C54A46F2902F01E00611E4E /* LoggerClient.swift in Sources */,
 				OBJ_37 /* ReachabilitySwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Adds some guards in track and identify to prevent test app crash.

# Testing
I tested this manually with the test by sending a push after stopping the app.
When starting the app from a dead state it would crash on launch due a missing API key.

I also added some unit test to increase coverage.