### PR TITLE
Enqueue profile events

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -6,9 +6,57 @@
       data-sdk-version="SDK_VERSION"
 >
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Klaviyo In-App Form Test - 1</title>
-        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Klaviyo In-App Form Test - 1</title>
+            <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+            <script type="text/javascript">
+                document.addEventListener('DOMContentLoaded', function () {
+                    onElementAvailable("button.klaviyo-close-form", function () {
+                        onElementRemoved("button.klaviyo-close-form", function () {
+                            var name = document.head.dataset.klaviyoMessageHandlerName
+                            window.webkit.messageHandlers.closeHandler.postMessage(JSON.stringify({
+                                "type": "trackProfileEvent",
+                                "version": 1,
+                                "data": {
+                                    "metric": "Form completed by profile",
+                                    "properties": {
+                                        "form_id": "7uSP7t",
+                                        "form_version_id": 8
+                                    }
+                                }
+                            }));
+                        });
+                    });
+                }, false);
+
+                function onElementAvailable(selector, callback) {
+                    var observer = new MutationObserver(function () {
+                        if (document.querySelector(selector)) {
+                            observer.disconnect();
+                            callback();
+                        }
+                    });
+
+                    observer.observe(document.body, {
+                        childList: true,
+                        subtree: true
+                    });
+                }
+
+                function onElementRemoved(selector, callback) {
+                    var observer = new MutationObserver(function () {
+                        if (!document.querySelector(selector)) {
+                            observer.disconnect();
+                            callback();
+                        }
+                    });
+
+                    observer.observe(document.body, {
+                        childList: true,
+                        subtree: true
+                    });
+                }
+            </script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -9,54 +9,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Klaviyo In-App Form Test - 1</title>
             <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
-            <script type="text/javascript">
-                document.addEventListener('DOMContentLoaded', function () {
-                    onElementAvailable("button.klaviyo-close-form", function () {
-                        onElementRemoved("button.klaviyo-close-form", function () {
-                            var name = document.head.dataset.klaviyoMessageHandlerName
-                            window.webkit.messageHandlers.closeHandler.postMessage(JSON.stringify({
-                                "type": "trackProfileEvent",
-                                "version": 1,
-                                "data": {
-                                    "metric": "Form completed by profile",
-                                    "properties": {
-                                        "form_id": "7uSP7t",
-                                        "form_version_id": 8
-                                    }
-                                }
-                            }));
-                        });
-                    });
-                }, false);
-
-                function onElementAvailable(selector, callback) {
-                    var observer = new MutationObserver(function () {
-                        if (document.querySelector(selector)) {
-                            observer.disconnect();
-                            callback();
-                        }
-                    });
-
-                    observer.observe(document.body, {
-                        childList: true,
-                        subtree: true
-                    });
-                }
-
-                function onElementRemoved(selector, callback) {
-                    var observer = new MutationObserver(function () {
-                        if (!document.querySelector(selector)) {
-                            observer.disconnect();
-                            callback();
-                        }
-                    });
-
-                    observer.observe(document.body, {
-                        childList: true,
-                        subtree: true
-                    });
-                }
-            </script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -6,9 +6,9 @@
       data-sdk-version="SDK_VERSION"
 >
     <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Klaviyo In-App Form Test - 1</title>
-            <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Klaviyo In-App Form Test - 1</title>
+        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -60,9 +60,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case let .trackAggregateEvent(data):
             KlaviyoInternal.create(aggregateEvent: data)
         case let .trackProfileEvent(data):
-            if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-               let metricName = json["metric"] as? String {
-                KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: json))
+            if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+               let metricName = jsonEventData["metric"] as? String {
+                KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: jsonEventData))
             }
         case .openDeepLink:
             // TODO: handle openDeepLink

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -82,8 +82,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case let .trackAggregateEvent(data):
             KlaviyoSDK().create(aggregateEvent: data)
         case let .trackProfileEvent(data):
-            if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                KlaviyoSDK().create(event: Event(name: .customEvent(json["metric"] as! String), properties: json))
+            if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+               let metricName = json["metric"] as? String {
+                KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: json))
             }
         case .openDeepLink:
             // TODO: handle openDeepLink

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -53,7 +53,6 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
             do {
                 let jsonData = Data(jsonString.utf8) // Convert string to Data
-                print(jsonString)
                 let messageBusEvent = try JSONDecoder().decode(IAFMessageBusEvent.self, from: jsonData)
                 handleMessageBusEvent(messageBusEvent)
             } catch {

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFMessageBusEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFMessageBusEvent.swift
@@ -13,7 +13,7 @@ enum IAFMessageBusEvent: Decodable, Equatable {
     case formsDataLoaded
     case formAppeared
     case trackAggregateEvent(Data)
-    case trackProfileEvent
+    case trackProfileEvent(Data)
     case openDeepLink
 
     private enum CodingKeys: String, CodingKey {
@@ -43,7 +43,9 @@ enum IAFMessageBusEvent: Decodable, Equatable {
             let data = try JSONEncoder().encode(decodedData)
             self = .trackAggregateEvent(data)
         case .trackProfileEvent:
-            self = .trackProfileEvent
+            let decodedData = try container.decode(AnyCodable.self, forKey: .data)
+            let data = try JSONEncoder().encode(decodedData)
+            self = .trackProfileEvent(data)
         case .openDeepLink:
             self = .openDeepLink
         }

--- a/Tests/KlaviyoUITests/IAFMessageBusEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFMessageBusEventTests.swift
@@ -60,11 +60,27 @@ struct IAFMessageBusEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
-        let event = try JSONDecoder().decode(IAFMessageBusEvent.self, from: data)
-        #expect(event == .trackProfileEvent)
+        let profileEvent = """
+        {
+          "metric": "Form completed by profile",
+          "properties": {
+            "form_id": "7uSP7t",
+            "form_version_id": 8
+          }
+        }
+        """
+        let jsonData = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFMessageBusEvent.self, from: jsonData)
+        guard case let .trackProfileEvent(associatedValueData) = event else {
+            Issue.record("event type should be .trackProfileEvent but was '.\(event)'")
+            return
+        }
+        let associatedValueDataDecoded = try JSONDecoder().decode(AnyCodable.self, from: associatedValueData)
 
-        // TODO: test that associated values are correct
+        let profileEventData = try #require(profileEvent.data(using: .utf8))
+        let profileEventDataDecoded = try JSONDecoder().decode(AnyCodable.self, from: profileEventData)
+
+        #expect(profileEventDataDecoded == associatedValueDataDecoded)
     }
 
     @Test func testDecodeAggregateEvent() async throws {


### PR DESCRIPTION
# Description

Builds out the .trackProfileEvent case of IAFMessageBusEvent and enqueues events utilizing the existing `KlaviyoSDK().create(event:..)` call

~~Note: for now I've put this in to be triggered through the closeHandler and added the extra listener in the `InAppFormsTemplate` to help test it~~ Edit: removed

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan


Was able to trigger the form and close it and send an event from that dumps the native bridge payload properties into the properties of the event.
<img src="https://github.com/user-attachments/assets/59fdb596-b6ac-45b0-87aa-15ca53c76b0b" height=500/>

Note: if we are using a Custom Event I assume we need to pull out the specific event name to be able to provide that as the event name

# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
