### PR TITLE
[CHNL-14651] refactor network request

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -9,14 +9,7 @@
 import AnyCodable
 import Foundation
 
-protocol Endpoint: Equatable, Codable {
-    var httpMethod: RequestMethod { get }
-    var path: String { get }
-
-    func body() throws -> Data
-}
-
-public enum KlaviyoEndpoint: Endpoint {
+public enum KlaviyoEndpoint: Equatable, Codable {
     case createProfile(CreateProfilePayload)
     case createEvent(CreateEventPayload)
     case registerPushToken(PushTokenPayload)

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -16,9 +16,42 @@ protocol Endpoint: Equatable, Codable {
     func body() throws -> Data
 }
 
-public enum KlaviyoEndpoint: Equatable, Codable {
+public enum KlaviyoEndpoint: Endpoint {
     case createProfile(CreateProfilePayload)
     case createEvent(CreateEventPayload)
     case registerPushToken(PushTokenPayload)
     case unregisterPushToken(UnregisterPushTokenPayload)
+
+    var httpMethod: RequestMethod {
+        switch self {
+        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:
+            return .post
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .createProfile:
+            return "/client/profiles/"
+        case .createEvent:
+            return "/client/events/"
+        case .registerPushToken:
+            return "/client/push-tokens/"
+        case .unregisterPushToken:
+            return "/client/push-token-unregister/"
+        }
+    }
+
+    func body() throws -> Data {
+        switch self {
+        case let .createProfile(payload):
+            return try environment.encodeJSON(AnyEncodable(payload))
+        case let .createEvent(payload):
+            return try environment.encodeJSON(AnyEncodable(payload))
+        case let .registerPushToken(payload):
+            return try environment.encodeJSON(AnyEncodable(payload))
+        case let .unregisterPushToken(payload):
+            return try environment.encodeJSON(AnyEncodable(payload))
+        }
+    }
 }

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -9,6 +9,13 @@
 import AnyCodable
 import Foundation
 
+protocol Endpoint: Equatable, Codable {
+    var httpMethod: RequestMethod { get }
+    var path: String { get }
+
+    func body() throws -> Data
+}
+
 public enum KlaviyoEndpoint: Equatable, Codable {
     case createProfile(CreateProfilePayload)
     case createEvent(CreateEventPayload)

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -28,11 +28,11 @@ public struct KlaviyoRequest: Equatable, Codable {
         }
         var request = URLRequest(url: url)
         // We only support post right now
-        guard let body = try? encodeBody() else {
+        guard let body = try? endpoint.body() else {
             throw KlaviyoAPIError.dataEncodingError(self)
         }
         request.httpBody = body
-        request.httpMethod = "POST"
+        request.httpMethod = endpoint.httpMethod.rawValue
         request.setValue("\(attemptNumber)/50", forHTTPHeaderField: "X-Klaviyo-Attempt-Count")
 
         return request
@@ -42,41 +42,9 @@ public struct KlaviyoRequest: Equatable, Codable {
         switch endpoint {
         case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:
             if !environment.apiURL().isEmpty {
-                return URL(string: "\(environment.apiURL())/\(path)/?company_id=\(apiKey)")
+                return URL(string: "\(environment.apiURL())\(endpoint.path)?company_id=\(apiKey)")
             }
             return nil
-        }
-    }
-
-    var path: String {
-        switch endpoint {
-        case .createProfile:
-            return "client/profiles"
-
-        case .createEvent:
-            return "client/events"
-
-        case .registerPushToken:
-            return "client/push-tokens"
-
-        case .unregisterPushToken:
-            return "client/push-token-unregister"
-        }
-    }
-
-    func encodeBody() throws -> Data {
-        switch endpoint {
-        case let .createProfile(payload):
-            return try environment.encodeJSON(AnyEncodable(payload))
-
-        case let .createEvent(payload):
-            return try environment.encodeJSON(AnyEncodable(payload))
-
-        case let .registerPushToken(payload):
-            return try environment.encodeJSON(AnyEncodable(payload))
-
-        case let .unregisterPushToken(payload):
-            return try environment.encodeJSON(AnyEncodable(payload))
         }
     }
 }

--- a/Sources/KlaviyoCore/Networking/RequestMethod.swift
+++ b/Sources/KlaviyoCore/Networking/RequestMethod.swift
@@ -1,0 +1,10 @@
+//
+//  RequestMethod.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 11/15/24.
+//
+
+enum RequestMethod: String {
+    case post = "POST"
+}


### PR DESCRIPTION
# Description

This PR refactors `KlaviyoRequest` and `KlaviyoEndpoint` so that the `KlaviyoEndpoint` enum now contains the values for `path` and `body`. The `KlaviyoRequest` struct now has no knowledge of individual endpoint details.

This work will make the `KlaviyoRequest` more flexible, and will enable us to add additional HTTP request methods other than "POST". I will make use of these changes in an upcoming PR. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?