### PR TITLE
[CHNL-16564] move console handler to sdk

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 import WebKit
 
+// ViewModel for testing the KlaviyoWebViewController & KlaviyoWebViewModeling protocol in Xcode previews only.
 class PreviewWebViewModel: KlaviyoWebViewModeling {
     private enum MessageHandler: String, CaseIterable {
         case toggleMessageHandler

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  JSTestWebViewModel.swift
+//  PreviewWebViewModel.swift
 //  klaviyo-swift-sdk
 //
 //  Created by Andrew Balmer on 11/18/24.
@@ -10,7 +10,7 @@ import Combine
 import Foundation
 import WebKit
 
-class JSTestWebViewModel: KlaviyoWebViewModeling {
+class PreviewWebViewModel: KlaviyoWebViewModeling {
     private enum MessageHandler: String, CaseIterable {
         case toggleMessageHandler
         case closeMessageHandler
@@ -19,7 +19,7 @@ class JSTestWebViewModel: KlaviyoWebViewModeling {
     weak var delegate: KlaviyoWebViewDelegate?
 
     let url: URL
-    var loadScripts: Set<WKUserScript>? = JSTestWebViewModel.initializeLoadScripts()
+    var loadScripts: Set<WKUserScript>? = PreviewWebViewModel.initializeLoadScripts()
     var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)

--- a/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/Scripts/toggleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Development Assets/Scripts/toggleHandler.js
@@ -1,6 +1,7 @@
 var _selector = document.querySelector('input[name=myCheckbox]');
 _selector.addEventListener('change', function(event) {
   if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.toggleMessageHandler) {
+    console.log("toggle changed; new value: " + _selector.checked);
     window.webkit.messageHandlers.toggleMessageHandler.postMessage({
       "toggleEnabled": _selector.checked
     });

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import OSLog
 import UIKit
 import WebKit
 
@@ -170,7 +171,7 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
                     let consoleMessage = try JSONDecoder().decode(WebViewConsoleRelayMessage.self, from: jsonData)
                     handleJsConsoleMessage(consoleMessage)
                 } catch {
-                    // TODO: log message
+                    Logger.webViewLogger.warning("Unable to decode WKWebView console relay message: \(error)")
                 }
             }
         } else {
@@ -184,7 +185,14 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
     #if DEBUG
     @available(iOS 14.0, *)
     private func handleJsConsoleMessage(_ consoleMessage: WebViewConsoleRelayMessage) {
-        // TODO: handle console message
+        switch consoleMessage.level {
+        case .log:
+            Logger.webViewLogger.log("\(consoleMessage.message)")
+        case .warn:
+            Logger.webViewLogger.warning("\(consoleMessage.message)")
+        case .error:
+            Logger.webViewLogger.error("\(consoleMessage.message)")
+        }
     }
     #endif
 }

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -241,7 +241,7 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 @available(iOS 17.0, *)
 #Preview("JS Test Page") {
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "jstest", type: "html")
-    let viewModel = JSTestWebViewModel(url: indexHtmlFileUrl)
+    let viewModel = PreviewWebViewModel(url: indexHtmlFileUrl)
     return KlaviyoWebViewController(viewModel: viewModel)
 }
 #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -171,7 +171,7 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
                     let consoleMessage = try JSONDecoder().decode(WebViewConsoleRelayMessage.self, from: jsonData)
                     handleJsConsoleMessage(consoleMessage)
                 } catch {
-                    Logger.webViewLogger.warning("Unable to decode WKWebView console relay message: \(error)")
+                    Logger.webViewConsoleLogger.warning("Unable to decode WKWebView console relay message: \(error)")
                 }
             }
         } else {
@@ -187,11 +187,11 @@ extension KlaviyoWebViewController: WKScriptMessageHandler {
     private func handleJsConsoleMessage(_ consoleMessage: WebViewConsoleRelayMessage) {
         switch consoleMessage.level {
         case .log:
-            Logger.webViewLogger.log("\(consoleMessage.message)")
+            Logger.webViewConsoleLogger.log("\(consoleMessage.message)")
         case .warn:
-            Logger.webViewLogger.warning("\(consoleMessage.message)")
+            Logger.webViewConsoleLogger.warning("\(consoleMessage.message)")
         case .error:
-            Logger.webViewLogger.error("\(consoleMessage.message)")
+            Logger.webViewConsoleLogger.error("\(consoleMessage.message)")
         }
     }
     #endif

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/bridge.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/bridge.js
@@ -1,6 +1,0 @@
-//
-//  Bridge.js
-//  klaviyo-swift-sdk
-//
-//  Created by Andrew Balmer on 10/1/24.
-//

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/closeHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/closeHandler.js
@@ -5,9 +5,11 @@
 //  Created by Andrew Balmer on 12/18/24.
 //
 
+const closeButton = document.getElementById('close-button');
 
-window.addEventListener("klaviyoForms", function(e) {
-  if (e.detail.type == 'close') {
-    window.webkit?.messageHandlers?.closeHandler?.postMessage('close');
+closeButton.addEventListener('click', function() {
+  if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.closeMessageHandler) {
+    console.log("user tapped close");
+    window.webkit.messageHandlers.closeMessageHandler.postMessage('close');
   }
 });

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
@@ -56,13 +56,15 @@
       },
     }
   }
-function unlinkConsole() {
+
+  function unlinkConsole() {
     ["log", "warn", "error"].forEach(function (method) {
       var bckKey = "_" + method
       console[method] = console[bckKey];
       delete console[bckKey]
     });
-}
+  }
+
   /**
    * Send all console output to native layer
    */

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
@@ -50,18 +50,27 @@
             window.webkit.messageHandlers[opts.bridgeName].postMessage(serializedPayload);
           }
         } catch (e) {
+          unlinkConsole()
           console.error("Failed to post message to native layer:", e.message);
         }
       },
     }
   }
-
+function unlinkConsole() {
+    ["log", "warn", "error"].forEach(function (method) {
+      var bckKey = "_" + method
+      console[method] = console[bckKey];
+      delete console[bckKey]
+    });
+}
   /**
    * Send all console output to native layer
    */
   if (!!window.WebViewBridge.opts.linkConsole) {
     ["log", "warn", "error"].forEach(function (method) {
       var _method = console[method];
+      var bckKey = "_" + method
+      console[bckKey] = _method
       console[method] = function () {
         var args = Array.prototype.slice.call(arguments, 0),
         message;

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
@@ -1,6 +1,4 @@
 /**
- * WARNING This JS file should be ES5 compatible to support older versions of Android WebView
- *
  * Inject this script file from native code into the head of the HTML document
  * Format string like this, where strWrapperScript is the contents of this file
  * and strJsonConfig is the json-encoded handoff parameters detailed below
@@ -10,7 +8,6 @@
  *
  * @param strJsonConfig - JSON encoded handoff dictionary containing:
  *    bridgeName: String - name of the native message handler
- *    defaultAction: String - default action keyword for data posted from JS -> Native
  */
 (function bridgeWrapper(strJsonConfig) {
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
+++ b/Sources/KlaviyoUI/KlaviyoWebView/Resources/Scripts/consoleHandler.js
@@ -1,0 +1,137 @@
+/**
+ * WARNING This JS file should be ES5 compatible to support older versions of Android WebView
+ *
+ * Inject this script file from native code into the head of the HTML document
+ * Format string like this, where strWrapperScript is the contents of this file
+ * and strJsonConfig is the json-encoded handoff parameters detailed below
+ * Always be careful to put quotes around your string arguments! *
+ *
+ *    strWrapperScript + "('" + strJsonConfig + "');"
+ *
+ * @param strJsonConfig - JSON encoded handoff dictionary containing:
+ *    bridgeName: String - name of the native message handler
+ *    defaultAction: String - default action keyword for data posted from JS -> Native
+ */
+(function bridgeWrapper(strJsonConfig) {
+
+  //Initialize web wrapper object
+  window.WebViewBridge = new Bridge(JSON.parse(strJsonConfig));
+
+  if (/complete|interactive|loaded/.test(document.readyState)) {
+    // In case the document has finished parsing, document's readyState will
+    // be one of "complete", "interactive" or (non-standard) "loaded".
+    WebViewBridge.initialize();
+  } else {
+    // The document is not ready yet, so wait for the DOMContentLoaded event
+    // https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event
+    document.addEventListener('DOMContentLoaded', function () {
+      WebViewBridge.initialize();
+    }, false);
+  }
+
+  /**
+   * Bridge object to handle communication between JavaScript and Native
+   */
+  function Bridge(opts) {
+    opts = opts || {};
+
+    return {
+      opts: opts,
+
+      initialize: function () {
+        WebViewBridge.postMessageToNative("documentReady", {});
+
+        var images = document.querySelectorAll("img");
+        var loadedCount = 0;
+        var onImgLoad = function() {
+          loadedCount++;
+
+          if (loadedCount === images.length) {
+            WebViewBridge.postMessageToNative("imagesLoaded", {});
+          }
+        };
+
+        images.forEach(function (img) {
+          if (img.complete) {
+            onImgLoad();
+          } else {
+            img.onload = onImgLoad;
+          }
+        });
+      },
+
+      /**
+       * Default keyword for JS -> Native messaging
+       */
+      defaultAction: opts.defaultAction || "message",
+
+      /**
+       * Bool test if this is Android WebView with registered JavaScript interface
+       */
+      isAndroid: function () {
+        return !!window[opts.bridgeName];
+      },
+
+      /**
+       * Bool test if this is an Apple WKWebView
+       */
+      isApple: function () {
+        return !!window.webkit && !!window.webkit.messageHandlers[opts.bridgeName];
+      },
+
+      /**
+       * Method to post string message to native layer
+       *
+       * Native layer should implement a common interface
+       * for reacting to messages of particular type
+       *
+       * @param type {String}
+       * @param data {Object}
+       */
+      postMessageToNative: function (type, data) {
+        const payload = {
+          type: type || this.defaultAction,
+          data: data || {}
+        };
+
+        try {
+          const serializedPayload = JSON.stringify(payload);
+
+          if (this.isApple()) {
+            window.webkit.messageHandlers[opts.bridgeName].postMessage(serializedPayload);
+          } else if (this.isAndroid()) {
+            window[opts.bridgeName].postMessage(serializedPayload);
+          }
+        } catch (e) {
+          console.error("Failed to post message to native layer:", e.message);
+        }
+      },
+    }
+  }
+
+  /**
+   * Send all console output to native layer
+   */
+  if (!!window.WebViewBridge.opts.linkConsole) {
+    ["log", "warn", "error"].forEach(function (method) {
+      var _method = console[method];
+      console[method] = function () {
+        var args = Array.prototype.slice.call(arguments, 0),
+        message;
+
+        try {
+          message = JSON.stringify(args);
+        } catch (e) {
+          message = "Couldn't parse arguments.";
+        }
+
+        WebViewBridge.postMessageToNative("console", {
+          level: method,
+          message: message
+        });
+
+        return _method.apply(console, arguments);
+      };
+    });
+  }
+})

--- a/Sources/KlaviyoUI/KlaviyoWebView/WebViewConsoleRelayMessage.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/WebViewConsoleRelayMessage.swift
@@ -1,0 +1,55 @@
+//
+//  WebViewConsoleRelayMessage.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 1/27/25.
+//
+
+struct WebViewConsoleRelayMessage: Decodable {
+    enum ResponseType: Decodable {
+        case imagesLoaded
+        case documentReady
+        case console(ConsoleData)
+
+        struct ConsoleData: Decodable {
+            let level: Level
+            let message: String
+
+            enum Level: String, Decodable {
+                case log
+                case warn
+                case error
+            }
+        }
+
+        enum TypeIdentifier: String, Decodable {
+            case imagesLoaded
+            case documentReady
+            case console
+        }
+    }
+
+    let type: ResponseType
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: WebViewConsoleRelayMessage.CodingKeys.self)
+        let typeIdentifier = try container.decode(ResponseType.TypeIdentifier.self, forKey: .type)
+
+        switch typeIdentifier {
+        case .imagesLoaded:
+            type = .imagesLoaded
+        case .documentReady:
+            type = .documentReady
+        case .console:
+            let consoleData = try container.decode(ResponseType.ConsoleData.self, forKey: .data)
+            type = .console(consoleData)
+        }
+    }
+}
+
+extension WebViewConsoleRelayMessage {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+}

--- a/Sources/KlaviyoUI/KlaviyoWebView/WebViewConsoleRelayMessage.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/WebViewConsoleRelayMessage.swift
@@ -6,50 +6,12 @@
 //
 
 struct WebViewConsoleRelayMessage: Decodable {
-    enum ResponseType: Decodable {
-        case imagesLoaded
-        case documentReady
-        case console(ConsoleData)
+    let level: Level
+    let message: String
 
-        struct ConsoleData: Decodable {
-            let level: Level
-            let message: String
-
-            enum Level: String, Decodable {
-                case log
-                case warn
-                case error
-            }
-        }
-
-        enum TypeIdentifier: String, Decodable {
-            case imagesLoaded
-            case documentReady
-            case console
-        }
-    }
-
-    let type: ResponseType
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: WebViewConsoleRelayMessage.CodingKeys.self)
-        let typeIdentifier = try container.decode(ResponseType.TypeIdentifier.self, forKey: .type)
-
-        switch typeIdentifier {
-        case .imagesLoaded:
-            type = .imagesLoaded
-        case .documentReady:
-            type = .documentReady
-        case .console:
-            let consoleData = try container.decode(ResponseType.ConsoleData.self, forKey: .data)
-            type = .console(consoleData)
-        }
-    }
-}
-
-extension WebViewConsoleRelayMessage {
-    enum CodingKeys: String, CodingKey {
-        case type
-        case data
+    enum Level: String, Decodable {
+        case log
+        case warn
+        case error
     }
 }

--- a/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
@@ -21,7 +21,7 @@ extension Logger {
 @available(iOS 14.0, *)
 extension Logger {
     /// Logger for Javascript console log messages from a WKWebView relayed to the native layer
-    static let webViewLogger = Logger(category: "WKWebView Console Log Relay")
+    static let webViewConsoleLogger = Logger(category: "WKWebView Console Log Relay")
 
     /// Logger for filesystem operations
     static let filesystem = Logger(category: "Filesystem")

--- a/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
@@ -20,9 +20,14 @@ extension Logger {
 
 @available(iOS 14.0, *)
 extension Logger {
-    /// Logger for Javascript console log messages from a WKWebView relayed to the native layer
+    /// Logger for Javascript console log messages from a WKWebView relayed to the native layer.
     static let webViewConsoleLogger = Logger(category: "WKWebView Console Log Relay")
 
-    /// Logger for filesystem operations
+    /// Logger for WKWebView related events.
+    ///
+    /// - Note: Javascript console logs relayed to the native layer should be handled by the ``webViewConsoleLogger``.
+    static let webViewLogger = Logger(category: "WKWebView Event Handling")
+
+    /// Logger for filesystem operations.
     static let filesystem = Logger(category: "Filesystem")
 }

--- a/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
@@ -22,4 +22,7 @@ extension Logger {
 extension Logger {
     /// Logger for Javascript console log messages from a WKWebView relayed to the native layer
     static let webViewLogger = Logger(category: "WKWebView Console Log Relay")
+
+    /// Logger for filesystem operations
+    static let filesystem = Logger(category: "Filesystem")
 }

--- a/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
@@ -15,3 +15,11 @@ extension Logger {
         self.init(subsystem: Self.subsystem, category: category)
     }
 }
+
+// MARK: - Loggers
+
+@available(iOS 14.0, *)
+extension Logger {
+    /// Logger for Javascript console log messages from a WKWebView relayed to the native layer
+    static let webViewLogger = Logger(category: "WKWebView Console Log Relay")
+}

--- a/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoUI/Utilities/Logger+Ext.swift
@@ -1,0 +1,17 @@
+//
+//  Logger+Ext.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 1/28/25.
+//
+
+import OSLog
+
+@available(iOS 14.0, *)
+extension Logger {
+    private static var subsystem = "com.klaviyo.klaviyo-swift-sdk.klaviyoUI"
+
+    init(category: String = #file) {
+        self.init(subsystem: Self.subsystem, category: category)
+    }
+}


### PR DESCRIPTION
# Description

I had previously opened a PR in the iOS test app repo to relay Javascript console log messages from the WKWebView to the native layer, to make dev/debugging easier. I realized that it would be better to have this code live in the Swift SDK, and to add the console logging within the KlaviyoWebViewController, rather than in the viewModels that get injected to the KlaviyoWebViewController. 

With these changes, any KlaviyoWebViewController that's presented on a debug build will automatically relay all Javascript console log messages to the native layer, and the native layer will log those messages to the Xcode console. This logic will not be executed in production builds.

This also adds some more robust logging to the `ResourceLoader`.

I will open a related PR in the iOS test app shortly.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I tested this by running the iOS test app and validating that javascript console log messages are successfully relayed to the native layer, and the native layer outputs those messages to the Xcode console.