### PR TITLE
Minor update to user agent format to reflect cross-platform SDK's name override

### DIFF
--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -34,8 +34,8 @@ public struct NetworkSession {
     fileprivate static let mobileHeader = "1"
 
     public static let defaultUserAgent = { () -> String in
-        let appContext = environment.appContextInfo()  
-        let klaivyoSDKVersion = "\(environment.sdkName())/\(environment.sdkVersion())"
+        let appContext = environment.appContextInfo()
+        let klaivyoSDKVersion = "klaviyo-\(environment.sdkName())/\(environment.sdkVersion())"
         return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
     }()
 

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -35,7 +35,7 @@ public struct NetworkSession {
 
     public static let defaultUserAgent = { () -> String in
         let appContext = environment.appContextInfo()
-        let klaivyoSDKVersion = "klaviyo-ios/\(environment.sdkVersion())"
+        let klaivyoSDKVersion = "\(environment.sdkName())/\(environment.sdkVersion())"
         return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
     }()
 

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -34,7 +34,7 @@ public struct NetworkSession {
     fileprivate static let mobileHeader = "1"
 
     public static let defaultUserAgent = { () -> String in
-        let appContext = environment.appContextInfo()
+        let appContext = environment.appContextInfo() 
         let klaivyoSDKVersion = "\(environment.sdkName())/\(environment.sdkVersion())"
         return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
     }()

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -34,7 +34,7 @@ public struct NetworkSession {
     fileprivate static let mobileHeader = "1"
 
     public static let defaultUserAgent = { () -> String in
-        let appContext = environment.appContextInfo() 
+        let appContext = environment.appContextInfo()  
         let klaivyoSDKVersion = "\(environment.sdkName())/\(environment.sdkVersion())"
         return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
     }()

--- a/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/4.0.0"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.0.0"
     ▿ (2 elements)
       - key: "X-Klaviyo-Mobile"
       - value: "1"

--- a/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-ios/4.0.0"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.0.0"


### PR DESCRIPTION
We want to be able to see react native or flutter in nginx logs, which can only see user agent.
We'll still be able differentiate android and iOS by the OS part of the user agent string.
See related [android PR](https://github.com/klaviyo/klaviyo-android-sdk/pull/195)

# Description

<!--
Please describe the changes you are making and why you are making them.
-->

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
