### PR TITLE
[CHNL-14651] add Klaviyo form preview

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,7 +61,11 @@ let package = Package(
             name: "KlaviyoUI",
             dependencies: ["KlaviyoSwift"],
             path: "Sources/KlaviyoUI",
-            resources: [.process("KlaviyoWebView/Resources")]),
+            resources: [
+                .process("KlaviyoWebView/Resources"),
+                .process("KlaviyoWebView/Development Assets/Scripts"),
+                .process("KlaviyoWebView/Development Assets/HTML")
+            ]),
         .testTarget(
             name: "KlaviyoUITests",
             dependencies: [

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+        <style>
+            * {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            }
+            body {
+                padding: 24px;
+                margin: 0;
+            }
+            .section {
+                background: white;
+                border-radius: 8px;
+                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+                margin-bottom: 16px;
+                overflow: hidden;
+            }
+            .section-title {
+                font-size: 16px;
+                font-weight: bold;
+                padding: 12px;
+                background-color: #f0f0f5;
+            }
+            .button-section {
+                padding: 12px;
+                display: flex;
+                justify-content: center;
+                flex-direction: column;
+                align-items: center;
+            }
+            .setting {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 12px 16px;
+                border-bottom: 1px solid #e0e0e0;
+                cursor: pointer;
+            }
+            .setting:last-child {
+                border-bottom: none;
+            }
+            .switch {
+                position: relative;
+                display: inline-block;
+                width: 60px;
+                height: 34px;
+                -webkit-tap-highlight-color: transparent;
+                -webkit-touch-callout: none;
+                -webkit-user-select: none;
+                -khtml-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+            }
+
+            .switch input {
+                display: none; /* Hide the default checkbox */
+            }
+
+            .slider {
+                position: absolute;
+                cursor: pointer;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background-color: #ccc;
+                transition: background-color 0.4s; /* Use shorthand for clarity */
+                border-radius: 34px; /* Rounded edges for the slider */
+            }
+
+            .slider:before {
+                position: absolute;
+                content: "";
+                height: 26px;
+                width: 26px;
+                left: 4px;
+                bottom: 4px;
+                background-color: white;
+                transition: transform 0.4s; /* Specify which property to transition */
+                border-radius: 50%; /* Rounded edges for the slider knob */
+            }
+
+            input:checked + .slider {
+                background-color: #2196F3; /* Change background when checked */
+            }
+
+            input:checked + .slider:before {
+                transform: translateX(26px); /* Move knob when checked */
+            }
+            .button {
+                padding: 12px 72px; /* Add top/bottom and left/right padding */
+                margin: 4px 8px; /* Properly formatted margin */
+                transition: background-color 0.3s;
+                box-sizing: border-box; /* Ensure padding is included in width and height calculations */
+                border-radius: 12px; /* Optional: add border radius for rounded corners */
+            }
+            .button:hover {
+                opacity: 0.8;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="title">
+            <h1>Javascript Bridge<br>Test Page</h1>
+        </div>
+
+        <div class="container">
+            <div class="section">
+                <div class="section-title">Toggle</div>
+                <div class="setting">
+                    <span id="toggle-status">Toggle is off</span>
+                    <label class="switch">
+                        <input type="checkbox" name="myCheckbox">
+                            <span class="slider round"></span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="section">
+                <div class="section-title">Buttons</div>
+                <div class="button-section">
+                    <button class="button" id="close-button">Close</button>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            document.getElementById("close-button").addEventListener("click", function() {
+                window.close();
+            });
+        </script>
+
+    </body>
+</html>

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
@@ -172,30 +172,6 @@
                 <div class="setting">
                     <span>Item 2</span>
                 </div>
-                <div class="setting">
-                    <span>Item 3</span>
-                </div>
-                <div class="setting">
-                    <span>Item 4</span>
-                </div>
-                <div class="setting">
-                    <span>Item 5</span>
-                </div>
-                <div class="setting">
-                    <span>Item 6</span>
-                </div>
-                <div class="setting">
-                    <span>Item 7</span>
-                </div>
-                <div class="setting">
-                    <span>Item 8</span>
-                </div>
-                <div class="setting">
-                    <span>Item 9</span>
-                </div>
-                <div class="setting">
-                    <span>Item 10</span>
-                </div>
             </div>
         </div>
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/HTML/jstest.html
@@ -1,15 +1,45 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"/>
         <style>
             * {
                 font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            }
-            body {
-                padding: 24px;
                 margin: 0;
+                padding: 0;
+                box-sizing: border-box;
             }
+
+            body {
+                margin: 0;
+                padding: 0;
+                background-color: rgba(0, 0, 0, 0.5); /* Translucent background */
+                display: flex;
+                align-items: start;
+                justify-content: center;
+                height: 100vh; /* Full height */
+                overflow: hidden; /* Prevent scrolling */
+                padding-top: env(safe-area-inset-top);
+                padding-right: env(safe-area-inset-right);
+                padding-bottom: env(safe-area-inset-bottom);
+                padding-left: env(safe-area-inset-left);
+            }
+
+            .content-container {
+                background: white;
+                border-radius: 16px;
+                box-shadow: 0 12px 12px rgba(0, 0, 0, 0.4);
+                width: 90%;
+                max-width: 500px; /* Limit the content width */
+                overflow: auto; /* Enable scrolling */
+                padding: 24px;
+                max-height: 100%; /* Prevent it from exceeding the viewport */
+            }
+
+            .title {
+                margin-bottom: 16px;
+            }
+
             .section {
                 background: white;
                 border-radius: 8px;
@@ -17,12 +47,14 @@
                 margin-bottom: 16px;
                 overflow: hidden;
             }
+
             .section-title {
                 font-size: 16px;
                 font-weight: bold;
                 padding: 12px;
                 background-color: #f0f0f5;
             }
+
             .button-section {
                 padding: 12px;
                 display: flex;
@@ -30,6 +62,7 @@
                 flex-direction: column;
                 align-items: center;
             }
+
             .setting {
                 display: flex;
                 justify-content: space-between;
@@ -38,9 +71,11 @@
                 border-bottom: 1px solid #e0e0e0;
                 cursor: pointer;
             }
+
             .setting:last-child {
                 border-bottom: none;
             }
+
             .switch {
                 position: relative;
                 display: inline-block;
@@ -56,7 +91,7 @@
             }
 
             .switch input {
-                display: none; /* Hide the default checkbox */
+                display: none;
             }
 
             .slider {
@@ -67,8 +102,8 @@
                 right: 0;
                 bottom: 0;
                 background-color: #ccc;
-                transition: background-color 0.4s; /* Use shorthand for clarity */
-                border-radius: 34px; /* Rounded edges for the slider */
+                transition: background-color 0.4s;
+                border-radius: 34px;
             }
 
             .slider:before {
@@ -79,35 +114,37 @@
                 left: 4px;
                 bottom: 4px;
                 background-color: white;
-                transition: transform 0.4s; /* Specify which property to transition */
-                border-radius: 50%; /* Rounded edges for the slider knob */
+                transition: transform 0.4s;
+                border-radius: 50%;
             }
 
             input:checked + .slider {
-                background-color: #2196F3; /* Change background when checked */
+                background-color: #2196F3;
             }
 
             input:checked + .slider:before {
-                transform: translateX(26px); /* Move knob when checked */
+                transform: translateX(26px);
             }
+
             .button {
-                padding: 12px 72px; /* Add top/bottom and left/right padding */
-                margin: 4px 8px; /* Properly formatted margin */
+                padding: 12px 72px;
+                margin: 4px 8px;
                 transition: background-color 0.3s;
-                box-sizing: border-box; /* Ensure padding is included in width and height calculations */
-                border-radius: 12px; /* Optional: add border radius for rounded corners */
+                box-sizing: border-box;
+                border-radius: 12px;
             }
+
             .button:hover {
                 opacity: 0.8;
             }
         </style>
     </head>
     <body>
-        <div class="title">
-            <h1>Javascript Bridge<br>Test Page</h1>
-        </div>
+        <div class="content-container">
+            <div class="title">
+                <h1>Javascript Bridge<br>Test Page</h1>
+            </div>
 
-        <div class="container">
             <div class="section">
                 <div class="section-title">Toggle</div>
                 <div class="setting">
@@ -125,6 +162,41 @@
                     <button class="button" id="close-button">Close</button>
                 </div>
             </div>
+
+            <!-- Added placeholder content to force scrolling -->
+            <div class="section">
+                <div class="section-title">Placeholder Content</div>
+                <div class="setting">
+                    <span>Item 1</span>
+                </div>
+                <div class="setting">
+                    <span>Item 2</span>
+                </div>
+                <div class="setting">
+                    <span>Item 3</span>
+                </div>
+                <div class="setting">
+                    <span>Item 4</span>
+                </div>
+                <div class="setting">
+                    <span>Item 5</span>
+                </div>
+                <div class="setting">
+                    <span>Item 6</span>
+                </div>
+                <div class="setting">
+                    <span>Item 7</span>
+                </div>
+                <div class="setting">
+                    <span>Item 8</span>
+                </div>
+                <div class="setting">
+                    <span>Item 9</span>
+                </div>
+                <div class="setting">
+                    <span>Item 10</span>
+                </div>
+            </div>
         </div>
 
         <script>
@@ -132,6 +204,5 @@
                 window.close();
             });
         </script>
-
     </body>
 </html>

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  JSTestWebViewModel.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 11/18/24.
+//
+
+#if DEBUG
+import Combine
+import Foundation
+import WebKit
+
+class JSTestWebViewModel: KlaviyoWebViewModeling {
+    let url: URL
+    let loadScripts: [String: WKUserScript]?
+
+    /// Publishes scripts for the `WKWebView` to execute.
+    private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?
+    lazy var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> = AsyncStream { [weak self] continuation in
+        self?.continuation = continuation
+    }
+
+    init(url: URL) {
+        self.url = url
+        loadScripts = JSTestWebViewModel.initializeLoadScripts()
+    }
+
+    private static func initializeLoadScripts() -> [String: WKUserScript] {
+        var scripts: [String: WKUserScript] = [:]
+
+        if let toggleHandlerScript = try? FileIO.getFileContents(path: "toggleHandler", type: "js") {
+            let script = WKUserScript(source: toggleHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+            scripts["toggleMessageHandler"] = script
+        }
+
+        return scripts
+    }
+
+    // MARK: handle WKWebView events
+
+    func handleNavigationEvent(_ event: WKNavigationEvent) {
+        // TODO: handle navigation events
+    }
+
+    func handleScriptMessage(_ message: WKScriptMessage) {
+        if message.name == "toggleMessageHandler" {
+            guard let dict = message.body as? [String: AnyObject] else {
+                return
+            }
+
+            guard let toggleEnabled = dict["toggleEnabled"] as? Bool else {
+                return
+            }
+
+            print("toggle enabled: \(toggleEnabled)")
+
+            let newStatus = toggleEnabled ? "Toggle is on" : "Toggle is off"
+
+            let script = "document.getElementById('toggle-status').innerText = \"\(newStatus)\""
+
+            continuation?.yield((script, { result in
+                switch result {
+                case let .success(content):
+                    if let successMessage = content as? String {
+                        print("Successfully evaluated Javascript; message: \(successMessage)")
+                    }
+                case let .failure(failure):
+                    print("Javascript evaluation failed; message: \(failure.localizedDescription)")
+                }
+            }))
+        }
+    }
+}
+#endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
@@ -1,0 +1,65 @@
+//
+//  PreviewGridViewController.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 10/23/24.
+//
+
+#if DEBUG
+import Foundation
+import UIKit
+
+/// A sample grid view with randomly-colored tiles for internal Xcode preview purposes only.
+class PreviewGridViewController: UIViewController, UICollectionViewDataSource {
+    var collectionView: UICollectionView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(0.4))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .flexible(12)
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 12
+        section.contentInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 16)
+
+        let layout = UICollectionViewCompositionalLayout(section: section)
+
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+        collectionView.dataSource = self
+
+        view.addSubview(collectionView)
+
+        // Disable autoresizing mask translation for Auto Layout
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Set up constraints using safeAreaLayoutGuide
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    // MARK: UICollectionViewDataSource
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        12
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+        cell.backgroundColor = UIColor(
+            red: .random(in: 0...1),
+            green: .random(in: 0...1),
+            blue: .random(in: 0...1),
+            alpha: 1.0)
+        cell.layer.cornerRadius = 12.0
+        return cell
+    }
+}
+#endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
@@ -62,4 +62,13 @@ class PreviewGridViewController: UIViewController, UICollectionViewDataSource {
         return cell
     }
 }
+
+// MARK: - Previews
+
+#if swift(>=5.9)
+@available(iOS 17.0, *)
+#Preview {
+    PreviewTabViewController()
+}
+#endif
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewTabViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewTabViewController.swift
@@ -1,0 +1,36 @@
+//
+//  PreviewTabViewController.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 10/23/24.
+//
+
+#if DEBUG
+import Foundation
+import UIKit
+
+/// A sample tab view for internal Xcode preview purposes only.
+class PreviewTabViewController: UITabBarController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let firstVC = PreviewGridViewController()
+        let secondVC = UIViewController()
+        let thirdVC = UIViewController()
+
+        firstVC.title = "Browse"
+
+        firstVC.tabBarItem = UITabBarItem(title: "Browse", image: UIImage(systemName: "house"), tag: 0)
+        secondVC.tabBarItem = UITabBarItem(title: "Search", image: UIImage(systemName: "magnifyingglass"), tag: 1)
+        thirdVC.tabBarItem = UITabBarItem(title: "Profile", image: UIImage(systemName: "person"), tag: 2)
+
+        viewControllers = [
+            UINavigationController(rootViewController: firstVC),
+            UINavigationController(rootViewController: secondVC),
+            UINavigationController(rootViewController: thirdVC)
+        ]
+
+        firstVC.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+}
+#endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/Scripts/toggleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/Scripts/toggleHandler.js
@@ -1,0 +1,8 @@
+var _selector = document.querySelector('input[name=myCheckbox]');
+_selector.addEventListener('change', function(event) {
+  if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.toggleMessageHandler) {
+    window.webkit.messageHandlers.toggleMessageHandler.postMessage({
+      "toggleEnabled": _selector.checked
+    });
+  }
+});

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -157,4 +157,11 @@ func createKlaviyoWebPreview(url: URL) -> UIViewController {
     let indexHtmlFileUrl = Bundle.module.url(forResource: "klaviyo", withExtension: "html")!
     return createKlaviyoWebPreview(url: indexHtmlFileUrl)
 }
+
+@available(iOS 17.0, *)
+#Preview("JS Test Page") {
+    let indexHtmlFileUrl = Bundle.module.url(forResource: "jstest", withExtension: "html")!
+    let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
+    return KlaviyoWebViewController(viewModel: viewModel)
+}
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -161,7 +161,7 @@ func createKlaviyoWebPreview(url: URL) -> UIViewController {
 @available(iOS 17.0, *)
 #Preview("JS Test Page") {
     let indexHtmlFileUrl = Bundle.module.url(forResource: "jstest", withExtension: "html")!
-    let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
+    let viewModel = JSTestWebViewModel(url: indexHtmlFileUrl)
     return KlaviyoWebViewController(viewModel: viewModel)
 }
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -148,4 +148,10 @@ func createKlaviyoWebPreview(url: URL) -> UIViewController {
     let url = URL(string: "https://picsum.photos/200/300")!
     return createKlaviyoWebPreview(url: url)
 }
+
+@available(iOS 17.0, *)
+#Preview("Klaviyo Form") {
+    let indexHtmlFileUrl = Bundle.module.url(forResource: "klaviyo", withExtension: "html")!
+    return createKlaviyoWebPreview(url: indexHtmlFileUrl)
+}
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -132,14 +132,24 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
 // MARK: - Previews
 
 #if DEBUG
-func createKlaviyoWebPreview(url: URL) -> UIViewController {
-    let viewModel = KlaviyoWebViewModel(url: url)
+func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewController {
     let viewController = KlaviyoWebViewController(viewModel: viewModel)
 
     // Add a dummy view as a parent to the KlaviyoWebViewController to preview what the
     // KlaviyoWebViewController might look like when it's displayed on top of a view in an app.
     let parentViewController = PreviewTabViewController()
+
+    parentViewController.addChild(viewController)
     parentViewController.view.addSubview(viewController.view)
+    viewController.didMove(toParent: parentViewController)
+
+    viewController.view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+        viewController.view.topAnchor.constraint(equalTo: parentViewController.view.topAnchor),
+        viewController.view.bottomAnchor.constraint(equalTo: parentViewController.view.bottomAnchor),
+        viewController.view.leadingAnchor.constraint(equalTo: parentViewController.view.leadingAnchor),
+        viewController.view.trailingAnchor.constraint(equalTo: parentViewController.view.trailingAnchor)
+    ])
 
     return parentViewController
 }
@@ -149,13 +159,15 @@ func createKlaviyoWebPreview(url: URL) -> UIViewController {
 @available(iOS 17.0, *)
 #Preview("Klaviyo.com") {
     let url = URL(string: "https://picsum.photos/200/300")!
-    return createKlaviyoWebPreview(url: url)
+    let viewModel = KlaviyoWebViewModel(url: url)
+    return createKlaviyoWebPreview(viewModel: viewModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("Klaviyo Form") {
     let indexHtmlFileUrl = Bundle.module.url(forResource: "klaviyo", withExtension: "html")!
-    return createKlaviyoWebPreview(url: indexHtmlFileUrl)
+    let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
+    return createKlaviyoWebPreview(viewModel: viewModel)
 }
 
 @available(iOS 17.0, *)

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -61,6 +61,8 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate {
         // customize any WKWebView behaviors here
         // ex: webView.allowsBackForwardNavigationGestures = true
         webView.isOpaque = false
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+
         return webView
     }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -128,11 +128,24 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
 
 // MARK: - Previews
 
+#if DEBUG
+func createKlaviyoWebPreview(url: URL) -> UIViewController {
+    let viewModel = KlaviyoWebViewModel(url: url)
+    let viewController = KlaviyoWebViewController(viewModel: viewModel)
+
+    // Add a dummy view as a parent to the KlaviyoWebViewController to preview what the
+    // KlaviyoWebViewController might look like when it's displayed on top of a view in an app.
+    let parentViewController = PreviewTabViewController()
+    parentViewController.view.addSubview(viewController.view)
+
+    return parentViewController
+}
+#endif
+
 #if swift(>=5.9)
 @available(iOS 17.0, *)
 #Preview("Klaviyo.com") {
     let url = URL(string: "https://picsum.photos/200/300")!
-    let viewModel = KlaviyoWebViewModel(url: url)
-    return KlaviyoWebViewController(viewModel: viewModel)
+    return createKlaviyoWebPreview(url: url)
 }
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -60,6 +60,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate {
         let webView = WKWebView(frame: .zero, configuration: config)
         // customize any WKWebView behaviors here
         // ex: webView.allowsBackForwardNavigationGestures = true
+        webView.isOpaque = false
         return webView
     }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -131,7 +131,7 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
 #if swift(>=5.9)
 @available(iOS 17.0, *)
 #Preview("Klaviyo.com") {
-    let url = URL(string: "https://www.klaviyo.com")!
+    let url = URL(string: "https://picsum.photos/200/300")!
     let viewModel = KlaviyoWebViewModel(url: url)
     return KlaviyoWebViewController(viewModel: viewModel)
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/HTML/klaviyo.html
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/HTML/klaviyo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <title>Mobile App Banner</title>
     <script type="text/javascript" src="https://static.klaviyo.com/onsite/js/klaviyo.js?company_id=LuYLmF&env=in-app"></script>
 </head>

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/HTML/klaviyo.html
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/HTML/klaviyo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mobile App Banner</title>
+    <script type="text/javascript" src="https://static.klaviyo.com/onsite/js/klaviyo.js?company_id=LuYLmF&env=in-app"></script>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
# Description

This PR adds some changes that we'll use for testing forms using Xcode previews. Changes include the following:

1. I created a "dummy" `PreviewGridViewController` as a sample of what a gridded app might look like underneath a Klaviyo form. It's an interactive view (you can scroll and change tabs) so we can test interactivity before and after the form is displayed. This is wrapped in an `#if DEBUG` flag so it can't be used in production code.
<img width="226" alt="Screenshot 2024-11-18 at 12 26 49" src="https://github.com/user-attachments/assets/94431c69-50b9-4dfd-af10-6f9b8ef39643">

2. I added a `klaviyo.html` file that will display a form when loaded into a `KlaviyoWebViewController`, and added an Xcode preview for this.
<img width="226" alt="Screenshot 2024-11-18 at 12 27 42" src="https://github.com/user-attachments/assets/f8814c8f-135b-421f-baeb-274f27e2dde4">

3. I added a `jstest.html` file that can be used for testing the javascript bridge between the native layer and the web layer. This and all relevant files are added under a directory called "Development Assets", following a [convention established by Apple](https://www.avanderlee.com/xcode/development-assets-preview-catalog/) for specifying files that are only used for Xcode previews.

https://github.com/user-attachments/assets/58d0deed-1d26-4c04-abb8-0aee94f4061e

4. I made the background for the `KlaviyoWebViewController` transparent, and made the WebView ignore the safe area so it extends to all edges of the screen


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?