### PR TITLE
CHNL-16714: Prevent multiple native view from being shown simultaneously

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -61,11 +61,9 @@ class IAFPresentationManager {
                 return
             }
 
-            let controllersInStack = topController.navigationController?.viewControllers ?? []
-
-            if topController.isKlaviyoVC || controllersInStack.contains(where: \.isKlaviyoVC) {
+            if topController.isKlaviyoVC || topController.hasKlaviyoVCInStack {
                 if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("In-App Form is already presenting; ignoring request")
+                    Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }
             } else {
                 topController.present(viewController, animated: true, completion: nil)
@@ -77,5 +75,12 @@ class IAFPresentationManager {
 extension UIViewController {
     fileprivate var isKlaviyoVC: Bool {
         self is KlaviyoWebViewController
+    }
+
+    fileprivate var hasKlaviyoVCInStack: Bool {
+        guard let navigationController = navigationController else {
+            return false
+        }
+        return navigationController.viewControllers.contains(where: \.isKlaviyoVC)
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -63,14 +63,19 @@ class IAFPresentationManager {
 
             let controllersInStack = topController.navigationController?.viewControllers ?? []
 
-            if topController is KlaviyoWebViewController || controllersInStack.contains(where: { $0 is KlaviyoWebViewController }) {
+            if topController.isKlaviyoVC || controllersInStack.contains(where: \.isKlaviyoVC) {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("In-App Form is already presenting; ignoring request")
                 }
-                return
             } else {
                 topController.present(viewController, animated: true, completion: nil)
             }
         }
+    }
+}
+
+extension UIViewController {
+    fileprivate var isKlaviyoVC: Bool {
+        self is KlaviyoWebViewController
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -61,13 +61,16 @@ class IAFPresentationManager {
                 return
             }
 
-            guard !(topController is KlaviyoWebViewController) else {
+            let controllersInStack = topController.navigationController?.viewControllers ?? []
+
+            if topController is KlaviyoWebViewController || controllersInStack.contains(where: { $0 is KlaviyoWebViewController }) {
                 if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("In-App Form is already presenting.")
+                    Logger.webViewLogger.warning("In-App Form is already presenting; ignoring request")
                 }
                 return
+            } else {
+                topController.present(viewController, animated: true, completion: nil)
             }
-            topController.present(viewController, animated: true, completion: nil)
         }
     }
 }

--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -60,6 +60,13 @@ class IAFPresentationManager {
             guard let topController = UIApplication.shared.topMostViewController else {
                 return
             }
+
+            guard !(topController is KlaviyoWebViewController) else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("In-App Form is already presenting.")
+                }
+                return
+            }
             topController.present(viewController, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
# Description
Part of https://klaviyo.atlassian.net/browse/CHNL-17524

Added guard to check there isn't already a KlaviyoWebViewController being presented

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan
When trying to call `presentIAF()` multiple times, the `!isLoading` guard already prevented multiple presentation a lot of the times, so this is just an extra level of protection. To test this new guard, I commented out the `!isLoading` guard and rapidly clicked the show in app form button. Before it was possible to trigger multiple native views one after another. Now this is prevented.

Before:

https://github.com/user-attachments/assets/b5659741-eccb-4cdd-9161-c1d2fdee1a84


After:

https://github.com/user-attachments/assets/85c51c62-1fac-439e-85ea-2442c9f45f49




# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
