### PR TITLE
Fixed opened push not getting called when app is terminated

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -144,11 +144,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
             state.initalizationState = .initializing
             state.apiKey = apiKey
-            // carry over pending events
-            let pendingRequests = state.pendingRequests
             return .run { send in
-                var initialState = loadKlaviyoStateFromDisk(apiKey: apiKey)
-                initialState.pendingRequests = pendingRequests
+                let initialState = loadKlaviyoStateFromDisk(apiKey: apiKey)
                 await send(.completeInitialization(initialState))
             }
 
@@ -165,12 +162,14 @@ struct KlaviyoReducer: ReducerProtocol {
             if let externalId = state.externalId {
                 initialState.externalId = externalId
             }
-            let queuedRequests = state.queue
-            initialState.queue += queuedRequests
+            // For any requests that get added between initilizing and initilized.
+            // Ex: when the app is invoked from a push notification after being killed from the app switcher.
+            let pendingRequests = state.pendingRequests
+            initialState.queue += state.queue
 
             state = initialState
             state.initalizationState = .initialized
-            let pendingRequests = state.pendingRequests
+
             state.pendingRequests = []
 
             return .run { send in

--- a/Tests/KlaviyoSwiftTests/LegacyTests.swift
+++ b/Tests/KlaviyoSwiftTests/LegacyTests.swift
@@ -81,7 +81,7 @@ class LegacyTests: XCTestCase {
             $0.initalizationState = .initializing
         }
 
-        let expectedState = KlaviyoState(apiKey: TEST_API_KEY, anonymousId: environment.analytics.uuid().uuidString, queue: [], requestsInFlight: [], pendingRequests: pendingRequests)
+        let expectedState = KlaviyoState(apiKey: TEST_API_KEY, anonymousId: environment.analytics.uuid().uuidString, queue: [], requestsInFlight: [])
         await store.receive(.completeInitialization(expectedState)) {
             $0.anonymousId = expectedState.anonymousId
             $0.initalizationState = .initialized

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -24,6 +24,16 @@ let INITIALIZED_TEST_STATE = {
         flushing: true)
 }
 
+let INITILIZING_TEST_STATE = {
+    KlaviyoState(
+        apiKey: TEST_API_KEY,
+        anonymousId: environment.analytics.uuid().uuidString,
+        queue: [],
+        requestsInFlight: [],
+        initalizationState: .initializing,
+        flushing: true)
+}
+
 let INITIALIZED_TEST_STATE_INVALID_PHONE = {
     KlaviyoState(
         apiKey: TEST_API_KEY,


### PR DESCRIPTION
# Description

We were handling pending requests but when an app is terminated and launched again from a push notification open it triggers  the open event and this open event is added to the pending requests since the SDK is not yet initialized (when the app is relaunched after terminating it's initialized again). However, between the SDK going from initializing to initialized the requests that were added to pending requests were ignored which is what was causing the opened push events from not getting enqueued and eventually sent out. 

The fix was to just use the pending requests from state and enqueue each of those instead of using the state that was taken from the disk.  

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
