### PR TITLE
V3 API updates and Device Metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Please describe the changes you are making and why you are making them.
 - [ ] Have you tested this change on real device?
 - [ ] Are your changes backwards compatible with previous SDK Versions?
 - [ ] Have you added unit test coverage for your changes?
-- [ ] Have you verified that your changes are compitable with all the operating system version this SDK currently supports?
+- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?
 
 # Manual Test Plan
 

--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -19,7 +19,8 @@ private func getDelaySeconds(for count: Int) -> Int {
 func handleRequestError(request: KlaviyoAPI.KlaviyoRequest, error: KlaviyoAPI.KlaviyoAPIError, retryInfo: RetryInfo) -> KlaviyoAction {
     switch error {
     case let .httpError(statuscode, data):
-        environment.logger.error("An http error occured status code: \(statuscode) data: \(data)")
+        let responseString = String(data: data, encoding: .utf8) ?? "[Unknown]"
+        environment.logger.error("An http error occured status code: \(statuscode) data: \(responseString)")
         return .dequeCompletedResults(request)
     case let .networkError(error):
         environment.logger.error("A network error occurred: \(error)")

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -24,6 +24,8 @@ private let DEFAULT_DEVICE_MODEL: String = {
     return String(cString: machine)
 }()
 
+private let DEVICE_ID_STORE_KEY = "_klaviyo_device_id"
+
 struct AppContextInfo {
     let executable: String
     let bundleId: String
@@ -34,6 +36,7 @@ struct AppContextInfo {
     let osName: String
     let manufacturer: String
     let deviceModel: String
+    let deviceId: String
 
     var osVersion: String {
         "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
@@ -51,7 +54,8 @@ struct AppContextInfo {
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
-         deviceModel: String = DEFAULT_DEVICE_MODEL) {
+         deviceModel: String = DEFAULT_DEVICE_MODEL,
+         deviceId: String? = nil) {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
@@ -61,5 +65,14 @@ struct AppContextInfo {
         self.osName = osName
         self.manufacturer = manufacturer
         self.deviceModel = deviceModel
+
+        if let _deviceId = deviceId {
+            self.deviceId = _deviceId
+        } else if let _deviceId = UserDefaults.standard.string(forKey: DEVICE_ID_STORE_KEY) {
+            self.deviceId = _deviceId
+        } else {
+            self.deviceId = UUID().uuidString
+            UserDefaults.standard.set(self.deviceId, forKey: DEVICE_ID_STORE_KEY)
+        }
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -12,16 +12,29 @@ private let DEFAULT_EXECUTABLE: String = (info?["CFBundleExecutable"] as? String
 private let DEFAULT_BUNDLE_ID: String = info?["CFBundleIdentifier"] as? String ?? "Unknown"
 private let DEFAULT_APP_VERSION: String = info?["CFBundleShortVersionString"] as? String ?? "Unknown"
 private let DEFAULT_APP_BUILD: String = info?["CFBundleVersion"] as? String ?? "Unknown"
+private let DEFAULT_APP_NAME: String = info?["CFBundleName"] as? String ?? "Unknown"
 private let DEFAULT_OS_VERSION = ProcessInfo.processInfo.operatingSystemVersion
+private let DEFAULT_MANUFACTURER = "Apple"
 private let DEFAULT_OS_NAME = "iOS"
+private let DEFAULT_DEVICE_MODEL = {
+    var size = 0
+    sysctlbyname("hw.machine", nil, &size, nil, 0)
+    var machine = [CChar](repeating: 0,  count: size)
+    sysctlbyname("hw.machine", &machine, &size, nil, 0)
+    return String(cString: machine)
+}()
 
 struct AppContextInfo {
-    let excutable: String
+    let executable: String
     let bundleId: String
     let appVersion: String
     let appBuild: String
+    let appName: String
     let version: OperatingSystemVersion
     let osName: String
+    let manufacturer: String
+    let deviceModel: String
+
     var osVersion: String {
         "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
@@ -30,17 +43,24 @@ struct AppContextInfo {
         "\(osName) \(osVersion)"
     }
 
-    init(excutable: String = DEFAULT_EXECUTABLE,
+    init(executable: String = DEFAULT_EXECUTABLE,
          bundleId: String = DEFAULT_BUNDLE_ID,
          appVersion: String = DEFAULT_APP_VERSION,
          appBuild: String = DEFAULT_APP_BUILD,
+         appName: String = DEFAULT_APP_NAME,
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
-         osName: String = DEFAULT_OS_NAME) {
-        self.excutable = excutable
+         osName: String = DEFAULT_OS_NAME,
+         manufacturer: String = DEFAULT_MANUFACTURER,
+         deviceModel: String = DEFAULT_DEVICE_MODEL
+    ) {
+        self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
         self.appBuild = appBuild
+        self.appName = appName
         self.version = version
         self.osName = osName
+        self.manufacturer = manufacturer
+        self.deviceModel = deviceModel
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -5,6 +5,7 @@
 //  Created by Noah Durell on 11/18/22.
 //
 import Foundation
+import UIKit
 
 private let info = Bundle.main.infoDictionary
 private let DEFAULT_EXECUTABLE: String = (info?["CFBundleExecutable"] as? String) ??
@@ -55,7 +56,7 @@ struct AppContextInfo {
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
          deviceModel: String = DEFAULT_DEVICE_MODEL,
-         deviceId: String? = nil) {
+         deviceId: String = UIDevice.current.identifierForVendor?.uuidString ?? "") {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion
@@ -65,14 +66,6 @@ struct AppContextInfo {
         self.osName = osName
         self.manufacturer = manufacturer
         self.deviceModel = deviceModel
-
-        if let _deviceId = deviceId {
-            self.deviceId = _deviceId
-        } else if let _deviceId = UserDefaults.standard.string(forKey: DEVICE_ID_STORE_KEY) {
-            self.deviceId = _deviceId
-        } else {
-            self.deviceId = UUID().uuidString
-            UserDefaults.standard.set(self.deviceId, forKey: DEVICE_ID_STORE_KEY)
-        }
+        self.deviceId = deviceId
     }
 }

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -16,10 +16,10 @@ private let DEFAULT_APP_NAME: String = info?["CFBundleName"] as? String ?? "Unkn
 private let DEFAULT_OS_VERSION = ProcessInfo.processInfo.operatingSystemVersion
 private let DEFAULT_MANUFACTURER = "Apple"
 private let DEFAULT_OS_NAME = "iOS"
-private let DEFAULT_DEVICE_MODEL = {
+private let DEFAULT_DEVICE_MODEL: String = {
     var size = 0
     sysctlbyname("hw.machine", nil, &size, nil, 0)
-    var machine = [CChar](repeating: 0,  count: size)
+    var machine = [CChar](repeating: 0, count: size)
     sysctlbyname("hw.machine", &machine, &size, nil, 0)
     return String(cString: machine)
 }()
@@ -51,8 +51,7 @@ struct AppContextInfo {
          version: OperatingSystemVersion = DEFAULT_OS_VERSION,
          osName: String = DEFAULT_OS_NAME,
          manufacturer: String = DEFAULT_MANUFACTURER,
-         deviceModel: String = DEFAULT_DEVICE_MODEL
-    ) {
+         deviceModel: String = DEFAULT_DEVICE_MODEL) {
         self.executable = executable
         self.bundleId = bundleId
         self.appVersion = appVersion

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -10,6 +10,8 @@ import AnyCodable
 import Foundation
 
 extension KlaviyoAPI.KlaviyoRequest {
+    private static let _appContextInfo = environment.analytics.appContextInfo()
+
     enum KlaviyoEndpoint: Equatable, Codable {
         struct CreateProfilePayload: Equatable, Codable {
             /**
@@ -121,8 +123,23 @@ extension KlaviyoAPI.KlaviyoRequest {
                     let uniqueId: String
                     init(attributes: KlaviyoSwift.Event,
                          anonymousId: String? = nil) {
+                        let context = KlaviyoAPI.KlaviyoRequest._appContextInfo
+                        let metadata = [
+                            "Device Manufacturer": context.manufacturer,
+                            "Device Model": context.deviceModel,
+                            "OS Name": context.osName,
+                            "OS Version": context.osVersion,
+                            "SDK Name": __klaviyoSwiftName,
+                            "SDK Version": __klaviyoSwiftVersion,
+                            "App Name": context.appName,
+                            "App ID": context.bundleId,
+                            "App Version": context.appVersion,
+                            "App Build": context.appBuild,
+                            "Push Token": environment.analytics.state().pushToken as Any
+                        ]
+
                         metric = Metric(name: attributes.metric.name.value)
-                        properties = AnyCodable(attributes.properties)
+                        properties = AnyCodable(attributes.properties.merging(metadata) { _, new in new })
                         value = attributes.value
                         time = attributes.time
                         uniqueId = attributes.uniqueId

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -319,7 +319,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                             appBuild = context.appBuild
                             environment = context.environment
                             klaviyoSdk = __klaviyoSwiftName
-                            sdkVersion = __klaviyoSwiftName
+                            sdkVersion = __klaviyoSwiftVersion
                         }
                     }
                 }

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -178,53 +178,105 @@ extension KlaviyoAPI.KlaviyoRequest {
         }
 
         struct PushTokenPayload: Equatable, Codable {
-            struct Properties: Equatable, Codable {
-                let anonymousId: String?
-                let append: Append
-                let email: String?
-                let phoneNumber: String?
-                let externalId: String?
-                struct Append: Equatable, Codable {
-                    let pushToken: String
-                    enum CodingKeys: String, CodingKey {
-                        case pushToken = "$ios_tokens"
+            var type = "push-token"
+            var attributes: Attributes
+
+            init(pushToken: String,
+                 profile: KlaviyoSwift.Profile,
+                 anonymousId: String) {
+                attributes = .init(
+                    pushToken: pushToken,
+                    profile: profile,
+                    anonymousId: anonymousId)
+            }
+
+            struct Attributes: Equatable, Codable {
+                let profile: Profile
+                let token: String
+                let enablementStatus: String = ""
+                let background: String = ""
+                let deviceMetadata: MetaData
+                let platform: String = "ios"
+                let vendor: String = "APNs"
+
+                enum CodingKeys: String, CodingKey {
+                    case token = "token_id"
+                    case platform
+                    case enablementStatus = "enablement_status"
+                    case profile
+                    case vendor
+                    case background
+                    case deviceMetadata = "device_metadata"
+                }
+
+                init(pushToken: String,
+                     profile: KlaviyoSwift.Profile,
+                     anonymousId: String) {
+                    token = pushToken
+
+                    self.profile = .init(attributes: profile, anonymousId: anonymousId)
+                    deviceMetadata = .init(context: KlaviyoAPI.KlaviyoRequest._appContextInfo)
+                }
+
+                struct Profile: Equatable, Codable {
+                    let data: CreateProfilePayload.Profile
+
+                    init(attributes: KlaviyoSwift.Profile,
+                         anonymousId: String) {
+                        data = .init(profile: attributes, anonymousId: anonymousId)
                     }
                 }
 
-                enum CodingKeys: String, CodingKey {
-                    case anonymousId = "$anonymous"
-                    case email = "$email"
-                    case phoneNumber = "$phone_number"
-                    case append = "$append"
-                    case externalId = "$id"
-                }
+                struct MetaData: Equatable, Codable {
+                    let deviceId: String
+                    let deviceModel: String
+                    let manufacturer: String
+                    let osName: String
+                    let osVersion: String
+                    let appId: String
+                    let appName: String
+                    let appVersion: String
+                    let appBuild: String
+                    let environment: String
+                    let klaviyoSdk: String
+                    let sdkVersion: String
 
-                init(anonymousId: String,
-                     pushToken: String,
-                     email: String? = nil,
-                     phoneNumber: String? = nil,
-                     externalId: String? = nil) {
-                    self.email = email
-                    self.phoneNumber = phoneNumber
-                    self.anonymousId = anonymousId
-                    append = Append(pushToken: pushToken)
-                    self.externalId = externalId
-                }
-            }
+                    enum CodingKeys: String, CodingKey {
+                        case deviceId = "device_id"
+                        case klaviyoSdk = "klaviyo_sdk"
+                        case sdkVersion = "sdk_version"
+                        case deviceModel = "device_model"
+                        case osName = "os_name"
+                        case osVersion = "os_version"
+                        case manufacturer
+                        case appName = "app_name"
+                        case appVersion = "app_version"
+                        case appBuild = "app_build"
+                        case appId = "app_id"
+                        case environment
+                    }
 
-            // This is actually the api key for this endpoint
-            let token: String
-            let properties: Properties
-            init(token: String,
-                 properties: Properties) {
-                self.token = token
-                self.properties = properties
+                    init(context: AppContextInfo) {
+                        deviceId = context.deviceId
+                        deviceModel = context.deviceModel
+                        manufacturer = context.manufacturer
+                        osName = context.osName
+                        osVersion = context.osVersion
+                        appId = context.bundleId
+                        appName = context.appName
+                        appVersion = context.appVersion
+                        appBuild = context.appBuild
+                        environment = context.environment
+                        klaviyoSdk = __klaviyoSwiftName
+                        sdkVersion = __klaviyoSwiftName
+                    }
+                }
             }
         }
 
         case createProfile(CreateProfilePayload)
         case createEvent(CreateEventPayload)
-        case storePushToken(PushTokenPayload)
+        case registerPushToken(PushTokenPayload)
     }
 }
 

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -125,6 +125,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                          anonymousId: String? = nil) {
                         let context = KlaviyoAPI.KlaviyoRequest._appContextInfo
                         let metadata = [
+                            "Device ID": context.deviceId,
                             "Device Manufacturer": context.manufacturer,
                             "Device Model": context.deviceModel,
                             "OS Name": context.osName,

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -182,10 +182,14 @@ extension KlaviyoAPI.KlaviyoRequest {
             var attributes: Attributes
 
             init(pushToken: String,
+                 enablement: String,
+                 background: String,
                  profile: KlaviyoSwift.Profile,
                  anonymousId: String) {
                 attributes = .init(
                     pushToken: pushToken,
+                    enablement: enablement,
+                    background: background,
                     profile: profile,
                     anonymousId: anonymousId)
             }
@@ -193,8 +197,8 @@ extension KlaviyoAPI.KlaviyoRequest {
             struct Attributes: Equatable, Codable {
                 let profile: Profile
                 let token: String
-                let enablementStatus: String = ""
-                let background: String = ""
+                let enablementStatus: String
+                let backgroundStatus: String
                 let deviceMetadata: MetaData
                 let platform: String = "ios"
                 let vendor: String = "APNs"
@@ -205,15 +209,19 @@ extension KlaviyoAPI.KlaviyoRequest {
                     case enablementStatus = "enablement_status"
                     case profile
                     case vendor
-                    case background
+                    case backgroundStatus = "background"
                     case deviceMetadata = "device_metadata"
                 }
 
                 init(pushToken: String,
+                     enablement: String,
+                     background: String,
                      profile: KlaviyoSwift.Profile,
                      anonymousId: String) {
                     token = pushToken
 
+                    enablementStatus = enablement
+                    backgroundStatus = background
                     self.profile = .init(attributes: profile, anonymousId: anonymousId)
                     deviceMetadata = .init(context: KlaviyoAPI.KlaviyoRequest._appContextInfo)
                 }

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -61,44 +61,15 @@ extension KlaviyoAPI.KlaviyoRequest {
                     }
                 }
 
-                struct Meta: Equatable, Codable {
-                    struct Identifiers: Equatable, Codable {
-                        let email: String?
-                        let phoneNumber: String?
-                        let externalId: String?
-                        let anonymousId: String
-                        init(attributes: KlaviyoSwift.Profile, anonymousId: String) {
-                            email = attributes.email
-                            phoneNumber = attributes.phoneNumber
-                            externalId = attributes.externalId
-                            self.anonymousId = anonymousId
-                        }
-
-                        enum CodingKeys: String, CodingKey {
-                            case email
-                            case phoneNumber = "phone_number"
-                            case externalId = "external_id"
-                            case anonymousId = "anonymous_id"
-                        }
-                    }
-
-                    let identifiers: Identifiers
-                }
-
                 let attributes: Attributes
-                let meta: Meta
                 init(profile: KlaviyoSwift.Profile, anonymousId: String) {
                     attributes = Attributes(
                         attributes: profile,
                         anonymousId: anonymousId)
-                    meta = Meta(identifiers: .init(
-                        attributes: profile,
-                        anonymousId: anonymousId))
                 }
 
-                init(attributes: Attributes, meta: Meta) {
+                init(attributes: Attributes) {
                     self.attributes = attributes
-                    self.meta = meta
                 }
             }
 

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -178,15 +178,14 @@ extension KlaviyoAPI.KlaviyoRequest {
         }
 
         struct PushTokenPayload: Equatable, Codable {
-            var type = "push-token"
-            var attributes: Attributes
+            let data: PushToken
 
             init(pushToken: String,
                  enablement: String,
                  background: String,
                  profile: KlaviyoSwift.Profile,
                  anonymousId: String) {
-                attributes = .init(
+                data = .init(
                     pushToken: pushToken,
                     enablement: enablement,
                     background: background,
@@ -194,89 +193,134 @@ extension KlaviyoAPI.KlaviyoRequest {
                     anonymousId: anonymousId)
             }
 
-            struct Attributes: Equatable, Codable {
-                let profile: Profile
-                let token: String
-                let enablementStatus: String
-                let backgroundStatus: String
-                let deviceMetadata: MetaData
-                let platform: String = "ios"
-                let vendor: String = "APNs"
-
-                enum CodingKeys: String, CodingKey {
-                    case token = "token_id"
-                    case platform
-                    case enablementStatus = "enablement_status"
-                    case profile
-                    case vendor
-                    case backgroundStatus = "background"
-                    case deviceMetadata = "device_metadata"
-                }
+            struct PushToken: Equatable, Codable {
+                var type = "push-token"
+                var attributes: Attributes
 
                 init(pushToken: String,
                      enablement: String,
                      background: String,
                      profile: KlaviyoSwift.Profile,
                      anonymousId: String) {
-                    token = pushToken
-
-                    enablementStatus = enablement
-                    backgroundStatus = background
-                    self.profile = .init(attributes: profile, anonymousId: anonymousId)
-                    deviceMetadata = .init(context: KlaviyoAPI.KlaviyoRequest._appContextInfo)
+                    attributes = .init(
+                        pushToken: pushToken,
+                        enablement: enablement,
+                        background: background,
+                        profile: profile,
+                        anonymousId: anonymousId)
                 }
 
-                struct Profile: Equatable, Codable {
-                    let data: CreateProfilePayload.Profile
-
-                    init(attributes: KlaviyoSwift.Profile,
-                         anonymousId: String) {
-                        data = .init(profile: attributes, anonymousId: anonymousId)
-                    }
-                }
-
-                struct MetaData: Equatable, Codable {
-                    let deviceId: String
-                    let deviceModel: String
-                    let manufacturer: String
-                    let osName: String
-                    let osVersion: String
-                    let appId: String
-                    let appName: String
-                    let appVersion: String
-                    let appBuild: String
-                    let environment: String
-                    let klaviyoSdk: String
-                    let sdkVersion: String
+                struct Attributes: Equatable, Codable {
+                    let profile: ProfileData
+                    let token: String
+                    let enablementStatus: String
+                    let backgroundStatus: String
+                    let deviceMetadata: MetaData
+                    let platform: String = "ios"
+                    let vendor: String = "APNs"
 
                     enum CodingKeys: String, CodingKey {
-                        case deviceId = "device_id"
-                        case klaviyoSdk = "klaviyo_sdk"
-                        case sdkVersion = "sdk_version"
-                        case deviceModel = "device_model"
-                        case osName = "os_name"
-                        case osVersion = "os_version"
-                        case manufacturer
-                        case appName = "app_name"
-                        case appVersion = "app_version"
-                        case appBuild = "app_build"
-                        case appId = "app_id"
-                        case environment
+                        case token = "token_id"
+                        case platform
+                        case enablementStatus = "enablement_status"
+                        case profile
+                        case vendor
+                        case backgroundStatus = "background"
+                        case deviceMetadata = "device_metadata"
                     }
 
-                    init(context: AppContextInfo) {
-                        deviceId = context.deviceId
-                        deviceModel = context.deviceModel
-                        manufacturer = context.manufacturer
-                        osName = context.osName
-                        osVersion = context.osVersion
-                        appId = context.bundleId
-                        appName = context.appName
-                        appVersion = context.appVersion
-                        appBuild = context.appBuild
-                        environment = context.environment
-                        klaviyoSdk = __klaviyoSwiftName
-                        sdkVersion = __klaviyoSwiftName
+                    init(pushToken: String,
+                         enablement: String,
+                         background: String,
+                         profile: KlaviyoSwift.Profile,
+                         anonymousId: String) {
+                        token = pushToken
+
+                        enablementStatus = enablement
+                        backgroundStatus = background
+                        self.profile = .init(profile: profile, anonymousId: anonymousId)
+                        deviceMetadata = .init(context: KlaviyoAPI.KlaviyoRequest._appContextInfo)
+                    }
+
+                    struct ProfileData: Equatable, Codable {
+                        let data: Profile
+
+                        init(profile: KlaviyoSwift.Profile,
+                             anonymousId: String) {
+                            data = .init(profile: profile, anonymousId: anonymousId)
+                        }
+
+                        struct Profile: Equatable, Codable {
+                            var type = "profile"
+                            let attributes: Attributes
+
+                            init(profile: KlaviyoSwift.Profile,
+                                 anonymousId: String) {
+                                attributes = .init(email: profile.email,
+                                                   phoneNumber: profile.phoneNumber,
+                                                   externalId: profile.externalId,
+                                                   anonymousId: anonymousId)
+                            }
+
+                            struct Attributes: Equatable, Codable {
+                                let email: String?
+                                let phoneNumber: String?
+                                let externalId: String?
+                                let anonymousId: String
+
+                                enum CodingKeys: String, CodingKey {
+                                    case email
+                                    case phoneNumber = "phone_number"
+                                    case externalId = "external_id"
+                                    case anonymousId = "anonymous_id"
+                                }
+                            }
+                        }
+                    }
+
+                    struct MetaData: Equatable, Codable {
+                        let deviceId: String
+                        let deviceModel: String
+                        let manufacturer: String
+                        let osName: String
+                        let osVersion: String
+                        let appId: String
+                        let appName: String
+                        let appVersion: String
+                        let appBuild: String
+                        let environment: String
+                        let klaviyoSdk: String
+                        let sdkVersion: String
+
+                        enum CodingKeys: String, CodingKey {
+                            case deviceId = "device_id"
+                            case klaviyoSdk = "klaviyo_sdk"
+                            case sdkVersion = "sdk_version"
+                            case deviceModel = "device_model"
+                            case osName = "os_name"
+                            case osVersion = "os_version"
+                            case manufacturer
+                            case appName = "app_name"
+                            case appVersion = "app_version"
+                            case appBuild = "app_build"
+                            case appId = "app_id"
+                            case environment
+                        }
+
+                        init(context: AppContextInfo) {
+                            deviceId = context.deviceId
+                            deviceModel = context.deviceModel
+                            manufacturer = context.manufacturer
+                            osName = context.osName
+                            osVersion = context.osVersion
+                            appId = context.bundleId
+                            appName = context.appName
+                            appVersion = context.appVersion
+                            appBuild = context.appBuild
+                            environment = context.environment
+                            klaviyoSdk = __klaviyoSwiftName
+                            sdkVersion = __klaviyoSwiftName
+                        }
                     }
                 }
             }

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -109,15 +109,43 @@ extension KlaviyoAPI.KlaviyoRequest {
             struct Event: Equatable, Codable {
                 struct Attributes: Equatable, Codable {
                     struct Metric: Equatable, Codable {
-                        let name: String
+                        let data: MetricData
+
+                        struct MetricData: Equatable, Codable {
+                            var type: String = "metric"
+
+                            let attributes: MetricAttributes
+
+                            init(name: String) {
+                                attributes = .init(name: name)
+                            }
+
+                            struct MetricAttributes: Equatable, Codable {
+                                let name: String
+
+                                init(name: String) {
+                                    self.name = name
+                                }
+                            }
+                        }
+
                         init(name: String) {
-                            self.name = name
+                            data = .init(name: name)
+                        }
+                    }
+
+                    struct Profile: Equatable, Codable {
+                        let data: CreateProfilePayload.Profile
+
+                        init(attributes: KlaviyoSwift.Profile,
+                             anonymousId: String) {
+                            data = .init(profile: attributes, anonymousId: anonymousId)
                         }
                     }
 
                     let metric: Metric
                     let properties: AnyCodable
-                    let profile: AnyCodable
+                    let profile: Profile
                     let time: Date
                     let value: Double?
                     let uniqueId: String
@@ -144,13 +172,12 @@ extension KlaviyoAPI.KlaviyoRequest {
                         value = attributes.value
                         time = attributes.time
                         uniqueId = attributes.uniqueId
-                        if let anonymousId = anonymousId {
-                            var updatedProfile = attributes.profile
-                            updatedProfile["$anonymous"] = anonymousId
-                            profile = AnyCodable(updatedProfile)
-                        } else {
-                            profile = AnyCodable(attributes.profile)
-                        }
+
+                        profile = .init(attributes: .init(
+                            email: attributes.identifiers?.email,
+                            phoneNumber: attributes.identifiers?.phoneNumber,
+                            externalId: attributes.identifiers?.externalId),
+                        anonymousId: anonymousId ?? "")
                     }
 
                     enum CodingKeys: String, CodingKey {
@@ -211,7 +238,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                 }
 
                 struct Attributes: Equatable, Codable {
-                    let profile: ProfileData
+                    let profile: Profile
                     let token: String
                     let enablementStatus: String
                     let backgroundStatus: String
@@ -220,7 +247,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                     let vendor: String = "APNs"
 
                     enum CodingKeys: String, CodingKey {
-                        case token = "token_id"
+                        case token
                         case platform
                         case enablementStatus = "enablement_status"
                         case profile
@@ -238,43 +265,16 @@ extension KlaviyoAPI.KlaviyoRequest {
 
                         enablementStatus = enablement
                         backgroundStatus = background
-                        self.profile = .init(profile: profile, anonymousId: anonymousId)
+                        self.profile = .init(attributes: profile, anonymousId: anonymousId)
                         deviceMetadata = .init(context: KlaviyoAPI.KlaviyoRequest._appContextInfo)
                     }
 
-                    struct ProfileData: Equatable, Codable {
-                        let data: Profile
+                    struct Profile: Equatable, Codable {
+                        let data: CreateProfilePayload.Profile
 
-                        init(profile: KlaviyoSwift.Profile,
+                        init(attributes: KlaviyoSwift.Profile,
                              anonymousId: String) {
-                            data = .init(profile: profile, anonymousId: anonymousId)
-                        }
-
-                        struct Profile: Equatable, Codable {
-                            var type = "profile"
-                            let attributes: Attributes
-
-                            init(profile: KlaviyoSwift.Profile,
-                                 anonymousId: String) {
-                                attributes = .init(email: profile.email,
-                                                   phoneNumber: profile.phoneNumber,
-                                                   externalId: profile.externalId,
-                                                   anonymousId: anonymousId)
-                            }
-
-                            struct Attributes: Equatable, Codable {
-                                let email: String?
-                                let phoneNumber: String?
-                                let externalId: String?
-                                let anonymousId: String
-
-                                enum CodingKeys: String, CodingKey {
-                                    case email
-                                    case phoneNumber = "phone_number"
-                                    case externalId = "external_id"
-                                    case anonymousId = "anonymous_id"
-                                }
-                            }
+                            data = .init(profile: attributes, anonymousId: anonymousId)
                         }
                     }
 
@@ -431,7 +431,8 @@ struct LegacyEvent: Equatable {
             // Special handling for $opened_push include push token at the time of open
             eventProperties["push_token"] = state.pushToken
         }
-        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, profile: customerProperties))
+        let identifiers: Event.Identifiers = .init(email: state.email, phoneNumber: state.phoneNumber, externalId: state.externalId)
+        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, identifiers: identifiers, profile: customerProperties), anonymousId: state.anonymousId)
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload(data: event)
         let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.createEvent(payload)
         return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -70,9 +70,6 @@ public class Klaviyo: NSObject {
 
     // KL Definitions File: API URL Constants
 
-    let KlaviyoServerTrackEventEndpoint = "/track"
-    let KlaviyoServerTrackPersonEndpoint = "/identify"
-
     let KlaviyoServerURLString = "https://a.klaviyo.com"
 
     let CustomerPropertiesAppendDictKey = "$append"

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -464,7 +464,13 @@ public struct KlaviyoSDK {
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
-        dispatchOnMainThread(action: .setPushToken(apnDeviceToken))
+
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            dispatchOnMainThread(action: .setPushToken(
+                apnDeviceToken,
+                .create(from: settings.authorizationStatus),
+                .create(from: UIApplication.shared.backgroundRefreshStatus)))
+        }
     }
 
     /// Track a notificationResponse open event in Klaviyo. NOTE: all callbacks will be made on the main thread.

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -465,11 +465,10 @@ public struct KlaviyoSDK {
     public func set(pushToken: Data) {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
 
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
+        environment.getNotificationSettings { enablement in
             dispatchOnMainThread(action: .setPushToken(
                 apnDeviceToken,
-                .create(from: settings.authorizationStatus),
-                .create(from: UIApplication.shared.backgroundRefreshStatus)))
+                enablement))
         }
     }
 

--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -96,7 +96,7 @@ extension KlaviyoAPI.KlaviyoRequest {
         switch endpoint {
         case .createProfile, .createEvent:
             return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)")
-        case .storePushToken:
+        case .registerPushToken:
             return URL(string: "\(environment.analytics.apiURL)/\(path)")
         }
     }
@@ -107,8 +107,8 @@ extension KlaviyoAPI.KlaviyoRequest {
             return "client/profiles"
         case .createEvent:
             return "client/events"
-        case .storePushToken:
-            return "api/identify"
+        case .registerPushToken:
+            return "client/push-tokens"
         }
     }
 
@@ -118,7 +118,7 @@ extension KlaviyoAPI.KlaviyoRequest {
             return try environment.analytics.encodeJSON(AnyEncodable(payload))
         case let .createEvent(payload):
             return try environment.analytics.encodeJSON(AnyEncodable(payload))
-        case let .storePushToken(payload):
+        case let .registerPushToken(payload):
             return try environment.analytics.encodeJSON(AnyEncodable(payload))
         }
     }

--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -94,10 +94,8 @@ extension KlaviyoAPI.KlaviyoRequest {
 
     var url: URL? {
         switch endpoint {
-        case .createProfile, .createEvent:
+        case .createProfile, .createEvent, .registerPushToken:
             return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)")
-        case .registerPushToken:
-            return URL(string: "\(environment.analytics.apiURL)/\(path)")
         }
     }
 

--- a/Sources/KlaviyoSwift/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEnvironment.swift
@@ -36,6 +36,8 @@ struct KlaviyoEnvironment {
     var getUserDefaultString: (String) -> String?
     var appLifeCycle: AppLifeCycleEvents
     var notificationCenterPublisher: (NSNotification.Name) -> AnyPublisher<Notification, Never>
+    var getNotificationSettings: (@escaping (KlaviyoState.PushEnablement) -> Void) -> Void
+    var getBackgroundSetting: () -> KlaviyoState.PushBackground
     var legacyIdentifier: () -> String
     var startReachability: () throws -> Void
     var stopReachability: () -> Void
@@ -54,6 +56,12 @@ struct KlaviyoEnvironment {
             NotificationCenter.default.publisher(for: name)
                 .eraseToAnyPublisher()
         },
+        getNotificationSettings: { callback in
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                callback(.create(from: settings.authorizationStatus))
+            }
+        },
+        getBackgroundSetting: { .create(from: UIApplication.shared.backgroundRefreshStatus) },
         legacyIdentifier: { "iOS:\(UIDevice.current.identifierForVendor!.uuidString)" },
         startReachability: {
             try reachabilityService?.startNotifier()

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -49,9 +49,21 @@ public struct Event: Equatable {
 
     public let metric: Metric
     public var properties: [String: Any] {
-        _properties.value as! [String: Any]
+        (_properties.value as! [String: Any]).merging([
+            "Device Manufacturer": Event._metadata.manufacturer,
+            "Device Model": Event._metadata.deviceModel,
+            "OS Name": Event._metadata.osName,
+            "OS Version": Event._metadata.osVersion,
+            "SDK Name": __klaviyoSwiftName,
+            "SDK Version": __klaviyoSwiftVersion,
+            "Application ID": Event._metadata.bundleId,
+            "App Version": Event._metadata.appVersion,
+            "App Build": Event._metadata.appBuild,
+            "App Name": Event._metadata.appName
+        ]) { (_, new) in new }
     }
 
+    static private let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -49,22 +49,9 @@ public struct Event: Equatable {
 
     public let metric: Metric
     public var properties: [String: Any] {
-        (_properties.value as! [String: Any]).merging([
-            "Device Manufacturer": Event._metadata.manufacturer,
-            "Device Model": Event._metadata.deviceModel,
-            "OS Name": Event._metadata.osName,
-            "OS Version": Event._metadata.osVersion,
-            "SDK Name": __klaviyoSwiftName,
-            "SDK Version": __klaviyoSwiftVersion,
-            "Application ID": Event._metadata.bundleId,
-            "App Version": Event._metadata.appVersion,
-            "App Build": Event._metadata.appBuild,
-            "App Name": Event._metadata.appName,
-            "Push Token": environment.analytics.state().pushToken
-        ]) { _, new in new }
+        _properties.value as! [String: Any]
     }
 
-    private static let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -59,11 +59,12 @@ public struct Event: Equatable {
             "Application ID": Event._metadata.bundleId,
             "App Version": Event._metadata.appVersion,
             "App Build": Event._metadata.appBuild,
-            "App Name": Event._metadata.appName
-        ]) { (_, new) in new }
+            "App Name": Event._metadata.appName,
+            "Push Token": environment.analytics.state().pushToken
+        ]) { _, new in new }
     }
 
-    static private let _metadata = environment.analytics.appContextInfo()
+    private static let _metadata = environment.analytics.appContextInfo()
     private let _properties: AnyCodable
     public var profile: [String: Any] {
         _profile.value as! [String: Any]

--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -23,12 +23,24 @@ struct KlaviyoState: Equatable, Codable {
         case profile(Profile)
     }
 
+    enum PushEnablement: Equatable {
+        case available
+        case unavailable
+    }
+
+    enum PushBackground: Equatable {
+        case available
+        case unavailable
+    }
+
     var apiKey: String?
     var email: String?
     var anonymousId: String?
     var phoneNumber: String?
     var externalId: String?
     var pushToken: String?
+    var pushEnablement: String?
+    var pushBackground: String?
     var queue: [KlaviyoAPI.KlaviyoRequest]
     var requestsInFlight: [KlaviyoAPI.KlaviyoRequest] = []
     var initalizationState = InitializationSate.uninitialized

--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -163,7 +163,7 @@ struct KlaviyoState: Equatable, Codable {
         attributes.properties = AnyCodable(properties)
         self.pendingProfile = nil
 
-        return .init(apiKey: request.apiKey, endpoint: .createProfile(.init(data: .init(attributes: attributes, meta: profile.data.meta))))
+        return .init(apiKey: request.apiKey, endpoint: .createProfile(.init(data: .init(attributes: attributes))))
     }
 
     var isIdentified: Bool {

--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -23,14 +23,41 @@ struct KlaviyoState: Equatable, Codable {
         case profile(Profile)
     }
 
-    enum PushEnablement: Equatable {
-        case available
-        case unavailable
+    enum PushEnablement: String {
+        case notDetermined = "NOT_DETERMINED"
+        case denied = "DENIED"
+        case authorized = "AUTHORIZED"
+        case provisional = "PROVISIONAL"
+        case ephemeral = "EPHEMERAL"
+
+        static func create(from status: UNAuthorizationStatus) -> PushEnablement {
+            switch status {
+            case .denied:
+                return PushEnablement.denied
+            case .authorized:
+                return PushEnablement.authorized
+            case .provisional:
+                return PushEnablement.provisional
+            case .ephemeral:
+                return PushEnablement.ephemeral
+            default:
+                return PushEnablement.notDetermined
+            }
+        }
     }
 
-    enum PushBackground: Equatable {
-        case available
-        case unavailable
+    enum PushBackground: String {
+        case available = "AVAILABLE"
+        case unavailable = "UNAVAILABLE"
+
+        static func create(from status: UIBackgroundRefreshStatus) -> PushBackground {
+            switch status {
+            case .available:
+                return PushBackground.available
+            default:
+                return PushBackground.unavailable
+            }
+        }
     }
 
     var apiKey: String?
@@ -39,8 +66,8 @@ struct KlaviyoState: Equatable, Codable {
     var phoneNumber: String?
     var externalId: String?
     var pushToken: String?
-    var pushEnablement: String?
-    var pushBackground: String?
+    var pushEnablement: PushEnablement?
+    var pushBackground: PushBackground?
     var queue: [KlaviyoAPI.KlaviyoRequest]
     var requestsInFlight: [KlaviyoAPI.KlaviyoRequest] = []
     var initalizationState = InitializationSate.uninitialized

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let CURRENT_API_REVISION = "2023-07-15.pre"
+let CURRENT_API_REVISION = "2023-07-15"
 let APPLICATION_JSON = "application/json"
 let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let CURRENT_API_REVISION = "2023-06-06"
+let CURRENT_API_REVISION = "2023-06-06.pre"
 let APPLICATION_JSON = "application/json"
 let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -14,7 +14,7 @@ let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 let defaultUserAgent = { () -> String in
     let appContext = environment.analytics.appContextInfo()
     let klaivyoSDKVersion = "klaviyo-ios/\(__klaviyoSwiftVersion)"
-    return "\(appContext.excutable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
+    return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
 }()
 
 func createEmphemeralSession(protocolClasses: [AnyClass] = URLProtocolOverrides.protocolClasses) -> URLSession {

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let CURRENT_API_REVISION = "2023-06-06.pre"
+let CURRENT_API_REVISION = "2023-07-15.pre"
 let APPLICATION_JSON = "application/json"
 let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 

--- a/Sources/KlaviyoSwift/NetworkSession.swift
+++ b/Sources/KlaviyoSwift/NetworkSession.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let CURRENT_API_REVISION = "2022-10-17"
+let CURRENT_API_REVISION = "2023-06-06"
 let APPLICATION_JSON = "application/json"
 let ACCEPTED_ENCODINGS = ["br", "gzip", "deflate"]
 

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -59,12 +59,12 @@ public struct SDKRequest: Identifiable, Equatable {
                 return .createEvent(
                     EventInfo(eventName: payload.data.attributes.metric.name),
                     ProfileInfo(anonymousId: profile["$anonymous"] as? String ?? "Unknown"))
-            case let .storePushToken(payload):
-                return .saveToken(token: payload.token, info:
-                    ProfileInfo(email: payload.properties.email,
-                                phoneNumber: payload.properties.phoneNumber,
-                                externalId: payload.properties.externalId,
-                                anonymousId: payload.properties.anonymousId ?? "Unknown"))
+            case let .registerPushToken(payload):
+                return .saveToken(token: payload.attributes.token, info:
+                    ProfileInfo(email: payload.attributes.profile.data.attributes.email,
+                                phoneNumber: payload.attributes.profile.data.attributes.phoneNumber,
+                                externalId: payload.attributes.profile.data.attributes.externalId,
+                                anonymousId: payload.attributes.profile.data.attributes.anonymousId))
             }
         }
     }

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -55,10 +55,12 @@ public struct SDKRequest: Identifiable, Equatable {
                     externalId: payload.data.attributes.externalId,
                     anonymousId: payload.data.attributes.anonymousId))
             case let .createEvent(payload):
-                let profile = payload.data.attributes.profile.value as? [String: Any] ?? [:]
                 return .createEvent(
-                    EventInfo(eventName: payload.data.attributes.metric.name),
-                    ProfileInfo(anonymousId: profile["$anonymous"] as? String ?? "Unknown"))
+                    EventInfo(eventName: payload.data.attributes.metric.data.attributes.name),
+                    ProfileInfo(email: payload.data.attributes.profile.data.attributes.email,
+                                phoneNumber: payload.data.attributes.profile.data.attributes.phoneNumber,
+                                externalId: payload.data.attributes.profile.data.attributes.externalId,
+                                anonymousId: payload.data.attributes.profile.data.attributes.anonymousId))
             case let .registerPushToken(payload):
                 return .saveToken(token: payload.data.attributes.token, info:
                     ProfileInfo(email: payload.data.attributes.profile.data.attributes.email,

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -60,11 +60,11 @@ public struct SDKRequest: Identifiable, Equatable {
                     EventInfo(eventName: payload.data.attributes.metric.name),
                     ProfileInfo(anonymousId: profile["$anonymous"] as? String ?? "Unknown"))
             case let .registerPushToken(payload):
-                return .saveToken(token: payload.attributes.token, info:
-                    ProfileInfo(email: payload.attributes.profile.data.attributes.email,
-                                phoneNumber: payload.attributes.profile.data.attributes.phoneNumber,
-                                externalId: payload.attributes.profile.data.attributes.externalId,
-                                anonymousId: payload.attributes.profile.data.attributes.anonymousId))
+                return .saveToken(token: payload.data.attributes.token, info:
+                    ProfileInfo(email: payload.data.attributes.profile.data.attributes.email,
+                                phoneNumber: payload.data.attributes.profile.data.attributes.phoneNumber,
+                                externalId: payload.data.attributes.profile.data.attributes.externalId,
+                                anonymousId: payload.data.attributes.profile.data.attributes.anonymousId))
             }
         }
     }

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -30,7 +30,7 @@ enum KlaviyoAction: Equatable {
     case setEmail(String)
     case setPhoneNumber(String)
     case setExternalId(String)
-    case setPushToken(String)
+    case setPushToken(String, KlaviyoState.PushEnablement, KlaviyoState.PushBackground)
     case dequeCompletedResults(KlaviyoAPI.KlaviyoRequest)
     case networkConnectivityChanged(Reachability.NetworkStatus)
     case flushQueue
@@ -122,11 +122,13 @@ struct KlaviyoReducer: ReducerProtocol {
             state.externalId = externalId
             state.enqueueProfileRequest()
             return .none
-        case let .setPushToken(pushToken):
+        case let .setPushToken(pushToken, enablement, background):
             guard case .initialized = state.initalizationState else {
                 return .none
             }
             state.pushToken = pushToken
+            state.pushEnablement = enablement
+            state.pushBackground = background
             guard let request = try? state.buildTokenRequest() else {
                 return .none
             }
@@ -381,6 +383,8 @@ extension KlaviyoState {
         }
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
             pushToken: token,
+            enablement: (pushEnablement ?? .notDetermined).rawValue,
+            background: (pushBackground ?? .available).rawValue,
             profile: .init(email: email, phoneNumber: phoneNumber, externalId: externalId),
             anonymousId: anonymousId)
         let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.registerPushToken(payload)

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -380,13 +380,10 @@ extension KlaviyoState {
             throw KlaviyoAPI.KlaviyoAPIError.internalError("missing push token")
         }
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
-            token: apiKey,
-            properties: .init(anonymousId: anonymousId,
-                              pushToken: token,
-                              email: email,
-                              phoneNumber: phoneNumber,
-                              externalId: externalId))
-        let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.storePushToken(payload)
+            pushToken: token,
+            profile: .init(email: email, phoneNumber: phoneNumber, externalId: externalId),
+            anonymousId: anonymousId)
+        let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.registerPushToken(payload)
         return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -30,7 +30,7 @@ enum KlaviyoAction: Equatable {
     case setEmail(String)
     case setPhoneNumber(String)
     case setExternalId(String)
-    case setPushToken(String, KlaviyoState.PushEnablement, KlaviyoState.PushBackground)
+    case setPushToken(String, KlaviyoState.PushEnablement)
     case dequeCompletedResults(KlaviyoAPI.KlaviyoRequest)
     case networkConnectivityChanged(Reachability.NetworkStatus)
     case flushQueue
@@ -122,13 +122,13 @@ struct KlaviyoReducer: ReducerProtocol {
             state.externalId = externalId
             state.enqueueProfileRequest()
             return .none
-        case let .setPushToken(pushToken, enablement, background):
+        case let .setPushToken(pushToken, enablement):
             guard case .initialized = state.initalizationState else {
                 return .none
             }
             state.pushToken = pushToken
             state.pushEnablement = enablement
-            state.pushBackground = background
+            state.pushBackground = environment.getBackgroundSetting()
             guard let request = try? state.buildTokenRequest() else {
                 return .none
             }

--- a/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
+++ b/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
@@ -51,7 +51,7 @@ final class Box<Wrapped> {
 @inline(__always)
 func runtimeWarn(
   _ message: @autoclosure () -> String,
-  category: String? = "ComposableArchitecture",
+  category: String? = __klaviyoSwiftName,
   file: StaticString? = nil,
   line: UInt? = nil
 ) {

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 public let __klaviyoSwiftName = "swift"
-public let __klaviyoSwiftVersion = "2.1.0"
+public let __klaviyoSwiftVersion = "2.2.0"

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 
-public let __klaviyoSwiftName = "klaviyo-swift-sdk"
+public let __klaviyoSwiftName = "swift"
 public let __klaviyoSwiftVersion = "2.1.0"

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -7,4 +7,5 @@
 
 import Foundation
 
-public let __klaviyoSwiftVersion = "2.1.0-beta1"
+public let __klaviyoSwiftName = "klaviyo-swift-sdk"
+public let __klaviyoSwiftVersion = "2.1.0"

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -11,6 +11,7 @@ import XCTest
 
 final class EncodableTests: XCTestCase {
     let testEncoder = encoder
+
     override func setUpWithError() throws {
         environment = KlaviyoEnvironment.test()
         testEncoder.outputFormatting = .prettyPrinted.union(.sortedKeys)
@@ -31,22 +32,18 @@ final class EncodableTests: XCTestCase {
 
     func testTokenPayload() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
-            token: "foo",
-            properties: .init(anonymousId: "foo",
-                              pushToken: "foo",
-                              email: "foo",
-                              phoneNumber: "foo"))
+            pushToken: "foo",
+            profile: .init(email: "foo", phoneNumber: "foo"),
+            anonymousId: "foo")
         assertSnapshot(matching: tokenPayload, as: .json(encoder))
     }
 
     func testKlaviyoState() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
-            token: "foo",
-            properties: .init(anonymousId: "foo",
-                              pushToken: "foo",
-                              email: "foo",
-                              phoneNumber: "foo"))
-        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .storePushToken(tokenPayload))
+            pushToken: "foo",
+            profile: .init(email: "foo", phoneNumber: "foo"),
+            anonymousId: "foo")
+        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
         let klaviyoState = KlaviyoState(email: "foo", anonymousId: "foo",
                                         phoneNumber: "foo", pushToken: "foo",
                                         queue: [request], requestsInFlight: [request])
@@ -55,12 +52,10 @@ final class EncodableTests: XCTestCase {
 
     func testKlaviyoRequest() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
-            token: "foo",
-            properties: .init(anonymousId: "foo",
-                              pushToken: "foo",
-                              email: "foo",
-                              phoneNumber: "foo"))
-        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .storePushToken(tokenPayload))
+            pushToken: "foo",
+            profile: .init(email: "foo", phoneNumber: "foo"),
+            anonymousId: "foo")
+        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
         assertSnapshot(matching: request, as: .json)
     }
 }

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -33,6 +33,8 @@ final class EncodableTests: XCTestCase {
     func testTokenPayload() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
             pushToken: "foo",
+            enablement: "AUTHORIZED",
+            background: "AVAILABLE",
             profile: .init(email: "foo", phoneNumber: "foo"),
             anonymousId: "foo")
         assertSnapshot(matching: tokenPayload, as: .json(encoder))
@@ -41,6 +43,8 @@ final class EncodableTests: XCTestCase {
     func testKlaviyoState() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
             pushToken: "foo",
+            enablement: "AUTHORIZED",
+            background: "AVAILABLE",
             profile: .init(email: "foo", phoneNumber: "foo"),
             anonymousId: "foo")
         let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
@@ -53,6 +57,8 @@ final class EncodableTests: XCTestCase {
     func testKlaviyoRequest() throws {
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
             pushToken: "foo",
+            enablement: "AUTHORIZED",
+            background: "AVAILABLE",
             profile: .init(email: "foo", phoneNumber: "foo"),
             anonymousId: "foo")
         let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -26,7 +26,7 @@ final class EncodableTests: XCTestCase {
 
     func testEventPayload() throws {
         let event = Event.test
-        let createEventPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload(data: .init(event: event))
+        let createEventPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload(data: .init(event: event, anonymousId: "anon-id"))
         assertSnapshot(matching: createEventPayload, as: .json(encoder))
     }
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
@@ -121,7 +121,7 @@ final class KlaviyoAPITests: XCTestCase {
             assertSnapshot(matching: request, as: .dump)
             return (Data(), .validResponse)
         }) }
-        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .storePushToken(.test))
+        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(.test))
         await sendAndAssert(with: request) { result in
 
             switch result {

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -169,7 +169,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test property getters
 
-    func testPropertGetters() throws {
+    func testPropertyGetters() throws {
         environment.analytics.state = { KlaviyoState(email: "foo@foo.com", phoneNumber: "555BLOB", externalId: "my_test_id", pushToken: "blobtoken", queue: []) }
         let klaviyo = KlaviyoSDK()
         XCTAssertEqual("foo@foo.com", klaviyo.email)

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -110,10 +110,7 @@ class KlaviyoSDKTests: XCTestCase {
     func testSetPushToken() throws {
         let tokenData = "mytoken".data(using: .utf8)!
         let strToken = tokenData.reduce("") { $0 + String(format: "%02.2hhx", $1) }
-        let expectation = setupActionAssertion(expectedAction: .setPushToken(
-            strToken,
-            .authorized,
-            .available))
+        let expectation = setupActionAssertion(expectedAction: .setPushToken(strToken, .authorized))
 
         klaviyo.set(pushToken: tokenData)
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -109,7 +109,11 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testSetPushToken() throws {
         let tokenData = "mytoken".data(using: .utf8)!
-        let expectation = setupActionAssertion(expectedAction: .setPushToken(tokenData.reduce("") { $0 + String(format: "%02.2hhx", $1) }))
+        let strToken = tokenData.reduce("") { $0 + String(format: "%02.2hhx", $1) }
+        let expectation = setupActionAssertion(expectedAction: .setPushToken(
+            strToken,
+            .authorized,
+            .available))
 
         klaviyo.set(pushToken: tokenData)
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -202,12 +202,10 @@ final class KlaviyoStateTests: XCTestCase {
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateProfilePayload(data: data)
         let profileRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .createProfile(payload))
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
-            token: "foo",
-            properties: .init(anonymousId: "foo",
-                              pushToken: "foo",
-                              email: "foo",
-                              phoneNumber: "foo"))
-        let tokenRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .storePushToken(tokenPayload))
+            pushToken: "foo",
+            profile: .init(email: "foo", phoneNumber: "foo"),
+            anonymousId: "foo")
+        let tokenRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
         let state = KlaviyoState(apiKey: "key", queue: [tokenRequest, profileRequest, eventRequest])
         let encodedState = try KlaviyoEnvironment.production.analytics.encodeJSON(AnyEncodable(state))
         let decodedState: KlaviyoState = try KlaviyoEnvironment.production.analytics.decoder.decode(encodedState)

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -203,6 +203,8 @@ final class KlaviyoStateTests: XCTestCase {
         let profileRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .createProfile(payload))
         let tokenPayload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
             pushToken: "foo",
+            enablement: "AUTHORIZED",
+            background: "AVAILABLE",
             profile: .init(email: "foo", phoneNumber: "foo"),
             anonymousId: "foo")
         let tokenRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -45,6 +45,8 @@ extension KlaviyoEnvironment {
         getUserDefaultString: { _ in "value" },
         appLifeCycle: AppLifeCycleEvents.test,
         notificationCenterPublisher: { _ in Empty<Notification, Never>().eraseToAnyPublisher() },
+        getNotificationSettings: { callback in callback(.authorized) },
+        getBackgroundSetting: { .available },
         legacyIdentifier: { "iOS:\(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!.uuidString)" },
         startReachability: {},
         stopReachability: {},

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -146,7 +146,8 @@ extension AppContextInfo {
                            version: OperatingSystemVersion(majorVersion: 1, minorVersion: 1, patchVersion: 1),
                            osName: "iOS",
                            manufacturer: "Orange",
-                           deviceModel: "jPhone 1,1")
+                           deviceModel: "jPhone 1,1",
+                           deviceId: "fe-fi-fo-fum")
 }
 
 extension StateChangePublisher {

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -138,12 +138,15 @@ extension NetworkSession {
 }
 
 extension AppContextInfo {
-    static let test = Self(excutable: "FooApp",
+    static let test = Self(executable: "FooApp",
                            bundleId: "com.klaviyo.fooapp",
                            appVersion: "1.2.3",
                            appBuild: "1",
+                           appName: "FooApp",
                            version: OperatingSystemVersion(majorVersion: 1, minorVersion: 1, patchVersion: 1),
-                           osName: "iOS")
+                           osName: "iOS",
+                           manufacturer: "Orange",
+                           deviceModel: "jPhone 1,1")
 }
 
 extension StateChangePublisher {

--- a/Tests/KlaviyoSwiftTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoSwiftTests/NetworkSessionTests.swift
@@ -26,7 +26,7 @@ class NetworkSessionTests: XCTestCase {
     func testSessionDataTask() async throws {
         URLProtocolOverrides.protocolClasses = [SimpleMockURLProtocol.self]
         let session = NetworkSession.production
-        let sampleRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .storePushToken(.test))
+        let sampleRequest = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(.test))
         let (data, response) = try await session.data(sampleRequest.urlRequest())
 
         assertSnapshot(matching: data, as: .dump)

--- a/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
@@ -65,7 +65,7 @@ final class StateChangePublisherTests: XCTestCase {
             _ = environment.analytics.send(.initialize("foo"))
             testScheduler.run()
             // This should not trigger a save since in our reducer it does not change the state.
-            _ = environment.analytics.send(.setPushToken("foo", .authorized, .available))
+            _ = environment.analytics.send(.setPushToken("foo", .authorized))
             _ = environment.analytics.send(.setEmail("foo"))
         }
         runDebouncedEffect()

--- a/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
@@ -65,7 +65,7 @@ final class StateChangePublisherTests: XCTestCase {
             _ = environment.analytics.send(.initialize("foo"))
             testScheduler.run()
             // This should not trigger a save since in our reducer it does not change the state.
-            _ = environment.analytics.send(.setPushToken("foo"))
+            _ = environment.analytics.send(.setPushToken("foo", .authorized, .available))
             _ = environment.analytics.send(.setEmail("foo"))
         }
         runDebouncedEffect()

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -165,7 +165,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token"))
+        _ = await store.send(.setPushToken("blob_token", .authorized, .available))
     }
 
     func testSetPushTokenWithMissingAnonymousIdStillSetsPushToken() async throws {
@@ -177,7 +177,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token")) {
+        _ = await store.send(.setPushToken("blob_token", .authorized, .available)) {
             $0.pushToken = "blob_token"
         }
     }
@@ -251,7 +251,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
             flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blobtoken")) {
+        _ = await store.send(.setPushToken("blobtoken", .authorized, .available)) {
             $0.pushToken = "blobtoken"
         }
     }

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -165,7 +165,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token", .authorized, .available))
+        _ = await store.send(.setPushToken("blob_token", .authorized))
     }
 
     func testSetPushTokenWithMissingAnonymousIdStillSetsPushToken() async throws {
@@ -177,8 +177,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token", .authorized, .available)) {
+        _ = await store.send(.setPushToken("blob_token", .authorized)) {
             $0.pushToken = "blob_token"
+            $0.pushEnablement = .authorized
+            $0.pushBackground = .available
         }
     }
 
@@ -251,8 +253,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
             flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blobtoken", .authorized, .available)) {
+        _ = await store.send(.setPushToken("blobtoken", .authorized)) {
             $0.pushToken = "blobtoken"
+            $0.pushEnablement = .authorized
+            $0.pushBackground = .available
         }
     }
 

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -127,7 +127,7 @@ class StateManagementTests: XCTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blobtoken", .authorized, .available)) {
+        _ = await store.send(.setPushToken("blobtoken", .authorized)) {
             $0.pushToken = "blobtoken"
             let request = try $0.buildTokenRequest()
             $0.queue = [request]

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -127,7 +127,7 @@ class StateManagementTests: XCTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blobtoken")) {
+        _ = await store.send(.setPushToken("blobtoken", .authorized, .available)) {
             $0.pushToken = "blobtoken"
             let request = try $0.buildTokenRequest()
             $0.queue = [request]

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -94,6 +94,8 @@ extension URLResponse {
 extension KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload {
     static let test = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
         pushToken: "foo",
+        enablement: "AUTHORIZED",
+        background: "AVAILABLE",
         profile: .init(),
         anonymousId: "anon-id")
 }

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -92,7 +92,10 @@ extension URLResponse {
 }
 
 extension KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload {
-    static let test = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(token: "foo", properties: Properties(anonymousId: "anon-id", pushToken: "foo"))
+    static let test = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload(
+        pushToken: "foo",
+        profile: .init(),
+        anonymousId: "anon-id")
 }
 
 extension KlaviyoState {

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -58,7 +58,15 @@ extension Event {
         "stuff": 2,
         "hello": [
             "sub": "dict"
-        ]
+        ],
+        "Application ID": "com.klaviyo.fooapp",
+        "App Version": "1.2.3",
+        "App Build": "1",
+        "App Name": "FooApp",
+        "OS Version": "1.1.1",
+        "OS Name": "iOS",
+        "Device Manufacturer": "Orange",
+        "Device Model": "jPhone 1,1"
     ] as [String: Any]
     static let SAMPLE_PROFILE_PROPERTIES = [
         "email": "blob@email.com",

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -14,6 +14,8 @@ let INITIALIZED_TEST_STATE = { KlaviyoState(
     apiKey: TEST_API_KEY,
     anonymousId: environment.analytics.uuid().uuidString,
     pushToken: "blob_token",
+    pushEnablement: .authorized,
+    pushBackground: .available,
     queue: [],
     requestsInFlight: [],
     initalizationState: .initialized,

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -77,7 +77,7 @@ extension Event {
             "city": "blob city"
         ]
     ] as [String: Any]
-    static let test = Self(name: .CustomEvent("blob"), properties: SAMPLE_PROPERTIES, profile: SAMPLE_PROFILE_PROPERTIES)
+    static let test = Self(name: .CustomEvent("blob"), properties: SAMPLE_PROPERTIES, identifiers: .init(email: "blob@email.com"), profile: SAMPLE_PROFILE_PROPERTIES)
 }
 
 extension Event.Metric {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -24,6 +24,7 @@
         },
         "OS Name" : "iOS",
         "OS Version" : "1.1.1",
+        "Push Token" : null,
         "SDK Name" : "klaviyo-swift-sdk",
         "SDK Version" : "2.0.1",
         "stuff" : 2

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -18,12 +18,6 @@
 
             }
           },
-          "meta" : {
-            "identifiers" : {
-              "anonymous_id" : "anon-id",
-              "email" : "blob@email.com"
-            }
-          },
           "type" : "profile"
         }
       },
@@ -44,7 +38,7 @@
         "OS Version" : "1.1.1",
         "Push Token" : null,
         "SDK Name" : "swift",
-        "SDK Version" : "2.0.1",
+        "SDK Version" : "2.1.0",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -18,6 +18,7 @@
         "App Version" : "1.2.3",
         "Application ID" : "com.klaviyo.fooapp",
         "blob" : "blob",
+        "Device ID" : "fe-fi-fo-fum",
         "Device Manufacturer" : "Orange",
         "Device Model" : "jPhone 1,1",
         "hello" : {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -12,10 +12,20 @@
         "stuff" : 2
       },
       "properties" : {
+        "App Build" : "1",
+        "App Name" : "FooApp",
+        "App Version" : "1.2.3",
+        "Application ID" : "com.klaviyo.fooapp",
         "blob" : "blob",
+        "Device Manufacturer" : "Orange",
+        "Device Model" : "jPhone 1,1",
         "hello" : {
           "sub" : "dict"
         },
+        "OS Name" : "iOS",
+        "OS Version" : "1.1.1",
+        "SDK Name" : "klaviyo-swift-sdk",
+        "SDK Version" : "2.0.1",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -13,6 +13,7 @@
       },
       "properties" : {
         "App Build" : "1",
+        "App ID" : "com.klaviyo.fooapp",
         "App Name" : "FooApp",
         "App Version" : "1.2.3",
         "Application ID" : "com.klaviyo.fooapp",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -38,7 +38,7 @@
         "OS Version" : "1.1.1",
         "Push Token" : null,
         "SDK Name" : "swift",
-        "SDK Version" : "2.1.0",
+        "SDK Version" : "2.2.0",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -2,14 +2,30 @@
   "data" : {
     "attributes" : {
       "metric" : {
-        "name" : "blob"
+        "data" : {
+          "attributes" : {
+            "name" : "blob"
+          },
+          "type" : "metric"
+        }
       },
       "profile" : {
-        "email" : "blob@email.com",
-        "location" : {
-          "city" : "blob city"
-        },
-        "stuff" : 2
+        "data" : {
+          "attributes" : {
+            "anonymous_id" : "anon-id",
+            "email" : "blob@email.com",
+            "properties" : {
+
+            }
+          },
+          "meta" : {
+            "identifiers" : {
+              "anonymous_id" : "anon-id",
+              "email" : "blob@email.com"
+            }
+          },
+          "type" : "profile"
+        }
       },
       "properties" : {
         "App Build" : "1",
@@ -27,7 +43,7 @@
         "OS Name" : "iOS",
         "OS Version" : "1.1.1",
         "Push Token" : null,
-        "SDK Name" : "klaviyo-swift-sdk",
+        "SDK Name" : "swift",
         "SDK Version" : "2.0.1",
         "stuff" : 2
       },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -1,17 +1,50 @@
 {
   "apiKey" : "foo",
   "endpoint" : {
-    "storePushToken" : {
+    "registerPushToken" : {
       "_0" : {
-        "properties" : {
-          "$anonymous" : "foo",
-          "$append" : {
-            "$ios_tokens" : "foo"
+        "attributes" : {
+          "background" : "",
+          "device_metadata" : {
+            "app_build" : "1",
+            "app_id" : "com.klaviyo.fooapp",
+            "app_name" : "FooApp",
+            "app_version" : "1.2.3",
+            "device_id" : "fe-fi-fo-fum",
+            "device_model" : "jPhone 1,1",
+            "environment" : "debug",
+            "klaviyo_sdk" : "klaviyo-swift-sdk",
+            "manufacturer" : "Orange",
+            "os_name" : "iOS",
+            "os_version" : "1.1.1",
+            "sdk_version" : "klaviyo-swift-sdk"
           },
-          "$email" : "foo",
-          "$phone_number" : "foo"
+          "enablement_status" : "",
+          "platform" : "ios",
+          "profile" : {
+            "data" : {
+              "attributes" : {
+                "anonymous_id" : "foo",
+                "email" : "foo",
+                "phone_number" : "foo",
+                "properties" : {
+
+                }
+              },
+              "meta" : {
+                "identifiers" : {
+                  "anonymous_id" : "foo",
+                  "email" : "foo",
+                  "phone_number" : "foo"
+                }
+              },
+              "type" : "profile"
+            }
+          },
+          "token_id" : "foo",
+          "vendor" : "APNs"
         },
-        "token" : "foo"
+        "type" : "push-token"
       }
     }
   },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "klaviyo-swift-sdk"
+              "sdk_version" : "2.0.1"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "2.0.1"
+              "sdk_version" : "2.1.0"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",
@@ -30,13 +30,6 @@
                   "phone_number" : "foo",
                   "properties" : {
 
-                  }
-                },
-                "meta" : {
-                  "identifiers" : {
-                    "anonymous_id" : "foo",
-                    "email" : "foo",
-                    "phone_number" : "foo"
                   }
                 },
                 "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -14,7 +14,7 @@
               "device_id" : "fe-fi-fo-fum",
               "device_model" : "jPhone 1,1",
               "environment" : "debug",
-              "klaviyo_sdk" : "klaviyo-swift-sdk",
+              "klaviyo_sdk" : "swift",
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
@@ -27,12 +27,22 @@
                 "attributes" : {
                   "anonymous_id" : "foo",
                   "email" : "foo",
-                  "phone_number" : "foo"
+                  "phone_number" : "foo",
+                  "properties" : {
+
+                  }
+                },
+                "meta" : {
+                  "identifiers" : {
+                    "anonymous_id" : "foo",
+                    "email" : "foo",
+                    "phone_number" : "foo"
+                  }
                 },
                 "type" : "profile"
               }
             },
-            "token_id" : "foo",
+            "token" : "foo",
             "vendor" : "APNs"
           },
           "type" : "push-token"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -4,7 +4,7 @@
     "registerPushToken" : {
       "_0" : {
         "attributes" : {
-          "background" : "",
+          "background" : "AVAILABLE",
           "device_metadata" : {
             "app_build" : "1",
             "app_id" : "com.klaviyo.fooapp",
@@ -19,7 +19,7 @@
             "os_version" : "1.1.1",
             "sdk_version" : "klaviyo-swift-sdk"
           },
-          "enablement_status" : "",
+          "enablement_status" : "AUTHORIZED",
           "platform" : "ios",
           "profile" : {
             "data" : {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -3,48 +3,40 @@
   "endpoint" : {
     "registerPushToken" : {
       "_0" : {
-        "attributes" : {
-          "background" : "AVAILABLE",
-          "device_metadata" : {
-            "app_build" : "1",
-            "app_id" : "com.klaviyo.fooapp",
-            "app_name" : "FooApp",
-            "app_version" : "1.2.3",
-            "device_id" : "fe-fi-fo-fum",
-            "device_model" : "jPhone 1,1",
-            "environment" : "debug",
-            "klaviyo_sdk" : "klaviyo-swift-sdk",
-            "manufacturer" : "Orange",
-            "os_name" : "iOS",
-            "os_version" : "1.1.1",
-            "sdk_version" : "klaviyo-swift-sdk"
-          },
-          "enablement_status" : "AUTHORIZED",
-          "platform" : "ios",
-          "profile" : {
-            "data" : {
-              "attributes" : {
-                "anonymous_id" : "foo",
-                "email" : "foo",
-                "phone_number" : "foo",
-                "properties" : {
-
-                }
-              },
-              "meta" : {
-                "identifiers" : {
+        "data" : {
+          "attributes" : {
+            "background" : "AVAILABLE",
+            "device_metadata" : {
+              "app_build" : "1",
+              "app_id" : "com.klaviyo.fooapp",
+              "app_name" : "FooApp",
+              "app_version" : "1.2.3",
+              "device_id" : "fe-fi-fo-fum",
+              "device_model" : "jPhone 1,1",
+              "environment" : "debug",
+              "klaviyo_sdk" : "klaviyo-swift-sdk",
+              "manufacturer" : "Orange",
+              "os_name" : "iOS",
+              "os_version" : "1.1.1",
+              "sdk_version" : "klaviyo-swift-sdk"
+            },
+            "enablement_status" : "AUTHORIZED",
+            "platform" : "ios",
+            "profile" : {
+              "data" : {
+                "attributes" : {
                   "anonymous_id" : "foo",
                   "email" : "foo",
                   "phone_number" : "foo"
-                }
-              },
-              "type" : "profile"
-            }
+                },
+                "type" : "profile"
+              }
+            },
+            "token_id" : "foo",
+            "vendor" : "APNs"
           },
-          "token_id" : "foo",
-          "vendor" : "APNs"
-        },
-        "type" : "push-token"
+          "type" : "push-token"
+        }
       }
     }
   },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "2.1.0"
+              "sdk_version" : "2.2.0"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -24,7 +24,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "2.1.0"
+                  "sdk_version" : "2.2.0"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -9,48 +9,40 @@
       "endpoint" : {
         "registerPushToken" : {
           "_0" : {
-            "attributes" : {
-              "background" : "AVAILABLE",
-              "device_metadata" : {
-                "app_build" : "1",
-                "app_id" : "com.klaviyo.fooapp",
-                "app_name" : "FooApp",
-                "app_version" : "1.2.3",
-                "device_id" : "fe-fi-fo-fum",
-                "device_model" : "jPhone 1,1",
-                "environment" : "debug",
-                "klaviyo_sdk" : "klaviyo-swift-sdk",
-                "manufacturer" : "Orange",
-                "os_name" : "iOS",
-                "os_version" : "1.1.1",
-                "sdk_version" : "klaviyo-swift-sdk"
-              },
-              "enablement_status" : "AUTHORIZED",
-              "platform" : "ios",
-              "profile" : {
-                "data" : {
-                  "attributes" : {
-                    "anonymous_id" : "foo",
-                    "email" : "foo",
-                    "phone_number" : "foo",
-                    "properties" : {
-
-                    }
-                  },
-                  "meta" : {
-                    "identifiers" : {
+            "data" : {
+              "attributes" : {
+                "background" : "AVAILABLE",
+                "device_metadata" : {
+                  "app_build" : "1",
+                  "app_id" : "com.klaviyo.fooapp",
+                  "app_name" : "FooApp",
+                  "app_version" : "1.2.3",
+                  "device_id" : "fe-fi-fo-fum",
+                  "device_model" : "jPhone 1,1",
+                  "environment" : "debug",
+                  "klaviyo_sdk" : "klaviyo-swift-sdk",
+                  "manufacturer" : "Orange",
+                  "os_name" : "iOS",
+                  "os_version" : "1.1.1",
+                  "sdk_version" : "klaviyo-swift-sdk"
+                },
+                "enablement_status" : "AUTHORIZED",
+                "platform" : "ios",
+                "profile" : {
+                  "data" : {
+                    "attributes" : {
                       "anonymous_id" : "foo",
                       "email" : "foo",
                       "phone_number" : "foo"
-                    }
-                  },
-                  "type" : "profile"
-                }
+                    },
+                    "type" : "profile"
+                  }
+                },
+                "token_id" : "foo",
+                "vendor" : "APNs"
               },
-              "token_id" : "foo",
-              "vendor" : "APNs"
-            },
-            "type" : "push-token"
+              "type" : "push-token"
+            }
           }
         }
       },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -24,7 +24,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "klaviyo-swift-sdk"
+                  "sdk_version" : "2.0.1"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -20,7 +20,7 @@
                   "device_id" : "fe-fi-fo-fum",
                   "device_model" : "jPhone 1,1",
                   "environment" : "debug",
-                  "klaviyo_sdk" : "klaviyo-swift-sdk",
+                  "klaviyo_sdk" : "swift",
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
@@ -33,12 +33,22 @@
                     "attributes" : {
                       "anonymous_id" : "foo",
                       "email" : "foo",
-                      "phone_number" : "foo"
+                      "phone_number" : "foo",
+                      "properties" : {
+
+                      }
+                    },
+                    "meta" : {
+                      "identifiers" : {
+                        "anonymous_id" : "foo",
+                        "email" : "foo",
+                        "phone_number" : "foo"
+                      }
                     },
                     "type" : "profile"
                   }
                 },
-                "token_id" : "foo",
+                "token" : "foo",
                 "vendor" : "APNs"
               },
               "type" : "push-token"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -10,7 +10,7 @@
         "registerPushToken" : {
           "_0" : {
             "attributes" : {
-              "background" : "",
+              "background" : "AVAILABLE",
               "device_metadata" : {
                 "app_build" : "1",
                 "app_id" : "com.klaviyo.fooapp",
@@ -25,7 +25,7 @@
                 "os_version" : "1.1.1",
                 "sdk_version" : "klaviyo-swift-sdk"
               },
-              "enablement_status" : "",
+              "enablement_status" : "AUTHORIZED",
               "platform" : "ios",
               "profile" : {
                 "data" : {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -24,7 +24,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "2.0.1"
+                  "sdk_version" : "2.1.0"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",
@@ -36,13 +36,6 @@
                       "phone_number" : "foo",
                       "properties" : {
 
-                      }
-                    },
-                    "meta" : {
-                      "identifiers" : {
-                        "anonymous_id" : "foo",
-                        "email" : "foo",
-                        "phone_number" : "foo"
                       }
                     },
                     "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -7,17 +7,50 @@
     {
       "apiKey" : "foo",
       "endpoint" : {
-        "storePushToken" : {
+        "registerPushToken" : {
           "_0" : {
-            "properties" : {
-              "$anonymous" : "foo",
-              "$append" : {
-                "$ios_tokens" : "foo"
+            "attributes" : {
+              "background" : "",
+              "device_metadata" : {
+                "app_build" : "1",
+                "app_id" : "com.klaviyo.fooapp",
+                "app_name" : "FooApp",
+                "app_version" : "1.2.3",
+                "device_id" : "fe-fi-fo-fum",
+                "device_model" : "jPhone 1,1",
+                "environment" : "debug",
+                "klaviyo_sdk" : "klaviyo-swift-sdk",
+                "manufacturer" : "Orange",
+                "os_name" : "iOS",
+                "os_version" : "1.1.1",
+                "sdk_version" : "klaviyo-swift-sdk"
               },
-              "$email" : "foo",
-              "$phone_number" : "foo"
+              "enablement_status" : "",
+              "platform" : "ios",
+              "profile" : {
+                "data" : {
+                  "attributes" : {
+                    "anonymous_id" : "foo",
+                    "email" : "foo",
+                    "phone_number" : "foo",
+                    "properties" : {
+
+                    }
+                  },
+                  "meta" : {
+                    "identifiers" : {
+                      "anonymous_id" : "foo",
+                      "email" : "foo",
+                      "phone_number" : "foo"
+                    }
+                  },
+                  "type" : "profile"
+                }
+              },
+              "token_id" : "foo",
+              "vendor" : "APNs"
             },
-            "token" : "foo"
+            "type" : "push-token"
           }
         }
       },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testProfilePayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testProfilePayload.1.json
@@ -29,14 +29,6 @@
       },
       "title" : "Jelly"
     },
-    "meta" : {
-      "identifiers" : {
-        "anonymous_id" : "foo",
-        "email" : "blobemail",
-        "external_id" : "blobid",
-        "phone_number" : "+15555555555"
-      }
-    },
     "type" : "profile"
   }
 }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -1,6 +1,6 @@
 {
   "attributes" : {
-    "background" : "",
+    "background" : "AVAILABLE",
     "device_metadata" : {
       "app_build" : "1",
       "app_id" : "com.klaviyo.fooapp",
@@ -15,7 +15,7 @@
       "os_version" : "1.1.1",
       "sdk_version" : "klaviyo-swift-sdk"
     },
-    "enablement_status" : "",
+    "enablement_status" : "AUTHORIZED",
     "platform" : "ios",
     "profile" : {
       "data" : {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -1,11 +1,44 @@
 {
-  "properties" : {
-    "$anonymous" : "foo",
-    "$append" : {
-      "$ios_tokens" : "foo"
+  "attributes" : {
+    "background" : "",
+    "device_metadata" : {
+      "app_build" : "1",
+      "app_id" : "com.klaviyo.fooapp",
+      "app_name" : "FooApp",
+      "app_version" : "1.2.3",
+      "device_id" : "fe-fi-fo-fum",
+      "device_model" : "jPhone 1,1",
+      "environment" : "debug",
+      "klaviyo_sdk" : "klaviyo-swift-sdk",
+      "manufacturer" : "Orange",
+      "os_name" : "iOS",
+      "os_version" : "1.1.1",
+      "sdk_version" : "klaviyo-swift-sdk"
     },
-    "$email" : "foo",
-    "$phone_number" : "foo"
+    "enablement_status" : "",
+    "platform" : "ios",
+    "profile" : {
+      "data" : {
+        "attributes" : {
+          "anonymous_id" : "foo",
+          "email" : "foo",
+          "phone_number" : "foo",
+          "properties" : {
+
+          }
+        },
+        "meta" : {
+          "identifiers" : {
+            "anonymous_id" : "foo",
+            "email" : "foo",
+            "phone_number" : "foo"
+          }
+        },
+        "type" : "profile"
+      }
+    },
+    "token_id" : "foo",
+    "vendor" : "APNs"
   },
-  "token" : "foo"
+  "type" : "push-token"
 }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -1,44 +1,36 @@
 {
-  "attributes" : {
-    "background" : "AVAILABLE",
-    "device_metadata" : {
-      "app_build" : "1",
-      "app_id" : "com.klaviyo.fooapp",
-      "app_name" : "FooApp",
-      "app_version" : "1.2.3",
-      "device_id" : "fe-fi-fo-fum",
-      "device_model" : "jPhone 1,1",
-      "environment" : "debug",
-      "klaviyo_sdk" : "klaviyo-swift-sdk",
-      "manufacturer" : "Orange",
-      "os_name" : "iOS",
-      "os_version" : "1.1.1",
-      "sdk_version" : "klaviyo-swift-sdk"
-    },
-    "enablement_status" : "AUTHORIZED",
-    "platform" : "ios",
-    "profile" : {
-      "data" : {
-        "attributes" : {
-          "anonymous_id" : "foo",
-          "email" : "foo",
-          "phone_number" : "foo",
-          "properties" : {
-
-          }
-        },
-        "meta" : {
-          "identifiers" : {
+  "data" : {
+    "attributes" : {
+      "background" : "AVAILABLE",
+      "device_metadata" : {
+        "app_build" : "1",
+        "app_id" : "com.klaviyo.fooapp",
+        "app_name" : "FooApp",
+        "app_version" : "1.2.3",
+        "device_id" : "fe-fi-fo-fum",
+        "device_model" : "jPhone 1,1",
+        "environment" : "debug",
+        "klaviyo_sdk" : "klaviyo-swift-sdk",
+        "manufacturer" : "Orange",
+        "os_name" : "iOS",
+        "os_version" : "1.1.1",
+        "sdk_version" : "klaviyo-swift-sdk"
+      },
+      "enablement_status" : "AUTHORIZED",
+      "platform" : "ios",
+      "profile" : {
+        "data" : {
+          "attributes" : {
             "anonymous_id" : "foo",
             "email" : "foo",
             "phone_number" : "foo"
-          }
-        },
-        "type" : "profile"
-      }
+          },
+          "type" : "profile"
+        }
+      },
+      "token_id" : "foo",
+      "vendor" : "APNs"
     },
-    "token_id" : "foo",
-    "vendor" : "APNs"
-  },
-  "type" : "push-token"
+    "type" : "push-token"
+  }
 }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "2.1.0"
+        "sdk_version" : "2.2.0"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "2.0.1"
+        "sdk_version" : "2.1.0"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",
@@ -26,13 +26,6 @@
             "phone_number" : "foo",
             "properties" : {
 
-            }
-          },
-          "meta" : {
-            "identifiers" : {
-              "anonymous_id" : "foo",
-              "email" : "foo",
-              "phone_number" : "foo"
             }
           },
           "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "klaviyo-swift-sdk"
+        "sdk_version" : "2.0.1"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -10,7 +10,7 @@
         "device_id" : "fe-fi-fo-fum",
         "device_model" : "jPhone 1,1",
         "environment" : "debug",
-        "klaviyo_sdk" : "klaviyo-swift-sdk",
+        "klaviyo_sdk" : "swift",
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
@@ -23,12 +23,22 @@
           "attributes" : {
             "anonymous_id" : "foo",
             "email" : "foo",
-            "phone_number" : "foo"
+            "phone_number" : "foo",
+            "properties" : {
+
+            }
+          },
+          "meta" : {
+            "identifiers" : {
+              "anonymous_id" : "foo",
+              "email" : "foo",
+              "phone_number" : "foo"
+            }
           },
           "type" : "profile"
         }
       },
-      "token_id" : "foo",
+      "token" : "foo",
       "vendor" : "APNs"
     },
     "type" : "push-token"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testEncodingError.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testEncodingError.1.txt
@@ -18,11 +18,5 @@
               ▿ properties: [:]
                 - value: 0 key/value pairs
               - title: Optional<String>.none
-            ▿ meta: Meta
-              ▿ identifiers: Identifiers
-                - anonymousId: "foo"
-                - email: Optional<String>.none
-                - externalId: Optional<String>.none
-                - phoneNumber: Optional<String>.none
             - type: "profile"
       - uuid: "00000000-0000-0000-0000-000000000001"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/api/identify
+▿ dead_beef/client/push-tokens
   ▿ url: Optional<URL>
-    - some: dead_beef/api/identify
+    - some: dead_beef/client/push-tokens
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/push-tokens
+▿ dead_beef/client/push-tokens/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/push-tokens
+    - some: dead_beef/client/push-tokens/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testInvalidEventPropertiesOnData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testInvalidEventPropertiesOnData.1.txt
@@ -13,8 +13,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testInvalidEventPropertiesOnData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testInvalidEventPropertiesOnData.1.txt
@@ -13,6 +13,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -11,8 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -11,6 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -30,6 +30,7 @@
                   "OS Name" : "iOS",
                   "OS Version" : "1.1.1",
                   "prop1" : "propValue",
+                  "Push Token" : null,
                   "SDK Name" : "klaviyo-swift-sdk",
                   "SDK Version" : "2.0.1"
                 },

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -45,7 +45,7 @@
                   "prop1" : "propValue",
                   "Push Token" : null,
                   "SDK Name" : "swift",
-                  "SDK Version" : "2.1.0"
+                  "SDK Version" : "2.2.0"
                 },
                 "time" : 256260690,
                 "unique_id" : "00000000-0000-0000-0000-000000000001"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -21,7 +21,17 @@
                   "foo" : "bar"
                 },
                 "properties" : {
-                  "prop1" : "propValue"
+                  "App Build" : "1",
+                  "App Name" : "FooApp",
+                  "App Version" : "1.2.3",
+                  "Application ID" : "com.klaviyo.fooapp",
+                  "Device Manufacturer" : "Orange",
+                  "Device Model" : "jPhone 1,1",
+                  "OS Name" : "iOS",
+                  "OS Version" : "1.1.1",
+                  "prop1" : "propValue",
+                  "SDK Name" : "klaviyo-swift-sdk",
+                  "SDK Version" : "2.0.1"
                 },
                 "time" : 256260690,
                 "unique_id" : "00000000-0000-0000-0000-000000000001"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -25,6 +25,7 @@
                   "App ID" : "com.klaviyo.fooapp",
                   "App Name" : "FooApp",
                   "App Version" : "1.2.3",
+                  "Device ID" : "fe-fi-fo-fum",
                   "Device Manufacturer" : "Orange",
                   "Device Model" : "jPhone 1,1",
                   "OS Name" : "iOS",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -29,13 +29,6 @@
 
                       }
                     },
-                    "meta" : {
-                      "identifiers" : {
-                        "anonymous_id" : "iOS:00000000-0000-0000-0000-000000000002",
-                        "email" : "value",
-                        "external_id" : "value"
-                      }
-                    },
                     "type" : "profile"
                   }
                 },
@@ -52,7 +45,7 @@
                   "prop1" : "propValue",
                   "Push Token" : null,
                   "SDK Name" : "swift",
-                  "SDK Version" : "2.0.1"
+                  "SDK Version" : "2.1.0"
                 },
                 "time" : 256260690,
                 "unique_id" : "00000000-0000-0000-0000-000000000001"
@@ -76,13 +69,6 @@
                 "external_id" : "value",
                 "properties" : {
                   "foo2" : "bar2"
-                }
-              },
-              "meta" : {
-                "identifiers" : {
-                  "anonymous_id" : "iOS:00000000-0000-0000-0000-000000000002",
-                  "email" : "value",
-                  "external_id" : "value"
                 }
               },
               "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -22,9 +22,9 @@
                 },
                 "properties" : {
                   "App Build" : "1",
+                  "App ID" : "com.klaviyo.fooapp",
                   "App Name" : "FooApp",
                   "App Version" : "1.2.3",
-                  "Application ID" : "com.klaviyo.fooapp",
                   "Device Manufacturer" : "Orange",
                   "Device Model" : "jPhone 1,1",
                   "OS Name" : "iOS",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -12,13 +12,32 @@
             "data" : {
               "attributes" : {
                 "metric" : {
-                  "name" : "$opened_push"
+                  "data" : {
+                    "attributes" : {
+                      "name" : "$opened_push"
+                    },
+                    "type" : "metric"
+                  }
                 },
                 "profile" : {
-                  "$anonymous" : "iOS:00000000-0000-0000-0000-000000000002",
-                  "$email" : "value",
-                  "$id" : "value",
-                  "foo" : "bar"
+                  "data" : {
+                    "attributes" : {
+                      "anonymous_id" : "iOS:00000000-0000-0000-0000-000000000002",
+                      "email" : "value",
+                      "external_id" : "value",
+                      "properties" : {
+
+                      }
+                    },
+                    "meta" : {
+                      "identifiers" : {
+                        "anonymous_id" : "iOS:00000000-0000-0000-0000-000000000002",
+                        "email" : "value",
+                        "external_id" : "value"
+                      }
+                    },
+                    "type" : "profile"
+                  }
                 },
                 "properties" : {
                   "App Build" : "1",
@@ -32,7 +51,7 @@
                   "OS Version" : "1.1.1",
                   "prop1" : "propValue",
                   "Push Token" : null,
-                  "SDK Name" : "klaviyo-swift-sdk",
+                  "SDK Name" : "swift",
                   "SDK Version" : "2.0.1"
                 },
                 "time" : 256260690,

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testMigrateInvalidDataSkipped.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testMigrateInvalidDataSkipped.1.txt
@@ -13,8 +13,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testMigrateInvalidDataSkipped.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testMigrateInvalidDataSkipped.1.txt
@@ -13,6 +13,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -11,8 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -11,6 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -11,8 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -11,6 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -11,8 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
-  - pushBackground: Optional<String>.none
-  - pushEnablement: Optional<String>.none
+  - pushBackground: Optional<PushBackground>.none
+  - pushEnablement: Optional<PushEnablement>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -11,6 +11,8 @@
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - phoneNumber: Optional<String>.none
+  - pushBackground: Optional<String>.none
+  - pushEnablement: Optional<String>.none
   - pushToken: Optional<String>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -17,4 +17,4 @@
       - value: "application/json"
     ▿ (2 elements)
       - key: "revision"
-      - value: "2023-06-06"
+      - value: "2023-06-06.pre"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -17,4 +17,4 @@
       - value: "application/json"
     ▿ (2 elements)
       - key: "revision"
-      - value: "2022-10-17"
+      - value: "2023-06-06"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -17,4 +17,4 @@
       - value: "application/json"
     ▿ (2 elements)
       - key: "revision"
-      - value: "2023-06-06.pre"
+      - value: "2023-07-15.pre"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.2.0"
     ▿ (2 elements)
       - key: "accept"
       - value: "application/json"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0-beta1"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0"
     ▿ (2 elements)
       - key: "accept"
       - value: "application/json"
@@ -17,4 +17,4 @@
       - value: "application/json"
     ▿ (2 elements)
       - key: "revision"
-      - value: "2023-07-15.pre"
+      - value: "2023-07-15"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.2.0"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0-beta1"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.1.0"


### PR DESCRIPTION
# Description
- Adds device metadata collection
- Tag all events created by Swift SDK with device metadata.
- Upgrades from using the V2 identify API for push tokens to new V3 Push Tokens API. 
- [ ] TODO - Update the V3 Event API payload structure -- See https://github.com/klaviyo/klaviyo-swift-sdk/pull/93

<!--
Please describe the changes you are making and why you are making them.
-->

# Check List

- [x] Are you changing anything with the public API? No
- [x] Have you tested this change on real device? Yes
- [x] Are your changes backwards compatible with previous SDK Versions? Yes
- [x] Have you added unit test coverage for your changes? Yes
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports? Yes

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. Updated unit tests
2. Tested with tester app against the alpha API release on production
3. 

