### PR TITLE
fix preload timeout

### DIFF
--- a/Tests/KlaviyoUITests/Assets/IAFUnitTest.html
+++ b/Tests/KlaviyoUITests/Assets/IAFUnitTest.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-<head data-klaviyo-message-handler-name="KlaviyoNativeBridge"
-      data-support-event-types='test1,test2'
->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Klaviyo In-App Form Test - 1</title>
-</head>
-<body></body>
+    <head data-klaviyo-message-handler-name="KlaviyoNativeBridge"
+        data-support-event-types='test1,test2'
+        >
+        <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>Klaviyo In-App Form Test - 1</title>
+                <script>
+                    document.addEventListener("DOMContentLoaded", function () {
+                        const message = JSON.stringify({
+                            type: "formWillAppear",
+                            data: {
+                                formId: "abc123"
+                            }
+                        });
+
+                        window.webkit.messageHandlers.KlaviyoNativeBridge.postMessage(message);
+                    });
+                </script>
+    </head>
+    <body></body>
 </html>

--- a/Tests/KlaviyoUITests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelPreloadingTests.swift
@@ -10,66 +10,6 @@ import KlaviyoCore
 import WebKit
 import XCTest
 
-class MockIAFWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
-    enum PreloadResult {
-        case formWillAppear(delay: UInt64)
-        case didFailNavigation(delay: UInt64)
-        case none
-    }
-
-    let viewModel: IAFWebViewModel
-
-    var preloadResult: PreloadResult?
-    var preloadUrlCalled = false
-    var evaluateJavaScriptCalled = false
-
-    init(viewModel: IAFWebViewModel) {
-        self.viewModel = viewModel
-    }
-
-    func preloadUrl() {
-        viewModel.handleNavigationEvent(.didCommitNavigation)
-        preloadUrlCalled = true
-
-        Task {
-            if let result = preloadResult {
-                switch result {
-                case let .formWillAppear(delay):
-                    try? await Task.sleep(nanoseconds: delay)
-
-                    let scriptMessage = MockWKScriptMessage(
-                        name: "KlaviyoNativeBridge",
-                        body: """
-                        {
-                          "type": "formWillAppear",
-                          "data": {
-                            "formId": "abc123"
-                          }
-                        }
-                        """)
-
-                    viewModel.handleScriptMessage(scriptMessage)
-
-                case let .didFailNavigation(delay):
-                    try? await Task.sleep(nanoseconds: delay)
-                    viewModel.handleNavigationEvent(.didFailNavigation)
-
-                case .none:
-                    // don't do anything
-                    return
-                }
-            }
-        }
-    }
-
-    func evaluateJavaScript(_ script: String) async throws -> Any {
-        evaluateJavaScriptCalled = true
-        return true
-    }
-
-    func dismiss() {}
-}
-
 class MockWKScriptMessage: WKScriptMessage {
     private let mockName: String
     private let mockBody: Any

--- a/Tests/KlaviyoUITests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelPreloadingTests.swift
@@ -10,25 +10,6 @@ import KlaviyoCore
 import WebKit
 import XCTest
 
-class MockWKScriptMessage: WKScriptMessage {
-    private let mockName: String
-    private let mockBody: Any
-
-    init(name: String, body: Any) {
-        mockName = name
-        mockBody = body
-        super.init() // Calling the superclass initializer
-    }
-
-    override var name: String {
-        mockName
-    }
-
-    override var body: Any {
-        mockBody
-    }
-}
-
 final class IAFWebViewModelPreloadingTests: XCTestCase {
     // MARK: - setup
 

--- a/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
@@ -40,7 +40,7 @@ final class IAFWebViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - tests
+    // MARK: - html injection tests
 
     func testInjectSdkNameAttribute() async throws {
         // This test has been flaky when running on CI. It seems to have something to do with instability when

--- a/Tests/KlaviyoUITests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoUITests/Mocks/MockIAFWebViewDelegate.swift
@@ -1,0 +1,69 @@
+//
+//  MockIAFWebViewDelegate.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2/12/25.
+//
+
+@testable @_spi(KlaviyoPrivate) import KlaviyoUI
+import Foundation
+
+class MockIAFWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
+    enum PreloadResult {
+        case formWillAppear(delay: UInt64)
+        case didFailNavigation(delay: UInt64)
+        case none
+    }
+
+    let viewModel: IAFWebViewModel
+
+    var preloadResult: PreloadResult?
+    var preloadUrlCalled = false
+    var evaluateJavaScriptCalled = false
+
+    init(viewModel: IAFWebViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func preloadUrl() {
+        viewModel.handleNavigationEvent(.didCommitNavigation)
+        preloadUrlCalled = true
+
+        Task {
+            if let result = preloadResult {
+                switch result {
+                case let .formWillAppear(delay):
+                    try? await Task.sleep(nanoseconds: delay)
+
+                    let scriptMessage = MockWKScriptMessage(
+                        name: "KlaviyoNativeBridge",
+                        body: """
+                        {
+                          "type": "formWillAppear",
+                          "data": {
+                            "formId": "abc123"
+                          }
+                        }
+                        """)
+
+                    viewModel.handleScriptMessage(scriptMessage)
+
+                case let .didFailNavigation(delay):
+                    try? await Task.sleep(nanoseconds: delay)
+                    viewModel.handleNavigationEvent(.didFailNavigation)
+
+                case .none:
+                    // don't do anything
+                    return
+                }
+            }
+        }
+    }
+
+    func evaluateJavaScript(_ script: String) async throws -> Any {
+        evaluateJavaScriptCalled = true
+        return true
+    }
+
+    func dismiss() {}
+}

--- a/Tests/KlaviyoUITests/Mocks/MockWKScriptMessage.swift
+++ b/Tests/KlaviyoUITests/Mocks/MockWKScriptMessage.swift
@@ -1,0 +1,27 @@
+//
+//  MockWKScriptMessage.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2/12/25.
+//
+
+import WebKit
+
+class MockWKScriptMessage: WKScriptMessage {
+    private let mockName: String
+    private let mockBody: Any
+
+    init(name: String, body: Any) {
+        mockName = name
+        mockBody = body
+        super.init() // Calling the superclass initializer
+    }
+
+    override var name: String {
+        mockName
+    }
+
+    override var body: Any {
+        mockBody
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes an issue where the preloading timeout wasn't working on the IAFWebViewModel

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

1. I manually simulated both a timeout and a successful `formWillAppear` event and validated that the code works as expected in both cases