### PR TITLE
Merged requesting and collecting tokens under the same section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 
         // you can check if the permission was granted or not but it's not necessary
         // especially if you are using provisional push notifications (or silent push notifications if we end up supporting them)
-	    DispatchQueue.main.async {
-	         // this will trigger the didRegisterForRemoteNotificationsWithDeviceToken method to be called where you can collect the push token
-             UIApplication.shared.registerForRemoteNotifications()
-         }
-	}
+        DispatchQueue.main.async {
+            // this will trigger the didRegisterForRemoteNotificationsWithDeviceToken method to be called where you can collect the push token
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    }
 
     return true
 }

--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 	        print("error = ", error)
 	    }
 
-        // you can check if the permission was granted or not but it's not necessary
-        // especially if you are using provisional push notifications (or silent push notifications if we end up supporting them)
+        // you can check if the permission was granted or not but it's not necessary especially if you are using provisional push notifications
         DispatchQueue.main.async {
             // this will trigger the didRegisterForRemoteNotificationsWithDeviceToken method to be called where you can collect the push token
             UIApplication.shared.registerForRemoteNotifications()


### PR DESCRIPTION
# Description

⚠️  README ⚠️ 

Realized that the SDK doesn't refresh the push enablement status automatically and hence my prior instructions were incorrect. Update them to now set the push token only after requesting push permissions. 

This won't allow for silent push to work in some cases as our SDK currently only allows setting token after requesting push permission. I can think of two options here - 

1. Having a seperate method for setting the push enablement status so that we can get the token on app launch and then allow the user to request push permission at any point in their app as they see fit and update our SDK when they have the permissions (or not).
2. The SDK listens for app foregrounded life cycle events and gets the push enablement status and updates the register token endpoint whenever the enablement status has changed. I think I prefer this over the first approach.