### PR TITLE
retry on 503

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -68,7 +68,7 @@ struct KlaviyoAPI {
             return .failure(.missingOrInvalidResponse(response))
         }
 
-        if httpResponse.statusCode == 429 {
+        if [429, 503].contains(httpResponse.statusCode) {
             let retryAfter = Int(httpResponse.value(forHTTPHeaderField: "Retry-After") ?? "0")
             requestRateLimited(request, retryAfter)
             return .failure(KlaviyoAPIError.rateLimitError(retryAfter))

--- a/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAPITests.swift
@@ -77,6 +77,38 @@ final class KlaviyoAPITests: XCTestCase {
         }
     }
 
+    func testRetryableStatusCode() async throws {
+        environment.analytics.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), .retryableResponse)
+        }) }
+        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .createProfile(.init(data: .init(profile: .init(), anonymousId: "foo"))))
+        await sendAndAssert(with: request) { result in
+
+            switch result {
+            case let .failure(error):
+                assertSnapshot(matching: error, as: .dump)
+            default:
+                XCTFail("Expected failure here.")
+            }
+        }
+    }
+
+    func testRetryable503StatusCode() async throws {
+        environment.analytics.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), .retryable503Response)
+        }) }
+        let request = KlaviyoAPI.KlaviyoRequest(apiKey: "foo", endpoint: .createProfile(.init(data: .init(profile: .init(), anonymousId: "foo"))))
+        await sendAndAssert(with: request) { result in
+
+            switch result {
+            case let .failure(error):
+                assertSnapshot(matching: error, as: .dump)
+            default:
+                XCTFail("Expected failure here.")
+            }
+        }
+    }
+
     func testSuccessfulResponseWithProfile() async throws {
         environment.analytics.networkSession = { NetworkSession.test(data: { request in
             assertSnapshot(matching: request, as: .dump)

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -127,6 +127,8 @@ extension KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.CreateEventPayload {
 extension URLResponse {
     static let non200Response = HTTPURLResponse(url: TEST_URL, statusCode: 500, httpVersion: nil, headerFields: nil)!
     static let validResponse = HTTPURLResponse(url: TEST_URL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    static let retryableResponse = HTTPURLResponse(url: TEST_URL, statusCode: 429, httpVersion: nil, headerFields: nil)!
+    static let retryable503Response = HTTPURLResponse(url: TEST_URL, statusCode: 503, httpVersion: nil, headerFields: nil)!
 }
 
 extension KlaviyoAPI.KlaviyoRequest.KlaviyoEndpoint.PushTokenPayload {

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testRetryable503StatusCode.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testRetryable503StatusCode.1.txt
@@ -1,0 +1,3 @@
+▿ KlaviyoAPIError
+  ▿ rateLimitError: Optional<Int>
+    - some: 0

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testRetryableStatusCode.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoAPITests/testRetryableStatusCode.1.txt
@@ -1,0 +1,3 @@
+▿ KlaviyoAPIError
+  ▿ rateLimitError: Optional<Int>
+    - some: 0


### PR DESCRIPTION
# Description

In cases where 503 is returned by the api we are allowed to retry the request. This adds the 503 status to the list of retryables. It also adds some missing test coverage for retryable stuff.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
