### PR TITLE
Trimming white spaces in identifiers

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -506,7 +506,7 @@ extension Profile {
 
 extension String {
     fileprivate func isNotEmptyOrSame(as state: String?, identifier: String) -> Bool {
-        let incoming = self
+        let incoming = trimmingCharacters(in: .whitespacesAndNewlines)
         if incoming.isEmpty || incoming == state {
             logDevWarning(for: identifier)
         }

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -158,6 +158,13 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.setEmail(""))
     }
 
+    func testSetEmailWithWhiteSpace() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.setEmail("        "))
+    }
+
     // MARK: - Set External Id
 
     @MainActor
@@ -196,6 +203,13 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.setExternalId(""))
     }
 
+    func testSetExternalIdWithWhiteSpaces() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.setExternalId(""))
+    }
+
     // MARK: - Set Phone number
 
     @MainActor
@@ -227,6 +241,13 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     func testSetEmptyPhoneNumber() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.setPhoneNumber(""))
+    }
+
+    func testSetPhoneNumberWithWhiteSpaces() async throws {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 


### PR DESCRIPTION
# Description

When testing noticed that if you added white space we would still be making a call to our APIs with that white space and then fail with a 400. Trimming white space now before comparing the identifiers to see if they are empty or same as what the SDK holds in state. If it's same we avoid the API call and the subsequent failure. Note that there is an exception to this, when setting a profile we will still make the network call but it won't fail since the identifier will not be included. This is because there is no dedup check for set profile calls.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
