### PR TITLE
[CHNL-12942] Create a hook to reset badge counts

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -82,6 +82,11 @@ public struct KlaviyoSDK {
     public func resetProfile() {
         dispatchOnMainThread(action: .resetProfile)
     }
+    
+    public func resetBadgeCount(defaults: String) {
+        dispatchOnMainThread(action: .resetBadgeCount(defaults))
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
 
     /// Set the current user's email.
     /// - Parameter email: a string contining the users email.

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -49,6 +49,9 @@ enum KlaviyoAction: Equatable {
 
     /// call this to sync the user's local push notification authorization setting with the user's profile on the Klaviyo back-end.
     case setPushEnablement(PushEnablement)
+    
+    /// call to reset the app badge count to 0 as well as update the stored value in the specified User Defaults suite
+    case resetBadgeCount(String)
 
     /// called when the user wants to reset the existing profile from state
     case resetProfile
@@ -100,7 +103,7 @@ enum KlaviyoAction: Equatable {
         case .setEmail, .setPhoneNumber, .setExternalId, .setPushToken, .setPushEnablement, .enqueueProfile, .setProfileProperty, .resetProfile, .resetStateAndDequeue, .enqueueEvent:
             return true
 
-        case .initialize, .completeInitialization, .deQueueCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed:
+        case .initialize, .completeInitialization, .deQueueCompletedResults, .networkConnectivityChanged, .flushQueue, .sendRequest, .stop, .start, .cancelInFlightRequests, .requestFailed, .resetBadgeCount:
             return false
         }
     }
@@ -479,6 +482,12 @@ struct KlaviyoReducer: ReducerProtocol {
 
             return .none
 
+        case let .resetBadgeCount(defaults):
+            if let userDefaults = UserDefaults(suiteName: defaults) {
+                userDefaults.set(0, forKey: "badgeCount")
+            }
+            return .none
+            
         case .resetProfile:
             guard case .initialized = state.initalizationState
             else {


### PR DESCRIPTION
# Description

This creates a new API method devs can call to reset the badge count to 0. It additionally sets the `badgeCount` value in a shared User Defaults to 0. That shared User Defaults will be a presumably set up following README updates to support badge incrementing. In the scenario the dev does not set the caching resource up correctly, this method will still set the badge to 0.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. In an app with Klaviyo SDK initialized, call `KlaviyoSDK().resetBadgeCount(defaults: appGroupSource)` where `appGroupSource` is the identifier of the app group between the Service Extension and App (per what would be set up in updated README)
2. Send some notification from Push Notification Console to populate the badge count (i.e. `badge = 3` in payload)
3. Observe when SDK call is triggered (i.e. a button or scene phase) the badge count is reset to 0


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
