### PR TITLE
remove initializer for setting identifiers in events

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -63,6 +63,7 @@ public struct Event: Equatable {
     public let uniqueId: String
     public let identifiers: Identifiers?
 
+    @available(*, deprecated, renamed: "init(name:properties:value:uniqueId:)", message: "This initializer has been deprecated. Setting profile properties should be set prior to logging events.")
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 identifiers: Identifiers? = nil,
@@ -86,6 +87,19 @@ public struct Event: Equatable {
         self.time = time ?? environment.analytics.date()
         self.uniqueId = uniqueId ?? environment.analytics.uuid().uuidString
         self.identifiers = identifiers
+    }
+
+    public init(name: EventName,
+                properties: [String: Any]? = nil,
+                value: Double? = nil,
+                uniqueId: String? = nil) {
+        metric = .init(name: name)
+        _profile = AnyCodable([:])
+        _properties = AnyCodable(properties ?? [:])
+        identifiers = nil
+        self.value = value
+        time = environment.analytics.date()
+        self.uniqueId = uniqueId ?? environment.analytics.uuid().uuidString
     }
 }
 

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -63,7 +63,7 @@ public struct Event: Equatable {
     public let uniqueId: String
     public let identifiers: Identifiers?
 
-    @available(*, deprecated, renamed: "init(name:properties:value:uniqueId:)", message: "This initializer has been deprecated. Setting profile properties should be set prior to logging events.")
+    @available(*, deprecated, renamed: "init(name:properties:value:uniqueId:)", message: "This initializer has been deprecated. Profile properties should be set prior to logging events.")
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 identifiers: Identifiers? = nil,


### PR DESCRIPTION
# Description

We no longer want to allow setting identifiers, time, and profile in events. This can create confusing bugs for developers and brings it in line with the Android SDK.

# Check List

- [x] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
