### PR TITLE
[CHNL-5395] (partial) refactored environment.getNotificationSettings

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -142,10 +142,9 @@ public struct KlaviyoSDK {
     /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
     /// - Parameter pushToken: String formatted push token.
     public func set(pushToken: String) {
-        environment.getNotificationSettings { enablement in
-            dispatchOnMainThread(action: .setPushToken(
-                pushToken,
-                enablement))
+        Task {
+            let enablement = await environment.getNotificationSettings()
+            dispatchOnMainThread(action: .setPushToken(pushToken, enablement))
         }
     }
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -82,7 +82,7 @@ extension KlaviyoEnvironment {
         getUserDefaultString: { _ in "value" },
         appLifeCycle: AppLifeCycleEvents.test,
         notificationCenterPublisher: { _ in Empty<Notification, Never>().eraseToAnyPublisher() },
-        getNotificationSettings: { callback in callback(.authorized) },
+        getNotificationSettings: { .authorized },
         getBackgroundSetting: { .available },
         legacyIdentifier: { "iOS:\(UUID(uuidString: "00000000-0000-0000-0000-000000000002")!.uuidString)" },
         startReachability: {},


### PR DESCRIPTION
# Description

This PR refactors `environment.getNotificationSettings` to use async/await make the code more readable.

These changes are a self-contained refactor that's not directly related to the AC on 5395, I figured I would put this up as a separate PR rather than include it with the rest of the 5395 work.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?