### PR TITLE
added private `fetchForms()` method

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -184,3 +184,18 @@ public struct KlaviyoSDK {
         return false
     }
 }
+
+// MARK: - SPI Private methods
+
+// for internal use only
+
+@_spi(KlaviyoPrivate)
+extension KlaviyoSDK {
+    /// Fetch the active forms for the current user.
+    ///
+    /// - warning: For internal use only. The host app should not manually call this method, as
+    /// the logic for fetching and displaying forms will be handled internally within the SDK.
+    public func fetchForms() {
+        dispatchOnMainThread(action: .fetchForms)
+    }
+}


### PR DESCRIPTION
# Description

This PR adds an `@_spi(KlaviyoPrivate)` `fetchForms()` method to the `KlaviyoSDK` struct. This method is intended for use in the test app, so we can tap a button to fetch the active forms and display the result in the request log. It's marked private because the host app should not manually call `fetchForms`, as this work will be handled with in the SDK.

Here's a preview of what the test app looks like with a button that's wired up to this new `fetchForms()` method:
<img width="368" alt="Screenshot 2024-12-04 at 15 15 42" src="https://github.com/user-attachments/assets/a79c1fb8-8d75-43b2-a88f-de297ef3c650">


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?