### PR TITLE
Enable enqueuing from KlaviyoUI

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -12,6 +12,15 @@ import UIKit
 
 typealias DeviceMetadata = PushTokenPayload.PushToken.Attributes.MetaData
 
+public class KlaviyoEventQueue: NSObject {
+    public static let shared = KlaviyoEventQueue()
+
+    @_spi(KlaviyoPrivateQueue)
+    public func enqueue(event: Event) {
+        dispatchOnMainThread(action: .enqueueEvent(event))
+    }
+}
+
 struct KlaviyoState: Equatable, Codable {
     enum InitializationState: Equatable, Codable {
         case uninitialized

--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -8,6 +8,7 @@
 import Combine
 import UIKit
 import WebKit
+@_spi(KlaviyoPrivateQueue) import KlaviyoSwift
 
 private func createDefaultWebView() -> WKWebView {
     let config = WKWebViewConfiguration()
@@ -82,7 +83,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     @MainActor
     func dismiss() {
-        dismiss(animated: true)
+        dismiss(animated: true) {
+            KlaviyoEventQueue.shared.enqueue(event: Event(name: .customEvent("From JS")))
+        }
     }
 
     // MARK: - Scripts


### PR DESCRIPTION
WIP branch for now where KlaviyoUI is able to send a custom event with name "From JS" to the queue. This structure with `@_spi(KlaviyoPrivateQueue)` somewhat protects access to the queue.

Current WIP:
- refactoring CreateEventPayload to support the new `profileEventTracked` type