### PR TITLE
Fix the api url for identify

### DIFF
--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -96,7 +96,6 @@ extension KlaviyoAPI.KlaviyoRequest {
                 struct Attributes: Equatable, Codable {
                     struct Metric: Equatable, Codable {
                         let name: String
-                        var service = "klaviyo"
                         init(name: String) {
                             self.name = name
                         }

--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -90,7 +90,7 @@ extension KlaviyoAPI.KlaviyoRequest {
         case .createEvent:
             return "client/events"
         case .storePushToken:
-            return "api/identify"
+            return "identify"
         }
     }
     

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -15,7 +15,6 @@ extension Klaviyo {
         struct Attributes {
             struct Metric {
                 let name: String
-                let service = "ios-analytics"
                 init(name: String) {
                     self.name = name
                 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -72,7 +72,7 @@ class InvalidJSONDecoder: JSONDecoder {
 extension AnalyticsEnvironment {
     static let test = AnalyticsEnvironment(
         networkSession: { NetworkSession.test() },
-        apiURL: "dead_beef",
+        apiURL: "dead_beef/api",
         encodeJSON: { _ in TEST_RETURN_DATA},
         decoder: DataDecoder(jsonDecoder: TestJSONDecoder()),
         uuid: { UUID(uuidString: "00000000-0000-0000-0000-000000000001")! },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -2,8 +2,7 @@
   "data" : {
     "attributes" : {
       "metric" : {
-        "name" : "blob",
-        "service" : "klaviyo"
+        "name" : "blob"
       },
       "profile" : {
         "email" : "blob@email.com",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/events/?company_id=foo
+▿ dead_beef/api/client/events/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/events/?company_id=foo
+    - some: dead_beef/api/client/events/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/profiles/?company_id=foo
+▿ dead_beef/api/client/profiles/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/profiles/?company_id=foo
+    - some: dead_beef/api/client/profiles/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -12,8 +12,7 @@
             "data" : {
               "attributes" : {
                 "metric" : {
-                  "name" : "$opened_push",
-                  "service" : "klaviyo"
+                  "name" : "$opened_push"
                 },
                 "profile" : {
                   "$anonymous" : "iOS:00000000-0000-0000-0000-000000000002",


### PR DESCRIPTION
We were formatting the url as api/api/identify. Luckily this redirected. 
This PR also removes the service from the api which prevents flow triggering when set to klaviyo.