### PR TITLE
As/2.5.2 xcode 14 fix

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        xcode: ['15.1']
+        xcode: ['15.1', '14.3.1']
         config: ['debug', 'release']
     steps:
       - uses: actions/checkout@v3

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwift"
-  s.version          = "2.5.1"
+  s.version          = "2.5.2"
   s.summary          = "Incorporate Klaviyo's event and person tracking and push notifications functionality into iOS applications"
 
   s.description      = <<-DESC

--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwiftExtension"
-  s.version          = "2.5.1"
+  s.version          = "2.5.2"
   s.summary          = "Incorporate Klaviyo's rich push notifications functionality into your iOS applications"
 
   s.description      = <<-DESC

--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -103,11 +103,10 @@ extension KlaviyoAPI.KlaviyoRequest {
     var url: URL? {
         switch endpoint {
         case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:
-            if #available(iOS 17.0, *) {
-                return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)", encodingInvalidCharacters: false)
-            } else {
+            if !environment.analytics.apiURL.isEmpty {
                 return URL(string: "\(environment.analytics.apiURL)/\(path)/?company_id=\(apiKey)")
             }
+            return nil
         }
     }
 

--- a/Sources/KlaviyoSwift/Version.swift
+++ b/Sources/KlaviyoSwift/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 public let __klaviyoSwiftName = "swift"
-public let __klaviyoSwiftVersion = "2.5.1"
+public let __klaviyoSwiftVersion = "2.5.2"

--- a/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
@@ -22,10 +22,9 @@ final class KlaviyoAPITests: XCTestCase {
     }
 
     func testInvalidURL() async throws {
-        environment.analytics.apiURL = ": : ::"
+        environment.analytics.apiURL = ""
 
         await sendAndAssert(with: .init(apiKey: "foo", endpoint: .createProfile(.init(data: .init(profile: .test, anonymousId: "foo"))))) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .description)

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testEventPayloadWithMetadata.1.json
@@ -42,7 +42,7 @@
         "OS Version" : "1.1.1",
         "Push Token" : null,
         "SDK Name" : "swift",
-        "SDK Version" : "2.5.1",
+        "SDK Version" : "2.5.2",
         "stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "2.5.1"
+              "sdk_version" : "2.5.2"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -15,7 +15,7 @@
       "manufacturer" : "Orange",
       "os_name" : "iOS",
       "os_version" : "1.1.1",
-      "sdk_version" : "2.5.1"
+      "sdk_version" : "2.5.2"
     },
     "pushBackground" : "AVAILABLE",
     "pushEnablement" : "AUTHORIZED",
@@ -42,7 +42,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "2.5.1"
+                  "sdk_version" : "2.5.2"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "2.5.1"
+        "sdk_version" : "2.5.2"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testInvalidURL.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testInvalidURL.1.txt
@@ -1,1 +1,1 @@
-internalRequestError(KlaviyoSwift.KlaviyoAPI.KlaviyoAPIError.internalError("Invalid url string. API URL: : : ::"))
+internalRequestError(KlaviyoSwift.KlaviyoAPI.KlaviyoAPIError.internalError("Invalid url string. API URL: "))

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.5.1"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.5.2"
     ▿ (2 elements)
       - key: "accept"
       - value: "application/json"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.5.1"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/2.5.2"


### PR DESCRIPTION
# Description

This is a patch release for major version 2 with changes that should allow for folks to run 2.x.x version on xcode 14. Plan is to create a tag and release and then delete the branch and create a new branch with `3.0.2` release version. Confirmed that tags will rename even if branch is deleted. TIL :)


https://github.com/klaviyo/klaviyo-swift-sdk/pull/152

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
