### PR TITLE
fill in identifiers for events

### DIFF
--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -389,7 +389,7 @@ struct LegacyEvent: Equatable {
         guard var eventProperties = properties as? [String: Any] else {
             throw KlaviyoAPI.KlaviyoAPIError.invalidData
         }
-        guard var customerProperties = customerProperties as? [String: Any] else {
+        guard let customerProperties = customerProperties as? [String: Any] else {
             throw KlaviyoAPI.KlaviyoAPIError.invalidData
         }
 

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -394,16 +394,12 @@ struct LegacyEvent: Equatable {
 
         // v3 events api still uses these properties - we are just ensuring we are using the latest
         // identifiers here.
-        customerProperties["$email"] = state.email
-        customerProperties["$phone_number"] = state.phoneNumber
-        customerProperties["$id"] = state.externalId
-        customerProperties["$anonymous"] = state.anonymousId
         if eventName == "$opened_push" {
             // Special handling for $opened_push include push token at the time of open
             eventProperties["push_token"] = state.pushToken
         }
         let identifiers: Event.Identifiers = .init(email: state.email, phoneNumber: state.phoneNumber, externalId: state.externalId)
-        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, identifiers: identifiers, profile: customerProperties), anonymousId: state.anonymousId)
+        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, identifiers: identifiers), anonymousId: state.anonymousId)
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload(data: event)
         let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.createEvent(payload)
         return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -147,7 +147,8 @@ extension KlaviyoAPI.KlaviyoRequest {
                         profile = .init(attributes: .init(
                             email: attributes.identifiers?.email,
                             phoneNumber: attributes.identifiers?.phoneNumber,
-                            externalId: attributes.identifiers?.externalId),
+                            externalId: attributes.identifiers?.externalId,
+                            properties: attributes.profile),
                         anonymousId: anonymousId ?? "")
                     }
 
@@ -399,7 +400,7 @@ struct LegacyEvent: Equatable {
             eventProperties["push_token"] = state.pushToken
         }
         let identifiers: Event.Identifiers = .init(email: state.email, phoneNumber: state.phoneNumber, externalId: state.externalId)
-        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, identifiers: identifiers), anonymousId: state.anonymousId)
+        let event = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload.Event(event: .init(name: .CustomEvent(eventName), properties: eventProperties, identifiers: identifiers, profile: customerProperties), anonymousId: state.anonymousId)
         let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload(data: event)
         let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.createEvent(payload)
         return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)

--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -393,8 +393,6 @@ struct LegacyEvent: Equatable {
             throw KlaviyoAPI.KlaviyoAPIError.invalidData
         }
 
-        // v3 events api still uses these properties - we are just ensuring we are using the latest
-        // identifiers here.
         if eventName == "$opened_push" {
             // Special handling for $opened_push include push token at the time of open
             eventProperties["push_token"] = state.pushToken

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -189,8 +189,7 @@ public class Klaviyo: NSObject {
            let body = properties["body"] as? [String: Any], let _ = body["_k"] {
             Self.sdkInstance
                 .create(event: Event(name: .OpenedPush,
-                                     properties: properties,
-                                     profile: [:]))
+                                     properties: properties))
             if let url = properties["url"] as? String, let url = URL(string: url) {
                 Task {
                     await MainActor.run {
@@ -481,7 +480,7 @@ public struct KlaviyoSDK {
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {
         if let properties = notificationResponse.notification.request.content.userInfo as? [String: Any],
            let body = properties["body"] as? [String: Any], let _ = body["_k"] {
-            create(event: Event(name: .OpenedPush, properties: properties, profile: [:]))
+            create(event: Event(name: .OpenedPush, properties: properties))
             Task {
                 await MainActor.run {
                     if let url = properties["url"] as? String, let url = URL(string: url) {

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -66,11 +66,10 @@ public struct Event: Equatable {
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 identifiers: Identifiers? = nil,
-                profile: [String: Any]? = nil,
                 value: Double? = nil,
                 time: Date? = nil,
                 uniqueId: String? = nil) {
-        _profile = AnyCodable(profile ?? [:])
+        _profile = AnyCodable()
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
         self.value = value

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -66,10 +66,11 @@ public struct Event: Equatable {
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 identifiers: Identifiers? = nil,
+                profile: [String: Any]? = nil,
                 value: Double? = nil,
                 time: Date? = nil,
                 uniqueId: String? = nil) {
-        _profile = AnyCodable()
+        _profile = AnyCodable(profile ?? [:])
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
         self.value = value

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -63,6 +63,8 @@ public struct Event: Equatable {
     public let uniqueId: String
     public let identifiers: Identifiers?
 
+    @available(
+        iOS, deprecated: 9999, message: "Please use alternative initializer.")
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 identifiers: Identifiers? = nil,
@@ -70,7 +72,30 @@ public struct Event: Equatable {
                 value: Double? = nil,
                 time: Date? = nil,
                 uniqueId: String? = nil) {
-        _profile = AnyCodable(profile ?? [:])
+        let email = profile?["$email"] as? String
+        let phoneNumber = profile?["$phone_number"] as? String
+        let externalId = profile?["$id"] as? String
+        let identifiers = identifiers ?? Identifiers(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId)
+        self.init(
+            name: name,
+            properties: properties,
+            identifiers: identifiers,
+            value: value,
+            time: time,
+            uniqueId: uniqueId)
+    }
+
+    public init(name: EventName,
+                properties: [String: Any]? = nil,
+                identifiers: Identifiers? = nil,
+                value: Double? = nil,
+                time: Date? = nil,
+                uniqueId: String? = nil) {
+        // leaving legacy property for until we come up with a migration strategy
+        _profile = AnyCodable()
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
         self.value = value

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -419,6 +419,7 @@ extension Event {
         return Event(name: metric.name,
                      properties: properties,
                      identifiers: identifiers,
+                     profile: profile,
                      value: value,
                      time: time,
                      uniqueId: uniqueId)

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -394,17 +394,20 @@ extension KlaviyoState {
 
 extension Event {
     func updateStateAndEvent(state: inout KlaviyoState) -> Event {
-        let identifiers = identifiers ?? Identifiers(
-            email: state.email,
-            phoneNumber: state.phoneNumber,
-            externalId: state.externalId)
-        if let email = identifiers.email ?? profile["$email"] as? String {
+        let email = identifiers?.email ?? state.email
+        let phoneNumber = identifiers?.phoneNumber ?? state.phoneNumber
+        let externalId = identifiers?.externalId ?? state.externalId
+        let identifiers = Identifiers(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId)
+        if let email = identifiers.email {
             state.email = email
         }
-        if let phoneNumber = identifiers.phoneNumber ?? profile["$phone_number"] as? String {
+        if let phoneNumber = identifiers.phoneNumber {
             state.phoneNumber = phoneNumber
         }
-        if let externalId = identifiers.externalId ?? profile["$id"] as? String {
+        if let externalId = identifiers.externalId {
             state.externalId = externalId
         }
 

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -394,7 +394,7 @@ extension KlaviyoState {
 
 extension Event {
     func updateStateAndEvent(state: inout KlaviyoState) -> Event {
-        var identifiers = identifiers ?? Identifiers(
+        let identifiers = identifiers ?? Identifiers(
             email: state.email,
             phoneNumber: state.phoneNumber,
             externalId: state.externalId)

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -394,23 +394,20 @@ extension KlaviyoState {
 
 extension Event {
     func updateStateAndEvent(state: inout KlaviyoState) -> Event {
-        let identifiers = identifiers
-        var profile = profile
-        if let email = identifiers?.email ?? profile["$email"] as? String {
+        var identifiers = identifiers ?? Identifiers(
+            email: state.email,
+            phoneNumber: state.phoneNumber,
+            externalId: state.externalId)
+        if let email = identifiers.email ?? profile["$email"] as? String {
             state.email = email
-        } else {
-            profile["$email"] = state.email
         }
-        if let phoneNumber = identifiers?.phoneNumber ?? profile["$phone_number"] as? String {
+        if let phoneNumber = identifiers.phoneNumber ?? profile["$phone_number"] as? String {
             state.phoneNumber = phoneNumber
-        } else {
-            profile["$phone_number"] = state.phoneNumber
         }
-        if let externalId = identifiers?.externalId ?? profile["$id"] as? String {
+        if let externalId = identifiers.externalId ?? profile["$id"] as? String {
             state.externalId = externalId
-        } else {
-            profile["$id"] = state.externalId
         }
+
         var properties = properties
         if metric.name == EventName.OpenedPush,
            let pushToken = state.pushToken {
@@ -418,7 +415,7 @@ extension Event {
         }
         return Event(name: metric.name,
                      properties: properties,
-                     profile: profile,
+                     identifiers: identifiers,
                      value: value,
                      time: time,
                      uniqueId: uniqueId)

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -131,7 +131,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: 20) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -152,7 +152,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: 20) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -9,6 +9,8 @@
 import Foundation
 import XCTest
 
+let TIMEOUT_NANOSECONDS: UInt64 = 5_000_000_000 // 5 seconds
+
 @MainActor
 class APIRequestErrorHandlingTests: XCTestCase {
     override func setUp() async throws {
@@ -66,7 +68,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retry(2))) {
+        await store.receive(.requestFailed(request, .retry(2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request, request2]
             $0.requestsInFlight = []
@@ -88,7 +90,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retry(MAX_RETRIES + 1))) {
+        await store.receive(.requestFailed(request, .retry(MAX_RETRIES + 1)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request2]
             $0.requestsInFlight = []
@@ -110,7 +112,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -131,7 +133,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 60) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -152,7 +154,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 60) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -172,7 +174,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 60) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -192,7 +194,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 60) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -212,7 +214,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 0)), timeout: 60) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 0)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
@@ -231,7 +233,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8)), timeout: 60) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
@@ -252,7 +254,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 60) {
+        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -131,7 +131,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 20) {
+        await store.receive(.dequeCompletedResults(request), timeout: 60) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -152,7 +152,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: 20) {
+        await store.receive(.dequeCompletedResults(request), timeout: 60) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -172,7 +172,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: 60) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -192,7 +192,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: 60) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -212,7 +212,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 0))) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 0)), timeout: 60) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
@@ -231,7 +231,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8))) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8)), timeout: 60) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
@@ -252,7 +252,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.dequeCompletedResults(request), timeout: 60) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -9,7 +9,7 @@
 import Foundation
 import XCTest
 
-let TIMEOUT_NANOSECONDS: UInt64 = 5_000_000_000 // 5 seconds
+let TIMEOUT_NANOSECONDS: UInt64 = 10_000_000_000 // 10 seconds
 
 @MainActor
 class APIRequestErrorHandlingTests: XCTestCase {
@@ -48,7 +48,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retry(1))) {
+        await store.receive(.requestFailed(request, .retry(1)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request, request2]
             $0.requestsInFlight = []

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -45,7 +45,7 @@ final class KlaviyoStateTests: XCTestCase {
     let TEST_INVALID_PROPERTIES_EVENT = [
         "properties": [
             1: "propValue"
-        ],
+        ] as [AnyHashable: String],
         "customer_properties": [
             "foo": "bar"
         ]

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -8,6 +8,7 @@ import AnyCodable
 import Combine
 import XCTest
 @_spi(KlaviyoPrivate) @testable import KlaviyoSwift
+import CombineSchedulers
 
 enum FakeFileError: Error {
     case fake
@@ -156,7 +157,7 @@ extension StateChangePublisher {
     static let test = { () -> StateChangePublisher in
         StateChangePublisher.debouncedPublisher = { publisher in
             publisher
-                .debounce(for: .seconds(0), scheduler: DispatchQueue.main)
+                .debounce(for: .seconds(0), scheduler: DispatchQueue.immediate)
                 .eraseToAnyPublisher()
         }
         return Self()

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -79,7 +79,7 @@ class StateManagementTests: XCTestCase {
         stateChangeSubject.send(completion: .finished)
         lifecycleSubject.send(completion: .finished)
 
-        wait(for: [stateChangeIsSubscribed, lifecycleExpectation], timeout: 1.0)
+        await fulfillment(of: [stateChangeIsSubscribed, lifecycleExpectation])
     }
 
     // MARK: - Set Email

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -382,9 +382,23 @@ class StateManagementTests: XCTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "555BLOB"
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushToken!], profile: ["$email": "foo", "$phone_number": "666BLOB", "$id": "my_user_id"])
+        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushToken!], profile: ["$email": "foo@foo.com", "$phone_number": "666BLOB", "$id": "my_user_id"])
         _ = await store.send(.enqueueEvent(event)) {
-            $0.email = "foo"
+            $0.email = "foo@foo.com"
+            $0.phoneNumber = "666BLOB"
+            $0.externalId = "my_user_id"
+            try $0.enqueueRequest(request: .init(apiKey: XCTUnwrap($0.apiKey), endpoint: .createEvent(.init(data: .init(event: event, anonymousId: XCTUnwrap($0.anonymousId))))))
+        }
+    }
+
+    func testEnqueueEventWithIdentifiers() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "555BLOB"
+        let identifiers = Event.Identifiers(email: "foo@foo.com", phoneNumber: "666BLOB", externalId: "my_user_id")
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushToken!], identifiers: identifiers)
+        _ = await store.send(.enqueueEvent(event)) {
+            $0.email = "foo@foo.com"
             $0.phoneNumber = "666BLOB"
             $0.externalId = "my_user_id"
             try $0.enqueueRequest(request: .init(apiKey: XCTUnwrap($0.apiKey), endpoint: .createEvent(.init(data: .init(event: event, anonymousId: XCTUnwrap($0.anonymousId))))))

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -15,7 +15,11 @@
             "anonymous_id" : "anon-id",
             "email" : "blob@email.com",
             "properties" : {
-
+              "email" : "blob@email.com",
+              "location" : {
+                "city" : "blob city"
+              },
+              "stuff" : 2
             }
           },
           "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadWithRequestMigration.1.json
@@ -26,7 +26,7 @@
                       "email" : "value",
                       "external_id" : "value",
                       "properties" : {
-
+                        "foo" : "bar"
                       }
                     },
                     "type" : "profile"


### PR DESCRIPTION
# Description
In updating the sdk to support the new event api changes we appear to have dropped the ids from some events in certain cases. It also looks like customer properties on events were dropped as well. This is now fixed and should get applied properly. Coincident with this PR we started seeing flakiness in the CI build. I've added some extra timeouts to help with that. Ideally though we should investigate this more deeply to determine the cause.


# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
