### PR TITLE
Corrected keypath to _k tracking properties

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -145,7 +145,7 @@ public class Klaviyo: NSObject  {
      - Parameter userInfo: NSDictionary containing the push notification text & metadata
      */
     public func handlePush(userInfo: NSDictionary) {
-        if let _ = userInfo["_k"] as? NSDictionary {
+        if let body = userInfo["body"] as? NSDictionary, let _ = body["_k"] {
             trackEvent(eventName: KLPersonOpenedPush, properties: userInfo)
         }
     }


### PR DESCRIPTION
this is the structure of userInfo: 
```
userInfo: [
                    "aps": [
                        "alert": [
                            "body": "Your last name is Masseau",
                            "title": "Hi Evan"
                        ],
                        "badge": 1,
                        "sound": "default"
                    ],
                    "body": [
                        "_k": [
                            "$flow": nil,
                            "$message": "01GK4P5W6AV4V3APTJ727JKSKQ",
                            "$variation": nil,
                            "Message Name": "Push Campaign 2022-11-30 11:33",
                            "Message Type": "campaign",
                            "c": "6U7nPA",
                            "cr": "31698553996657051350694345805149781",
                            "m": "01GK4P5W6AV4V3APTJ727JKSKQ",
                            "t": "1669826094",
                            "timestamp": "2022-11-30T16:34:54.444462+00:00",
                            "x": "manual"
                        ]
                    ]
                ]
```

so as written we'll never send $opened_push events.