### PR TITLE
Updated KlaviyoCore to 4.0.0 and pointing to the just released tag

### DIFF
--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile.lock
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - AnyCodable-FlightSchool (0.6.7)
-  - KlaviyoCore (0.1.0):
+  - KlaviyoCore (4.0.0):
     - AnyCodable-FlightSchool
-  - KlaviyoSwift (3.2.0):
+  - KlaviyoSwift (4.0.0):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 0.1.0)
+    - KlaviyoCore (~> 4.0.0)
   - KlaviyoSwiftExtension (3.0.1)
 
 DEPENDENCIES:
@@ -23,10 +23,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AnyCodable-FlightSchool: 261cbe76757802b17d471b9059b21e6fa5edf57b
-  KlaviyoCore: a1c8bce61e3bf059e2122c68de67c0848ab18691
-  KlaviyoSwift: c846f16783dcf74b57a002479806453f9533291f
+  KlaviyoCore: 64cf0767bd46055245b778702a55ccc1f18d4eb1
+  KlaviyoSwift: f7ee04bdd50b42dcc6ede4efdeb6f05d1cc4549f
   KlaviyoSwiftExtension: 3aa3f39f2d8b25424d17cd41e1e717939dea91dd
 
-PODFILE CHECKSUM: 2d7781d04aac78e610350f0ce4d243bf150f8667
+PODFILE CHECKSUM: 44a7fe4dd4e0011a89381b330b57033015d73a87
 
 COCOAPODS: 1.15.2

--- a/KlaviyoCore.podspec
+++ b/KlaviyoCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoCore"
-  s.version          = "0.1.0"
+  s.version          = "4.0.0"
   s.summary          = "Core functionalities for the Klaviyo SDK"
   s.description      = <<-DESC
                         Core functionalities and utilities for the Klaviyo SDK.
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/klaviyo/klaviyo-swift-sdk"
   s.license          = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Mobile @ Klaviyo" => "mobile@klaviyo.com" }
-  # TODO: update the branch to a tag once created
-  s.source           = { :git => "https://github.com/klaviyo/klaviyo-swift-sdk.git", :branch => 'master' }
+  s.source           = { :git => "https://github.com/klaviyo/klaviyo-swift-sdk.git", :tag => s.version.to_s }
   s.swift_version    = '5.7'
   s.platform         = :ios, '13.0'
   s.source_files     = 'Sources/KlaviyoCore/**/*.swift'

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
-  s.dependency     'KlaviyoCore', '~> 0.1.0'
+  s.dependency     'KlaviyoCore', '~> 4.0.0'
   s.dependency     'AnyCodable-FlightSchool'
 end


### PR DESCRIPTION
# Description

The new private pod `KlaviyoCore` now is versioned at 4.0.0 for consistency with the other pods and also to match the major version tag just released to avoid any confusion. Since we just have one repo that we release we only have one tag for all three pods so it's easier matching the versions of the pods. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
