### PR TITLE
[CHNL-16714] add registerForInAppForms

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -10,10 +10,8 @@ import KlaviyoCore
 import OSLog
 import UIKit
 
-@_spi(KlaviyoPrivate)
-public class IAFPresentationManager {
-    @_spi(KlaviyoPrivate)
-    public static let shared = IAFPresentationManager()
+class IAFPresentationManager {
+    static let shared = IAFPresentationManager()
 
     lazy var indexHtmlFileUrl: URL? = {
         do {
@@ -25,8 +23,8 @@ public class IAFPresentationManager {
 
     private var isLoading: Bool = false
 
-    @_spi(KlaviyoPrivate)
-    @MainActor public func presentIAF() {
+    @MainActor
+    func presentIAF() {
         guard !isLoading else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.log("In-App Form is already loading; ignoring request.")

--- a/Sources/KlaviyoUI/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoUI/KlaviyoSDK+Forms.swift
@@ -1,0 +1,16 @@
+//
+//  KlaviyoSDK+Forms.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2/20/25.
+//
+
+import Foundation
+import KlaviyoSwift
+
+extension KlaviyoSDK {
+    @MainActor
+    public func registerForInAppForms() {
+        IAFPresentationManager.shared.presentIAF()
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a `registerForInAppForms` method that, when called, will present the IAF web view and display a form, if one is available.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I wired up the "Show In-App Form Test" button in the iOS test app to the new `registerForInAppForms` method and validated that it works as expected