### PR TITLE
remove deprecated event initializer

### DIFF
--- a/Sources/KlaviyoSwift/InternalAPIModels.swift
+++ b/Sources/KlaviyoSwift/InternalAPIModels.swift
@@ -127,8 +127,7 @@ extension KlaviyoAPI.KlaviyoRequest {
                         profile = .init(attributes: .init(
                             email: attributes.identifiers?.email,
                             phoneNumber: attributes.identifiers?.phoneNumber,
-                            externalId: attributes.identifiers?.externalId,
-                            properties: attributes.profile),
+                            externalId: attributes.identifiers?.externalId),
                         anonymousId: anonymousId ?? "")
                     }
 

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -45,11 +45,6 @@ public struct Event: Equatable {
     }
 
     private let _properties: AnyCodable
-    var profile: [String: Any] {
-        _profile.value as? [String: Any] ?? [:]
-    }
-
-    let _profile: AnyCodable
     public var time: Date
     public let value: Double?
     public let uniqueId: String
@@ -58,15 +53,13 @@ public struct Event: Equatable {
     init(name: EventName,
          properties: [String: Any]? = nil,
          identifiers: Identifiers? = nil,
-         profile: [String: Any]? = nil,
          value: Double? = nil,
          time: Date? = nil,
          uniqueId: String? = nil) {
-        _profile = AnyCodable(profile)
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
-        self.value = value
         self.time = time ?? environment.analytics.date()
+        self.value = value
         self.uniqueId = uniqueId ?? environment.analytics.uuid().uuidString
         self.identifiers = identifiers
     }
@@ -76,7 +69,6 @@ public struct Event: Equatable {
                 value: Double? = nil,
                 uniqueId: String? = nil) {
         metric = .init(name: name)
-        _profile = AnyCodable([:])
         _properties = AnyCodable(properties ?? [:])
         identifiers = nil
         self.value = value

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -26,7 +26,7 @@ public struct Event: Equatable {
         }
     }
 
-    public struct Identifiers: Equatable {
+    struct Identifiers: Equatable {
         public let email: String?
         public let phoneNumber: String?
         public let externalId: String?
@@ -45,33 +45,23 @@ public struct Event: Equatable {
     }
 
     private let _properties: AnyCodable
-    public var profile: [String: Any] {
+    var profile: [String: Any] {
         _profile.value as? [String: Any] ?? [:]
     }
 
-    internal var _profile: AnyCodable
+    let _profile: AnyCodable
     public var time: Date
     public let value: Double?
     public let uniqueId: String
-    public let identifiers: Identifiers?
+    let identifiers: Identifiers?
 
-    @available(*, deprecated, renamed: "init(name:properties:value:uniqueId:)", message: "This initializer has been deprecated. Profile properties should be set prior to logging events.")
-    public init(name: EventName,
-                properties: [String: Any]? = nil,
-                identifiers: Identifiers? = nil,
-                profile: [String: Any]? = nil,
-                value: Double? = nil,
-                time: Date? = nil,
-                uniqueId: String? = nil) {
-        var profile = profile
-        let email = profile?.removeValue(forKey: "$email") as? String
-        let phoneNumber = profile?.removeValue(forKey: "$phone_number") as? String
-        let externalId = profile?.removeValue(forKey: "$id") as? String
-        // identifiers takes precedence if available otherwise fallback to profile.
-        let identifiers = identifiers ?? Identifiers(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId)
+    init(name: EventName,
+         properties: [String: Any]? = nil,
+         identifiers: Identifiers? = nil,
+         profile: [String: Any]? = nil,
+         value: Double? = nil,
+         time: Date? = nil,
+         uniqueId: String? = nil) {
         _profile = AnyCodable(profile)
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -386,7 +386,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            event = event.updateStateAndEvent(state: &state)
+            event = event.updateEventWithState(state: &state)
             state.enqueueRequest(request: .init(apiKey: apiKey,
                                                 endpoint: .createEvent(
                                                     .init(data: .init(event: event, anonymousId: anonymousId))
@@ -507,7 +507,7 @@ extension KlaviyoState {
 }
 
 extension Event {
-    func updateStateAndEvent(state: inout KlaviyoState) -> Event {
+    func updateEventWithState(state: inout KlaviyoState) -> Event {
         let identifiers = Identifiers(
             email: state.email,
             phoneNumber: state.phoneNumber,
@@ -520,7 +520,6 @@ extension Event {
         return Event(name: metric.name,
                      properties: properties,
                      identifiers: identifiers,
-                     profile: profile,
                      value: value,
                      time: time,
                      uniqueId: uniqueId)

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -508,23 +508,10 @@ extension KlaviyoState {
 
 extension Event {
     func updateStateAndEvent(state: inout KlaviyoState) -> Event {
-        let email = identifiers?.email ?? state.email
-        let phoneNumber = identifiers?.phoneNumber ?? state.phoneNumber
-        let externalId = identifiers?.externalId ?? state.externalId
         let identifiers = Identifiers(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId)
-        if let email = identifiers.email {
-            state.email = email
-        }
-        if let phoneNumber = identifiers.phoneNumber {
-            state.phoneNumber = phoneNumber
-        }
-        if let externalId = identifiers.externalId {
-            state.externalId = externalId
-        }
-
+            email: state.email,
+            phoneNumber: state.phoneNumber,
+            externalId: state.externalId)
         var properties = properties
         if metric.name == EventName.OpenedPush,
            let pushToken = state.pushTokenData?.pushToken {

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -93,10 +93,6 @@ class KlaviyoSDKTests: XCTestCase {
         let event = Event(name: .AddedToCartMetric, properties: [
             "Total Price": 10.99,
             "Items Purchased": ["Hot Dog", "Fries", "Shake"]
-        ], identifiers: .init(email: "junior@blob.com"),
-        profile: [
-            "$first_name": "Blob",
-            "$last_name": "Jr"
         ], value: 10.99)
         let expectation = setupActionAssertion(expectedAction: .enqueueEvent(event))
 

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -315,7 +315,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
             expection.fulfill()
         }
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
-        let event = Event(name: .OpenedPush, profile: ["$email": "foo", "$phone_number": "666BLOB", "$id": "my_user_id"])
+        let event = Event(name: .OpenedPush)
         _ = await store.send(.enqueueEvent(event))
         await fulfillment(of: [expection])
     }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -419,26 +419,10 @@ class StateManagementTests: XCTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "555BLOB"
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushTokenData!.pushToken], profile: ["$email": "foo@foo.com", "$phone_number": "666BLOB", "$id": "my_user_id"])
+        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushTokenData!.pushToken])
         _ = await store.send(.enqueueEvent(event)) {
-            $0.email = "foo@foo.com"
-            $0.phoneNumber = "666BLOB"
-            $0.externalId = "my_user_id"
-            try $0.enqueueRequest(request: .init(apiKey: XCTUnwrap($0.apiKey), endpoint: .createEvent(.init(data: .init(event: event, anonymousId: XCTUnwrap($0.anonymousId))))))
-        }
-    }
-
-    func testEnqueueEventWithIdentifiers() async throws {
-        var initialState = INITIALIZED_TEST_STATE()
-        initialState.phoneNumber = "555BLOB"
-        let identifiers = Event.Identifiers(email: "foo@foo.com", phoneNumber: "666BLOB", externalId: "my_user_id")
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        let event = Event(name: .OpenedPush, properties: ["push_token": initialState.pushTokenData!.pushToken], identifiers: identifiers)
-        _ = await store.send(.enqueueEvent(event)) {
-            $0.email = "foo@foo.com"
-            $0.phoneNumber = "666BLOB"
-            $0.externalId = "my_user_id"
-            try $0.enqueueRequest(request: .init(apiKey: XCTUnwrap($0.apiKey), endpoint: .createEvent(.init(data: .init(event: event, anonymousId: XCTUnwrap($0.anonymousId))))))
+            let newEvent = Event(name: .OpenedPush, properties: event.properties, identifiers: .init(phoneNumber: $0.phoneNumber))
+            try $0.enqueueRequest(request: .init(apiKey: XCTUnwrap($0.apiKey), endpoint: .createEvent(.init(data: .init(event: newEvent, anonymousId: XCTUnwrap($0.anonymousId))))))
         }
     }
 }

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -103,14 +103,7 @@ extension Event {
         "Device Manufacturer": "Orange",
         "Device Model": "jPhone 1,1"
     ] as [String: Any]
-    static let SAMPLE_PROFILE_PROPERTIES = [
-        "email": "blob@email.com",
-        "stuff": 2,
-        "location": [
-            "city": "blob city"
-        ]
-    ] as [String: Any]
-    static let test = Self(name: .CustomEvent("blob"), properties: SAMPLE_PROPERTIES, identifiers: .init(email: "blob@email.com"), profile: SAMPLE_PROFILE_PROPERTIES)
+    static let test = Self(name: .CustomEvent("blob"), properties: SAMPLE_PROPERTIES)
 }
 
 extension Event.Metric {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
@@ -13,13 +13,8 @@
         "data" : {
           "attributes" : {
             "anonymous_id" : "anon-id",
-            "email" : "blob@email.com",
             "properties" : {
-              "email" : "blob@email.com",
-              "location" : {
-                "city" : "blob city"
-              },
-              "stuff" : 2
+
             }
           },
           "type" : "profile"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithoutMetadata.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithoutMetadata.1.json
@@ -13,13 +13,8 @@
         "data" : {
           "attributes" : {
             "anonymous_id" : "anon-id",
-            "email" : "blob@email.com",
             "properties" : {
-              "email" : "blob@email.com",
-              "location" : {
-                "city" : "blob city"
-              },
-              "stuff" : 2
+
             }
           },
           "type" : "profile"


### PR DESCRIPTION
# Description

Removes access to the event initializer (still used internally).

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
