### PR TITLE
CHNL-16703: Enable deep links from IAF

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -6,54 +6,9 @@
       data-sdk-version="SDK_VERSION"
 >
     <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Klaviyo In-App Form Test - 1</title>
-            <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
-            <script type="text/javascript">
-                            document.addEventListener('DOMContentLoaded', function () {
-                                onElementAvailable("button.klaviyo-close-form", function () {
-                                    onElementRemoved("button.klaviyo-close-form", function () {
-                                        var name = document.head.dataset.klaviyoMessageHandlerName
-                                        window.webkit.messageHandlers.closeHandler.postMessage(JSON.stringify({
-                                            "type": "openDeepLink",
-                                            "version": 1,
-                                            "data": {
-                                                "ios": "klaviyotest://accountInfo",
-                                                "android": "klaviyotest://settings"
-                                            }
-                                        }));
-                                    });
-                                });
-                            }, false);
-
-                            function onElementAvailable(selector, callback) {
-                                var observer = new MutationObserver(function () {
-                                    if (document.querySelector(selector)) {
-                                        observer.disconnect();
-                                        callback();
-                                    }
-                                });
-
-                                observer.observe(document.body, {
-                                    childList: true,
-                                    subtree: true
-                                });
-                            }
-
-                            function onElementRemoved(selector, callback) {
-                                var observer = new MutationObserver(function () {
-                                    if (!document.querySelector(selector)) {
-                                        observer.disconnect();
-                                        callback();
-                                    }
-                                });
-
-                                observer.observe(document.body, {
-                                    childList: true,
-                                    subtree: true
-                                });
-                            }
-                        </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Klaviyo In-App Form Test - 1</title>
+        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -6,9 +6,54 @@
       data-sdk-version="SDK_VERSION"
 >
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Klaviyo In-App Form Test - 1</title>
-        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Klaviyo In-App Form Test - 1</title>
+            <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=9BX3wh&env=in-app"></script>
+            <script type="text/javascript">
+                            document.addEventListener('DOMContentLoaded', function () {
+                                onElementAvailable("button.klaviyo-close-form", function () {
+                                    onElementRemoved("button.klaviyo-close-form", function () {
+                                        var name = document.head.dataset.klaviyoMessageHandlerName
+                                        window.webkit.messageHandlers.closeHandler.postMessage(JSON.stringify({
+                                            "type": "openDeepLink",
+                                            "version": 1,
+                                            "data": {
+                                                "ios": "klaviyotest://accountInfo",
+                                                "android": "klaviyotest://settings"
+                                            }
+                                        }));
+                                    });
+                                });
+                            }, false);
+
+                            function onElementAvailable(selector, callback) {
+                                var observer = new MutationObserver(function () {
+                                    if (document.querySelector(selector)) {
+                                        observer.disconnect();
+                                        callback();
+                                    }
+                                });
+
+                                observer.observe(document.body, {
+                                    childList: true,
+                                    subtree: true
+                                });
+                            }
+
+                            function onElementRemoved(selector, callback) {
+                                var observer = new MutationObserver(function () {
+                                    if (!document.querySelector(selector)) {
+                                        observer.disconnect();
+                                        callback();
+                                    }
+                                });
+
+                                observer.observe(document.body, {
+                                    childList: true,
+                                    subtree: true
+                                });
+                            }
+                        </script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -65,7 +65,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: jsonEventData))
             }
         case let .openDeepLink(url):
-            UIApplication.shared.open(url)
+            if let validUrl = URL(string: url) {
+                UIApplication.shared.open(validUrl)
+            }
         }
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -65,8 +65,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: jsonEventData))
             }
         case let .openDeepLink(url):
-            if let validUrl = URL(string: url) {
-                UIApplication.shared.open(validUrl)
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url)
             }
         }
     }

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -14,7 +14,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formAppeared
     case trackAggregateEvent(Data)
     case trackProfileEvent(Data)
-    case openDeepLink
+    case openDeepLink(URL)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -47,7 +47,14 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             let data = try JSONEncoder().encode(decodedData)
             self = .trackProfileEvent(data)
         case .openDeepLink:
-            self = .openDeepLink
+            let url = try container.decode(DeepLinkEventPayload.self, forKey: .data)
+            self = .openDeepLink(url.ios)
         }
+    }
+}
+
+extension IAFNativeBridgeEvent {
+    struct DeepLinkEventPayload: Codable {
+        let ios: URL
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -14,7 +14,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formAppeared
     case trackAggregateEvent(Data)
     case trackProfileEvent(Data)
-    case openDeepLink(URL)
+    case openDeepLink(String)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -55,6 +55,6 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
 
 extension IAFNativeBridgeEvent {
     struct DeepLinkEventPayload: Codable {
-        let ios: URL
+        let ios: String
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -14,7 +14,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formAppeared
     case trackAggregateEvent(Data)
     case trackProfileEvent(Data)
-    case openDeepLink(String)
+    case openDeepLink(URL)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -55,6 +55,6 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
 
 extension IAFNativeBridgeEvent {
     struct DeepLinkEventPayload: Codable {
-        let ios: String
+        let ios: URL
     }
 }

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -24,11 +24,23 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
+        let deepLinkEvent = """
+        {
+            "ios": "klaviyotest://settings",
+            "android": "klaviyotest://settings"
+        }
+        """
+
         let data = json.data(using: .utf8)!
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        #expect(event == .openDeepLink)
+        guard case let .openDeepLink(url) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+        let deepLinkEventData = try #require(deepLinkEvent.data(using: .utf8))
+        let deepLinkEventDataDecoded = try JSONDecoder().decode(IAFNativeBridgeEvent.DeepLinkEventPayload.self, from: deepLinkEventData)
 
-        // TODO: test that associated values are correct
+        #expect(deepLinkEventDataDecoded.ios == url)
     }
 
     @Test func testDecodeFormAppeared() async throws {

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -24,23 +24,15 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let deepLinkEvent = """
-        {
-            "ios": "klaviyotest://settings",
-            "android": "klaviyotest://settings"
-        }
-        """
-
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .openDeepLink(url) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
-        let deepLinkEventData = try #require(deepLinkEvent.data(using: .utf8))
-        let deepLinkEventDataDecoded = try JSONDecoder().decode(IAFNativeBridgeEvent.DeepLinkEventPayload.self, from: deepLinkEventData)
 
-        #expect(deepLinkEventDataDecoded.ios == url)
+        let expectedUrl = try #require(URL(string: "klaviyotest://settings"))
+        #expect(url == expectedUrl)
     }
 
     @Test func testDecodeFormAppeared() async throws {


### PR DESCRIPTION
# Description
Added support for deep links building out the `IAFNativeBridgeEvent` for `openDeepLink`

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

For testing I (re)added the close event listener + closeHandler to the template HTML, so on close, 
```
{
    "type": "openDeepLink",
    "version": 1,
    "data": {
        "ios": "klaviyotest://accountInfo",
        "android": "klaviyotest://settings"
    }
}
```
is posted and sent to the handler and opens it

https://github.com/user-attachments/assets/931ea501-4d71-4c09-a367-504e3e31ee18


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
