### PR TITLE
Bump KlaviyoCore 4.0.0 -> 4.1.0

### DIFF
--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile
@@ -4,6 +4,7 @@ use_frameworks!
 target 'CocoapodsExample' do
   # update this to a actual version once KlaviyoCore is published
   pod 'KlaviyoSwift', :path => '../../..'
+  pod 'KlaviyoCore', :path => '../../..'
 end
 
 target 'NotificationServiceExtension' do

--- a/KlaviyoCore.podspec
+++ b/KlaviyoCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoCore"
-  s.version          = "0.1.0"
+  s.version          = "4.1.0"
   s.summary          = "Core functionalities for the Klaviyo SDK"
   s.description      = <<-DESC
                         Core functionalities and utilities for the Klaviyo SDK.

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
-  s.dependency     'KlaviyoCore', '~> 0.1.0'
+  s.dependency     'KlaviyoCore', '~> 4.1.0'
   s.dependency     'AnyCodable-FlightSchool'
 end


### PR DESCRIPTION
# Description

This release branch was branched off of 4.0.0 which did not have KlaviyoCore updated to 4.0.0 work [here](https://github.com/klaviyo/klaviyo-swift-sdk/pull/211) -- but to bring it back into sync this is an effective minor bump from 4.0.0 to 4.1.0 for the additional badge count work + V3 revision update that went into KlaviyoCore