### PR TITLE
Adding privacy manifest to KlaviyoSwift and KlaviyoSwiftExtension 

### DIFF
--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
+  s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
   s.dependency     'AnyCodable-FlightSchool'
 end

--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwiftExtension/**/*.swift'
+  s.resource_bundles = {"KlaviyoSwiftExtension" => ["Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy"]}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
         .target(
             name: "KlaviyoSwiftExtension",
             dependencies: [],
-            path: "Sources/KlaviyoSwiftExtension"),
+            path: "Sources/KlaviyoSwiftExtension",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "KlaviyoSwiftTests",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         .target(
             name: "KlaviyoSwift",
             dependencies: [.product(name: "AnyCodable", package: "AnyCodable")],
-            path: "Sources/KlaviyoSwift"),
+            path: "Sources/KlaviyoSwift",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
         .target(
             name: "KlaviyoSwiftExtension",
             dependencies: [],

--- a/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
@@ -2,15 +2,58 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-            <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-                <string>CA92.1</string>
-            </array>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
 		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>

--- a/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
@@ -14,6 +14,8 @@
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
 			</array>
 		</dict>
 		<dict>
@@ -27,7 +29,7 @@
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeDeveloperAdvertising</string>
 			</array>
 		</dict>
 		<dict>
@@ -39,9 +41,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 	</array>

--- a/Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
# Description

Apple requires SDK to add a privacy manifest listing, 
1. If the SDK does tracking.
2. If it does tracking, what domains does it use for that purpose
3. What required reason APIs does the SDK use 
4. What data points does the SDK collect. 

The privacy manifest we added here is a least common denominator of what the SDK does, if developers are doing anything in addition to this in their specific apps like gathering emails/phone numbers they need to listed in your applications privacy manifest.

Some material from Apple about this -
 
[Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc)
[Describing data use in privacy manifests](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests#4250555) 
[WWDC 23 session on this topic](https://developer.apple.com/videos/play/wwdc2023/10060/)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Tested this using our test app and this is how the report looks like - 

<img width="1640" alt="image" src="https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/fe6cde45-a154-4867-88ea-037b0540ecc1">

# Supporting Materials

Developers can do the same when releasing their apps using archive - 

![image](https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/4060b62d-9f54-4470-b300-9a811e1d0b6d)

