### PR TITLE
Removed .provisional from the example to setup push 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Add the below code to your application wherever you would like to prompt users t
 
     let center = UNUserNotificationCenter.current()
     center.delegate = self as? UNUserNotificationCenterDelegate
-    let options: UNAuthorizationOptions = [.alert, .sound, .badge, .provisional]
+    let options: UNAuthorizationOptions = [.alert, .sound, .badge]
 
     center.requestAuthorization(options: options) { (granted, error) in
         // Enable / disable features based on response


### PR DESCRIPTION
Removed .provisional from the example to setup push since it's more of a niche usecase and also aligning closer to [apple docs](https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications).

Also, having `.provisional` will not bring up the alert controller for developers to ask users permission of push which may not be the behaviour they intend. 