### PR TITLE
[CHNL-16694] move IAF viewmodel to SDK

### DIFF
--- a/KlaviyoUI.podspec
+++ b/KlaviyoUI.podspec
@@ -12,6 +12,9 @@ Pod::Spec.new do |s|
   s.swift_version    = '5.7'
   s.platform         = :ios, '13.0'
   s.source_files     = 'Sources/KlaviyoUI/**/*.swift'
+  s.resource_bundles = {
+    'KlaviyoUIResources' => ['Sources/KlaviyoUI/InAppForms/Assets/*.{html}']
+  }
   # update once modularization changes are merged in.
   s.dependency     'KlaviyoSwift', '~> 4.0.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ let package = Package(
             dependencies: ["KlaviyoSwift"],
             path: "Sources/KlaviyoUI",
             resources: [
+                .process("InAppForms/Assets"),
                 .process("KlaviyoWebView/Resources"),
                 .process("KlaviyoWebView/Development Assets/Scripts"),
                 .process("KlaviyoWebView/Development Assets/HTML")

--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head data-klaviyo-message-handler-name="KlaviyoNativeBridge"
+      data-support-event-types='test1,test2'
+      data-sdk-name="SDK_NAME"
+      data-sdk-version="SDK_VERSION"
+>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Klaviyo In-App Form Test - 1</title>
+        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+</head>
+<body></body>
+</html>

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -25,7 +25,7 @@ public class IAFPresentationManager {
     private var isLoading: Bool = false
 
     @_spi(KlaviyoPrivate)
-    @MainActor public func presentIaf() {
+    @MainActor public func presentIAF() {
         guard !isLoading else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.log("In-App Form is already loading; ignoring request.")

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -1,5 +1,5 @@
 //
-//  IafPresentationManager.swift
+//  IAFPresentationManager.swift
 //  klaviyo-swift-sdk
 //
 //  Created by Andrew Balmer on 2/3/25.
@@ -10,9 +10,9 @@ import OSLog
 import UIKit
 
 @_spi(KlaviyoPrivate)
-public class IafPresentationManager {
+public class IAFPresentationManager {
     @_spi(KlaviyoPrivate)
-    public static let shared = IafPresentationManager()
+    public static let shared = IAFPresentationManager()
 
     lazy var indexHtmlFileUrl: URL? = {
         do {

--- a/Sources/KlaviyoUI/InAppForms/IafPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IafPresentationManager.swift
@@ -1,0 +1,57 @@
+//
+//  IafPresentationManager.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2/3/25.
+//
+
+import Foundation
+import OSLog
+import UIKit
+
+class IafPresentationManager {
+    static let shared = IafPresentationManager()
+
+    lazy var indexHtmlFileUrl: URL? = {
+        do {
+            return try ResourceLoader.getResourceUrl(path: "InAppFormsTemplate", type: "html")
+        } catch {
+            return nil
+        }
+    }()
+
+    private var isLoading: Bool = false
+
+    @MainActor func presentIaf() {
+        guard !isLoading else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.log("In-App Form is already loading; ignoring request.")
+            }
+            return
+        }
+
+        guard let fileUrl = indexHtmlFileUrl else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("URL for local HTML file is nil; unable to present In-App Form.")
+            }
+            return
+        }
+
+        isLoading = true
+
+        let viewModel = IafWebViewModel(url: fileUrl)
+        let viewController = KlaviyoWebViewController(viewModel: viewModel)
+        viewController.modalPresentationStyle = .overCurrentContext
+
+        Task {
+            defer { isLoading = false }
+
+            try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+
+            guard let topController = UIApplication.shared.topMostViewController else {
+                return
+            }
+            topController.present(viewController, animated: true, completion: nil)
+        }
+    }
+}

--- a/Sources/KlaviyoUI/InAppForms/IafPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IafPresentationManager.swift
@@ -9,8 +9,10 @@ import Foundation
 import OSLog
 import UIKit
 
-class IafPresentationManager {
-    static let shared = IafPresentationManager()
+@_spi(KlaviyoPrivate)
+public class IafPresentationManager {
+    @_spi(KlaviyoPrivate)
+    public static let shared = IafPresentationManager()
 
     lazy var indexHtmlFileUrl: URL? = {
         do {
@@ -22,7 +24,8 @@ class IafPresentationManager {
 
     private var isLoading: Bool = false
 
-    @MainActor func presentIaf() {
+    @_spi(KlaviyoPrivate)
+    @MainActor public func presentIaf() {
         guard !isLoading else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.log("In-App Form is already loading; ignoring request.")

--- a/Sources/KlaviyoUI/InAppForms/IafWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IafWebViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  IafWebViewModel.swift
+//  TestApp
+//
+//  Created by Andrew Balmer on 1/27/25.
+//
+
+import Combine
+import Foundation
+import WebKit
+
+class IafWebViewModel: KlaviyoWebViewModeling {
+    private enum MessageHandler: String, CaseIterable {
+        case klaviyoNativeBridge = "KlaviyoNativeBridge"
+    }
+
+    weak var delegate: KlaviyoWebViewDelegate?
+
+    let url: URL
+    var loadScripts: Set<WKUserScript>?
+    var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
+
+    public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    // MARK: handle WKWebView events
+
+    func handleScriptMessage(_ message: WKScriptMessage) {
+        guard let handler = MessageHandler(rawValue: message.name) else {
+            // script message has no handler
+            return
+        }
+
+        switch handler {
+        case .klaviyoNativeBridge:
+            guard let jsonString = message.body as? String else {
+                return
+            }
+            // TODO: handle bridge messages
+        }
+    }
+}

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -15,6 +15,9 @@ enum ResourceLoaderError: Error {
 }
 
 enum ResourceLoader {
+    /// The name of the resource bundle specified in the podspec.
+    private static let resourceBundleName = "KlaviyoUIResources"
+
     static func getResourceUrl(path: String, type: String) throws -> URL {
         let bundle = try resourceBundle()
 
@@ -55,7 +58,7 @@ enum ResourceLoader {
         return Bundle.module
         #else
         do {
-            return try Bundle(for: BundleLocator.self).resourceBundle(named: "KlaviyoUIResources")
+            return try Bundle(for: BundleLocator.self).resourceBundle(named: resourceBundleName)
         } catch {
             throw ResourceLoaderError.bundleError
         }


### PR DESCRIPTION
# Description

This PR, in conjunction with [this test app PR](https://github.com/klaviyo/klaviyo-ios-test-app/pull/53), moves the IAF ViewModel from the test app to the SDK. I had initially added the ViewModel to the test app thinking it would be more useful to have it there during development so we could make changes fully within the test app repo without touching the SDK, but I think it turns out that we can just as easily to the dev work within the SDK. 

The new `IafWebViewModel` will be the production viewModel for managing the In-App Form, though of course we'll continue making changes to it in the next few weeks during the dev process.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. While using the `ab/CHNL-16694/move-IAF-viewmodel-to-SDK` branch of the test app, I validated that the In-App Form displays correctly when tapping the "Show In-App Form Test" button