### PR TITLE
Allowing opened push event to be transmitted when SDK is not initialized 

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -92,11 +92,11 @@ enum KlaviyoAction: Equatable {
 
     var requiresInitialization: Bool {
         switch self {
-        case let .enqueueEvent(event):
-            // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
-            return event.metric.name != .OpenedPush
+        // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
+        case let .enqueueEvent(event) where event.metric.name == .OpenedPush:
+            return false
 
-        case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue:
+        case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue, .enqueueEvent:
             return true
 
         case .initialize, .completeInitialization, .deQueueCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed:

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -92,7 +92,11 @@ enum KlaviyoAction: Equatable {
 
     var requiresInitialization: Bool {
         switch self {
-        case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueEvent, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue:
+        case let .enqueueEvent(event):
+            // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
+            return event.metric.name == .OpenedPush ? false : true
+
+        case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue:
             return true
 
         case .initialize, .completeInitialization, .deQueueCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed:
@@ -112,6 +116,7 @@ struct KlaviyoReducer: ReducerProtocol {
         if action.requiresInitialization,
            case .uninitialized = state.initalizationState {
             environment.emitDeveloperWarning("SDK must be initialized before usage.")
+            return .none
         }
 
         switch action {

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -112,7 +112,6 @@ struct KlaviyoReducer: ReducerProtocol {
         if action.requiresInitialization,
            case .uninitialized = state.initalizationState {
             environment.emitDeveloperWarning("SDK must be initialized before usage.")
-            return .none
         }
 
         switch action {

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -94,7 +94,7 @@ enum KlaviyoAction: Equatable {
         switch self {
         case let .enqueueEvent(event):
             // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
-            return event.metric.name == .OpenedPush ? false : true
+            return event.metric.name != .OpenedPush
 
         case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue:
             return true

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -131,7 +131,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setEmail("test@blob.com"))
+        _ = await store.send(.setEmail("test@blob.com")) {
+            $0.pendingRequests = [.setEmail("test@blob.com")]
+        }
 
         await fulfillment(of: [expection])
     }
@@ -178,7 +180,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setExternalId("external-blob-id"))
+        _ = await store.send(.setExternalId("external-blob-id")) {
+            $0.pendingRequests = [.setExternalId("external-blob-id")]
+        }
     }
 
     @MainActor
@@ -223,7 +227,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPhoneNumber("1-800-Blobs4u"))
+        _ = await store.send(.setPhoneNumber("1-800-Blobs4u")) {
+            $0.pendingRequests = [.setPhoneNumber("1-800-Blobs4u")]
+        }
     }
 
     @MainActor
@@ -267,7 +273,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token", .authorized))
+        _ = await store.send(.setPushToken("blob_token", .authorized)) {
+            $0.pendingRequests = [.pushToken("blob_token", .authorized)]
+        }
     }
 
     @MainActor
@@ -377,7 +385,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
         }
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
         let event = Event(name: .OpenedPush)
-        _ = await store.send(.enqueueEvent(event))
+        _ = await store.send(.enqueueEvent(event)) {
+            $0.pendingRequests = [.event(event)]
+        }
         await fulfillment(of: [expection])
     }
 
@@ -392,7 +402,9 @@ class StateManagementEdgeCaseTests: XCTestCase {
         }
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
         let profile = Profile(email: "foo")
-        _ = await store.send(.enqueueProfile(profile))
+        _ = await store.send(.enqueueProfile(profile)) {
+            $0.pendingRequests = [.profile(profile)]
+        }
         await fulfillment(of: [expection])
     }
 

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -131,9 +131,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setEmail("test@blob.com")) {
-            $0.pendingRequests = [.setEmail("test@blob.com")]
-        }
+        _ = await store.send(.setEmail("test@blob.com"))
 
         await fulfillment(of: [expection])
     }
@@ -180,9 +178,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setExternalId("external-blob-id")) {
-            $0.pendingRequests = [.setExternalId("external-blob-id")]
-        }
+        _ = await store.send(.setExternalId("external-blob-id"))
     }
 
     @MainActor
@@ -227,9 +223,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPhoneNumber("1-800-Blobs4u")) {
-            $0.pendingRequests = [.setPhoneNumber("1-800-Blobs4u")]
-        }
+        _ = await store.send(.setPhoneNumber("1-800-Blobs4u"))
     }
 
     @MainActor
@@ -273,9 +267,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPushToken("blob_token", .authorized)) {
-            $0.pendingRequests = [.pushToken("blob_token", .authorized)]
-        }
+        _ = await store.send(.setPushToken("blob_token", .authorized))
     }
 
     @MainActor
@@ -378,17 +370,11 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
     @MainActor
     func testEnqueueEventUninitialized() async throws {
-        let expection = XCTestExpectation(description: "fatal error expected")
-        environment.emitDeveloperWarning = { _ in
-            // Would really runTimeWarn - not happening because we can't do that in tests so we fake it.
-            expection.fulfill()
-        }
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
         let event = Event(name: .OpenedPush)
         _ = await store.send(.enqueueEvent(event)) {
             $0.pendingRequests = [.event(event)]
         }
-        await fulfillment(of: [expection])
     }
 
     // MARK: - set profile uninitialized
@@ -402,9 +388,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
         }
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
         let profile = Profile(email: "foo")
-        _ = await store.send(.enqueueProfile(profile)) {
-            $0.pendingRequests = [.profile(profile)]
-        }
+        _ = await store.send(.enqueueProfile(profile))
         await fulfillment(of: [expection])
     }
 


### PR DESCRIPTION
# Description

## Background

The SDK can be in three states of initialization -
* Initialized - The SDK is initialized and any requests it gets is queued immediately and flushed at certain intervals.
* Initializing - The SDK is initializing (reading from disk etc) and any requests that the SDK gets is held in memory and enqueued once the SDK is fully initialized. 
* un-initialized - The SDK will ignore the request and log a warning message to the developer (which they probably won't see if the app is terminated when testing locally).

The issue with react native is that by the time react native is booted from the native code the opened event request has already hit our SDK and the SDK is in the un-initialized state so the request is simply ignored. This logic has been in place since Dec 2023 on iOS and is part of requirement at that point and also now that developers should always initialize the SDK before interacting with it. When we implemented initialize in react native we didn't test this edge case.

While we still want our devs to initialize the SDK before calling any of it's methods. As long as they stick to interfacing with the SDK on just one of the layers (native or RN) they shouldn't encounter any issues. There is an exception to this with calling the SDK when a user opens push and this has to happen on the native side because of the application delegation pattern on iOS.

We want to keep the SDK simple in terms of logic and not queue up things which we don't know which company it belong to. For instance,  if we allow devs to set profile and then initialize there is a chance that the profile wasn't intended to be associated with the company that was set later. In short, it keeps us from making too many assumptions on the SDK.

Finally, since we are the ones queueing up the opened push event when the devs calls our SDK to handle a push opened action from the user, it seems reasonable make an exception just in this case since we know for react native it is possible that the SDK may not be initialized in time to handle sending opened push event.

## Solution 

When the SDK is un-initialized and receives an opened push event, keep it in state until the SDK is initialized and then queue it up. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. Test all SDK interactions w/o initializing it locally: This should not enqueue any request other than opened push event ✅
2. Test all SDK interactions after initializing and make sure this change didn't impact any existing use cases ✅
