### PR TITLE
Using plist values for sdk name and version

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -119,7 +119,7 @@ public struct KlaviyoEnvironment {
     public var sdkVersion: () -> String
 
     private static let rnSDKConfig: [String: AnyObject] = {
-        loadPlist(named: "klaviyo-sdk-configuration") ?? [:]
+        loadPlist(named: "klaviyo-react-native-sdk-configuration") ?? [:]
     }()
 
     private static func getSDKName() -> String {

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -118,6 +118,24 @@ public struct KlaviyoEnvironment {
     public var sdkName: () -> String
     public var sdkVersion: () -> String
 
+    private static let rnSDKConfig: [String: AnyObject] = {
+        loadPlist(named: "klaviyo-sdk-configuration") ?? [:]
+    }()
+
+    private static func getSDKName() -> String {
+        if let sdkName = KlaviyoEnvironment.rnSDKConfig["react_native_sdk_name"] as? String {
+            return sdkName
+        }
+        return __klaviyoSwiftName
+    }
+
+    private static func getSDKVersion() -> String {
+        if let sdkVersion = KlaviyoEnvironment.rnSDKConfig["react_native_sdk_version"] as? String {
+            return sdkVersion
+        }
+        return __klaviyoSwiftVersion
+    }
+
     public static var production = KlaviyoEnvironment(
         archiverClient: ArchiverClient.production,
         fileClient: FileClient.production,
@@ -163,30 +181,8 @@ public struct KlaviyoEnvironment {
                 .autoconnect()
                 .eraseToAnyPublisher()
         },
-        SDKName: {
-            let config = getRNSDKConfig()
-            if let sdkName = config["sdk_name"] as? String {
-                return sdkName
-            } else {
-                return __klaviyoSwiftName
-            }
-        },
-        SDKVersion: {
-            let config = getRNSDKConfig()
-            if let sdkVersion = config["sdk_version"] as? String {
-                return sdkVersion
-            } else {
-                return __klaviyoSwiftVersion
-            }
-        })
-}
-
-private func getRNSDKConfig() -> [String: AnyObject] {
-    if let path = Bundle.main.path(forResource: "klaviyo-sdk-configuration", ofType: "plist"),
-       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
-        return dict
-    }
-    return [:]
+        SDKName: KlaviyoEnvironment.getSDKName,
+        SDKVersion: KlaviyoEnvironment.getSDKVersion)
 }
 
 public var networkSession: NetworkSession!

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -163,8 +163,30 @@ public struct KlaviyoEnvironment {
                 .autoconnect()
                 .eraseToAnyPublisher()
         },
-        SDKName: { __klaviyoSwiftName },
-        SDKVersion: { __klaviyoSwiftVersion })
+        SDKName: {
+            let config = getRNSDKConfig()
+            if let sdkName = config["sdk_name"] as? String {
+                return sdkName
+            } else {
+                return __klaviyoSwiftName
+            }
+        },
+        SDKVersion: {
+            let config = getRNSDKConfig()
+            if let sdkVersion = config["sdk_version"] as? String {
+                return sdkVersion
+            } else {
+                return __klaviyoSwiftVersion
+            }
+        })
+}
+
+private func getRNSDKConfig() -> [String: AnyObject] {
+    if let path = Bundle.main.path(forResource: "klaviyo-sdk-configuration", ofType: "plist"),
+       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
+        return dict
+    }
+    return [:]
 }
 
 public var networkSession: NetworkSession!

--- a/Sources/KlaviyoCore/Networking/PrivateMethods.swift
+++ b/Sources/KlaviyoCore/Networking/PrivateMethods.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  PrivateMethods.swift
 //
 //
 //  Created by Ajay Subramanya on 8/29/24.
@@ -9,20 +9,10 @@ import Foundation
 
 /// Used to override SDK defailts for INTERNAL USE ONLY
 /// - Parameter url: The  URL to use for Klaviyo client APIs, This is used internally to test the SDK against different backends, DO NOT use this in your apps.
-/// - Parameter name: The name of the SDK, defaults to swift but react native will pass it's own name. DO NOT override this in your apps as our backend will not accept unsupported values here and your network requests will fail.
-/// - Parameter version: The version of the swift SDK default to hard coded values here but react native will pass it's own values here. DO NOT override this in your apps.
 @_spi(KlaviyoPrivate)
 @available(*, deprecated, message: "This function is for internal use only, and should NOT be used in production applications")
-public func overrideSDKDefaults(url: String? = nil, name: String? = nil, version: String? = nil) {
+public func overrideSDKDefaults(url: String? = nil) {
     if let url = url {
         environment.apiURL = { url }
-    }
-
-    if let name = name {
-        environment.sdkName = { name }
-    }
-
-    if let version = version {
-        environment.sdkVersion = { version }
     }
 }

--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -66,3 +66,14 @@ public func removeFile(at url: URL) -> Bool {
     }
     return false
 }
+
+/// load any plist from app main bundle
+/// - Parameter name: the name of the plist
+/// - Returns: the contents of the plist in `[String: AnyObject]` or nil if not found
+func loadPlist(named name: String) -> [String: AnyObject]? {
+    if let path = Bundle.main.path(forResource: name, ofType: "plist"),
+       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
+        return dict
+    }
+    return nil
+}


### PR DESCRIPTION
# Description

Looking for a plist resource that our react native SDK adds to the host app's bundle. If this plist is found then use the sdk name and version from that plist else use the name and version hardcoded within this SDK.

This is how the plist looks, 

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<!--
   config.plist
   Pods

   Created by Ajay Subramanya on 9/18/24.
   Copyright (c) 2024 Klaviyo. All rights reserved.
-->
<plist version="1.0">
<dict>
    <key>react_native_sdk_name</key>
    <string>react_native</string>
    <key>react_native_sdk_version</key>
    <string>9.8.8</string>
</dict>
</plist>
```

This plist is loaded to the host app's bundle using the react native SDK podspec like below, 

```
require "json"

package = JSON.parse(File.read(File.join(__dir__, "package.json")))

Pod::Spec.new do |s|
  s.name         = package["name"]
  s.version      = package["version"]
  s.summary      = package["description"]
  s.homepage     = package["homepage"]
  s.license      = package["license"]
  s.authors      = package["author"]

  s.platforms    = { :ios => "13.0" }
  s.source       = { :git => "https://github.com/klaviyo/klaviyo-react-native-sdk.git", :tag => "#{s.version}" }
  s.source_files = "ios/**/*.{h,m,mm,swift}"
  s.resources    = ["ios/klaviyo-sdk-configuration.plist"]

  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }

  s.dependency "React-Core"
  s.dependency "KlaviyoSwift", "3.2.0"
end

```

notice the `s.resources    = ["ios/klaviyo-sdk-configuration.plist"]` is what copies this over to the host app's bundle. 

The reason I think this method is better than the private API method is because, we don't have to worry about making sure that the values are overridden at any given point (initializing from native SDK vs react native etc). With this approach, we know that as long as the plist is correctly bundled on react native we'll always have the right value when the `SDKName` and `SDKVersion` variables are accessed from `KlaviyoEnvironment`.

Thanks to @evan-masseau for this idea.

# Manual Test Plan

1. Using the iOS test app, made sure that the hardcoded version of the SDK is being used when making event and token calls.
2. Using the RN test app validated that the values in the plist are being used when making the same network calls. 
3. Alternate and quicker way to test this w/o going through RN is placing the above plist within the iOS test app and naming it `klaviyo-sdk-configuration.plist`


