### PR TITLE
[CHNL-16215] refactor KlaviyoWebViewController/ViewModel 2

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -70,7 +70,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     // MARK: - Scripts
 
     /// Configures the scripts to be injected into the website when the website loads.
-    func configureLoadScripts() {
+    private func configureLoadScripts() {
         guard let scriptsDict = viewModel.loadScripts else { return }
 
         for (name, script) in scriptsDict {
@@ -86,7 +86,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     // MARK: - Layout
 
-    func configureSubviewConstraints() {
+    private func configureSubviewConstraints() {
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -9,14 +9,30 @@ import Combine
 import UIKit
 import WebKit
 
+private func createDefaultWebView() -> WKWebView {
+    let config = WKWebViewConfiguration()
+    let webView = WKWebView(frame: .zero, configuration: config)
+    webView.isOpaque = false
+    webView.scrollView.contentInsetAdjustmentBehavior = .never
+    return webView
+}
+
 class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDelegate {
-    var webView: WKWebView!
+    private lazy var webView: WKWebView = {
+        let webView = createWebView()
+        webView.navigationDelegate = self
+        webView.uiDelegate = self
+        return webView
+    }()
+
     private var viewModel: KlaviyoWebViewModeling
+    private let createWebView: () -> WKWebView
 
     // MARK: - Initializers
 
-    init(viewModel: KlaviyoWebViewModeling) {
+    init(viewModel: KlaviyoWebViewModeling, webViewFactory: @escaping () -> WKWebView = createDefaultWebView) {
         self.viewModel = viewModel
+        createWebView = webViewFactory
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self
     }
@@ -29,11 +45,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     // MARK: - View loading
 
     override func loadView() {
-        let config = createWebViewConfiguration()
-        webView = createWebView(with: config)
-        webView.navigationDelegate = self
-        webView.uiDelegate = self
-
         view = UIView()
         view.addSubview(webView)
 
@@ -54,25 +65,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         for scriptName in scriptNames {
             webView.configuration.userContentController.removeScriptMessageHandler(forName: scriptName)
         }
-    }
-
-    // MARK: - WKWebView configuration
-
-    func createWebViewConfiguration() -> WKWebViewConfiguration {
-        let config = WKWebViewConfiguration()
-        // customize any WKWebViewConfiguration properties here
-        // ex: config.allowsInlineMediaPlayback = true
-        return config
-    }
-
-    func createWebView(with config: WKWebViewConfiguration) -> WKWebView {
-        let webView = WKWebView(frame: .zero, configuration: config)
-        // customize any WKWebView behaviors here
-        // ex: webView.allowsBackForwardNavigationGestures = true
-        webView.isOpaque = false
-        webView.scrollView.contentInsetAdjustmentBehavior = .never
-
-        return webView
     }
 
     // MARK: - Scripts


### PR DESCRIPTION
# Description

following on #254, this PR adds a small improvement to the KlaviyoWebViewController. The ViewController now uses a factory method to create the WKWebView, which adds some flexibility to create a custom WKWebView, set properties on it, and inject it into the existing KlaviyoWebViewController without needing to create a new ViewController class.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. I validated that the KlaviyoWebViewController/ViewModel works as expected using both Xcode previews and the iOS test app
