### PR TITLE
[CHNL-14651] refactor KlaviyoRequest to use URLComponents

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -68,7 +68,7 @@ public struct KlaviyoEnvironment {
         sdkVersion = SDKVersion
     }
 
-    static let productionHost = "https://a.klaviyo.com"
+    static let productionHost = "a.klaviyo.com"
     public static let encoder = { () -> JSONEncoder in
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -81,7 +81,7 @@ public struct KlaviyoEnvironment {
         return decoder
     }()
 
-    private static let reachabilityService = Reachability(hostname: URL(string: productionHost)!.host!)
+    private static let reachabilityService = Reachability(hostname: productionHost)
 
     public var archiverClient: ArchiverClient
     public var fileClient: FileClient

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -15,6 +15,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
     case registerPushToken(PushTokenPayload)
     case unregisterPushToken(UnregisterPushTokenPayload)
 
+    var httpScheme: String { "https" }
+
     var httpMethod: RequestMethod {
         switch self {
         case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -39,12 +39,16 @@ public struct KlaviyoRequest: Equatable, Codable {
     }
 
     var url: URL? {
-        switch endpoint {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken:
-            if !environment.apiURL().isEmpty {
-                return URL(string: "\(environment.apiURL())\(endpoint.path)?company_id=\(apiKey)")
-            }
-            return nil
-        }
+        guard !environment.apiURL().isEmpty else { return nil }
+
+        var components = URLComponents()
+        components.scheme = endpoint.httpScheme
+        components.host = environment.apiURL()
+        components.path = endpoint.path
+        components.queryItems = [
+            URLQueryItem(name: "company_id", value: apiKey)
+        ]
+
+        return components.url
     }
 }

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/events/?company_id=foo
+▿ https://dead_beef/client/events/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/events/?company_id=foo
+    - some: https://dead_beef/client/events/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/profiles/?company_id=foo
+▿ https://dead_beef/client/profiles/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/profiles/?company_id=foo
+    - some: https://dead_beef/client/profiles/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
@@ -1,6 +1,6 @@
-▿ dead_beef/client/push-tokens/?company_id=foo
+▿ https://dead_beef/client/push-tokens/?company_id=foo
   ▿ url: Optional<URL>
-    - some: dead_beef/client/push-tokens/?company_id=foo
+    - some: https://dead_beef/client/push-tokens/?company_id=foo
   - cachePolicy: 0
   - timeoutInterval: 60.0
   - mainDocumentURL: Optional<URL>.none


### PR DESCRIPTION
# Description

This PR refactors `KlaviyoRequest` to use `URLComponents`. This is easier to read and less error-prone than assembling the URL from a `String`. 

This work will be used in an upcoming PR to add support for calling the fullforms API.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?