### PR TITLE
Using iOS 13 as min deployment version in the package.swift file

### DIFF
--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwift"
-  s.version          = "3.0.0"
+  s.version          = "3.0.1"
   s.summary          = "Incorporate Klaviyo's event and person tracking and push notifications functionality into iOS applications"
 
   s.description      = <<-DESC

--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwiftExtension"
-  s.version          = "3.0.0"
+  s.version          = "3.0.1"
   s.summary          = "Incorporate Klaviyo's rich push notifications functionality into your iOS applications"
 
   s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "klaviyo-swift-sdk",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(
             name: "KlaviyoSwift",

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 public let __klaviyoSwiftName = "swift"
-public let __klaviyoSwiftVersion = "3.0.0"
+public let __klaviyoSwiftVersion = "3.0.1"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
@@ -37,7 +37,7 @@
         "OS Version" : "1.1.1",
         "Push Token" : null,
         "SDK Name" : "swift",
-        "SDK Version" : "3.0.0",
+        "SDK Version" : "3.0.1",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "3.0.0"
+              "sdk_version" : "3.0.1"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -15,7 +15,7 @@
       "manufacturer" : "Orange",
       "os_name" : "iOS",
       "os_version" : "1.1.1",
-      "sdk_version" : "3.0.0"
+      "sdk_version" : "3.0.1"
     },
     "pushBackground" : "AVAILABLE",
     "pushEnablement" : "AUTHORIZED",
@@ -42,7 +42,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "3.0.0"
+                  "sdk_version" : "3.0.1"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "3.0.0"
+        "sdk_version" : "3.0.1"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/3.0.0"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/3.0.1"
     ▿ (2 elements)
       - key: "accept"
       - value: "application/json"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/3.0.0"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/3.0.1"


### PR DESCRIPTION
# Description

Might be a merge conflict gone wrong but the platforms changed to 14 where as the cocoapods one is 13 and we intent to support 13 as the minimum deployment version.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
