### PR TITLE
Fix retain cycle on consoleMessageHandler

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -93,6 +93,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     @MainActor
     func dismiss() {
+        #if DEBUG
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
+        #endif
         dismiss(animated: true)
     }
 


### PR DESCRIPTION
# Description
When testing, tapping "Show In-App Form Test" button multiple times created a new ViewModel and ViewController each time. Seems to be this consoleMessageHandler that's causing the strong retain cycle

Before:
![image](https://github.com/user-attachments/assets/cea534a2-2ded-4058-bb6f-8d00307ab1ee)

After:

![image](https://github.com/user-attachments/assets/1833d258-9dff-412b-b637-6d5c6aecf551)
 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
