### PR TITLE
[CHNL-16220] FileIO changes

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -23,7 +23,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     private static func initializeLoadScripts() -> [String: WKUserScript] {
         var scripts: [String: WKUserScript] = [:]
 
-        if let toggleHandlerScript = try? FileIO.getFileContents(path: "toggleHandler", type: "js") {
+        if let toggleHandlerScript = try? ResourceLoader.getFileContents(path: "toggleHandler", type: "js") {
             let script = WKUserScript(source: toggleHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
             scripts["toggleMessageHandler"] = script
         }

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -23,7 +23,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     private static func initializeLoadScripts() -> [String: WKUserScript] {
         var scripts: [String: WKUserScript] = [:]
 
-        if let toggleHandlerScript = try? ResourceLoader.getFileContents(path: "toggleHandler", type: "js") {
+        if let toggleHandlerScript = try? ResourceLoader.getResourceContents(path: "toggleHandler", type: "js") {
             let script = WKUserScript(source: toggleHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
             scripts["toggleMessageHandler"] = script
         }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -169,15 +169,15 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 
 @available(iOS 17.0, *)
 #Preview("Klaviyo Form") {
-    let indexHtmlFileUrl = Bundle.module.url(forResource: "klaviyo", withExtension: "html")!
+    let indexHtmlFileUrl = try! ResourceLoader.getFileUrl(path: "klaviyo", type: "html")
     let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
     return createKlaviyoWebPreview(viewModel: viewModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("JS Test Page") {
-    let indexHtmlFileUrl = Bundle.module.url(forResource: "jstest", withExtension: "html")!
+    let indexHtmlFileUrl = try! ResourceLoader.getFileUrl(path: "jstest", type: "html")
     let viewModel = JSTestWebViewModel(url: indexHtmlFileUrl)
-    return KlaviyoWebViewController(viewModel: viewModel)
+    KlaviyoWebViewController(viewModel: viewModel)
 }
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -169,14 +169,14 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 
 @available(iOS 17.0, *)
 #Preview("Klaviyo Form") {
-    let indexHtmlFileUrl = try! ResourceLoader.getFileUrl(path: "klaviyo", type: "html")
+    let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "klaviyo", type: "html")
     let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
-    return createKlaviyoWebPreview(viewModel: viewModel)
+    createKlaviyoWebPreview(viewModel: viewModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("JS Test Page") {
-    let indexHtmlFileUrl = try! ResourceLoader.getFileUrl(path: "jstest", type: "html")
+    let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "jstest", type: "html")
     let viewModel = JSTestWebViewModel(url: indexHtmlFileUrl)
     KlaviyoWebViewController(viewModel: viewModel)
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -171,13 +171,13 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 #Preview("Klaviyo Form") {
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "klaviyo", type: "html")
     let viewModel = KlaviyoWebViewModel(url: indexHtmlFileUrl)
-    createKlaviyoWebPreview(viewModel: viewModel)
+    return createKlaviyoWebPreview(viewModel: viewModel)
 }
 
 @available(iOS 17.0, *)
 #Preview("JS Test Page") {
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "jstest", type: "html")
     let viewModel = JSTestWebViewModel(url: indexHtmlFileUrl)
-    KlaviyoWebViewController(viewModel: viewModel)
+    return KlaviyoWebViewController(viewModel: viewModel)
 }
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -37,7 +37,7 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     private static func initializeLoadScripts() -> [String: WKUserScript] {
         var scripts: [String: WKUserScript] = [:]
 
-        if let closeHandlerScript = try? FileIO.getFileContents(path: "closeHandler", type: "js") {
+        if let closeHandlerScript = try? ResourceLoader.getFileContents(path: "closeHandler", type: "js") {
             let script = WKUserScript(source: closeHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
             scripts["closeHandler"] = script
         }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -37,7 +37,7 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     private static func initializeLoadScripts() -> [String: WKUserScript] {
         var scripts: [String: WKUserScript] = [:]
 
-        if let closeHandlerScript = try? ResourceLoader.getFileContents(path: "closeHandler", type: "js") {
+        if let closeHandlerScript = try? ResourceLoader.getResourceContents(path: "closeHandler", type: "js") {
             let script = WKUserScript(source: closeHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
             scripts["closeHandler"] = script
         }

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 enum ResourceLoaderError: Error {
-    case notFound
+    case resourceNotFound
 }
 
 enum ResourceLoader {
     static func getResourceUrl(path: String, type: String) throws -> URL {
         guard let fileUrl = Bundle.module.url(forResource: path, withExtension: type) else {
-            throw ResourceLoaderError.notFound
+            throw ResourceLoaderError.resourceNotFound
         }
 
         return fileUrl
@@ -22,7 +22,7 @@ enum ResourceLoader {
 
     static func getResourceContents(path: String, type: String) throws -> String {
         guard let path = Bundle.module.path(forResource: path, ofType: type) else {
-            throw ResourceLoaderError.notFound
+            throw ResourceLoaderError.resourceNotFound
         }
 
         do {

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew Balmer on 9/27/24.
 //
 
+#if DEBUG
 import Foundation
 
 enum ResourceLoaderError: Error {
@@ -60,3 +61,4 @@ extension Bundle {
         return bundle
     }
 }
+#endif

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -1,5 +1,5 @@
 //
-//  FileIO.swift
+//  ResourceLoader.swift
 //  KlaviyoSwiftUIWebView
 //
 //  Created by Andrew Balmer on 9/27/24.
@@ -7,22 +7,22 @@
 
 import Foundation
 
-enum FileIOError: Error {
+public enum ResourceLoaderError: Error {
     case notFound
 }
 
-enum FileIO {
-    static func getFileUrl(path: String, type: String) throws -> URL {
+public enum ResourceLoader {
+    public static func getFileUrl(path: String, type: String) throws -> URL {
         guard let fileUrl = Bundle.module.url(forResource: path, withExtension: type) else {
-            throw FileIOError.notFound
+            throw ResourceLoaderError.notFound
         }
 
         return fileUrl
     }
 
-    static func getFileContents(path: String, type: String) throws -> String {
+    public static func getFileContents(path: String, type: String) throws -> String {
         guard let path = Bundle.module.path(forResource: path, ofType: type) else {
-            throw FileIOError.notFound
+            throw ResourceLoaderError.notFound
         }
 
         do {

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -12,7 +12,7 @@ enum ResourceLoaderError: Error {
 }
 
 enum ResourceLoader {
-    static func getFileUrl(path: String, type: String) throws -> URL {
+    static func getResourceUrl(path: String, type: String) throws -> URL {
         guard let fileUrl = Bundle.module.url(forResource: path, withExtension: type) else {
             throw ResourceLoaderError.notFound
         }
@@ -20,7 +20,7 @@ enum ResourceLoader {
         return fileUrl
     }
 
-    static func getFileContents(path: String, type: String) throws -> String {
+    static func getResourceContents(path: String, type: String) throws -> String {
         guard let path = Bundle.module.path(forResource: path, ofType: type) else {
             throw ResourceLoaderError.notFound
         }

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-public enum ResourceLoaderError: Error {
+enum ResourceLoaderError: Error {
     case notFound
 }
 
-public enum ResourceLoader {
-    public static func getFileUrl(path: String, type: String) throws -> URL {
+enum ResourceLoader {
+    static func getFileUrl(path: String, type: String) throws -> URL {
         guard let fileUrl = Bundle.module.url(forResource: path, withExtension: type) else {
             throw ResourceLoaderError.notFound
         }
@@ -20,7 +20,7 @@ public enum ResourceLoader {
         return fileUrl
     }
 
-    public static func getFileContents(path: String, type: String) throws -> String {
+    static func getFileContents(path: String, type: String) throws -> String {
         guard let path = Bundle.module.path(forResource: path, ofType: type) else {
             throw ResourceLoaderError.notFound
         }

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -13,11 +13,11 @@ enum ResourceLoaderError: Error {
 
 enum ResourceLoader {
     static func getResourceUrl(path: String, type: String) throws -> URL {
-        guard let fileUrl = Bundle.module.url(forResource: path, withExtension: type) else {
+        guard let resourceUrl = Bundle.module.url(forResource: path, withExtension: type) else {
             throw ResourceLoaderError.resourceNotFound
         }
 
-        return fileUrl
+        return resourceUrl
     }
 
     static func getResourceContents(path: String, type: String) throws -> String {


### PR DESCRIPTION
# Description

This PR makes some changes to the `FileIO` enum:

- it renames FileIO to ResourceLoader, as this object is responsible for reading resources within the app or framework bundle rather than managing files in the os filesystem
- it adds handling for cases when the SDK is imported via Cocoapods. Previously there would be a compiler error because Cocoapods implementations cannot use `Bundle.module`.
- it wraps `ResourceLoader` in `#if DEBUG` tags, because the ResourceLoader is currently only being used for Xcode previews.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. I've validated that the Xcode previews for `KlaviyoWebViewController` still work as expected