### PR TITLE
Fixing a user reported crash on device model code

### DIFF
--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -20,10 +20,14 @@ struct AppContextInfo {
     private static let defaultOSName = "iOS"
     private static let defaultDeviceModel: String = {
         var size = 0
+        var deviceModel = ""
         sysctlbyname("hw.machine", nil, &size, nil, 0)
         var machine = [CChar](repeating: 0, count: size)
-        sysctlbyname("hw.machine", &machine, &size, nil, 0)
-        return String(cString: machine)
+        if size > 0 {
+            sysctlbyname("hw.machine", &machine, &size, nil, 0)
+            deviceModel = String(cString: machine)
+        }
+        return deviceModel
     }()
 
     private static let deviceIdStoreKey = "_klaviyo_device_id"

--- a/Sources/KlaviyoSwift/AppContextInfo.swift
+++ b/Sources/KlaviyoSwift/AppContextInfo.swift
@@ -22,8 +22,8 @@ struct AppContextInfo {
         var size = 0
         var deviceModel = ""
         sysctlbyname("hw.machine", nil, &size, nil, 0)
-        var machine = [CChar](repeating: 0, count: size)
         if size > 0 {
+            var machine = [CChar](repeating: 0, count: size)
             sysctlbyname("hw.machine", &machine, &size, nil, 0)
             deviceModel = String(cString: machine)
         }


### PR DESCRIPTION
# Description

Added a check to the device model code to avoid a reported crash. Checking the size before copying over the data to the pointer.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Checked on a test app and device model showed up fine on the server for an iPhone 13 mini. 

```json
{
  "SDK Version": "2.3.0",
  "Device ID": "XXXX",
  "Total Price": 10.99,
  "OS Version": "17.1.2",
  "OS Name": "iOS",
  "App ID": "com.klaviyo.testiosforbfcm",
  "Device Manufacturer": "Apple",
  "App Name": "testingKlaviyo",
  "Device Model": "iPhone14,4",
  "App Version": "1.0",
  "Items Purchased": [
    "Hot Dog",
    "Fries",
    "Shake"
  ],
  "SDK Name": "swift",
  "Push Token": "XXX",
  "App Build": "1",
  "$value": 10.99
}
```

Reproduced the crash by commenting the line where the size is assigned - 
![image](https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/f3e21958-f509-4774-bcf1-d32a1a645a8f)

