### PR TITLE
[CHNL-6170] added deprecation warnings

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -10,11 +10,22 @@ import Foundation
 
 public struct Event: Equatable {
     public enum EventName: Equatable {
+        @available(*, deprecated, message: "This enum case will be removed in SDK v4.0.0")
         case OpenedPush
+
+        @available(*, deprecated, message: "This will be renamed to `openedAppMetric` in SDK v4.0.0")
         case OpenedAppMetric
+
+        @available(*, deprecated, message: "This will be renamed to `viewedProductMetric` in SDK v4.0.0")
         case ViewedProductMetric
+
+        @available(*, deprecated, message: "This will be renamed to `addedToCartMetric` in SDK v4.0.0")
         case AddedToCartMetric
+
+        @available(*, deprecated, message: "This will be renamed to `startedCheckoutMetric` in SDK v4.0.0")
         case StartedCheckoutMetric
+
+        @available(*, deprecated, message: "This will be renamed to `customEvent(...)` in SDK v4.0.0")
         case CustomEvent(String)
     }
 


### PR DESCRIPTION
# Description

This adds deprecation warnings to the `EventName` enum cases, in preparation for the breaking changes that will be introduced in v4.0.0 with #195 and #196 (as part of [CHNL-6170](https://klaviyo.atlassian.net/browse/CHNL-6170))

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

These are only warnings, so they do not introduce any functional changes

# Supporting Materials

#### warnings for capitalization changes:

<img width="840" alt="Screenshot 2024-09-04 at 13 04 31" src="https://github.com/user-attachments/assets/8422f442-3cb3-452a-b78e-a0c726338123">


#### warning for removed `OpenedPush` case:

<img width="560" alt="Screenshot 2024-09-04 at 13 04 59" src="https://github.com/user-attachments/assets/bba48e78-fc57-4ad2-a7ea-c3ff267cbb9e">


#### note that Xcode won't display warnings when the enum cases are used in a `switch` statement:

<img width="439" alt="Screenshot 2024-09-04 at 13 04 19" src="https://github.com/user-attachments/assets/0a99487b-a36f-4fdf-a9c1-e1649a2ee48b">



[CHNL-6170]: https://klaviyo.atlassian.net/browse/CHNL-6170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ