### PR TITLE
Fix for SDK stuck in bad state when email or phone number fails API validation

### DIFF
--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -67,7 +67,7 @@ func handleRequestError(
         if let invalidFields, !invalidFields.isEmpty {
             return .resetStateAndDequeue(request, invalidFields)
         } else {
-            return .dequeCompletedResults(request)
+            return .deQueueCompletedResults(request)
         }
 
     case let .networkError(error):
@@ -82,23 +82,23 @@ func handleRequestError(
 
     case let .internalError(data):
         runtimeWarn("An internal error occurred msg: \(data)")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
 
     case let .internalRequestError(error):
         runtimeWarn("An internal request error occurred msg: \(error)")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
 
     case let .unknownError(error):
         runtimeWarn("An unknown request error occured \(error)")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
 
     case .dataEncodingError:
         runtimeWarn("A data encoding error occurred during transmission.")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
 
     case .invalidData:
         runtimeWarn("Invalid data supplied for request. Skipping.")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
 
     case .rateLimitError:
         var requestRetryCount = 0
@@ -122,6 +122,6 @@ func handleRequestError(
 
     case .missingOrInvalidResponse:
         runtimeWarn("Missing or invalid response from api.")
-        return .dequeCompletedResults(request)
+        return .deQueueCompletedResults(request)
     }
 }

--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -125,21 +125,3 @@ func handleRequestError(
         return .dequeCompletedResults(request)
     }
 }
-
-struct ErrorResponse: Codable {
-    let errors: [ErrorDetail]
-}
-
-struct ErrorDetail: Codable {
-    let id: String
-    let status: Int
-    let code: String
-    let title: String
-    let detail: String
-    let source: ErrorSource
-    let meta: [String: String]
-}
-
-struct ErrorSource: Codable {
-    let pointer: String
-}

--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -40,18 +40,14 @@ private func getDelaySeconds(for count: Int) -> Int {
 }
 
 private func parseError(_ data: Data) -> [InvalidField]? {
-    var invalidFields: [InvalidField]?
-    do {
-        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
-
-        invalidFields = errorResponse.errors.compactMap { error in
-            InvalidField.getInvalidField(sourcePointer: error.source.pointer)
-        }
-    } catch {
+    guard let errorResponse: ErrorResponse = try? environment.analytics.decoder.decode(data) else {
         environment.logger.error("error when decoding error data")
+        return nil
     }
 
-    return invalidFields
+    return errorResponse.errors.compactMap { error in
+        InvalidField.getInvalidField(sourcePointer: error.source.pointer)
+    }
 }
 
 func handleRequestError(

--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -40,14 +40,18 @@ private func getDelaySeconds(for count: Int) -> Int {
 }
 
 private func parseError(_ data: Data) -> [InvalidField]? {
-    guard let errorResponse: ErrorResponse = try? environment.analytics.decoder.decode(data) else {
+    var invalidFields: [InvalidField]?
+    do {
+        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
+
+        invalidFields = errorResponse.errors.compactMap { error in
+            InvalidField.getInvalidField(sourcePointer: error.source.pointer)
+        }
+    } catch {
         environment.logger.error("error when decoding error data")
-        return nil
     }
 
-    return errorResponse.errors.compactMap { error in
-        InvalidField.getInvalidField(sourcePointer: error.source.pointer)
-    }
+    return invalidFields
 }
 
 func handleRequestError(

--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -12,10 +12,46 @@ struct ErrorHandlingConstants {
     static let maxBackoff = 60 * 3 // 3 minutes
 }
 
+enum InvalidField: Equatable {
+    case email
+    case phone
+
+    /// gets the invalid field based on the source.pointer from klaviyo API.
+    /// this assumes that source.pointer will not change
+    /// Client APIs to have better error codes in the future at which point we should use that instead of source.pointer
+    /// - Parameter sourcePointer: pointers to the source of the error
+    /// - Returns: the field that is invalid else `nil`
+    static func getInvalidField(sourcePointer: String) -> InvalidField? {
+        if sourcePointer == "/data/attributes/phone_number" {
+            return .phone
+        }
+        if sourcePointer == "/data/attributes/email" {
+            return .email
+        }
+
+        return nil
+    }
+}
+
 private func getDelaySeconds(for count: Int) -> Int {
     let delay = Int(pow(2.0, Double(count)))
     let jitter = environment.randomInt()
     return min(delay + jitter, ErrorHandlingConstants.maxBackoff)
+}
+
+private func parseError(_ data: Data) -> [InvalidField]? {
+    var invalidFields: [InvalidField]?
+    do {
+        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
+
+        invalidFields = errorResponse.errors.compactMap { error in
+            InvalidField.getInvalidField(sourcePointer: error.source.pointer)
+        }
+    } catch {
+        environment.logger.error("error when decoding error data")
+    }
+
+    return invalidFields
 }
 
 func handleRequestError(
@@ -26,7 +62,13 @@ func handleRequestError(
     case let .httpError(statuscode, data):
         let responseString = String(data: data, encoding: .utf8) ?? "[Unknown]"
         environment.logger.error("An http error occured status code: \(statuscode) data: \(responseString)")
-        return .dequeCompletedResults(request)
+
+        let invalidFields = parseError(data)
+        if let invalidFields, !invalidFields.isEmpty {
+            return .resetStateAndDequeue(request, invalidFields)
+        } else {
+            return .dequeCompletedResults(request)
+        }
 
     case let .networkError(error):
         environment.logger.error("A network error occurred: \(error)")
@@ -82,4 +124,22 @@ func handleRequestError(
         runtimeWarn("Missing or invalid response from api.")
         return .dequeCompletedResults(request)
     }
+}
+
+struct ErrorResponse: Codable {
+    let errors: [ErrorDetail]
+}
+
+struct ErrorDetail: Codable {
+    let id: String
+    let status: Int
+    let code: String
+    let title: String
+    let detail: String
+    let source: ErrorSource
+    let meta: [String: String]
+}
+
+struct ErrorSource: Codable {
+    let pointer: String
 }

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -196,3 +196,21 @@ extension Event.EventName {
         }
     }
 }
+
+struct ErrorResponse: Codable {
+    let errors: [ErrorDetail]
+}
+
+struct ErrorDetail: Codable {
+    let id: String
+    let status: Int
+    let code: String
+    let title: String
+    let detail: String
+    let source: ErrorSource
+    let meta: [String: String]
+}
+
+struct ErrorSource: Codable {
+    let pointer: String
+}

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -208,7 +208,6 @@ struct ErrorDetail: Codable {
     let title: String
     let detail: String
     let source: ErrorSource
-    let meta: [String: String]
 }
 
 struct ErrorSource: Codable {

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -52,7 +52,7 @@ enum KlaviyoAction: Equatable {
     case resetProfile
 
     /// dequeues requests that completed and contuinues to flush other requests if they exist.
-    case dequeCompletedResults(KlaviyoAPI.KlaviyoRequest)
+    case deQueueCompletedResults(KlaviyoAPI.KlaviyoRequest)
 
     /// when the network connectivity change we want to use a different flush interval to flush out the pending requests
     case networkConnectivityChanged(Reachability.NetworkStatus)
@@ -100,7 +100,7 @@ enum KlaviyoAction: Equatable {
         case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueLegacyEvent, .enqueueLegacyProfile, .enqueueEvent, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue:
             return true
 
-        case .initialize, .completeInitialization, .dequeCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed:
+        case .initialize, .completeInitialization, .deQueueCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed:
             return false
         }
     }
@@ -290,7 +290,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 .eraseToEffect()
                 .cancellable(id: FlushTimer.self, cancelInFlight: true)
 
-        case let .dequeCompletedResults(completedRequest):
+        case let .deQueueCompletedResults(completedRequest):
             if case let .registerPushToken(payload) = completedRequest.endpoint {
                 let requestData = payload.data.attributes
                 let enablement = KlaviyoState.PushEnablement(rawValue: requestData.enablementStatus) ?? .authorized
@@ -329,7 +329,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 switch result {
                 case .success:
                     // TODO: may want to inspect response further.
-                    await send(.dequeCompletedResults(request))
+                    await send(.deQueueCompletedResults(request))
                 case let .failure(error):
                     await send(handleRequestError(request: request, error: error, retryInfo: retryInfo))
                 }
@@ -497,7 +497,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 }
             }
 
-            return .task { .dequeCompletedResults(request) }
+            return .task { .deQueueCompletedResults(request) }
         }
     }
 }

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -29,7 +29,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.deQueueCompletedResults(request)) {
             $0.flushing = false
             $0.requestsInFlight = []
         }
@@ -49,7 +49,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.phoneNumber = nil
         }
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -71,7 +71,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.email = nil
         }
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -156,7 +156,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -177,7 +177,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -198,7 +198,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -218,7 +218,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -238,7 +238,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
@@ -298,7 +298,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -25,6 +25,42 @@ let SAMPLE_DATA: NSMutableArray = [
 let TEST_URL = URL(string: "fake_url")!
 let TEST_RETURN_DATA = Data()
 
+let TEST_FAILURE_JSON_INVALID_PHONE_NUMBER = """
+{
+    "errors": [
+      {
+        "id": "9997bd4f-7d5f-4f01-bbd1-df0065ef4faa",
+        "status": 400,
+        "code": "invalid",
+        "title": "Invalid input.",
+        "detail": "Invalid phone number format (Example of a valid format: +12345678901)",
+        "source": {
+          "pointer": "/data/attributes/phone_number"
+        },
+        "meta": {}
+      }
+    ]
+}
+"""
+
+let TEST_FAILURE_JSON_INVALID_EMAIL = """
+{
+  "errors": [
+    {
+      "id": "dce2d180-0f36-4312-aa6d-92d025c17147",
+      "status": 400,
+      "code": "invalid",
+      "title": "Invalid input.",
+      "detail": "Invalid email address",
+      "source": {
+        "pointer": "/data/attributes/email"
+      },
+      "meta": {}
+    }
+  ]
+}
+"""
+
 extension ArchiverClient {
     static let test = ArchiverClient(
         archivedData: { _, _ in ARCHIVED_RETURNED_DATA },

--- a/Tests/KlaviyoSwiftTests/LegacyTests.swift
+++ b/Tests/KlaviyoSwiftTests/LegacyTests.swift
@@ -123,7 +123,7 @@ class LegacyTests: XCTestCase {
             $0.requestsInFlight = [pushRequest, secondProfile]
         }
         await store.receive(.sendRequest)
-        await store.receive(.dequeCompletedResults(openedPushRequest)) {
+        await store.receive(.deQueueCompletedResults(openedPushRequest)) {
             $0.flushing = false
             $0.requestsInFlight = []
         }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -134,7 +134,7 @@ class StateManagementTests: XCTestCase {
 
         await store.receive(.sendRequest)
 
-        _ = await store.receive(.dequeCompletedResults(pushTokenRequest)) {
+        _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
             $0.flushing = false
             $0.requestsInFlight = []
             $0.pushTokenData = KlaviyoState.PushTokenData(pushToken: "blobtoken", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.analytics.appContextInfo()))
@@ -161,7 +161,7 @@ class StateManagementTests: XCTestCase {
 
         await store.receive(.sendRequest)
 
-        _ = await store.receive(.dequeCompletedResults(pushTokenRequest)) {
+        _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
             $0.flushing = false
             $0.requestsInFlight = []
             $0.pushTokenData = KlaviyoState.PushTokenData(pushToken: "blobtoken", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.analytics.appContextInfo()))
@@ -232,13 +232,13 @@ class StateManagementTests: XCTestCase {
         }
         await store.receive(.sendRequest)
 
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.deQueueCompletedResults(request)) {
             $0.flushing = true
             $0.requestsInFlight = [request2]
             $0.queue = []
         }
         await store.receive(.sendRequest)
-        await store.receive(.dequeCompletedResults(request2)) {
+        await store.receive(.deQueueCompletedResults(request2)) {
             $0.pushTokenData = KlaviyoState.PushTokenData(pushToken: "blob_token", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.analytics.appContextInfo()))
             $0.flushing = false
             $0.requestsInFlight = []
@@ -278,7 +278,7 @@ class StateManagementTests: XCTestCase {
         await store.receive(.sendRequest)
 
         // didn't fake uuid since we are not testing this.
-        await store.receive(.dequeCompletedResults(request)) {
+        await store.receive(.deQueueCompletedResults(request)) {
             $0.flushing = false
             $0.retryInfo = .retry(0)
             $0.requestsInFlight = []
@@ -391,7 +391,7 @@ class StateManagementTests: XCTestCase {
         }
 
         await store.receive(.sendRequest)
-        await store.receive(.dequeCompletedResults(request!)) {
+        await store.receive(.deQueueCompletedResults(request!)) {
             $0.requestsInFlight = $0.queue
             $0.flushing = false
             $0.pushTokenData = initialState.pushTokenData

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -10,17 +10,49 @@ import Foundation
 
 let TEST_API_KEY = "fake-key"
 
-let INITIALIZED_TEST_STATE = { KlaviyoState(
-    apiKey: TEST_API_KEY,
-    anonymousId: environment.analytics.uuid().uuidString,
-    pushTokenData: .init(pushToken: "blob_token",
-                         pushEnablement: .authorized,
-                         pushBackground: .available,
-                         deviceData: .init(context: environment.analytics.appContextInfo())),
-    queue: [],
-    requestsInFlight: [],
-    initalizationState: .initialized,
-    flushing: true) }
+let INITIALIZED_TEST_STATE = {
+    KlaviyoState(
+        apiKey: TEST_API_KEY,
+        anonymousId: environment.analytics.uuid().uuidString,
+        pushTokenData: .init(pushToken: "blob_token",
+                             pushEnablement: .authorized,
+                             pushBackground: .available,
+                             deviceData: .init(context: environment.analytics.appContextInfo())),
+        queue: [],
+        requestsInFlight: [],
+        initalizationState: .initialized,
+        flushing: true)
+}
+
+let INITIALIZED_TEST_STATE_INVALID_PHONE = {
+    KlaviyoState(
+        apiKey: TEST_API_KEY,
+        anonymousId: environment.analytics.uuid().uuidString,
+        phoneNumber: "invalid_phone_number",
+        pushTokenData: .init(pushToken: "blob_token",
+                             pushEnablement: .authorized,
+                             pushBackground: .available,
+                             deviceData: .init(context: environment.analytics.appContextInfo())),
+        queue: [],
+        requestsInFlight: [],
+        initalizationState: .initialized,
+        flushing: true)
+}
+
+let INITIALIZED_TEST_STATE_INVALID_EMAIL = {
+    KlaviyoState(
+        apiKey: TEST_API_KEY,
+        email: "invalid_email",
+        anonymousId: environment.analytics.uuid().uuidString,
+        pushTokenData: .init(pushToken: "blob_token",
+                             pushEnablement: .authorized,
+                             pushBackground: .available,
+                             deviceData: .init(context: environment.analytics.appContextInfo())),
+        queue: [],
+        requestsInFlight: [],
+        initalizationState: .initialized,
+        flushing: true)
+}
 
 extension Profile {
     static let SAMPLE_PROPERTIES = [


### PR DESCRIPTION
# Description

We had a customer open a [issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues/122) where they pointed out that the app is stuck in a bad state whenever the email or phone number fails validation. This code aims to do two things - 
1. If the phone number fails API validation we will erase the state and dequeue this request.
2. If the email is invalid, we do the same, reset the state and dequeue the request.

We try to keep the SDK fairly light weight and dequeue the request vs. trying again. 


# Check List

- [x] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Case 1: Invalid phone number 

1. Add an invalid phone number on a test app using the SDK
2. After this request fails, send a event request using a test event 
3. This event succeeded vs. it used to fail in the past

Case 2: Invalid email
Same as above except using a invalid email instead of a phone number.