### PR TITLE
[CHNL-11785] fixed concurrency issue

### DIFF
--- a/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Store.swift
+++ b/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Store.swift
@@ -273,7 +273,7 @@ final class Store<State, Action> {
     }
 
     guard !tasks.wrappedValue.isEmpty else { return nil }
-    return Task {
+    return Task { @MainActor in
       await withTaskCancellationHandler {
         var index = tasks.wrappedValue.startIndex
         while index < tasks.wrappedValue.endIndex {


### PR DESCRIPTION
# Description

This fixes a potential concurrency issue by adding a `@MainActor` tag in the `Store.send(...)` method. It addresses [CHNL-11785](https://klaviyo.atlassian.net/browse/CHNL-11785).

The fix comes from an update made to the TCA framework in [this PR](https://github.com/pointfreeco/swift-composable-architecture/pull/2382). 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?