### PR TITLE
replace `PassthroughSubject` with `AsyncStream`

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -14,7 +14,10 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     let loadScripts: [String: WKUserScript]?
 
     /// Publishes scripts for the `WKWebView` to execute.
-    let scriptSubject = PassthroughSubject<(script: String, callback: ((Result<Any?, Error>) -> Void)?), Never>()
+    private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?
+    lazy var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> = AsyncStream { [weak self] continuation in
+        self?.continuation = continuation
+    }
 
     init(url: URL) {
         self.url = url

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -15,8 +15,8 @@ protocol KlaviyoWebViewModeling {
     /// Scripts to be injected into the ``WKWebView`` when the website loads.
     var loadScripts: [String: WKUserScript]? { get }
 
-    /// Publishes scripts for the ``WKWebView`` to execute.
-    var scriptSubject: PassthroughSubject<(script: String, callback: ((Result<Any?, Error>) -> Void)?), Never> { get }
+    /// Streams scripts for the ``WKWebView`` to execute.
+    var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> { get }
 
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)


### PR DESCRIPTION
# Description

This PR replaces a Combine `PassthroughSubject` with an `AsyncStream` for the IAM Web View logic.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Use the `ab/CHNL-11919/web-view-local-index-script` branch and run the Xcode preview in the `KlaviyoWebViewController` file. Validate that the toggle works as expected and the view updates when enabling/disabling the toggle.