### PR TITLE
[CHNL-6170] renamed enum cases

### DIFF
--- a/Sources/KlaviyoSwift/Models/Event.swift
+++ b/Sources/KlaviyoSwift/Models/Event.swift
@@ -11,14 +11,14 @@ import KlaviyoCore
 
 public struct Event: Equatable {
     public enum EventName: Equatable {
-        case OpenedAppMetric
-        case ViewedProductMetric
-        case AddedToCartMetric
-        case StartedCheckoutMetric
-        case CustomEvent(String)
+        case openedAppMetric
+        case viewedProductMetric
+        case addedToCartMetric
+        case startedCheckoutMetric
+        case customEvent(String)
 
         internal static var _openedPush: EventName {
-            EventName.CustomEvent("_openedPush")
+            EventName.customEvent("_openedPush")
         }
     }
 
@@ -91,11 +91,11 @@ extension Event.EventName {
     public var value: String {
         switch self {
         case ._openedPush: return "$opened_push"
-        case .OpenedAppMetric: return "Opened App"
-        case .ViewedProductMetric: return "Viewed Product"
-        case .AddedToCartMetric: return "Added to Cart"
-        case .StartedCheckoutMetric: return "Started Checkout"
-        case let .CustomEvent(value): return "\(value)"
+        case .openedAppMetric: return "Opened App"
+        case .viewedProductMetric: return "Viewed Product"
+        case .addedToCartMetric: return "Added to Cart"
+        case .startedCheckoutMetric: return "Started Checkout"
+        case let .customEvent(value): return "\(value)"
         }
     }
 }

--- a/Tests/KlaviyoSwiftTests/EventTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventTests.swift
@@ -12,6 +12,6 @@ import XCTest
 class KlaviyoEventTests: XCTestCase {
     func testOpenedPushEvent() {
         let openedPushEvent = Event.EventName._openedPush
-        XCTAssertEqual(openedPushEvent, .CustomEvent("_openedPush"))
+        XCTAssertEqual(openedPushEvent, .customEvent("_openedPush"))
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -82,7 +82,7 @@ class KlaviyoSDKTests: XCTestCase {
     // MARK: test create event
 
     func testCreateEvent() throws {
-        let event = Event(name: .OpenedAppMetric)
+        let event = Event(name: .openedAppMetric)
         let expectation = setupActionAssertion(expectedAction: .enqueueEvent(event))
 
         klaviyo.create(event: event)
@@ -91,7 +91,7 @@ class KlaviyoSDKTests: XCTestCase {
     }
 
     func testCreateEventFromDocumentation() throws {
-        let event = Event(name: .AddedToCartMetric, properties: [
+        let event = Event(name: .addedToCartMetric, properties: [
             "Total Price": 10.99,
             "Items Purchased": ["Hot Dog", "Fries", "Shake"]
         ], value: 10.99)

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -444,6 +444,6 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
 extension Event.EventName: CaseIterable {
     public static var allCases: [KlaviyoSwift.Event.EventName] {
-        [._openedPush, .OpenedAppMetric, .ViewedProductMetric, .AddedToCartMetric, .StartedCheckoutMetric, .CustomEvent("someEvent")]
+        [._openedPush, .openedAppMetric, .viewedProductMetric, .addedToCartMetric, .startedCheckoutMetric, .customEvent("someEvent")]
     }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -587,7 +587,7 @@ class StateManagementTests: XCTestCase {
         let initialState = INITILIZING_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let event = Event(name: .OpenedAppMetric)
+        let event = Event(name: .openedAppMetric)
         await store.send(.enqueueEvent(event)) {
             $0.pendingRequests = [KlaviyoState.PendingRequest.event(event)]
         }
@@ -603,7 +603,7 @@ class StateManagementTests: XCTestCase {
                     apiKey: XCTUnwrap($0.apiKey),
                     endpoint: .createEvent(CreateEventPayload(
                         data: CreateEventPayload.Event(
-                            name: Event.EventName.OpenedAppMetric.value,
+                            name: Event.EventName.openedAppMetric.value,
                             properties: event.properties,
                             phoneNumber: $0.phoneNumber,
                             anonymousId: initialState.anonymousId!,

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -115,11 +115,11 @@ extension Event {
         "Device Manufacturer": "Orange",
         "Device Model": "jPhone 1,1"
     ] as [String: Any]
-    static let test = Self(name: .CustomEvent("blob"), properties: nil, time: KlaviyoEnvironment.test().date())
+    static let test = Self(name: .customEvent("blob"), properties: nil, time: KlaviyoEnvironment.test().date())
 }
 
 extension Event.Metric {
-    static let test = Self(name: .CustomEvent("blob"))
+    static let test = Self(name: .customEvent("blob"))
 }
 
 extension KlaviyoState {


### PR DESCRIPTION
# Description

This renames the cases in the `Event.EventName` enum to be consistent with [Swift naming conventions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations/). This will be a breaking change.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?
