### PR TITLE
Update example app plists for badge count

### DIFF
--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>klaviyo_app_group</key>
+	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 </dict>

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>klaviyo_app_group</key>
+	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>klaviyo_app_group</key>
+	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>klaviyo_app_group</key>
+	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Examples/KlaviyoSwiftExamples/Shared/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/Shared/Info.plist
@@ -2,10 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Klaviyo_badge_autoclearing</key>
-	<true/>
-	<key>Klaviyo_App_Group</key>
-	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>klaviyo_app_group</key>
+	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# Description

Adding `klaviyo_app_group` with the suggested naming scheme per the new [README](https://github.com/klaviyo/klaviyo-swift-sdk/pull/247) to support badge count. Decided not to add the `klaviyo_badge_autoclearing` key since we already default to autoclear and adding it just to set it to `NO` or `YES` seemed redundant for these examples. 