### PR TITLE
Fixing removing white space identifiers 

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -10,7 +10,7 @@ import KlaviyoCore
 
 extension String {
     fileprivate func returnNilIfEmpty() -> String? {
-        isEmpty ? nil : self
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
     }
 }
 


### PR DESCRIPTION
# Description

When identifiers were just a bunch of whitespace characters, we were still making a network call and getting 400'ed. This fixes that by trimming white spaces and newline before checking if the identifiers is empty. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. Add an empty identifier to the profile (white spaces would work too) - email, phone number or external id
2. Tap on create profile 
3. Notice that a request will be made (since we don't have dedup logic for profile requests) but the request will not contain the empty identifier that was added.