### PR TITLE
Fix access control

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -234,7 +234,6 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 
     return parentViewController
 }
-#endif
 
 #if swift(>=5.9)
 @available(iOS 17.0, *)
@@ -257,4 +256,5 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
     let viewModel = PreviewWebViewModel(url: indexHtmlFileUrl)
     return KlaviyoWebViewController(viewModel: viewModel)
 }
+#endif
 #endif

--- a/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoUI/Utilities/ResourceLoader.swift
@@ -5,7 +5,6 @@
 //  Created by Andrew Balmer on 9/27/24.
 //
 
-#if DEBUG
 import Foundation
 import OSLog
 
@@ -82,4 +81,3 @@ extension Bundle {
         return bundle
     }
 }
-#endif


### PR DESCRIPTION
# Description

There was an issue archiving the iOS test app because

1.  an `#if DEBUG` tag was restricting access to `ResourceLoader` in production code
2. some non-production Xcode preview code was not marked with an `#if DEBUG` tag. This caused an error because the preview code depends on some debug-only code

This PR fixes these two issues

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?