### PR TITLE
[CHNL-16564] update script and message handling

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -11,9 +11,9 @@ import Foundation
 import WebKit
 
 class JSTestWebViewModel: KlaviyoWebViewModeling {
-    public enum MessageHandler: String, CaseIterable {
+    private enum MessageHandler: String, CaseIterable {
         case toggleMessageHandler
-        case closeHandler
+        case closeMessageHandler
     }
 
     weak var delegate: KlaviyoWebViewDelegate?
@@ -78,7 +78,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
                     print("Javascript evaluation failed; message: \(error.localizedDescription)")
                 }
             }
-        case .closeHandler:
+        case .closeMessageHandler:
             Task {
                 await delegate?.dismiss()
             }

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/JSTestWebViewModel.swift
@@ -11,23 +11,34 @@ import Foundation
 import WebKit
 
 class JSTestWebViewModel: KlaviyoWebViewModeling {
-    let url: URL
-    let loadScripts: [String: WKUserScript]?
+    public enum MessageHandler: String, CaseIterable {
+        case toggleMessageHandler
+        case closeHandler
+    }
+
     weak var delegate: KlaviyoWebViewDelegate?
+
+    let url: URL
+    var loadScripts: Set<WKUserScript>? = JSTestWebViewModel.initializeLoadScripts()
+    var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
 
     init(url: URL) {
         self.url = url
-        loadScripts = JSTestWebViewModel.initializeLoadScripts()
     }
 
-    private static func initializeLoadScripts() -> [String: WKUserScript] {
-        var scripts: [String: WKUserScript] = [:]
+    private static func initializeLoadScripts() -> Set<WKUserScript> {
+        var scripts = Set<WKUserScript>()
 
         if let toggleHandlerScript = try? ResourceLoader.getResourceContents(path: "toggleHandler", type: "js") {
             let script = WKUserScript(source: toggleHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-            scripts["toggleMessageHandler"] = script
+            scripts.insert(script)
+        }
+
+        if let closeHandlerScript = try? ResourceLoader.getResourceContents(path: "closeHandler", type: "js") {
+            let script = WKUserScript(source: closeHandlerScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+            scripts.insert(script)
         }
 
         return scripts
@@ -36,7 +47,13 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     // MARK: handle WKWebView events
 
     func handleScriptMessage(_ message: WKScriptMessage) {
-        if message.name == "toggleMessageHandler" {
+        guard let handler = MessageHandler(rawValue: message.name) else {
+            // script message has no handler
+            return
+        }
+
+        switch handler {
+        case .toggleMessageHandler:
             guard let dict = message.body as? [String: AnyObject] else {
                 return
             }
@@ -60,6 +77,10 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
                 } catch {
                     print("Javascript evaluation failed; message: \(error.localizedDescription)")
                 }
+            }
+        case .closeHandler:
+            Task {
+                await delegate?.dismiss()
             }
         }
     }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -63,9 +63,8 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
-        let scriptNames = viewModel.loadScripts?.keys.compactMap { $0 } ?? []
-        for scriptName in scriptNames {
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: scriptName)
+        viewModel.messageHandlers?.forEach {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: $0)
         }
     }
 
@@ -90,11 +89,12 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     /// Configures the scripts to be injected into the website when the website loads.
     private func configureLoadScripts() {
-        guard let scriptsDict = viewModel.loadScripts else { return }
+        viewModel.loadScripts?.forEach {
+            webView.configuration.userContentController.addUserScript($0)
+        }
 
-        for (name, script) in scriptsDict {
-            webView.configuration.userContentController.addUserScript(script)
-            webView.configuration.userContentController.add(self, name: name)
+        viewModel.messageHandlers?.forEach {
+            webView.configuration.userContentController.add(self, name: $0)
         }
     }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -14,8 +14,10 @@ public protocol KlaviyoWebViewModeling: AnyObject {
     var url: URL { get }
     var delegate: KlaviyoWebViewDelegate? { get set }
 
-    /// Scripts to be injected into the ``WKWebView`` when the website loads.
-    var loadScripts: [String: WKUserScript]? { get }
+    /// Scripts & message handlers to be injected into the ``WKWebView`` when the website loads.
+    var loadScripts: Set<WKUserScript>? { get }
+    var messageHandlers: Set<String>? { get }
+
     var navEventStream: AsyncStream<WKNavigationEvent> { get }
     var navEventContinuation: AsyncStream<WKNavigationEvent>.Continuation { get }
 


### PR DESCRIPTION
# Description

This PR makes some updates to the KlaviyoWebViewModeling protocol, all conforming ViewModels, and the KlaviyoWebViewController. We will need these changes in order to handle the javascript messages that the in-app forms emit. 

With this PR, I'm decoupling the javascript that gets injected into the WKWebView from the message handlers that get injected. This will allow us, in a future PR, to tell the WKWebView to listen for messages from  the `KlaviyoNativeBridge`, even though we aren't injecting a script with the same name. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. I've tested this using Xcode previews and with the iOS test app