### PR TITLE
[CHNL-9369] iOS test app fix attempt count

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoAPI.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAPI.swift
@@ -34,7 +34,7 @@ struct KlaviyoAPI {
 
     // For internal testing use only
     static var requestHandler: (KlaviyoRequest, URLRequest?, RequestStatus) -> Void = { _, _, _ in }
-    
+
     var send: (KlaviyoRequest, Int) async -> Result<Data, KlaviyoAPIError> = { request, attemptNumber in
         let start = Date()
 

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -129,6 +129,23 @@ public struct SDKRequest: Identifiable, Equatable {
 }
 
 @_spi(KlaviyoPrivate)
+public enum RequestStatus {
+    public enum RequestError: Error {
+        case requestFailed(Error)
+        /// The server responded with a 429 HTTP status code, indicating that the client is being rate-limited.
+        /// - Parameter retryAfter: The amount of time, in seconds, that the client should wait before making another request.
+        case rateLimited(retryAfter: Int)
+        /// - Parameter duration: The elapsed time, in seconds, between the API call and the server’s response.
+        case httpError(statusCode: Int, duration: TimeInterval)
+    }
+    
+    case started
+    /// - Parameter duration: The elapsed time, in seconds, between the API call and the server’s response.
+    case completed(data: Data, duration: TimeInterval)
+    case error(RequestError)
+}
+
+@_spi(KlaviyoPrivate)
 public func requestIterator() -> AsyncStream<SDKRequest> {
     AsyncStream<SDKRequest> { continuation in
         continuation.onTermination = { _ in

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -149,10 +149,10 @@ public enum RequestStatus {
 public func requestIterator() -> AsyncStream<SDKRequest> {
     AsyncStream<SDKRequest> { continuation in
         continuation.onTermination = { _ in
-            KlaviyoAPI.requestCompletion = { _, _, _ in }
+            KlaviyoAPI.requestHandler = { _, _, _ in }
         }
         
-        KlaviyoAPI.requestCompletion = { request, urlRequest, result in
+        KlaviyoAPI.requestHandler = { request, urlRequest, result in
             switch result {
             case .started:
                 continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .inProgress))

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -83,7 +83,7 @@ public struct SDKRequest: Identifiable, Equatable {
         case inProgress
         case success(String, Double)
         case httpError(Int, Double)
-        case reqeustError(String, Double)
+        case requestError(String, Double)
     }
 
     static func fromAPIRequest(request: KlaviyoAPI.KlaviyoRequest, urlRequest: URLRequest?, response: SDKRequest.Response) -> SDKRequest {
@@ -163,11 +163,11 @@ public func requestIterator() -> AsyncStream<SDKRequest> {
                 switch error {
                 case .requestFailed(let requestError):
                     let duration = 0.0
-                    continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .reqeustError(requestError.localizedDescription, duration)))
+                    continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .requestError(requestError.localizedDescription, duration)))
                 case .httpError(let statusCode, duration: let duration):
                     continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .httpError(statusCode, duration)))
                 case .rateLimited(let retryAfter):
-                    continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .reqeustError("Rate Limited", Double(retryAfter))))
+                    continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .requestError("Rate Limited", Double(retryAfter))))
                 }
             }
         }

--- a/Sources/KlaviyoSwift/SDKRequestIterator.swift
+++ b/Sources/KlaviyoSwift/SDKRequestIterator.swift
@@ -138,7 +138,7 @@ public enum RequestStatus {
         /// - Parameter duration: The elapsed time, in seconds, between the API call and the server’s response.
         case httpError(statusCode: Int, duration: TimeInterval)
     }
-    
+
     case started
     /// - Parameter duration: The elapsed time, in seconds, between the API call and the server’s response.
     case completed(data: Data, duration: TimeInterval)
@@ -151,22 +151,22 @@ public func requestIterator() -> AsyncStream<SDKRequest> {
         continuation.onTermination = { _ in
             KlaviyoAPI.requestHandler = { _, _, _ in }
         }
-        
+
         KlaviyoAPI.requestHandler = { request, urlRequest, result in
             switch result {
             case .started:
                 continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .inProgress))
-            case .completed(let data, let duration):
+            case let .completed(data, duration):
                 let dataDescription = String(data: data, encoding: .utf8) ?? "Invalid Data"
                 continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .success(dataDescription, duration)))
-            case .error(let error):
+            case let .error(error):
                 switch error {
-                case .requestFailed(let requestError):
+                case let .requestFailed(requestError):
                     let duration = 0.0
                     continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .requestError(requestError.localizedDescription, duration)))
-                case .httpError(let statusCode, duration: let duration):
+                case let .httpError(statusCode, duration: duration):
                     continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .httpError(statusCode, duration)))
-                case .rateLimited(let retryAfter):
+                case let .rateLimited(retryAfter):
                     continuation.yield(SDKRequest.fromAPIRequest(request: request, urlRequest: urlRequest, response: .requestError("Rate Limited", Double(retryAfter))))
                 }
             }


### PR DESCRIPTION
# Description

This PR addresses [CHNL-9369](https://klaviyo.atlassian.net/browse/CHNL-9369). It fixes an issue where the test app wasn't correctly displaying the attempt count when making an API call.

In addition to fixing the attempt count, I made a small refactor by condensing the various request closures into one, and adding a new enum to switch over the various request outcomes.

# Check List

- [x] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I simulated the various API failures by using a network link conditioner and via temporary code changes to validate that the attempt count is getting incremented successfully.


# Supporting Materials

This GIF demonstrates that the attempt count is correctly getting incremented. To capture it, I simulated an API failure by setting a "100% loss" network condition.

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-20 at 10 57 11](https://github.com/user-attachments/assets/f2912964-1149-4363-9614-7abf6eaeb34b)

[CHNL-9369]: https://klaviyo.atlassian.net/browse/CHNL-9369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ