### PR TITLE
Fixed retry after logic to fire at retry after intervals

### DIFF
--- a/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/APIRequestErrorHandling.swift
@@ -102,7 +102,9 @@ func handleRequestError(
     case let .rateLimitError(retryAfter):
         var requestRetryCount = 0
         var totalRetryCount = 0
-        var nextBackoff = 0
+        let exponentialBackOff = Int(pow(2.0, Double(totalRetryCount)))
+
+        let nextBackoff = addJitter(to: retryAfter ?? exponentialBackOff)
         switch retryInfo {
         case let .retry(count):
             requestRetryCount = count + 1
@@ -111,9 +113,6 @@ func handleRequestError(
         case let .retryWithBackoff(requestCount, totalCount, _):
             requestRetryCount = requestCount + 1
             totalRetryCount = totalCount + 1
-            let exponentialBackOff = Int(pow(2.0, Double(totalRetryCount)))
-
-            nextBackoff = addJitter(to: retryAfter ?? exponentialBackOff)
         }
         return .requestFailed(
             request, .retryWithBackoff(

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -270,11 +270,11 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 0)), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 1)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
-            $0.retryInfo = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 0)
+            $0.retryInfo = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 1)
         }
     }
 
@@ -290,11 +290,11 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8)), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 1)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
-            $0.retryInfo = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 8)
+            $0.retryInfo = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 1)
         }
     }
 


### PR DESCRIPTION
# Description

The existing logic in master was still causing retries to happen every 10secs on wifi since the backoff was not being set for the switch case of just `retry`. This is the case that is set in the `flushQueue` action once the back off interval is exhaused and a call is made. 

Additionally, in the first 429, the `retry` is the default value set to `state.retryInfo` and not having the backoff set in `handleRequestError.rateLimitError` was causing the network request to fire every 10sec on wifi.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
