### PR TITLE
store identifiers sent to sdk during initialization

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -100,26 +100,24 @@ struct KlaviyoReducer: ReducerProtocol {
             .merge(with: environment.appLifeCycle.lifeCycleEvents().eraseToEffect())
             .merge(with: environment.stateChangePublisher().eraseToEffect())
         case let .setEmail(email):
+            state.email = email
             guard case .initialized = state.initalizationState else {
                 return .none
             }
-            // We could move this linebefore initialization...
-            // once the sdk initialized it would send the email.
-            state.email = email
             state.enqueueProfileRequest()
             return .none
         case let .setPhoneNumber(phoneNumber):
+            state.phoneNumber = phoneNumber
             guard case .initialized = state.initalizationState else {
                 return .none
             }
-            state.phoneNumber = phoneNumber
             state.enqueueProfileRequest()
             return .none
         case let .setExternalId(externalId):
+            state.externalId = externalId
             guard case .initialized = state.initalizationState else {
                 return .none
             }
-            state.externalId = externalId
             state.enqueueProfileRequest()
             return .none
         case let .setPushToken(pushToken, enablement):

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -72,6 +72,15 @@ struct KlaviyoReducer: ReducerProtocol {
             guard case .initializing = state.initalizationState else {
                 return .none
             }
+            if let email = state.email {
+                initialState.email = email
+            }
+            if let phoneNumber = state.phoneNumber {
+                initialState.phoneNumber = phoneNumber
+            }
+            if let externalId = state.externalId {
+                initialState.externalId = externalId
+            }
             let queuedRequests = state.queue
             initialState.queue += queuedRequests
 

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -79,7 +79,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setEmail("test@blob.com"))
+        _ = await store.send(.setEmail("test@blob.com")) {
+            $0.email = "test@blob.com"
+        }
     }
 
     func testSetEmailMissingAnonymousIdStillSetsEmail() async throws {
@@ -108,7 +110,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setExternalId("external-blob-id"))
+        _ = await store.send(.setExternalId("external-blob-id")) {
+            $0.externalId = "external-blob-id"
+        }
     }
 
     func testSetExternalIdMissingAnonymousIdStillSetsExternalId() async throws {
@@ -137,7 +141,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPhoneNumber("1-800-Blobs4u"))
+        _ = await store.send(.setPhoneNumber("1-800-Blobs4u")) {
+            $0.phoneNumber = "1-800-Blobs4u"
+        }
     }
 
     func testSetPhoneNumberMissingApiKeyStillSetsPhoneNumber() async throws {


### PR DESCRIPTION
# Description

We ignore identifiers sent to prior to initialization. Instead of doing this we should probably save them. Once the sdk is initialized we merge the existing identifiers with the loaded state from disk (overwriting them if needed).

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
