### PR TITLE
CHNL-17239: Implement handshake with JS

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head data-klaviyo-message-handler-name="KlaviyoNativeBridge"
+<head data-native-bridge-name="KlaviyoNativeBridge"
       data-support-event-types='test1,test2'
 >
     <meta charset="UTF-8">

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -28,13 +28,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     private var sdkNameWKScript: WKUserScript {
         let sdkName = environment.sdkName()
-        let sdkNameScript = "document.head.setAttribute('data-klaviyo-sdk-name', '\(sdkName)');"
+        let sdkNameScript = "document.head.setAttribute('data-sdk-name', '\(sdkName)');"
         return WKUserScript(source: sdkNameScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
     private var sdkVersionWKScript: WKUserScript {
         let sdkVersion = environment.sdkVersion()
-        let sdkVersionScript = "document.head.setAttribute('data-klaviyo-sdk-version', '\(sdkVersion)');"
+        let sdkVersionScript = "document.head.setAttribute('data-sdk-version', '\(sdkVersion)');"
         return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -26,25 +26,32 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
+    private var sdkNameWKScript: WKUserScript {
+        let sdkName = environment.sdkName()
+        let sdkNameScript = "document.head.setAttribute('data-klaviyo-sdk-name', '\(sdkName)');"
+        return WKUserScript(source: sdkNameScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
+    private var sdkVersionWKScript: WKUserScript {
+        let sdkVersion = environment.sdkVersion()
+        let sdkVersionScript = "document.head.setAttribute('data-klaviyo-sdk-version', '\(sdkVersion)');"
+        return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
+    private var handshakeWKScript: WKUserScript {
+        let handshakeStringified = IAFNativeBridgeEvent.handshake
+        let handshakeScript = "document.head.setAttribute('data-native-bridge-handshake', '\(handshakeStringified)');"
+        return WKUserScript(source: handshakeScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
     init(url: URL) {
         self.url = url
         initializeLoadScripts()
     }
 
     func initializeLoadScripts() {
-        let sdkName = environment.sdkName()
-        let sdkNameScript = "document.head.setAttribute('data-sdk-name', '\(sdkName)');"
-        let sdkNameWKScript = WKUserScript(source: sdkNameScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         loadScripts?.insert(sdkNameWKScript)
-
-        let sdkVersion = environment.sdkVersion()
-        let sdkVersionScript = "document.head.setAttribute('data-sdk-version', '\(sdkVersion)');"
-        let sdkVersionWKScript = WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         loadScripts?.insert(sdkVersionWKScript)
-
-        let handshakeStringified = IAFNativeBridgeEvent.handshake
-        let handshakeScript = "document.head.setAttribute('data-native-bridge-handshake', '\(handshakeStringified)');"
-        let handshakeWKScript = WKUserScript(source: handshakeScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         loadScripts?.insert(handshakeWKScript)
     }
 

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -7,6 +7,7 @@
 
 import AnyCodable
 import Foundation
+import OSLog
 
 enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formsDataLoaded
@@ -75,14 +76,14 @@ extension IAFNativeBridgeEvent {
     }
 }
 
-extension IAFNativeBridgeEvent: CaseIterable {
+extension IAFNativeBridgeEvent {
     public static var handshake: String {
         struct HandshakeData: Codable {
             var type: String
             var version: Int
         }
 
-        let handshakeArray = allCases.map { event -> HandshakeData in
+        let handshakeArray = handshakeEvents.map { event -> HandshakeData in
             HandshakeData(type: event.name, version: event.version)
         }
 
@@ -93,12 +94,14 @@ extension IAFNativeBridgeEvent: CaseIterable {
                 return jsonString
             }
         } catch {
-            print("Error encoding handshake data: \(error)")
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("Error encoding handshake data: \(error)")
+            }
         }
         return ""
     }
 
-    public static var allCases: [IAFNativeBridgeEvent] {
+    private static var handshakeEvents: [IAFNativeBridgeEvent] {
         // events that JS is permitted to sending
         [
             .formWillAppear,

--- a/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoUI/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -9,14 +9,14 @@ import AnyCodable
 import Foundation
 
 enum IAFNativeBridgeEvent: Decodable, Equatable {
-    // TODO: add associated values with the appropriate data types
     case formsDataLoaded
     case formWillAppear
-    case trackAggregateEvent(Data)
-    case trackProfileEvent(Data)
-    case openDeepLink(URL)
     case formDisappeared
+    case trackProfileEvent(Data)
+    case trackAggregateEvent(Data)
+    case openDeepLink(URL)
     case abort(String)
+    case handShook
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -26,11 +26,12 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     private enum TypeIdentifier: String, Decodable {
         case formsDataLoaded
         case formWillAppear
-        case trackAggregateEvent
-        case trackProfileEvent
-        case openDeepLink
         case formDisappeared
+        case trackProfileEvent
+        case trackAggregateEvent
+        case openDeepLink
         case abort
+        case handShook
     }
 
     init(from decoder: Decoder) throws {
@@ -42,22 +43,24 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .formsDataLoaded
         case .formWillAppear:
             self = .formWillAppear
-        case .trackAggregateEvent:
-            let decodedData = try container.decode(AnyCodable.self, forKey: .data)
-            let data = try JSONEncoder().encode(decodedData)
-            self = .trackAggregateEvent(data)
+        case .formDisappeared:
+            self = .formDisappeared
         case .trackProfileEvent:
             let decodedData = try container.decode(AnyCodable.self, forKey: .data)
             let data = try JSONEncoder().encode(decodedData)
             self = .trackProfileEvent(data)
+        case .trackAggregateEvent:
+            let decodedData = try container.decode(AnyCodable.self, forKey: .data)
+            let data = try JSONEncoder().encode(decodedData)
+            self = .trackAggregateEvent(data)
         case .openDeepLink:
             let url = try container.decode(DeepLinkEventPayload.self, forKey: .data)
             self = .openDeepLink(url.ios)
-        case .formDisappeared:
-            self = .formDisappeared
         case .abort:
             let data = try container.decode(AbortPayload.self, forKey: .data)
             self = .abort(data.reason)
+        case .handShook:
+            self = .handShook
         }
     }
 }
@@ -69,5 +72,67 @@ extension IAFNativeBridgeEvent {
 
     struct AbortPayload: Codable {
         let reason: String
+    }
+}
+
+extension IAFNativeBridgeEvent: CaseIterable {
+    public static var handshake: String {
+        struct HandshakeData: Codable {
+            var type: String
+            var version: Int
+        }
+
+        let handshakeArray = allCases.map { event -> HandshakeData in
+            HandshakeData(type: event.name, version: event.version)
+        }
+
+        do {
+            let encoder = JSONEncoder()
+            let jsonData = try encoder.encode(handshakeArray)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return jsonString
+            }
+        } catch {
+            print("Error encoding handshake data: \(error)")
+        }
+        return ""
+    }
+
+    public static var allCases: [IAFNativeBridgeEvent] {
+        // events that JS is permitted to sending
+        [
+            .formWillAppear,
+            .formDisappeared,
+            .trackProfileEvent(Data()),
+            .trackAggregateEvent(Data()),
+            .openDeepLink(URL(string: "https://example.com")!),
+            .abort("")
+        ]
+    }
+
+    private var version: Int {
+        switch self {
+        case .formsDataLoaded: return 1
+        case .formWillAppear: return 1
+        case .formDisappeared: return 1
+        case .trackProfileEvent: return 1
+        case .trackAggregateEvent: return 1
+        case .openDeepLink: return 1
+        case .abort: return 1
+        case .handShook: return 1
+        }
+    }
+
+    private var name: String {
+        switch self {
+        case .formsDataLoaded: return "formsDataLoaded"
+        case .formWillAppear: return "formWillAppear"
+        case .formDisappeared: return "formDisappeared"
+        case .trackProfileEvent: return "trackProfileEvent"
+        case .trackAggregateEvent: return "trackAggregateEvent"
+        case .openDeepLink: return "openDeepLink"
+        case .abort: return "abort"
+        case .handShook: return "handShook"
+        }
     }
 }

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -13,6 +13,13 @@ import Foundation
 import Testing
 
 struct IAFNativeBridgeEventTests {
+    @Test func testHandshakeCreated() async throws {
+        let expectedHandshake = """
+        [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1}]
+        """
+        #expect(IAFNativeBridgeEvent.handshake == expectedHandshake)
+    }
+
     @Test func testHandShook() async throws {
         let json = """
         {

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -13,6 +13,19 @@ import Foundation
 import Testing
 
 struct IAFNativeBridgeEventTests {
+    @Test func testHandShook() async throws {
+        let json = """
+        {
+          "type": "handShook",
+          "data": {}
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        #expect(event == .handShook)
+    }
+
     @Test func testAbort() async throws {
         let json = """
         {

--- a/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoUITests/IAFNativeBridgeEventTests.swift
@@ -14,10 +14,20 @@ import Testing
 
 struct IAFNativeBridgeEventTests {
     @Test func testHandshakeCreated() async throws {
+        struct TestableHandshakeData: Codable, Equatable {
+            var type: String
+            var version: Int
+        }
         let expectedHandshake = """
         [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1}]
         """
-        #expect(IAFNativeBridgeEvent.handshake == expectedHandshake)
+        let expectedData = try #require(expectedHandshake.data(using: .utf8))
+        let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
+
+        let actualHandshake = IAFNativeBridgeEvent.handshake
+        let actualData = try #require(actualHandshake.data(using: .utf8))
+        let actualHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: actualData)
+        #expect(actualHandshakeData == expectedHandshakeData)
     }
 
     @Test func testHandShook() async throws {

--- a/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
@@ -79,4 +79,27 @@ final class IAFWebViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(resultString, "0.0.1")
     }
+
+    func testInjectHandshakeAttribute() async throws {
+        // This test has been flaky when running on CI. It seems to have something to do with instability when
+        // running a WKWebView in a CI test environment. Until we find a fix for this, we'll skip running this test on CI.
+        let isRunningOnCI = Bool(ProcessInfo.processInfo.environment["GITHUB_CI"] ?? "false") ?? false
+        try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
+
+        // Given
+        try await viewModel.preloadWebsite(timeout: 3_000_000_000)
+
+        // When
+        let script = "document.head.getAttribute('data-native-bridge-handshake');"
+        let delegate = try XCTUnwrap(viewModel.delegate)
+        let result = try await delegate.evaluateJavaScript(script)
+        let resultString = try XCTUnwrap(result as? String)
+
+        // Then
+        let handshakeString =
+            """
+            [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1}]
+            """
+        XCTAssertEqual(resultString, handshakeString)
+    }
 }

--- a/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
@@ -93,13 +93,23 @@ final class IAFWebViewModelTests: XCTestCase {
         let script = "document.head.getAttribute('data-native-bridge-handshake');"
         let delegate = try XCTUnwrap(viewModel.delegate)
         let result = try await delegate.evaluateJavaScript(script)
-        let resultString = try XCTUnwrap(result as? String)
+        let actualHandshakeString = try XCTUnwrap(result as? String)
 
         // Then
-        let handshakeString =
+        struct TestableHandshakeData: Codable, Equatable {
+            var type: String
+            var version: Int
+        }
+
+        let expectedHandshakeString =
             """
             [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1}]
             """
-        XCTAssertEqual(resultString, handshakeString)
+        let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
+        let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
+
+        let actualData = try XCTUnwrap(actualHandshakeString.data(using: .utf8))
+        let actualHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: actualData)
+        XCTAssertEqual(actualHandshakeData, expectedHandshakeData)
     }
 }


### PR DESCRIPTION
# Description
- injects the handshake array of events with its versions it supports
- builds out the IAFNativeBridgeEvents to support future versioning differences
- adds the `handShook` event (nothing to really handle just avoids a warning when receiving it)
- reordered events for tidiness
- fixes naming of `data-klaviyo-message-handler-name` to `data-native-bridge-name`

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Some things needed to test on this branch:
- change `company_id` in InAppFormsTemplate.html to local test account
- change where we are injecting `data-sdk-name` to `data-klaviyo-sdk-name` (to be reverted on fender side at some point)
- change where we are injecting `data-sdk-version` to `data-klaviyo-sdk-version` (to be reverted on fender side at some point)

Currently, the `handShook` event is emitted so long as there is at least one event included, doesn't matter which one. It just restricts what JS sends. Changing what cases are included in `allCases`, removing `formWillAppear` prevents the form from being presented. 


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
