### PR TITLE
Added timeout for flaky test

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -465,10 +465,15 @@ public struct KlaviyoSDK {
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
-
+        set(pushToken: apnDeviceToken)
+    }
+    
+    /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
+    /// - Parameter pushToken: String formatted push token.
+    public func set(pushToken: String) {
         environment.getNotificationSettings { enablement in
             dispatchOnMainThread(action: .setPushToken(
-                apnDeviceToken,
+                pushToken,
                 enablement))
         }
     }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -467,7 +467,7 @@ public struct KlaviyoSDK {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
         set(pushToken: apnDeviceToken)
     }
-    
+
     /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
     /// - Parameter pushToken: String formatted push token.
     public func set(pushToken: String) {

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -45,7 +45,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.resetStateAndDequeue(request, [InvalidField.phone])) {
+        await store.receive(.resetStateAndDequeue(request, [InvalidField.phone]), timeout: TIMEOUT_NANOSECONDS) {
             $0.phoneNumber = nil
         }
 
@@ -67,7 +67,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.resetStateAndDequeue(request, [InvalidField.email])) {
+        await store.receive(.resetStateAndDequeue(request, [InvalidField.email]), timeout: TIMEOUT_NANOSECONDS) {
             $0.email = nil
         }
 


### PR DESCRIPTION
# Description

This is inline with the other existing tests and the suggestion from the failure message. 

![image](https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/adb7b402-60a2-450a-bb7f-76a14861b635)


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
