### PR TITLE
CHNL-6305:  Fix set profile properties method

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -217,7 +217,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 state.pendingRequests.append(.pushToken(pushToken, enablement))
                 return .none
             }
-            guard state.shouldSendTokenUpdate(newToken: pushToken, enablement: enablement) else {
+            if !state.shouldSendTokenUpdate(newToken: pushToken, enablement: enablement) {
                 return .none
             }
 
@@ -464,129 +464,6 @@ extension Store where State == KlaviyoState, Action == KlaviyoAction {
     static let production = Store(
         initialState: KlaviyoState(queue: [], requestsInFlight: []),
         reducer: KlaviyoReducer())
-}
-
-extension KlaviyoState {
-    func checkPreconditions() {}
-
-    func buildProfileRequest(apiKey: String, anonymousId: String, properties: [String: Any] = [:]) -> KlaviyoAPI.KlaviyoRequest {
-        let payload = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateProfilePayload(
-            data: .init(
-                profile: Profile(
-                    email: email,
-                    phoneNumber: phoneNumber,
-                    externalId: externalId,
-                    properties: properties),
-                anonymousId: anonymousId)
-        )
-        let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.createProfile(payload)
-
-        return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
-    }
-
-    mutating func buildTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoAPI.KlaviyoRequest {
-        print("in token update", pendingProfile)
-        guard let pendingProfile = pendingProfile else {
-            let payload = PushTokenPayload(
-                pushToken: pushToken,
-                enablement: enablement.rawValue,
-                background: environment.getBackgroundSetting().rawValue,
-                profile: Profile(email: email, phoneNumber: phoneNumber, externalId: externalId),
-                anonymousId: anonymousId)
-            let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.registerPushToken(payload)
-            return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
-        }
-
-        var firstName: String?
-        var lastName: String?
-        var address1: String?
-        var address2: String?
-        var title: String?
-        var organization: String?
-        var city: String?
-        var region: String?
-        var country: String?
-        var zip: String?
-        var image: String?
-        var latitude: Double?
-        var longitude: Double?
-        var customProperties: [String: Any] = [:]
-
-        for (key, value) in pendingProfile {
-            switch key {
-            case .firstName:
-                firstName = value.value as? String
-            case .lastName:
-                lastName = value.value as? String
-            case .address1:
-                address1 = value.value as? String
-            case .address2:
-                address2 = value.value as? String
-            case .title:
-                title = value.value as? String
-            case .organization:
-                organization = value.value as? String
-            case .city:
-                city = value.value as? String
-            case .region:
-                region = value.value as? String
-            case .country:
-                country = value.value as? String
-            case .zip:
-                zip = value.value as? String
-            case .image:
-                image = value.value as? String
-            case .latitude:
-                latitude = value.value as? Double
-            case .longitude:
-                longitude = value.value as? Double
-            case let .custom(customKey: customKey):
-                customProperties[customKey] = value.value
-            }
-        }
-
-        let location = Profile.Location(
-            address1: address1,
-            address2: address2,
-            city: city,
-            country: country,
-            latitude: latitude,
-            longitude: longitude,
-            region: region,
-            zip: zip)
-
-        let profile = Profile(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
-            firstName: firstName,
-            lastName: lastName,
-            organization: organization,
-            title: title,
-            image: image,
-            location: location,
-            properties: customProperties)
-
-        self.pendingProfile = nil
-
-        let payload = PushTokenPayload(
-            pushToken: pushToken,
-            enablement: enablement.rawValue,
-            background: environment.getBackgroundSetting().rawValue,
-            profile: profile,
-            anonymousId: anonymousId)
-        let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.registerPushToken(payload)
-        return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
-    }
-
-    func buildUnregisterRequest(apiKey: String, anonymousId: String, pushToken: String) -> KlaviyoAPI.KlaviyoRequest {
-        let payload = UnregisterPushTokenPayload(
-            pushToken: pushToken,
-            profile: .init(email: email, phoneNumber: phoneNumber, externalId: externalId),
-            anonymousId: anonymousId)
-        let endpoint = KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.unregisterPushToken(payload)
-        return KlaviyoAPI.KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
-    }
 }
 
 extension Event {


### PR DESCRIPTION
# Description

* Fixed set profile attributes not being set when a token request is made. Token request is made whenever set token is called.
* Edge case: Token request was being made repeatedly since the pending profile was never set to nil. Fixed this as well. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. Set profile with most properties and then set profile properties and profile properties override the earlier stuff set with the profile.
2. Setting profile properties first and then set profile should override the previously set profile properties. 
3. Tested w/o setting token and making sure profile request was successful.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
