### PR TITLE
CHNL-16216: Implement abort and timeout

### DIFF
--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -33,6 +33,8 @@ public struct NetworkSession {
     fileprivate static let acceptedEncodings = ["br", "gzip", "deflate"]
     fileprivate static let mobileHeader = "1"
 
+    public static let networkTimeout: UInt64 = 10_000_000_000 // in nanoseconds (10 seconds)
+
     public static let defaultUserAgent = { () -> String in
         let appContext = environment.appContextInfo()
         let klaivyoSDKVersion = "klaviyo-\(environment.sdkName())/\(environment.sdkVersion())"

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -52,7 +52,6 @@ public class IAFPresentationManager {
             do {
                 try await viewModel.preloadWebsite(timeout: 8_000_000_000)
             } catch {
-                isLoading = false
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")
                 }

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -49,7 +49,15 @@ public class IAFPresentationManager {
         Task {
             defer { isLoading = false }
 
-            try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+            do {
+                try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+            } catch {
+                isLoading = false
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")
+                }
+                return
+            }
 
             guard let topController = UIApplication.shared.topMostViewController else {
                 return

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import KlaviyoCore
 import OSLog
 import UIKit
 
@@ -50,7 +51,7 @@ public class IAFPresentationManager {
             defer { isLoading = false }
 
             do {
-                try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+                try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
             } catch {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -113,6 +113,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             Task {
                 await delegate?.dismiss()
             }
+        case let .abort(reason):
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("Aborting webview: \(reason)")
+            }
+            Task {
+                await delegate?.dismiss()
+            }
         }
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -148,7 +148,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
         case let .abort(reason):
             if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Aborting webview: \(reason)")
+                Logger.webViewLogger.info("Aborting webview: \(reason)")
             }
             Task {
                 await delegate?.dismiss()

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -16,6 +16,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case trackProfileEvent(Data)
     case openDeepLink(URL)
     case formDisappeared
+    case abort(String)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -29,6 +30,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case trackProfileEvent
         case openDeepLink
         case formDisappeared
+        case abort
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +55,9 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .openDeepLink(url.ios)
         case .formDisappeared:
             self = .formDisappeared
+        case .abort:
+            let data = try container.decode(AbortPayload.self, forKey: .data)
+            self = .abort(data.reason)
         }
     }
 }
@@ -60,5 +65,9 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
 extension IAFNativeBridgeEvent {
     struct DeepLinkEventPayload: Codable {
         let ios: URL
+    }
+
+    struct AbortPayload: Codable {
+        let reason: String
     }
 }

--- a/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebViewOverlayManager.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew Balmer on 1/15/25.
 //
 
+import KlaviyoCore
 import SwiftUI
 import UIKit
 
@@ -36,7 +37,7 @@ public class KlaviyoWebViewOverlayManager {
         Task {
             defer { isLoading = false }
 
-            try await viewModel.preloadWebsite(timeout: 8_000_000_000)
+            try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
 
             guard let topController = UIApplication.shared.topMostViewController else {
                 return

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -13,6 +13,26 @@ import Foundation
 import Testing
 
 struct IAFNativeBridgeEventTests {
+    @Test func testAbort() async throws {
+        let json = """
+        {
+          "type": "abort",
+          "data": {
+            "reason": "because"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .abort(reason) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        #expect(reason == "because")
+    }
+
     @Test func testDecodeOpenDeepLink() async throws {
         let json = """
         {


### PR DESCRIPTION
# Description

~~Reused the existing timeout of 8.0 seconds~~ Defined new timeout const of 10 seconds (or 10_000_000_000 nanoseconds) and used where the viewModel preloads the website to catch any errors that occur

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan
1. In the case of the webview being initialized to preload the form and it times out/is unable to load it, the webview just never loads but logs the error. This was tested by giving an invalid src address. No webview is shown and app is usable as normal.

https://github.com/user-attachments/assets/285ee789-3429-43d0-a761-016d4f891f4b


2. In the case of the webview receiving an abort event at any other point (ex. after successfully presenting), the webview is destroyed and reason is logged, and the app is usable as normal with the webview gone.


https://github.com/user-attachments/assets/18e947bc-a192-4171-89d0-7ae6ea536c1b


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
