### PR TITLE
[CHNL-16220] present webview from host app

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -15,6 +15,8 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     let loadScripts: [String: WKUserScript]?
     weak var delegate: KlaviyoWebViewDelegate?
 
+    public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
+
     init(url: URL) {
         self.url = url
         loadScripts = JSTestWebViewModel.initializeLoadScripts()

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -33,15 +33,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
         return scripts
     }
 
-    func preloadWebsite(timeout: UInt64) async {
-        // TODO: implement this
-    }
-
     // MARK: handle WKWebView events
-
-    func handleNavigationEvent(_ event: WKNavigationEvent) {
-        // TODO: handle navigation events
-    }
 
     func handleScriptMessage(_ message: WKScriptMessage) {
         if message.name == "toggleMessageHandler" {

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -81,6 +81,11 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         loadUrl()
     }
 
+    @MainActor
+    func dismiss() {
+        dismiss(animated: true)
+    }
+
     // MARK: - Scripts
 
     /// Configures the scripts to be injected into the website when the website loads.

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -48,7 +48,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         view = UIView()
         view.addSubview(webView)
 
-        configureLoadScripts()
         configureSubviewConstraints()
     }
 
@@ -72,6 +71,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     @MainActor
     private func loadUrl() {
+        configureLoadScripts()
         let request = URLRequest(url: viewModel.url)
         webView.load(request)
     }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -20,11 +20,6 @@ public protocol KlaviyoWebViewDelegate: AnyObject {
 
 @_spi(KlaviyoPrivate)
 public class KlaviyoWebViewModel: KlaviyoWebViewModeling {
-    enum PreloadError: Error {
-        case timeout
-        case navigationFailed
-    }
-
     public let url: URL
     public let loadScripts: [String: WKUserScript]?
     public weak var delegate: KlaviyoWebViewDelegate?

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -42,71 +42,7 @@ public class KlaviyoWebViewModel: KlaviyoWebViewModeling {
         return scripts
     }
 
-    /// Tells the delegate's ``WKWebView`` to preload the URL provided in this ViewModel.
-    ///
-    /// This async method will return after the preload has completed.
-    ///
-    /// By preloading, we can load the URL "headless", so that the ViewController containing
-    /// the ``WKWebView`` will only be presented after the site has successfully loaded.
-    ///
-    /// The caller of this method should `await` completion of this method, then present the ViewController.
-    /// - Parameter timeout: the amount of time, in milliseconds, to wait before throwing a `timeout` error.
-    public func preloadWebsite(timeout: UInt64) async throws {
-        guard let delegate else { return }
-
-        await delegate.preloadUrl()
-
-        do {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    try await Task.sleep(nanoseconds: timeout)
-                    throw PreloadError.timeout
-                }
-
-                // Add the navigation event task to the group
-                group.addTask { [weak self] in
-                    guard let self else { return }
-                    for await event in self.navEventStream {
-                        switch event {
-                        case .didFinishNavigation:
-                            return
-                        case .didFailNavigation:
-                            throw PreloadError.navigationFailed
-                        case .didCommitNavigation,
-                             .didStartProvisionalNavigation,
-                             .didFailProvisionalNavigation,
-                             .didReceiveServerRedirectForProvisionalNavigation:
-                            continue
-                        }
-                    }
-                }
-
-                if let _ = try await group.next() {
-                    // when the navigation task returns, we want to
-                    // cancel both the timeout task and the navigation task
-                    group.cancelAll()
-                }
-            }
-        } catch let error as PreloadError {
-            switch error {
-            case .timeout:
-                print("Operation timed out: \(error)")
-                throw error
-            case .navigationFailed:
-                print("Navigation failed: \(error)")
-                throw error
-            }
-        } catch {
-            print("Operation encountered an error: \(error)")
-            throw error
-        }
-    }
-
     // MARK: handle WKWebView events
-
-    public func handleNavigationEvent(_ event: WKNavigationEvent) {
-        navEventContinuation.yield(event)
-    }
 
     public func handleScriptMessage(_ message: WKScriptMessage) {
         if message.name == "closeHandler" {

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -16,6 +16,9 @@ public protocol KlaviyoWebViewDelegate: AnyObject {
 
     @MainActor
     func evaluateJavaScript(_ script: String) async throws -> Any
+
+    @MainActor
+    func dismiss()
 }
 
 @_spi(KlaviyoPrivate)
@@ -48,6 +51,10 @@ public class KlaviyoWebViewModel: KlaviyoWebViewModeling {
         if message.name == "closeHandler" {
             // TODO: handle close button tap
             print("user tapped close button")
+
+            Task {
+                await delegate?.dismiss()
+            }
         }
     }
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -24,7 +24,7 @@ public class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     public let loadScripts: [String: WKUserScript]?
     public weak var delegate: KlaviyoWebViewDelegate?
 
-    private let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
+    public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
 
     public init(url: URL) {
         self.url = url

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModel.swift
@@ -9,7 +9,8 @@ import Combine
 import Foundation
 import WebKit
 
-protocol KlaviyoWebViewDelegate: AnyObject {
+@_spi(KlaviyoPrivate)
+public protocol KlaviyoWebViewDelegate: AnyObject {
     @MainActor
     func preloadUrl()
 
@@ -17,19 +18,20 @@ protocol KlaviyoWebViewDelegate: AnyObject {
     func evaluateJavaScript(_ script: String) async throws -> Any
 }
 
-class KlaviyoWebViewModel: KlaviyoWebViewModeling {
+@_spi(KlaviyoPrivate)
+public class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     enum PreloadError: Error {
         case timeout
         case navigationFailed
     }
 
-    let url: URL
-    let loadScripts: [String: WKUserScript]?
-    weak var delegate: KlaviyoWebViewDelegate?
+    public let url: URL
+    public let loadScripts: [String: WKUserScript]?
+    public weak var delegate: KlaviyoWebViewDelegate?
 
     private let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
 
-    init(url: URL) {
+    public init(url: URL) {
         self.url = url
         loadScripts = KlaviyoWebViewModel.initializeLoadScripts()
     }
@@ -54,7 +56,7 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
     ///
     /// The caller of this method should `await` completion of this method, then present the ViewController.
     /// - Parameter timeout: the amount of time, in milliseconds, to wait before throwing a `timeout` error.
-    func preloadWebsite(timeout: UInt64) async throws {
+    public func preloadWebsite(timeout: UInt64) async throws {
         guard let delegate else { return }
 
         await delegate.preloadUrl()
@@ -107,11 +109,11 @@ class KlaviyoWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: handle WKWebView events
 
-    func handleNavigationEvent(_ event: WKNavigationEvent) {
+    public func handleNavigationEvent(_ event: WKNavigationEvent) {
         navEventContinuation.yield(event)
     }
 
-    func handleScriptMessage(_ message: WKScriptMessage) {
+    public func handleScriptMessage(_ message: WKScriptMessage) {
         if message.name == "closeHandler" {
             // TODO: handle close button tap
             print("user tapped close button")

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -23,3 +23,71 @@ public protocol KlaviyoWebViewModeling: AnyObject {
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)
 }
+
+// MARK: - Default implementation
+
+extension KlaviyoWebViewModeling {
+    /// Tells the delegate's ``WKWebView`` to preload the URL provided in this ViewModel.
+    ///
+    /// This async method will return after the preload has completed.
+    ///
+    /// By preloading, we can load the URL "headless", so that the ViewController containing
+    /// the ``WKWebView`` will only be presented after the site has successfully loaded.
+    ///
+    /// The caller of this method should `await` completion of this method, then present the ViewController.
+    /// - Parameter timeout: the amount of time, in milliseconds, to wait before throwing a `timeout` error.
+    public func preloadWebsite(timeout: UInt64) async throws {
+        guard let delegate else { return }
+
+        await delegate.preloadUrl()
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await Task.sleep(nanoseconds: timeout)
+                    throw PreloadError.timeout
+                }
+
+                // Add the navigation event task to the group
+                group.addTask { [weak self] in
+                    guard let self else { return }
+                    for await event in self.navEventStream {
+                        switch event {
+                        case .didFinishNavigation:
+                            return
+                        case .didFailNavigation:
+                            throw PreloadError.navigationFailed
+                        case .didCommitNavigation,
+                             .didStartProvisionalNavigation,
+                             .didFailProvisionalNavigation,
+                             .didReceiveServerRedirectForProvisionalNavigation:
+                            continue
+                        }
+                    }
+                }
+
+                if let _ = try await group.next() {
+                    // when the navigation task returns, we want to
+                    // cancel both the timeout task and the navigation task
+                    group.cancelAll()
+                }
+            }
+        } catch let error as PreloadError {
+            switch error {
+            case .timeout:
+                print("Operation timed out: \(error)")
+                throw error
+            case .navigationFailed:
+                print("Navigation failed: \(error)")
+                throw error
+            }
+        } catch {
+            print("Operation encountered an error: \(error)")
+            throw error
+        }
+    }
+
+    public func handleNavigationEvent(_ event: WKNavigationEvent) {
+        navEventContinuation.yield(event)
+    }
+}

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -16,6 +16,8 @@ public protocol KlaviyoWebViewModeling: AnyObject {
 
     /// Scripts to be injected into the ``WKWebView`` when the website loads.
     var loadScripts: [String: WKUserScript]? { get }
+    var navEventStream: AsyncStream<WKNavigationEvent> { get }
+    var navEventContinuation: AsyncStream<WKNavigationEvent>.Continuation { get }
 
     func preloadWebsite(timeout: UInt64) async throws
     func handleNavigationEvent(_ event: WKNavigationEvent)

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -9,7 +9,8 @@ import Combine
 import Foundation
 import WebKit
 
-protocol KlaviyoWebViewModeling {
+@_spi(KlaviyoPrivate)
+public protocol KlaviyoWebViewModeling {
     var url: URL { get }
     var delegate: KlaviyoWebViewDelegate? { get set }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -10,7 +10,7 @@ import Foundation
 import WebKit
 
 @_spi(KlaviyoPrivate)
-public protocol KlaviyoWebViewModeling {
+public protocol KlaviyoWebViewModeling: AnyObject {
     var url: URL { get }
     var delegate: KlaviyoWebViewDelegate? { get set }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/PreloadError.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/PreloadError.swift
@@ -1,0 +1,11 @@
+//
+//  PreloadError.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 1/21/25.
+//
+
+enum PreloadError: Error {
+    case timeout
+    case navigationFailed
+}

--- a/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
@@ -28,10 +28,6 @@ public class KlaviyoWebViewOverlayManager {
             return
         }
 
-        guard let topController = UIApplication.shared.topMostViewController else {
-            return
-        }
-
         isLoading = true
 
         let viewController = KlaviyoWebViewController(viewModel: viewModel)
@@ -41,6 +37,10 @@ public class KlaviyoWebViewOverlayManager {
             defer { isLoading = false }
 
             try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+
+            guard let topController = UIApplication.shared.topMostViewController else {
+                return
+            }
             topController.present(viewController, animated: true, completion: nil)
         }
     }

--- a/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
@@ -1,0 +1,47 @@
+//
+//  KlaviyoWebViewOverlayManager.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 1/15/25.
+//
+
+import SwiftUI
+import UIKit
+
+@_spi(KlaviyoPrivate)
+public class KlaviyoWebViewOverlayManager {
+    public static let shared = KlaviyoWebViewOverlayManager()
+    private var isLoading: Bool = false
+
+    /// Presents a view controller on the top-most view controller
+    /// - Parameters:
+    ///   - viewController: A `UIViewController` instance to present.
+    ///   - modalPresentationStyle: The modal presentation style to use (default is `.overCurrentContext`).
+    ///
+    /// - warning: For internal use only. The host app should not manually call this method, as
+    /// the logic for fetching and displaying forms will be handled internally within the SDK.
+    @_spi(KlaviyoPrivate)
+    @MainActor public func preloadAndShow(
+        viewModel: KlaviyoWebViewModeling,
+        modalPresentationStyle: UIModalPresentationStyle = .overCurrentContext) {
+        guard !isLoading else {
+            return
+        }
+
+        guard let topController = UIApplication.shared.topMostViewController else {
+            return
+        }
+
+        isLoading = true
+
+        let viewController = KlaviyoWebViewController(viewModel: viewModel)
+        viewController.modalPresentationStyle = modalPresentationStyle
+
+        Task {
+            defer { isLoading = false }
+
+            try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+            topController.present(viewController, animated: true, completion: nil)
+        }
+    }
+}

--- a/Sources/KlaviyoUI/Models/WKNavigationEvent.swift
+++ b/Sources/KlaviyoUI/Models/WKNavigationEvent.swift
@@ -5,7 +5,8 @@
 //  Created by Andrew Balmer on 9/30/24.
 //
 
-enum WKNavigationEvent {
+@_spi(KlaviyoPrivate)
+public enum WKNavigationEvent {
     /// Invoked when a main frame navigation starts.
     case didStartProvisionalNavigation
 

--- a/Sources/KlaviyoUI/Utilities/UIApplication+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/UIApplication+Ext.swift
@@ -1,0 +1,34 @@
+//
+//  UIApplication+Ext.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 12/4/24.
+//
+
+import Foundation
+import UIKit
+
+extension UIApplication {
+    var topMostViewController: UIViewController? {
+        guard let keyWindow = getKeyWindow() else { return nil }
+        var topController = keyWindow.rootViewController
+        while let presentedController = topController?.presentedViewController {
+            if let navigationController = presentedController as? UINavigationController {
+                topController = navigationController.visibleViewController
+            } else if let tabBarController = presentedController as? UITabBarController {
+                topController = tabBarController.selectedViewController
+            } else {
+                topController = presentedController
+            }
+        }
+        return topController
+    }
+
+    private func getKeyWindow() -> UIWindow? {
+        connectedScenes
+            .filter { $0 is UIWindowScene }
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })
+    }
+}

--- a/Tests/KlaviyoUITests/KlaviyoWebViewModelTests.swift
+++ b/Tests/KlaviyoUITests/KlaviyoWebViewModelTests.swift
@@ -5,7 +5,7 @@
 //  Created by Andrew Balmer on 1/21/25.
 //
 
-@testable import KlaviyoUI
+@testable @_spi(KlaviyoPrivate) import KlaviyoUI
 import WebKit
 import XCTest
 
@@ -47,6 +47,8 @@ class MockKlaviyoWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
         evaluateJavaScriptCalled = true
         return true
     }
+
+    func dismiss() {}
 }
 
 final class KlaviyoWebViewModelTests: XCTestCase {
@@ -99,7 +101,7 @@ final class KlaviyoWebViewModelTests: XCTestCase {
         do {
             try await viewModel.preloadWebsite(timeout: 100_000_000) // 0.1 second in nanoseconds
             XCTFail("Expected timeout error, but succeeded")
-        } catch KlaviyoWebViewModel.PreloadError.timeout {
+        } catch PreloadError.timeout {
             expectation.fulfill()
         } catch {
             XCTFail("Expected timeout error, but got: \(error)")
@@ -119,7 +121,7 @@ final class KlaviyoWebViewModelTests: XCTestCase {
         do {
             try await viewModel.preloadWebsite(timeout: 1_000_000_000) // 1 second in nanoseconds
             XCTFail("Expected navigation failed error, but succeeded")
-        } catch KlaviyoWebViewModel.PreloadError.navigationFailed {
+        } catch PreloadError.navigationFailed {
             expectation.fulfill()
         } catch {
             XCTFail("Expected navigation failed error, but got: \(error)")


### PR DESCRIPTION
# Description

This PR adds the architecture to a) preload a website, and b) once the site is preloaded, present the website as a modal on top of whatever screen is currently visible.

I have also marked some objects as `@_spi(KlaviyoPrivate)`, because we need to use these objects in the iOS test app without exposing them publicly to consumers of the SKD.

I also added some default implementation for the `preloadWebsite` and `handleNavigationEvent` functions to the `KlaviyoWebViewModeling` protocol.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. I wired up an example in the iOS test app to validate the changes. 


# Supporting Materials

This video shows the example I wired up in the iOS test app. After tapping the button, the KlavyioWebViewController preloads an "expensive" website (it's loading a very large image). After the preload completes, the image appears as a modal. Notice that I can still navigate through the app while the site is preloading.

https://github.com/user-attachments/assets/f8d2539e-4abd-473f-921c-c10f193a3475

