### PR TITLE
Badge count | privacy manifest 

### DIFF
--- a/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
+++ b/Sources/KlaviyoSwift/PrivacyInfo.xcprivacy
@@ -52,7 +52,7 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
+				<string>C56D.1</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/c6fee401-f81a-44a4-8b54-e5d94e7b7a5a)


Since we use UserDefaults to store and access badge count we need to specify this in the privacy manifest to [comply](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype) with Apple. 

