### PR TITLE
remove `unchecked` from `FileClient`

### DIFF
--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -11,28 +11,34 @@ func write(data: Data, url: URL) throws {
     try data.write(to: url, options: .atomic)
 }
 
-public struct FileClient: @unchecked Sendable {
+public struct FileClient: Sendable {
     public init(
-        write: @escaping (Data, URL) throws -> Void,
-        fileExists: @escaping (String) -> Bool,
-        removeItem: @escaping (String) throws -> Void,
-        libraryDirectory: @escaping () -> URL) {
+        write: @Sendable @escaping (Data, URL) throws -> Void,
+        fileExists: @Sendable @escaping (String) -> Bool,
+        removeItem: @Sendable @escaping (String) throws -> Void,
+        libraryDirectory: @Sendable @escaping () -> URL) {
         self.write = write
         self.fileExists = fileExists
         self.removeItem = removeItem
         self.libraryDirectory = libraryDirectory
     }
 
-    public var write: (Data, URL) throws -> Void
-    public var fileExists: (String) -> Bool
-    public var removeItem: (String) throws -> Void
-    public var libraryDirectory: () -> URL
+    public var write: @Sendable (Data, URL) throws -> Void
+    public var fileExists: @Sendable (String) -> Bool
+    public var removeItem: @Sendable (String) throws -> Void
+    public var libraryDirectory: @Sendable () -> URL
 
     public static let production = FileClient(
         write: write(data:url:),
-        fileExists: FileManager.default.fileExists(atPath:),
-        removeItem: FileManager.default.removeItem(atPath:),
-        libraryDirectory: { FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first! })
+        fileExists: { path in
+            FileManager.default.fileExists(atPath: path)
+        },
+        removeItem: { path in
+            try FileManager.default.removeItem(atPath: path)
+        },
+        libraryDirectory: {
+            FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
+        })
 }
 
 /**

--- a/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
@@ -10,7 +10,7 @@ import Combine
 import XCTest
 
 @MainActor
-class ArchivalUtilsTests: XCTestCase {
+class ArchivalUtilsTests: XCTestCase, Sendable {
     #if swift(>=6)
     nonisolated(unsafe) var dataToWrite: Data?
     nonisolated(unsafe) var wroteToFile = false
@@ -86,14 +86,8 @@ class ArchivalUtilsTests: XCTestCase {
     }
 
     func testUnarchiveUnableToRemoveFile() throws {
-        var firstCall = true
-        environment.fileClient.fileExists = { _ in
-            if firstCall {
-                firstCall = false
-                return true
-            }
-            return false
-        }
+        environment.fileClient.fileExists = { _ in true }
+        environment.fileClient.removeItem = { _ in }
         let archiveResult = unarchiveFromFile(fileClient: environment.fileClient, fileURL: TEST_URL)
 
         XCTAssertEqual(SAMPLE_DATA, archiveResult)

--- a/Tests/KlaviyoCoreTests/FileUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/FileUtilsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 @MainActor
-class FileUtilsTests: XCTestCase {
+class FileUtilsTests: XCTestCase, Sendable {
     #if swift(>=6)
     nonisolated(unsafe) var dataToWrite: Data?
     nonisolated(unsafe) var wroteToFile = false


### PR DESCRIPTION
# Description

I wanted to see if I could remove the `@unchecked` from `FileClient`. Seems like this works, @ndurell what do you think?