### PR TITLE
Suggest adding a set push token method that takes string

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -465,10 +465,15 @@ public struct KlaviyoSDK {
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
-
+        set(pushToken: apnDeviceToken)
+    }
+    
+    /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
+    /// - Parameter pushToken: String formatted push token.
+    public func set(pushToken: String) {
         environment.getNotificationSettings { enablement in
             dispatchOnMainThread(action: .setPushToken(
-                apnDeviceToken,
+                pushToken,
                 enablement))
         }
     }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -467,7 +467,7 @@ public struct KlaviyoSDK {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
         set(pushToken: apnDeviceToken)
     }
-    
+
     /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
     /// - Parameter pushToken: String formatted push token.
     public func set(pushToken: String) {


### PR DESCRIPTION
Adds a method to set push token as string. This will be consumed from the react-native SDK and could be useful to devs who might want to parse the token to a string in their code

# Description

<!--
Please describe the changes you are making and why you are making them.
-->

# Check List

- [x] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
