### PR TITLE
Dropped support for iOS 13

### DIFF
--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/klaviyo/klaviyo-swift-sdk.git", :tag => s.version.to_s }
   s.swift_version = '5.7'
   s.platform = :ios
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '14.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.dependency     'AnyCodable-FlightSchool'
 end

--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/klaviyo/klaviyo-swift-sdk.git", :tag => s.version.to_s }
   s.swift_version = '5.7'
   s.platform = :ios
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '14.0'
   s.source_files = 'Sources/KlaviyoSwiftExtension/**/*.swift'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "klaviyo-swift-sdk",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "KlaviyoSwift",


### PR DESCRIPTION
# Description

This is going out in the next major version and we'll be dropping support for iOS 13 and min deployment version support will be iOS 14.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
