### PR TITLE
Add asset source option

### DIFF
--- a/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFPresentationManager.swift
@@ -24,7 +24,7 @@ class IAFPresentationManager {
     private var isLoading: Bool = false
 
     @MainActor
-    func presentIAF() {
+    func presentIAF(assetSource: String? = nil) {
         guard !isLoading else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.log("In-App Form is already loading; ignoring request.")
@@ -41,7 +41,7 @@ class IAFPresentationManager {
 
         isLoading = true
 
-        let viewModel = IAFWebViewModel(url: fileUrl)
+        let viewModel = IAFWebViewModel(url: fileUrl, assetSource: assetSource)
         let viewController = KlaviyoWebViewController(viewModel: viewModel)
         viewController.modalPresentationStyle = .overCurrentContext
 

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -17,6 +17,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case klaviyoNativeBridge = "KlaviyoNativeBridge"
     }
 
+    // MARK: - Properties
+
     weak var delegate: KlaviyoWebViewDelegate?
 
     let url: URL
@@ -25,6 +27,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
+
+    // MARK: - Scripts
 
     private var klaviyoJsWKScript: WKUserScript? {
         guard let companyId = KlaviyoInternal.apiKey else {
@@ -71,6 +75,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         return WKUserScript(source: handshakeScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    // MARK: - Initializer
+
     init(url: URL) {
         self.url = url
         initializeLoadScripts()
@@ -83,6 +89,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
     }
+
+    // MARK: - Loading
 
     func preloadWebsite(timeout: UInt64) async throws {
         guard let delegate else { return }
@@ -140,7 +148,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         }
     }
 
-    // MARK: handle WKWebView events
+    // MARK: - handle WKWebView events
 
     func handleScriptMessage(_ message: WKScriptMessage) {
         guard let handler = MessageHandler(rawValue: message.name) else {

--- a/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoUI/InAppForms/IAFWebViewModel.swift
@@ -25,6 +25,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     var loadScripts: Set<WKUserScript>? = Set<WKUserScript>()
     var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
+    let assetSource: String?
+
     public let (navEventStream, navEventContinuation) = AsyncStream.makeStream(of: WKNavigationEvent.self)
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
@@ -45,6 +47,11 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             URLQueryItem(name: "company_id", value: companyId),
             URLQueryItem(name: "env", value: "in-app")
         ]
+
+        if let assetSource {
+            let assetSourceQueryItem = URLQueryItem(name: "assetSource", value: assetSource)
+            apiURL.queryItems?.append(assetSourceQueryItem)
+        }
 
         let klaviyoJsScript = """
             var script = document.createElement('script');
@@ -77,8 +84,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Initializer
 
-    init(url: URL) {
+    init(url: URL, assetSource: String? = nil) {
         self.url = url
+        self.assetSource = assetSource
         initializeLoadScripts()
     }
 

--- a/Sources/KlaviyoUI/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoUI/KlaviyoSDK+Forms.swift
@@ -13,4 +13,11 @@ extension KlaviyoSDK {
     public func registerForInAppForms() {
         IAFPresentationManager.shared.presentIAF()
     }
+
+    @MainActor
+    @_spi(KlaviyoPrivate)
+    @available(*, deprecated, message: "This function is for internal use only, and should not be used in production applications")
+    public func registerForInAppForms(assetSource: String) {
+        IAFPresentationManager.shared.presentIAF(assetSource: assetSource)
+    }
 }


### PR DESCRIPTION
# Description

This updates the SDK to allow for injecting a custom `assetSource` query parameter into the URL that fetches the KlaviyoJS script for In-App Forms. This change is intended to be used only by the iOS test app for testing & development purposes.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I used the iOS test app to validate that this works as expected.