### PR TITLE
Add localStorage persistence and inspectable flag

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -12,19 +12,19 @@ import WebKit
 
 private func createDefaultWebView() -> WKWebView {
     let config = WKWebViewConfiguration()
-    //Required to allow localStorage data to be retained between webview instances
+    // Required to allow localStorage data to be retained between webview instances
     config.websiteDataStore = WKWebsiteDataStore.default()
-    
+
     let webView = WKWebView(frame: .zero, configuration: config)
     webView.isOpaque = false
     webView.scrollView.contentInsetAdjustmentBehavior = .never
-    
-#if DEBUG
+
+    #if DEBUG
     if #available(iOS 16.4, *) {
-        //Earlier versions do not require setting any kind of flag
+        // Earlier versions do not require setting any kind of flag
         webView.isInspectable = true
     }
-#endif
+    #endif
     return webView
 }
 

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -12,9 +12,19 @@ import WebKit
 
 private func createDefaultWebView() -> WKWebView {
     let config = WKWebViewConfiguration()
+    //Required to allow localStorage data to be retained between webview instances
+    config.websiteDataStore = WKWebsiteDataStore.default()
+    
     let webView = WKWebView(frame: .zero, configuration: config)
     webView.isOpaque = false
     webView.scrollView.contentInsetAdjustmentBehavior = .never
+    
+#if DEBUG
+    if #available(iOS 16.4, *) {
+        //Earlier versions do not require setting any kind of flag
+        webView.isInspectable = true
+    }
+#endif
     return webView
 }
 


### PR DESCRIPTION
# Description
This will enable localStorage to be retained between sessions, necessary for form display frequency settings to be obeyed. 
Threw in the inspectable flag since while I was here. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
