### PR TITLE
Fix broken invalid url handling on iOS 17

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        xcode: ['14.3']
+        xcode: ['15.1']
         config: ['debug', 'release']
     steps:
       - uses: actions/checkout@v3

--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -103,7 +103,11 @@ extension KlaviyoAPI.KlaviyoRequest {
     var url: URL? {
         switch endpoint {
         case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:
-            return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)")
+            if #available(iOS 17.0, *) {
+                return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)", encodingInvalidCharacters: false)
+            } else {
+                return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)")
+            }
         }
     }
 


### PR DESCRIPTION
# Description

In iOS 17 apple changes how url's string initializer works and this was causing one of our tests that validates invalid urls to fail. I reverted the URL initializer to not use the new decoding and sticking with the pre iOS 17 logic of keeping invalid characters from decoding. This is fine since the string we are using the URL initializer is a static one and the idea is to align the code with the tests we had. 

[Change](https://ihor.pro/handling-a-new-url-parsing-behavior-in-ios-17-c08598d28659) in iOS 17 for more context.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
