### PR TITLE
add note about user defaults usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,3 +436,14 @@ The SDK will retry API requests that fail under certain conditions. For example,
 ## License
 
 KlaviyoSwift is available under the MIT license. See the LICENSE file for more info.
+
+
+## UserDefaults access
+
+As of fall 2023, Apple requires apps that access specific Apple APIs to provide a reason for this access. Previous versions of the Klaviyo SDK used UserDefaults to store data about the current user. Today, when the SDK starts up, it must access this data to migrate to a new format. Below, we've provided a sample reason you can include with your app submission (if requested):
+
+```
+UserDefaults is accessed by the Klaviyo SDK within our app to migrate some user data (previously stored there). None of this data is shared with other apps.
+```
+
+If your app or other SDKs also access UserDefaults, you may need to amend the reason to include that usage as well. Use the string NSPrivacyAccessedAPICategoryUserDefaults as the value for the NSPrivacyAccessedAPIType key in your NSPrivacyAccessedAPITypes dictionary. For more information, see this [guide](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401).


### PR DESCRIPTION
# Description

This adds some text to the README about Apple's requirement for UserDefaults access.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

N/A


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
