### PR TITLE
Lowercasing tokens on SDK 

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/KlaviyoState.swift
@@ -40,6 +40,13 @@ struct KlaviyoState: Equatable, Codable {
             case pushBackground
             case deviceData
         }
+
+        static func ==(lhs: PushTokenData, rhs: PushTokenData) -> Bool {
+            lhs.pushToken.lowercased() == rhs.pushToken.lowercased() &&
+                lhs.pushEnablement == rhs.pushEnablement &&
+                lhs.pushBackground == rhs.pushBackground &&
+                lhs.deviceData == rhs.deviceData
+        }
     }
 
     enum PushEnablement: String, Codable {

--- a/Sources/KlaviyoSwift/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement.swift
@@ -226,7 +226,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            let request = state.buildTokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement)
+            let request = state.buildTokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken.lowercased(), enablement: enablement)
             state.enqueueRequest(request: request)
             return .none
 
@@ -290,7 +290,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 let enablement = KlaviyoState.PushEnablement(rawValue: requestData.enablementStatus) ?? .authorized
                 let backgroundStatus = KlaviyoState.PushBackground(rawValue: requestData.backgroundStatus) ?? .available
                 state.pushTokenData = KlaviyoState.PushTokenData(
-                    pushToken: requestData.token,
+                    pushToken: requestData.token.lowercased(),
                     pushEnablement: enablement,
                     pushBackground: backgroundStatus,
                     deviceData: requestData.deviceMetadata)

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -186,4 +186,22 @@ final class KlaviyoStateTests: XCTestCase {
         // Fake value to test availability
         XCTAssertEqual(KlaviyoState.PushEnablement.create(from: UNAuthorizationStatus(rawValue: 50)!), .notDetermined)
     }
+
+    func testPushTokenDataEquatableIgnoresCaseForPushToken() {
+        let pushTokenData = ["abcd", "ABCD"].map { tokens in
+            KlaviyoState.PushTokenData(pushToken: tokens, pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.analytics.appContextInfo()))
+        }
+
+        XCTAssertEqual(pushTokenData.first!, pushTokenData.last!)
+    }
+
+    func testPushTokenDataEquatableWithDifferentEnablement() {
+        let pushTokenData = [
+            ("abcd", KlaviyoState.PushEnablement.authorized),
+            ("ABCD", KlaviyoState.PushEnablement.denied)
+        ].map { tuple in
+            KlaviyoState.PushTokenData(pushToken: tuple.0, pushEnablement: tuple.1, pushBackground: .available, deviceData: .init(context: environment.analytics.appContextInfo()))
+        }
+        XCTAssertNotEqual(pushTokenData.first!, pushTokenData.last!)
+    }
 }


### PR DESCRIPTION
# Description

React native when using firebase sets uppercase tokens which is causing unnecessary calls to our backend. This fix only calls our backend if the token data is different (case insensitive push token string comparison)

Downside of this change is if apple decides to make APNs tokens case sensitive we'd be left with a lot of app sending us lower case tokens which we potentially won't be able to send to. Keeping this in draft until we discuss this internally.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
