### PR TITLE
Add two cases for Push Background, denied & restricted 

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -48,14 +48,17 @@ struct KlaviyoState: Equatable, Codable {
 
     enum PushBackground: String {
         case available = "AVAILABLE"
-        case unavailable = "UNAVAILABLE"
+        case restricted = "RESTRICTED"
+        case denied = "DENIED"
 
         static func create(from status: UIBackgroundRefreshStatus) -> PushBackground {
             switch status {
             case .available:
                 return PushBackground.available
-            default:
-                return PushBackground.unavailable
+            case .restricted:
+                return PushBackground.restricted
+            case .denied:
+                return PushBackground.denied
             }
         }
     }

--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -59,6 +59,8 @@ struct KlaviyoState: Equatable, Codable {
                 return PushBackground.restricted
             case .denied:
                 return PushBackground.denied
+            @unknown default:
+                return PushBackground.available
             }
         }
     }


### PR DESCRIPTION
# Description
Currently, Push tokens api fails when we send unavailable in that API. I have mentioned more details in this issue
https://github.com/klaviyo/klaviyo-swift-sdk/issues/100

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. I used proxy tools and tested by sending background field as restricted or denied or available and API is returning 202 status code.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
