### PR TITLE
[CHNL-17241] refactor sdk url

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -29,7 +29,7 @@ public struct KlaviyoEnvironment {
         raiseFatalError: @escaping (String) -> Void,
         emitDeveloperWarning: @escaping (String) -> Void,
         networkSession: @escaping () -> NetworkSession,
-        apiURL: @escaping () -> String,
+        apiURL: @escaping () -> URLComponents,
         encodeJSON: @escaping (Encodable) throws -> Data,
         decoder: DataDecoder,
         uuid: @escaping () -> UUID,
@@ -69,7 +69,13 @@ public struct KlaviyoEnvironment {
         sdkVersion = SDKVersion
     }
 
-    static let productionHost = "a.klaviyo.com"
+    static let productionHost: URLComponents = {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "a.klaviyo.com"
+        return components
+    }()
+
     public static let encoder = { () -> JSONEncoder in
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -82,7 +88,7 @@ public struct KlaviyoEnvironment {
         return decoder
     }()
 
-    private static let reachabilityService = Reachability(hostname: productionHost)
+    private static let reachabilityService = Reachability(hostname: productionHost.host ?? "")
 
     public var archiverClient: ArchiverClient
     public var fileClient: FileClient
@@ -107,7 +113,7 @@ public struct KlaviyoEnvironment {
     public var emitDeveloperWarning: (String) -> Void
 
     public var networkSession: () -> NetworkSession
-    public var apiURL: () -> String
+    public var apiURL: () -> URLComponents
     public var encodeJSON: (Encodable) throws -> Data
     public var decoder: DataDecoder
     public var uuid: () -> UUID

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -15,8 +15,6 @@ public enum KlaviyoEndpoint: Equatable, Codable {
     case unregisterPushToken(UnregisterPushTokenPayload)
     case aggregateEvent(AggregateEventPayload)
 
-    var httpScheme: String { "https" }
-
     var httpMethod: RequestMethod {
         switch self {
         case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent:

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -43,16 +43,17 @@ public struct KlaviyoRequest: Equatable, Codable {
     }
 
     var url: URL? {
-        guard !environment.apiURL().isEmpty else { return nil }
+        var urlComponents = environment.apiURL()
 
-        var components = URLComponents()
-        components.scheme = endpoint.httpScheme
-        components.host = environment.apiURL()
-        components.path = endpoint.path
-        components.queryItems = [
+        guard urlComponents.scheme != nil, urlComponents.host != nil else {
+            return nil
+        }
+
+        urlComponents.path = endpoint.path
+        urlComponents.queryItems = [
             URLQueryItem(name: "company_id", value: apiKey)
         ]
 
-        return components.url
+        return urlComponents.url
     }
 }

--- a/Sources/KlaviyoCore/Networking/PrivateMethods.swift
+++ b/Sources/KlaviyoCore/Networking/PrivateMethods.swift
@@ -11,8 +11,8 @@ import Foundation
 /// - Parameter url: The  URL to use for Klaviyo client APIs, This is used internally to test the SDK against different backends, DO NOT use this in your apps.
 @_spi(KlaviyoPrivate)
 @available(*, deprecated, message: "This function is for internal use only, and should NOT be used in production applications")
-public func overrideSDKDefaults(url: String? = nil) {
-    if let url = url {
-        environment.apiURL = { url }
+public func overrideSDKDefaults(urlComponents: URLComponents? = nil) {
+    if let urlComponents {
+        environment.apiURL = { urlComponents }
     }
 }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -7,7 +7,9 @@
 
 import KlaviyoCore
 
-/// The internal interface for the Klaviyo SDK. Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
+/// The internal interface for the Klaviyo SDK.
+///
+/// - Note: Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
 package struct KlaviyoInternal {
     /// Create and send an aggregate event.
     /// - Parameter event: the event to be tracked in Klaviyo

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -16,7 +16,7 @@ final class KlaviyoAPITests: XCTestCase {
     }
 
     func testInvalidURL() async throws {
-        environment.apiURL = { "" }
+        environment.apiURL = { URLComponents() }
 
         await sendAndAssert(with: KlaviyoRequest(
             apiKey: "foo",

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -94,7 +94,7 @@ extension KlaviyoEnvironment {
             raiseFatalError: { _ in },
             emitDeveloperWarning: { _ in },
             networkSession: { NetworkSession.test() },
-            apiURL: { "dead_beef" },
+            apiURL: { URLComponents(string: "https://dead_beef")! },
             encodeJSON: { _ in TEST_RETURN_DATA },
             decoder: DataDecoder(jsonDecoder: TestJSONDecoder()),
             uuid: { UUID(uuidString: "00000000-0000-0000-0000-000000000001")! },

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -43,7 +43,7 @@ extension KlaviyoEnvironment {
             raiseFatalError: { _ in },
             emitDeveloperWarning: { _ in },
             networkSession: { NetworkSession.test() },
-            apiURL: { "dead_beef" },
+            apiURL: { URLComponents(string: "https://dead_beef")! },
             encodeJSON: { _ in TEST_RETURN_DATA },
             decoder: DataDecoder(jsonDecoder: TestJSONDecoder()),
             uuid: { UUID(uuidString: "00000000-0000-0000-0000-000000000001")! },


### PR DESCRIPTION
# Description

This PR makes some changes to the way that the `apiURL` is set in the `KlaviyoEnvironment`. Instead a `String` type, this PR changes the `apiURL` to being `URLComponents`. This adds some flexibility to set certain URL components independently; i.e., setting the URL scheme, the host, and/or the port each independently. An accompanying test app PR makes some UI changes in the test app to account for the changes in this PR.

The changes in this PR are a prerequisite to the changes necessary to dynamically inject the company ID into the In-App Forms HTML. After this PR is merged, I will open a second PR to inject the company ID into the IAF HTML.

[CHNL-17241](https://klaviyo.atlassian.net/browse/CHNL-17241)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1. I used the test app to validate that the SDK still works as expected.

[CHNL-17241]: https://klaviyo.atlassian.net/browse/CHNL-17241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ