### PR TITLE
Fixed retry not working

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -40,7 +40,7 @@ public struct KlaviyoAPI {
             return .failure(.missingOrInvalidResponse(response))
         }
 
-        if httpResponse.statusCode == 429, httpResponse.statusCode == 503 {
+        if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
             let exponentialBackOff = Int(pow(2.0, Double(attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             if let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After") {


### PR DESCRIPTION
# Description

There is a logical error in the `if` condition. I am using `if httpResponse.statusCode == 429, httpResponse.statusCode == 503` which checks if `httpResponse.statusCode` is both `429` and `503` at the same time, which is not possible. Instead, I should use an `||` to check if `httpResponse.statusCode` is either `429` or `503`.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
