### PR TITLE
[CHNL-5340] Minor update to push permission request

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 	        print("error = ", error)
 	    }
 
-	    // Enable or disable features based on the authorization status.
-	    // if you didn't register for remote notifications above you can call `registerForRemoteNotifications` here
-	    // Klaviyo SDK will automatically update the authorization status on next app launch
+	    // Irrespective of the authorization status call `registerForRemoteNotifications` here so that
+	    // the `didRegisterForRemoteNotificationsWithDeviceToken` delegate is called. Doing this
+	    // will make sure that Klaviyo always has the latest push authorization status.
 	}
 
     return true

--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 	    // Irrespective of the authorization status call `registerForRemoteNotifications` here so that
 	    // the `didRegisterForRemoteNotificationsWithDeviceToken` delegate is called. Doing this
 	    // will make sure that Klaviyo always has the latest push authorization status.
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
 	}
 
     return true


### PR DESCRIPTION
# Description

Can close #156 in favor of this. On speaking with @evan-masseau realized that we we don't need to combine collecting tokens with request permission as when the app is launched we instruct users to register for push token and that should trigger calling setToken. setToken method will update the push enablement status and we should be good. 

Finally, I will cut a ticket for us so that we can refresh the enablement status on the SDK just as a safety measure.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
