### PR TITLE
Flush requests queue on opened push event

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -400,7 +400,13 @@ struct KlaviyoReducer: ReducerProtocol {
                                                 endpoint: .createEvent(
                                                     .init(data: .init(event: event, anonymousId: anonymousId))
                                                 )))
-            return .none
+
+            /*
+             if we receive an opened push event we want to flush the queue right away so that
+             we don't miss any user engagement events. In all other cases we will flush the queue
+             using the flush intervals defined above in `StateManagementConstants`
+             */
+            return event.metric.name == .OpenedPush ? .task { .flushQueue } : .none
 
         case let .enqueueProfile(profile):
             guard case .initialized = state.initalizationState


### PR DESCRIPTION
# Description
In order to keep engagement metric as up to date as possible we want to try and flush the queue whenever an opened push event request is enqueued. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Unit tests but also using a proxy - 
1. Increased the flush interval to something very high (100 secs)
2. Enqueued various events and confirmed they didn't flush 
3. Enqueued a opened push event and noticed in the proxy that they all flushed.
