### PR TITLE
Removed privacy policy for klaviyo swift extension

### DIFF
--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwiftExtension/**/*.swift'
-  s.resource_bundles = {"KlaviyoSwiftExtension" => ["Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy"]}
 end

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,7 @@ let package = Package(
         .target(
             name: "KlaviyoSwiftExtension",
             dependencies: [],
-            path: "Sources/KlaviyoSwiftExtension",
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            path: "Sources/KlaviyoSwiftExtension"),
         .testTarget(
             name: "KlaviyoSwiftTests",
             dependencies: [

--- a/Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwiftExtension/PrivacyInfo.xcprivacy
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
-</dict>
-</plist>


### PR DESCRIPTION
# Description

When testing noticed that there was an error reported when I generated the privacy report. This was because we included a privacy report for the extension but it doesn't need based on apple docs, 

![image](https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/21b429d7-128a-42b5-8108-f7c9e6d82646)

Mainly the section about, 

Otherwise, include a privacy manifest file in your third-party SDK _if_ it uses required reasons API, collects data about the person using apps that include the third-party SDK, enables the app to collect data about people using the app, or contacts tracking domains.

Since the extension doesn't do any of these we don't need to include. I initially had included it just to be safe and say that we don't track using this SDK but if you include it expects you to list the required items which made me revisit this. 

The report w/ the error on the top and one w/o at the bottom.

<img width="1676" alt="image" src="https://github.com/klaviyo/klaviyo-swift-sdk/assets/118314354/24e39568-90a4-4a9e-87e5-39f5f757405d">


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
