### PR TITLE
3.3.0 release revisions

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -10,7 +10,7 @@ The old case PascalCase names are currently still in place and have the same fun
 
 This update is non-breaking for most use-cases, but any consumers who are `switch`ing over the `Event.EventName` enum will need to make minor changes. There are two scenarios that will require different changes:
 
-    1. If the existing `switch` statement does not include a `default` case, the compiler will throw a "Switch must be exhaustive" error. You may click "Fix" to have Xcode automatically add the missing cases, but we recommend that you add the new camelCase names alongside the old ones in your branching logic. For example:
+1. If the existing `switch` statement does not include a `default` case, the compiler will throw a "Switch must be exhaustive" error. You may click "Fix" to have Xcode automatically add the missing cases, but we recommend that you add the new camelCase names alongside the old ones in your branching logic. For example:
 
     ```swift
     switch event {
@@ -29,7 +29,7 @@ This update is non-breaking for most use-cases, but any consumers who are `switc
     }
     ```
 
-    2. If the existing `switch` statement does include a `default` case, any logic touching the new camelCase names will be branched into the `default` case unless the `switch` statement is updated. We recommend updating the `switch` statement as described in (1) above to address this situation.
+2. If the existing `switch` statement does include a `default` case, any logic touching the new camelCase names will be branched into the `default` case unless the `switch` statement is updated. We recommend updating the `switch` statement as described in (1) above to address this situation.
 
 ## Migrating to v3.0.0
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -3,6 +3,33 @@
 
 This guide outlines how developers can migrate from older versions of our SDK to newer ones.
 
+## Migrating to v3.3.0
+
+We've updated the case names in the `Event.EventName` enum from PascalCase to camelCase, to be consistent with [Swift naming conventions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations/).
+The old case PascalCase names are currently still in place and have the same functionality as the new camelCase names, but will be removed in a future release. Any direct references to the old PascalCase names will now show a deprecation warning, along with an option to "fix" the name by replacing it with the camelCase version.
+
+This update is non-breaking for most use-cases, but any consumers who are `switch`ing over the `Event.EventName` enum will need to make minor changes. There are two scenarios that will require different changes:
+
+    1. If the existing `switch` statement does not include a `default` case, the compiler will throw a "Switch must be exhaustive" error. You may click "Fix" to have Xcode automatically add the missing cases, but we recommend that you add the new camelCase names alongside the old ones in your branching logic. For example:
+    ```swift
+    switch event {
+    case .OpenedPush:
+        <...>
+    case .OpenedAppMetric, .openedAppMetric:
+        <...>
+    case .ViewedProductMetric, .viewedProductMetric:
+        <...>
+    case .AddedToCartMetric, .addedToCartMetric:
+        <...>
+    case .StartedCheckoutMetric, .startedCheckoutMetric:
+        <...>
+    case .CustomEvent(let string), .customEvent(let string):
+        <...>
+    }
+    ```
+
+    2. If the existing `switch` statement does include a `default` case, any logic touching the new camelCase names will be branched into the `default` case unless the `switch` statement is updated. We recommend updating the `switch` statement as described in (1) above to address this situation.
+
 ## Migrating to v3.0.0
 
 Deprecated event type enum cases have been removed.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,7 +8,7 @@ This guide outlines how developers can migrate from older versions of our SDK to
 We've updated the case names in the `Event.EventName` enum from PascalCase to camelCase, to be consistent with [Swift naming conventions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/enumerations/).
 The old case PascalCase names are currently still in place and have the same functionality as the new camelCase names, but will be removed in a future release. Any direct references to the old PascalCase names will now show a deprecation warning, along with an option to "fix" the name by replacing it with the camelCase version.
 
-This update is non-breaking for most use-cases, but any consumers who are `switch`ing over the `Event.EventName` enum will need to make minor changes. There are two scenarios that will require different changes:
+This update is non-breaking for most use-cases, but any consumers who are `switch`ing over the `Event.EventName` enum will need to make minor changes. There are two scenarios:
 
 1. If the existing `switch` statement does not include a `default` case, the compiler will throw a "Switch must be exhaustive" error. You may click "Fix" to have Xcode automatically add the missing cases, but we recommend that you add the new camelCase names alongside the old ones in your branching logic. For example:
 

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -15,18 +15,23 @@ public struct Event: Equatable {
 
         @available(*, deprecated, message: "This will be renamed to `openedAppMetric` in SDK v4.0.0")
         case OpenedAppMetric
+        case openedAppMetric
 
         @available(*, deprecated, message: "This will be renamed to `viewedProductMetric` in SDK v4.0.0")
         case ViewedProductMetric
+        case viewedProductMetric
 
         @available(*, deprecated, message: "This will be renamed to `addedToCartMetric` in SDK v4.0.0")
         case AddedToCartMetric
+        case addedToCartMetric
 
         @available(*, deprecated, message: "This will be renamed to `startedCheckoutMetric` in SDK v4.0.0")
         case StartedCheckoutMetric
+        case startedCheckoutMetric
 
         @available(*, deprecated, message: "This will be renamed to `customEvent(...)` in SDK v4.0.0")
         case CustomEvent(String)
+        case customEvent(String)
     }
 
     public struct Metric: Equatable {

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -184,11 +184,11 @@ extension Event.EventName {
     public var value: String {
         switch self {
         case .OpenedPush: return "$opened_push"
-        case .OpenedAppMetric: return "Opened App"
-        case .ViewedProductMetric: return "Viewed Product"
-        case .AddedToCartMetric: return "Added to Cart"
-        case .StartedCheckoutMetric: return "Started Checkout"
-        case let .CustomEvent(value): return "\(value)"
+        case .OpenedAppMetric, .openedAppMetric: return "Opened App"
+        case .ViewedProductMetric, .viewedProductMetric: return "Viewed Product"
+        case .AddedToCartMetric, .addedToCartMetric: return "Added to Cart"
+        case .StartedCheckoutMetric, .startedCheckoutMetric: return "Started Checkout"
+        case let .CustomEvent(value), let .customEvent(value): return "\(value)"
         }
     }
 }

--- a/Sources/KlaviyoSwift/KlaviyoModels.swift
+++ b/Sources/KlaviyoSwift/KlaviyoModels.swift
@@ -10,26 +10,26 @@ import Foundation
 
 public struct Event: Equatable {
     public enum EventName: Equatable {
-        @available(*, deprecated, message: "This enum case will be removed in SDK v4.0.0")
+        @available(*, deprecated, message: "This enum case will be removed in a future release")
         case OpenedPush
 
-        @available(*, deprecated, message: "This will be renamed to `openedAppMetric` in SDK v4.0.0")
+        @available(*, deprecated, renamed: "openedAppMetric", message: "Use `openedAppMetric` instead. See migration guide.")
         case OpenedAppMetric
         case openedAppMetric
 
-        @available(*, deprecated, message: "This will be renamed to `viewedProductMetric` in SDK v4.0.0")
+        @available(*, deprecated, renamed: "viewedProductMetric", message: "Use `viewedProductMetric` instead. See migration guide.")
         case ViewedProductMetric
         case viewedProductMetric
 
-        @available(*, deprecated, message: "This will be renamed to `addedToCartMetric` in SDK v4.0.0")
+        @available(*, deprecated, renamed: "addedToCartMetric", message: "Use `addedToCartMetric` instead. See migration guide.")
         case AddedToCartMetric
         case addedToCartMetric
 
-        @available(*, deprecated, message: "This will be renamed to `startedCheckoutMetric` in SDK v4.0.0")
+        @available(*, deprecated, renamed: "startedCheckoutMetric", message: "Use `startedCheckoutMetric` instead. See migration guide.")
         case StartedCheckoutMetric
         case startedCheckoutMetric
 
-        @available(*, deprecated, message: "This will be renamed to `customEvent(...)` in SDK v4.0.0")
+        @available(*, deprecated, renamed: "customEvent", message: "Use `customEvent(...)` instead. See migration guide.")
         case CustomEvent(String)
         case customEvent(String)
     }


### PR DESCRIPTION
# Description

This PR adds the revised `EventName` enum cases alongside the old ones so that consumers of the 3.3.0 release can proactively update their code.

This should be a non-breaking change for most users, but there's an edge case for any users who are `switch`ing over the `EventName` enum. This change will be breaking for them, although it is a quick fix. It will be documented in the migration guide.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?