### PR TITLE
Add device metadata to events' payload

### DIFF
--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -24,6 +24,8 @@ private let DEFAULT_DEVICE_MODEL: String = {
     return String(cString: machine)
 }()
 
+private let DEVICE_ID_STORE_KEY = "_klaviyo_device_id"
+
 struct AppContextInfo {
     let executable: String
     let bundleId: String
@@ -34,6 +36,7 @@ struct AppContextInfo {
     let osName: String
     let manufacturer: String
     let deviceModel: String
+    let deviceId: String
 
     var osVersion: String {
         "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
@@ -51,7 +54,8 @@ struct AppContextInfo {
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
-         deviceModel: String = DEFAULT_DEVICE_MODEL) {
+         deviceModel: String = DEFAULT_DEVICE_MODEL,
+         deviceId: String? = nil) {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
@@ -61,5 +65,14 @@ struct AppContextInfo {
         self.osName = osName
         self.manufacturer = manufacturer
         self.deviceModel = deviceModel
+
+        if let _deviceId = deviceId {
+            self.deviceId = _deviceId
+        } else if let _deviceId = UserDefaults.standard.string(forKey: DEVICE_ID_STORE_KEY) {
+            self.deviceId = _deviceId
+        } else {
+            self.deviceId = UUID().uuidString
+            UserDefaults.standard.set(self.deviceId, forKey: DEVICE_ID_STORE_KEY)
+        }
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -12,16 +12,29 @@ private let DEFAULT_EXECUTABLE: String = (info?["CFBundleExecutable"] as? String
 private let DEFAULT_BUNDLE_ID: String = info?["CFBundleIdentifier"] as? String ?? "Unknown"
 private let DEFAULT_APP_VERSION: String = info?["CFBundleShortVersionString"] as? String ?? "Unknown"
 private let DEFAULT_APP_BUILD: String = info?["CFBundleVersion"] as? String ?? "Unknown"
+private let DEFAULT_APP_NAME: String = info?["CFBundleName"] as? String ?? "Unknown"
 private let DEFAULT_OS_VERSION = ProcessInfo.processInfo.operatingSystemVersion
+private let DEFAULT_MANUFACTURER = "Apple"
 private let DEFAULT_OS_NAME = "iOS"
+private let DEFAULT_DEVICE_MODEL = {
+    var size = 0
+    sysctlbyname("hw.machine", nil, &size, nil, 0)
+    var machine = [CChar](repeating: 0,  count: size)
+    sysctlbyname("hw.machine", &machine, &size, nil, 0)
+    return String(cString: machine)
+}()
 
 struct AppContextInfo {
-    let excutable: String
+    let executable: String
     let bundleId: String
     let appVersion: String
     let appBuild: String
+    let appName: String
     let version: OperatingSystemVersion
     let osName: String
+    let manufacturer: String
+    let deviceModel: String
+
     var osVersion: String {
         "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
@@ -30,17 +43,24 @@ struct AppContextInfo {
         "\(osName) \(osVersion)"
     }
 
-    init(excutable: String = DEFAULT_EXECUTABLE,
+    init(executable: String = DEFAULT_EXECUTABLE,
          bundleId: String = DEFAULT_BUNDLE_ID,
          appVersion: String = DEFAULT_APP_VERSION,
          appBuild: String = DEFAULT_APP_BUILD,
+         appName: String = DEFAULT_APP_NAME,
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
-         osName: String = DEFAULT_OS_NAME) {
-        self.excutable = excutable
+         osName: String = DEFAULT_OS_NAME,
+         manufacturer: String = DEFAULT_MANUFACTURER,
+         deviceModel: String = DEFAULT_DEVICE_MODEL
+    ) {
+        self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
         self.appBuild = appBuild
+        self.appName = appName
         self.version = version
         self.osName = osName
+        self.manufacturer = manufacturer
+        self.deviceModel = deviceModel
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -5,6 +5,7 @@
 //  Created by Noah Durell on 11/18/22.
 //
 import Foundation
+import UIKit
 
 private let info = Bundle.main.infoDictionary
 private let DEFAULT_EXECUTABLE: String = (info?["CFBundleExecutable"] as? String) ??
@@ -55,7 +56,7 @@ struct AppContextInfo {
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
          deviceModel: String = DEFAULT_DEVICE_MODEL,
-         deviceId: String? = nil) {
+         deviceId: String = UIDevice.current.identifierForVendor?.uuidString ?? "") {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
@@ -65,14 +66,6 @@ struct AppContextInfo {
         self.osName = osName
         self.manufacturer = manufacturer
         self.deviceModel = deviceModel
-
-        if let _deviceId = deviceId {
-            self.deviceId = _deviceId
-        } else if let _deviceId = UserDefaults.standard.string(forKey: DEVICE_ID_STORE_KEY) {
-            self.deviceId = _deviceId
-        } else {
-            self.deviceId = UUID().uuidString
-            UserDefaults.standard.set(self.deviceId, forKey: DEVICE_ID_STORE_KEY)
-        }
+        self.deviceId = deviceId
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -16,10 +16,10 @@ private let DEFAULT_APP_NAME: String = info?["CFBundleName"] as? String ?? "Unkn
 private let DEFAULT_OS_VERSION = ProcessInfo.processInfo.operatingSystemVersion
 private let DEFAULT_MANUFACTURER = "Apple"
 private let DEFAULT_OS_NAME = "iOS"
-private let DEFAULT_DEVICE_MODEL = {
+private let DEFAULT_DEVICE_MODEL: String = {
     var size = 0
     sysctlbyname("hw.machine", nil, &size, nil, 0)
-    var machine = [CChar](repeating: 0,  count: size)
+    var machine = [CChar](repeating: 0, count: size)
     sysctlbyname("hw.machine", &machine, &size, nil, 0)
     return String(cString: machine)
 }()
@@ -51,8 +51,7 @@ struct AppContextInfo {
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
-         deviceModel: String = DEFAULT_DEVICE_MODEL
-    ) {
+         deviceModel: String = DEFAULT_DEVICE_MODEL) {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -10,6 +10,8 @@ import AnyCodable
 import Foundation
 
 extension KlaviyoAPI.KlaviyoRequest {
+    private static let _appContextInfo = environment.analytics.appContextInfo()
+
     enum KlaviyoEndpoint: Equatable, Codable {
         struct CreateProfilePayload: Equatable, Codable {
             /**
@@ -121,8 +123,23 @@ extension KlaviyoAPI.KlaviyoRequest {
                     let uniqueId: String
                     init(attributes: KlaviyoSwift.Event,
                          anonymousId: String? = nil) {
+                        let context = KlaviyoAPI.KlaviyoRequest._appContextInfo
+                        let metadata = [
+                            "Device Manufacturer": context.manufacturer,
+                            "Device Model": context.deviceModel,
+                            "OS Name": context.osName,
+                            "OS Version": context.osVersion,
+                            "SDK Name": __klaviyoSwiftName,
+                            "SDK Version": __klaviyoSwiftVersion,
+                            "App Name": context.appName,
+                            "App ID": context.bundleId,
+                            "App Version": context.appVersion,
+                            "App Build": context.appBuild,
+                            "Push Token": environment.analytics.state().pushToken as Any
+                        ]
+
                         metric = Metric(name: attributes.metric.name.value)
-                        properties = AnyCodable(attributes.properties)
+                        properties = AnyCodable(attributes.properties.merging(metadata) { _, new in new })
                         value = attributes.value
                         time = attributes.time
                         uniqueId = attributes.uniqueId

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -125,6 +125,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                          anonymousId: String? = nil) {
                         let context = KlaviyoAPI.KlaviyoRequest._appContextInfo
                         let metadata = [
+                            "Device ID": context.deviceId,
                             "Device Manufacturer": context.manufacturer,
                             "Device Model": context.deviceModel,
                             "OS Name": context.osName,

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -49,9 +49,21 @@ public struct Event: Equatable {
 
     public let metric: Metric
     public var properties: [String: Any] {
-        _properties.value as! [String: Any]
+        (_properties.value as! [String: Any]).merging([
+            "Device Manufacturer": Event._metadata.manufacturer,
+            "Device Model": Event._metadata.deviceModel,
+            "OS Name": Event._metadata.osName,
+            "OS Version": Event._metadata.osVersion,
+            "SDK Name": __klaviyoSwiftName,
+            "SDK Version": __klaviyoSwiftVersion,
+            "Application ID": Event._metadata.bundleId,
+            "App Version": Event._metadata.appVersion,
+            "App Build": Event._metadata.appBuild,
+            "App Name": Event._metadata.appName
+        ]) { (_, new) in new }
     }
 
+    static private let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -49,22 +49,9 @@ public struct Event: Equatable {
 
     public let metric: Metric
     public var properties: [String: Any] {
-        (_properties.value as! [String: Any]).merging([
-            "Device Manufacturer": Event._metadata.manufacturer,
-            "Device Model": Event._metadata.deviceModel,
-            "OS Name": Event._metadata.osName,
-            "OS Version": Event._metadata.osVersion,
-            "SDK Name": __klaviyoSwiftName,
-            "SDK Version": __klaviyoSwiftVersion,
-            "Application ID": Event._metadata.bundleId,
-            "App Version": Event._metadata.appVersion,
-            "App Build": Event._metadata.appBuild,
-            "App Name": Event._metadata.appName,
-            "Push Token": environment.analytics.state().pushToken
-        ]) { _, new in new }
+        _properties.value as! [String: Any]
     }
 
-    private static let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -59,11 +59,12 @@ public struct Event: Equatable {
             "Application ID": Event._metadata.bundleId,
             "App Version": Event._metadata.appVersion,
             "App Build": Event._metadata.appBuild,
-            "App Name": Event._metadata.appName
-        ]) { (_, new) in new }
+            "App Name": Event._metadata.appName,
+            "Push Token": environment.analytics.state().pushToken
+        ]) { _, new in new }
     }
 
-    static private let _metadata = environment.analytics.appContextInfo()
+    private static let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -14,7 +14,7 @@ let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 let defaultUserAgent = { () -> String in
     let appContext = environment.analytics.appContextInfo()
     let klaivyoSDKVersion = "klaviyo-ios/\(__klaviyoSwiftVersion)"
-    return "\(appContext.excutable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
+    return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
 }()
 
 func createEmphemeralSession(protocolClasses: [AnyClass] = URLProtocolOverrides.protocolClasses) -> URLSession {

--- a/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
+++ b/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
@@ -51,7 +51,7 @@ final class Box<Wrapped> {
 @inline(__always)
 func runtimeWarn(
   _ message: @autoclosure () -> String,
-  category: String? = "ComposableArchitecture",
+  category: String? = __klaviyoSwiftName,
   file: StaticString? = nil,
   line: UInt? = nil
 ) {

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -7,4 +7,5 @@
 
 import Foundation
 
+public let __klaviyoSwiftName = "klaviyo-swift-sdk"
 public let __klaviyoSwiftVersion = "2.0.1"

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -169,7 +169,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test property getters
 
-    func testPropertGetters() throws {
+    func testPropertyGetters() throws {
         environment.analytics.state = { KlaviyoState(email: "foo@foo.com", phoneNumber: "555BLOB", externalId: "my_test_id", pushToken: "blobtoken", queue: []) }
         let klaviyo = KlaviyoSDK()
         XCTAssertEqual("foo@foo.com", klaviyo.email)

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -146,7 +146,8 @@ extension AppContextInfo {
                            version: OperatingSystemVersion(majorVersion: 1, minorVersion: 1, patchVersion: 1),
                            osName: "iOS",
                            manufacturer: "Orange",
-                           deviceModel: "jPhone 1,1")
+                           deviceModel: "jPhone 1,1",
+                           deviceId: "fe-fi-fo-fum")
 }
 
 extension StateChangePublisher {

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -138,12 +138,15 @@ extension NetworkSession {
 }
 
 extension AppContextInfo {
-    static let test = Self(excutable: "FooApp",
+    static let test = Self(executable: "FooApp",
                            bundleId: "com.klaviyo.fooapp",
                            appVersion: "1.2.3",
                            appBuild: "1",
+                           appName: "FooApp",
                            version: OperatingSystemVersion(majorVersion: 1, minorVersion: 1, patchVersion: 1),
-                           osName: "iOS")
+                           osName: "iOS",
+                           manufacturer: "Orange",
+                           deviceModel: "jPhone 1,1")
 }
 
 extension StateChangePublisher {

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -58,7 +58,15 @@ extension Event {
         "stuff": 2,
         "hello": [
             "sub": "dict"
-        ]
+        ],
+        "Application ID": "com.klaviyo.fooapp",
+        "App Version": "1.2.3",
+        "App Build": "1",
+        "App Name": "FooApp",
+        "OS Version": "1.1.1",
+        "OS Name": "iOS",
+        "Device Manufacturer": "Orange",
+        "Device Model": "jPhone 1,1"
     ] as [String: Any]
     static let SAMPLE_PROFILE_PROPERTIES = [
         "email": "blob@email.com",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -24,6 +24,7 @@
         },
         "OS Name" : "iOS",
         "OS Version" : "1.1.1",
+        "Push Token" : null,
         "SDK Name" : "klaviyo-swift-sdk",
         "SDK Version" : "2.0.1",
         "stuff" : 2

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -18,6 +18,7 @@
         "App Version" : "1.2.3",
         "Application ID" : "com.klaviyo.fooapp",
         "blob" : "blob",
+        "Device ID" : "fe-fi-fo-fum",
         "Device Manufacturer" : "Orange",
         "Device Model" : "jPhone 1,1",
         "hello" : {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -12,10 +12,20 @@
         "stuff" : 2
       },
       "properties" : {
+        "App Build" : "1",
+        "App Name" : "FooApp",
+        "App Version" : "1.2.3",
+        "Application ID" : "com.klaviyo.fooapp",
         "blob" : "blob",
+        "Device Manufacturer" : "Orange",
+        "Device Model" : "jPhone 1,1",
         "hello" : {
           "sub" : "dict"
         },
+        "OS Name" : "iOS",
+        "OS Version" : "1.1.1",
+        "SDK Name" : "klaviyo-swift-sdk",
+        "SDK Version" : "2.0.1",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -13,6 +13,7 @@
       },
       "properties" : {
         "App Build" : "1",
+        "App ID" : "com.klaviyo.fooapp",
         "App Name" : "FooApp",
         "App Version" : "1.2.3",
         "Application ID" : "com.klaviyo.fooapp",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -30,6 +30,7 @@
                   "OS Name" : "iOS",
                   "OS Version" : "1.1.1",
                   "prop1" : "propValue",
+                  "Push Token" : null,
                   "SDK Name" : "klaviyo-swift-sdk",
                   "SDK Version" : "2.0.1"
                 },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -21,7 +21,17 @@
                   "foo" : "bar"
                 },
                 "properties" : {
-                  "prop1" : "propValue"
+                  "App Build" : "1",
+                  "App Name" : "FooApp",
+                  "App Version" : "1.2.3",
+                  "Application ID" : "com.klaviyo.fooapp",
+                  "Device Manufacturer" : "Orange",
+                  "Device Model" : "jPhone 1,1",
+                  "OS Name" : "iOS",
+                  "OS Version" : "1.1.1",
+                  "prop1" : "propValue",
+                  "SDK Name" : "klaviyo-swift-sdk",
+                  "SDK Version" : "2.0.1"
                 },
                 "time" : 256260690,
                 "unique_id" : "00000000-0000-0000-0000-000000000001"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -25,6 +25,7 @@
                   "App ID" : "com.klaviyo.fooapp",
                   "App Name" : "FooApp",
                   "App Version" : "1.2.3",
+                  "Device ID" : "fe-fi-fo-fum",
                   "Device Manufacturer" : "Orange",
                   "Device Model" : "jPhone 1,1",
                   "OS Name" : "iOS",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -22,9 +22,9 @@
                 },
                 "properties" : {
                   "App Build" : "1",
+                  "App ID" : "com.klaviyo.fooapp",
                   "App Name" : "FooApp",
                   "App Version" : "1.2.3",
-                  "Application ID" : "com.klaviyo.fooapp",
                   "Device Manufacturer" : "Orange",
                   "Device Model" : "jPhone 1,1",
                   "OS Name" : "iOS",


### PR DESCRIPTION
# Description
Added device metadata in the same manner as Kenny's android PR [here](https://github.com/klaviyo/klaviyo-android-sdk/pull/76/files) 

This will make sure that all events from the Swift SDK are tagged with metadata. 

<!--
Please describe the changes you are making and why you are making them.
-->

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compitable with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. Updated the unit tests


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
