### PR TITLE
[CHNL-16215] refactor KlaviyoWebViewController/ViewModel

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -59,16 +59,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
 
             let script = "document.getElementById('toggle-status').innerText = \"\(newStatus)\""
 
-            continuation?.yield((script, { result in
-                switch result {
-                case let .success(content):
-                    if let successMessage = content as? String {
-                        print("Successfully evaluated Javascript; message: \(successMessage)")
-                    }
-                case let .failure(failure):
-                    print("Javascript evaluation failed; message: \(failure.localizedDescription)")
-                }
-            }))
+            // TODO: evaluate script in WebView
         }
     }
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -13,6 +13,7 @@ import WebKit
 class JSTestWebViewModel: KlaviyoWebViewModeling {
     let url: URL
     let loadScripts: [String: WKUserScript]?
+    weak var delegate: KlaviyoWebViewDelegate?
 
     /// Publishes scripts for the `WKWebView` to execute.
     private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -53,7 +53,16 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
 
             let script = "document.getElementById('toggle-status').innerText = \"\(newStatus)\""
 
-            // TODO: evaluate script in WebView
+            Task {
+                do {
+                    let result = try await delegate?.evaluateJavaScript(script)
+                    if let successMessage = result as? String {
+                        print("Successfully evaluated Javascript; message: \(successMessage)")
+                    }
+                } catch {
+                    print("Javascript evaluation failed; message: \(error.localizedDescription)")
+                }
+            }
         }
     }
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -15,12 +15,6 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     let loadScripts: [String: WKUserScript]?
     weak var delegate: KlaviyoWebViewDelegate?
 
-    /// Publishes scripts for the `WKWebView` to execute.
-    private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?
-    lazy var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> = AsyncStream { [weak self] continuation in
-        self?.continuation = continuation
-    }
-
     init(url: URL) {
         self.url = url
         loadScripts = JSTestWebViewModel.initializeLoadScripts()

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -43,6 +43,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
         let request = URLRequest(url: viewModel.url)
         webView.load(request)
     }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -9,15 +9,16 @@ import Combine
 import UIKit
 import WebKit
 
-class KlaviyoWebViewController: UIViewController, WKUIDelegate {
+class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDelegate {
     var webView: WKWebView!
-    private let viewModel: KlaviyoWebViewModeling
+    private var viewModel: KlaviyoWebViewModeling
 
     // MARK: - Initializers
 
     init(viewModel: KlaviyoWebViewModeling) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        self.viewModel.delegate = self
     }
 
     @available(*, unavailable)

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -28,13 +28,12 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate {
     // MARK: - View loading
 
     override func loadView() {
-        super.loadView()
-
         let config = createWebViewConfiguration()
         webView = createWebView(with: config)
         webView.navigationDelegate = self
         webView.uiDelegate = self
 
+        view = UIView()
         view.addSubview(webView)
 
         configureLoadScripts()

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -87,6 +87,11 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         }
     }
 
+    @MainActor
+    func evaluateJavaScript(_ script: String) async throws -> Any {
+        try await webView.evaluateJavaScript(script)
+    }
+
     // MARK: - Layout
 
     func configureSubviewConstraints() {

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -38,7 +38,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         view.addSubview(webView)
 
         configureLoadScripts()
-        configureScriptEvaluator()
         configureSubviewConstraints()
     }
 
@@ -85,22 +84,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         for (name, script) in scriptsDict {
             webView.configuration.userContentController.addUserScript(script)
             webView.configuration.userContentController.add(self, name: name)
-        }
-    }
-
-    @MainActor
-    func configureScriptEvaluator() {
-        Task { [weak self] in
-            guard let self else { return }
-
-            for await (script, callback) in self.viewModel.scriptStream {
-                do {
-                    let result = try await self.webView.evaluateJavaScript(script)
-                    callback?(.success(result))
-                } catch {
-                    callback?(.failure(error))
-                }
-            }
         }
     }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -47,6 +47,15 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate {
         webView.load(request)
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        let scriptNames = viewModel.loadScripts?.keys.compactMap { $0 } ?? []
+        for scriptName in scriptNames {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: scriptName)
+        }
+    }
+
     // MARK: - WKWebView configuration
 
     func createWebViewConfiguration() -> WKWebViewConfiguration {

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -14,6 +14,7 @@ protocol KlaviyoWebViewDelegate: AnyObject {}
 class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     let url: URL
     let loadScripts: [String: WKUserScript]?
+    weak var delegate: KlaviyoWebViewDelegate?
 
     /// Publishes scripts for the `WKWebView` to execute.
     private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -16,12 +16,6 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     let loadScripts: [String: WKUserScript]?
     weak var delegate: KlaviyoWebViewDelegate?
 
-    /// Publishes scripts for the `WKWebView` to execute.
-    private var continuation: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)>.Continuation?
-    lazy var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> = AsyncStream { [weak self] continuation in
-        self?.continuation = continuation
-    }
-
     init(url: URL) {
         self.url = url
         loadScripts = KlaviyoWebViewModel.initializeLoadScripts()

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -9,7 +9,10 @@ import Combine
 import Foundation
 import WebKit
 
-protocol KlaviyoWebViewDelegate: AnyObject {}
+protocol KlaviyoWebViewDelegate: AnyObject {
+    @MainActor
+    func evaluateJavaScript(_ script: String) async throws -> Any
+}
 
 class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     let url: URL

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -9,6 +9,8 @@ import Combine
 import Foundation
 import WebKit
 
+protocol KlaviyoWebViewDelegate: AnyObject {}
+
 class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     let url: URL
     let loadScripts: [String: WKUserScript]?

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -16,9 +16,6 @@ protocol KlaviyoWebViewModeling {
     /// Scripts to be injected into the ``WKWebView`` when the website loads.
     var loadScripts: [String: WKUserScript]? { get }
 
-    /// Streams scripts for the ``WKWebView`` to execute.
-    var scriptStream: AsyncStream<(script: String, callback: ((Result<Any?, Error>) -> Void)?)> { get }
-
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -11,6 +11,7 @@ import WebKit
 
 protocol KlaviyoWebViewModeling {
     var url: URL { get }
+    var delegate: KlaviyoWebViewDelegate? { get set }
 
     /// Scripts to be injected into the ``WKWebView`` when the website loads.
     var loadScripts: [String: WKUserScript]? { get }


### PR DESCRIPTION
# Description

This PR makes some improvements to the KlaviyoWebViewController and KlaviyoWebViewModel. This includes:

- Implementing a delegate/protocol pattern for the ViewModel to communicate with the ViewController to execute methods in the ViewController.
- Using the delegate/protocol pattern to replace the previous implementation of having the ViewModel execute Javascript in the ViewController's WebView
- Resolving a memory leak that prevented the ViewController and ViewModel from being deallocated

These changes are all refactors and bug fixes that do not introduce any functional changes to the SDK.

This PR is one of several that I will open in the coming days as part of [CHNL-16215](https://klaviyo.atlassian.net/browse/CHNL-16215).

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. I used the SwiftUI previews and the iOS test app to validate that the view is working as expected
2. I validated that the ViewController and ViewModel are getting deallocated by verifying that `deinit` is getting called on both when the view is dismissed.

# Supporting Materials

Validating that script evaluation is working as expected:

https://github.com/user-attachments/assets/a5b0ff87-57cd-4fbb-a57d-b37ff3aa1c49


[CHNL-16215]: https://klaviyo.atlassian.net/browse/CHNL-16215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ