### PR TITLE
[CHNL-17241] make IAF HTML company agnostic

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -11,6 +11,9 @@ import KlaviyoCore
 ///
 /// - Note: Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
 package struct KlaviyoInternal {
+    /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
+    package static var apiKey: String? { klaviyoSwiftEnvironment.state().apiKey }
+
     /// Create and send an aggregate event.
     /// - Parameter event: the event to be tracked in Klaviyo
     package static func create(aggregateEvent: AggregateEventPayload) {

--- a/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoUI/InAppForms/Assets/InAppFormsTemplate.html
@@ -6,7 +6,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Klaviyo In-App Form Test - 1</title>
-        <script type="text/javascript" src="http://localhost:8080/onsite/js/klaviyo.js?company_id=ABC123&env=in-app"></script>
 </head>
 <body></body>
 </html>

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -28,6 +28,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     private var klaviyoJsWKScript: WKUserScript? {
         guard let companyId = KlaviyoInternal.apiKey else {
+            environment.emitDeveloperWarning("SDK must be initialized before usage.")
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.warning("Unable to initialize KlaviyoJS script on In-App Form HTML due to missing API key.")
             }

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -27,7 +27,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
     private var klaviyoJsWKScript: WKUserScript? {
-        guard let companyId = KlaviyoInternal.apiKey else { 
+        guard let companyId = KlaviyoInternal.apiKey else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.warning("Unable to initialize KlaviyoJS script on In-App Form HTML due to missing API key.")
             }

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -27,7 +27,12 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
     private var klaviyoJsWKScript: WKUserScript? {
-        guard let companyId = KlaviyoInternal.apiKey else { return nil }
+        guard let companyId = KlaviyoInternal.apiKey else { 
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("Unable to initialize KlaviyoJS script on In-App Form HTML due to missing API key.")
+            }
+            return nil
+        }
 
         var apiURL = environment.apiURL()
         apiURL.path = "/onsite/js/klaviyo.js"
@@ -71,9 +76,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     }
 
     func initializeLoadScripts() {
-        guard let klaviyoJsWKScript else {
-            return
-		}
+        guard let klaviyoJsWKScript else { return }
         loadScripts?.insert(klaviyoJsWKScript)
         loadScripts?.insert(sdkNameWKScript)
         loadScripts?.insert(sdkVersionWKScript)

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -26,6 +26,27 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
+    private var klaviyoJsWKScript: WKUserScript? {
+        guard let companyId = KlaviyoInternal.apiKey else { return nil }
+
+        var apiURL = environment.apiURL()
+        apiURL.path = "/onsite/js/klaviyo.js"
+        apiURL.queryItems = [
+            URLQueryItem(name: "company_id", value: companyId),
+            URLQueryItem(name: "env", value: "in-app")
+        ]
+
+        let klaviyoJsScript = """
+            var script = document.createElement('script');
+            script.id = 'klaviyoJS';
+            script.type = 'text/javascript';
+            script.src = '\(apiURL)';
+            document.head.appendChild(script)
+        """
+
+        return WKUserScript(source: klaviyoJsScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
     private var sdkNameWKScript: WKUserScript {
         let sdkName = environment.sdkName()
         let sdkNameScript = "document.head.setAttribute('data-sdk-name', '\(sdkName)');"
@@ -50,6 +71,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     }
 
     func initializeLoadScripts() {
+        guard let klaviyoJsWKScript else {
+            return
+		}
+        loadScripts?.insert(klaviyoJsWKScript)
         loadScripts?.insert(sdkNameWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)

--- a/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoUITests/IAFWebViewModelTests.swift
@@ -7,6 +7,7 @@
 
 @testable @_spi(KlaviyoPrivate) import KlaviyoUI
 import KlaviyoCore
+import KlaviyoSwift
 import WebKit
 import XCTest
 
@@ -17,6 +18,11 @@ final class IAFWebViewModelTests: XCTestCase {
     var viewController: KlaviyoWebViewController!
 
     override func setUpWithError() throws {
+        // FIXME: refactor the KlaviyoUI test suite so we can use the TCA tools to initialize a test Klaviyo environment and set the Company ID, similar to how we do it here: https://github.com/klaviyo/klaviyo-swift-sdk/blob/c9bdf25e65a9c575d1e30216dcfcaa156c2ac60b/Tests/KlaviyoSwiftTests/StateManagementTests.swift#L29. Until we're able to do this, the apiKey in the test suite will be nil, and IAFWebViewModel.initializeLoadScripts() will return without injecting the required scripts. Once this is fixed, we should remove the `XCTSkipIf` line.
+        try XCTSkipIf(
+            KlaviyoInternal.apiKey == nil,
+            "Skipping this test until the KlaviyoUI test suite is able to initialize a Company ID")
+
         super.setUp()
 
         environment.sdkName = { "swift" }


### PR DESCRIPTION
# Description

This PR dynamically injects the KlaviyoJS load script into the IAF HTML when it's loaded into the WKWebView. Before injecting the script, this code will assemble the script's `src` URL using the URL host and Company ID from the SDK's environment.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

As validation that the script is successfully injected when the IAF WebView loads, I used Safari to inspect the form. As you can see, the KlaviyoJS script appears in the DOM:

![Screenshot 2025-02-18 at 14 42 29](https://github.com/user-attachments/assets/d304ce7d-6dac-433c-88ad-dc023383d2c2)