### PR TITLE
Update contributing guidelines and templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers of this repository.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Welcome to Klaviyo SDK contributing guide
+
+Thank you for considering contributing to the Klaviyo SDK!
+
+In this guide you will get an overview of the contribution workflow from engaging in discussion to
+opening an issue, creating a PR, reviewing, and merging the PR.
+
+We welcome your contributions and strive to respond in a timely manner. In return, we ask that you do your
+**due diligence** to answer your own questions using public resources, and check for related issues (including
+closed ones) before posting. This helps keep the discussion focused on the most important topics. Issues deemed
+off-topic or out of scope for the SDK will be closed. Likewise, please keep comments on-topic and productive. If
+you have a different question, please open a new issue rather than commenting on an unrelated issue.
+
+Before contributing, please read the [code of conduct](./CODE_OF_CONDUCT.md). We want this community to be friendly
+and respectful to each other. Please follow it in all your interactions with the project.
+
+## Github Issues
+
+If you suspect a bug or have a feature request, please open an issue, following the guidelines below:
+
+- Research your issue using public resources such as Google, Stack Overflow, Apple documentation, etc.
+- Check if the issue has already been reported before.
+- Use a clear and descriptive title for the issue to identify the problem.
+- Include as much information as possible, including:
+  - The version of the SDK you are using.
+  - The version of iOS, Swift and XCode you are using.
+  - Any error messages you are seeing.
+  - The expected behavior and what went wrong.
+  - Detailed steps to reproduce the issue
+  - A code snippet or a minimal example that reproduces the issue.
+
+> Answer all questions in the issue template. It is designed to help you follow all the above guidelines.
+>
+> ⚠️ Incomplete issues will be de-prioritized or closed. ⚠️
+
+## New contributor guide
+
+To get an overview of the project, read the [README](README.md).
+Here are some additional resources to help you get started:
+
+- [Engage in Discussions](https://docs.github.com/en/discussions/collaborating-with-your-community-using-discussions/participating-in-a-discussion)
+- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
+- [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
+- [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+
+### Create a new issue
+
+If you spot a problem, or want to suggest a new feature, first
+[search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments).
+If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/klaviyo/klaviyo-swift-sdk/issues/new/choose).
+
+### Solve an issue
+
+If you want to recommend a code fix for an existing issue, you are welcome to open a PR with a fix.
+
+1. Fork the repository and clone to your machine, open in XCode
+2. Make your changes to the SDK. While we encourage test-driven development, we will not require
+   unit tests to submit a PR. That said, tests are an easy way to verify your changes as you go.
+   We have a very high coverage rate, so there are plenty of examples to follow.
+3. We also encourage you to test your changes against your own app or the sample app in this repository.
+4. Commit the changes once you are happy with them, please include a detailed commit message.
+
+### Pull Request
+
+When you're finished with the changes, create a pull request, also known as a PR.
+- Fill the template so that we can review your PR. This template helps reviewers
+  understand your changes and the purpose of your pull request.
+- Don't forget to [link the PR to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+  if you are solving one.
+- Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
+  so the branch can be updated for a merge. Once you submit your PR, a team member will review your
+  proposal. We may ask questions or request additional information.
+- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request)
+  or pull request comments.
+- As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
+- Alternatively, we may incorporate your suggestions into another feature branch and communicate
+  progress in the original issue or PR.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Welcome to Klaviyo SDK contributing guide
+# Welcome to Klaviyo Swift SDK contributing guide
 
-Thank you for considering contributing to the Klaviyo SDK!
+Thank you for considering contributing to the Klaviyo Swift SDK!
 
 In this guide you will get an overview of the contribution workflow from engaging in discussion to
 opening an issue, creating a PR, reviewing, and merging the PR.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,13 +7,25 @@ body:
     value: |
         Thank you for contributing to the Klaviyo Swift SDK!
 
-        Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
-        text area below with the relevant details for your bug.
+        Before you submit your issue, please read our [contributing guidelines](https://github.com/klaviyo/klaviyo-swift-sdk/blob/master/.github/CONTRIBUTING.md)
+        and answer each question with as much detail as you can.
 
-        Note: incomplete issues may be de-prioritized or closed.
+        > Note: incomplete issues may be de-prioritized or closed.
 
         We welcome your input! If you have any code suggestions regarding your issue, feel free to
         [submit a pull request](https://github.com/klaviyo/klaviyo-swift-sdk/pulls) after creating an issue.
+- type: checkboxes
+  attributes:
+    label: Checklist
+    options:
+    - label: I have read the [contributing guidelines](https://github.com/klaviyo/klaviyo-swift-sdk/blob/master/.github/CONTRIBUTING.md)
+      required: true
+    - label: I have determined whether this bug is also reproducible in a vanilla SwiftUI project.
+      required: false
+    - label: If possible, I've reproduced the issue using the `main` branch of this package.
+      required: false
+    - label: This issue hasn't been addressed in an [existing GitHub issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues) or [discussion](https://github.com/pointfreeco/klaviyo/klaviyo-swift-sdk/discussions).
+      required: true
 - type: textarea
   attributes:
     label: Description
@@ -24,16 +36,6 @@ body:
       If possible, include the last version that the behavior was correct in addition to your current version.
   validations:
     required: true
-- type: checkboxes
-  attributes:
-    label: Checklist
-    options:
-    - label: I have determined whether this bug is also reproducible in a vanilla SwiftUI project.
-      required: false
-    - label: If possible, I've reproduced the issue using the `main` branch of this package.
-      required: false
-    - label: This issue hasn't been addressed in an [existing GitHub issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues) or [discussion](https://github.com/pointfreeco/klaviyo/klaviyo-swift-sdk/discussions).
-      required: true
 - type: textarea
   attributes:
     label: Expected behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,16 +5,23 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thank you for contributing to the Klaviyo Swift SDK!
+        Thank you for contributing to the Klaviyo Android SDK!
 
-      Before you submit your issue, please complete each text area below with the relevant details for your bug, and complete the steps in the checklist
+        Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
+        text area below with the relevant details for your bug.
+
+        Note: incomplete issues may be de-prioritized or closed.
+
+        We welcome your input! If you have any code suggestions regarding your issue, feel free to
+        [submit a pull request](https://github.com/klaviyo/klaviyo-swift-sdk/pulls) after creating an issue.
 - type: textarea
   attributes:
     label: Description
     description: |
       A short description of the incorrect behavior.
 
-      If you think this issue has been recently introduced and did not occur in an earlier version, please note that. If possible, include the last version that the behavior was correct in addition to your current version.
+      If you think this issue has been recently introduced and did not occur in an earlier version, please note that.
+      If possible, include the last version that the behavior was correct in addition to your current version.
   validations:
     required: true
 - type: checkboxes
@@ -32,13 +39,13 @@ body:
     label: Expected behavior
     description: Describe what you expected to happen.
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Actual behavior
     description: Describe or copy/paste the behavior you observe.
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Steps to reproduce
@@ -49,22 +56,28 @@ body:
     placeholder: |
       1. ...
   validations:
-    required: false
+    required: true
 - type: input
   attributes:
     label: The Klaviyo Swift SDK version information
     description: The version of the Klaviyo Swift SDK used to reproduce this issue.
     placeholder: "'1.7.2' for example, or a commit hash"
+  validations:
+    required: true
 - type: input
   attributes:
     label: Destination operating system
     description: The OS running your application.
     placeholder: "'iOS 15' for example"
+  validations:
+    required: true
 - type: input
   attributes:
     label: Xcode version information
     description: The version of Xcode used to reproduce this issue.
     placeholder: "The version displayed from 'Xcode 〉About Xcode'"
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Swift Compiler version information

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
 - type: markdown
   attributes:
     value: |
-        Thank you for contributing to the Klaviyo Android SDK!
+        Thank you for contributing to the Klaviyo Swift SDK!
 
         Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
         text area below with the relevant details for your bug.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,13 +7,21 @@ body:
       value: |
         Thank you for contributing to the Klaviyo Swift SDK!
 
-        Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
-        text area below with the relevant details for your bug.
+        Before you submit your issue, please read our [contributing guidelines](https://github.com/klaviyo/klaviyo-swift-sdk/blob/master/.github/CONTRIBUTING.md)
+        and answer each question with as much detail as you can.
 
-        Note: incomplete issues may be de-prioritized or closed.
+        > Note: incomplete issues may be de-prioritized or closed.
 
         We welcome your input! If you have any code suggestions regarding your issue, feel free to
         [submit a pull request](https://github.com/klaviyo/klaviyo-swift-sdk/pulls) after creating an issue.
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+      - label: I have read the [contributing guidelines](https://github.com/klaviyo/klaviyo-swift-sdk/blob/master/.github/CONTRIBUTING.md)
+        required: true
+      - label: This issue hasn't been addressed in an [existing issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues) or [pull request](https://github.com/klaviyo/klaviyo-swift-sdk/pulls)
+        required: true
   - type: textarea
     attributes:
       label: Description

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to the Klaviyo SDK!
+
+        Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
+        text area below with the relevant details for your bug.
+
+        Note: incomplete issues may be de-prioritized or closed.
+
+        We welcome your input! If you have any code suggestions regarding your issue, feel free to
+        [submit a pull request](https://github.com/klaviyo/klaviyo-swift-sdk/pulls) after creating an issue.
+  - type: textarea
+    attributes:
+      label: Description
+      render: markdown
+      description: |
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      render: markdown
+      description: |
+        A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives Considered
+      render: markdown
+      description: |
+        A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional Context
+      render: markdown
+      description: |
+        Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for contributing to the Klaviyo SDK!
+        Thank you for contributing to the Klaviyo Swift SDK!
 
         Before you submit your issue, please read our [contributing guidelines](./CONTRIBUTING.md) and complete each
         text area below with the relevant details for your bug.

--- a/README.md
+++ b/README.md
@@ -511,5 +511,9 @@ All data sent by the SDK should be available shortly after it is flushed by the 
 The SDK will retry API requests that fail under certain conditions. For example, if a network timeout occurs, the request will be retried on the next flush interval.
 In addition, if the SDK receives a rate limiting error `429` from the Klaviyo API, it will use exponential backoff with jitter to retry the next request.
 
+## Contributing
+See the [contributing guide](.github/CONTRIBUTING.md) to learn how to contribute to the Klaviyo Swift SDK.
+We welcome your feedback in the [issues](https://github.com/klaviyo/klaviyo-android-sdk/issues) section of our public GitHub repository.
+
 ### License
 KlaviyoSwift is available under the MIT license. See the LICENSE file for more info.

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ In addition, if the SDK receives a rate limiting error `429` from the Klaviyo AP
 
 ## Contributing
 See the [contributing guide](.github/CONTRIBUTING.md) to learn how to contribute to the Klaviyo Swift SDK.
-We welcome your feedback in the [issues](https://github.com/klaviyo/klaviyo-android-sdk/issues) section of our public GitHub repository.
+We welcome your feedback in the [issues](https://github.com/klaviyo/klaviyo-swift-sdk/issues) section of our public GitHub repository.
 
 ### License
 KlaviyoSwift is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
# Description
Documentation updates to sync up contribution guidelines with the other repos.

- Added code of conduct and contributing doc with guidelines about opening issues, and firm language about expectations.
- Linked to contributing guides in the issue templates, made important questions required, added feature template
- [x] Close all discussion topics except Announcements (now directing people to issues)
- [x] Create labels for missing-details or off-topic issues

## Related Issues/Tickets
<!-- Link to relevant issues or discussion -->
CHNL-5893