### PR TITLE
Implement decidePolicyFor to intercept links

### DIFF
--- a/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoUI/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -168,6 +168,15 @@ extension KlaviyoWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
         viewModel.handleNavigationEvent(.didFailNavigation)
     }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
+        if let url = navigationAction.request.url,
+           await UIApplication.shared.open(url) {
+            return .cancel
+        } else {
+            return .allow
+        }
+    }
 }
 
 // MARK: - Message Handling


### PR DESCRIPTION
# Description
https://klaviyo.atlassian.net/browse/CHNL-17745

Intercepts links in `webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction)` to ensure opening web links in external browser. Future proofing for when hyperlinks are officially supported in the editor.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

(in app in `clean_data.py` I removed `"a"` from INVALID_TAG_TYPES to be able to put hyperlinks into IAF body)
- Web links in IAF body > open in default browser
- Web links in button action > open in default browser
- Deep links in IAF body > redirect in app
- Deep links in button action > redirect in app

https://github.com/user-attachments/assets/8c0b0968-8606-46ca-9d1c-24e8c1a9dde0


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
