### PR TITLE
remove didFailNavigation handling

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -124,15 +124,6 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                     await iterator.next()
                 }
 
-                group.addTask { [weak self] in
-                    guard let self else { return }
-                    for await event in self.navEventStream {
-                        if case .didFailNavigation = event {
-                            throw PreloadError.navigationFailed
-                        }
-                    }
-                }
-
                 try await group.next()
             }
         } catch let error as PreloadError {


### PR DESCRIPTION
# Description

Following a discussion on Friday, this PR removes handling of a `didFailNavigation` event from the IAFWebViewModel. When loading an IAF, we shouldn't encounter a `didFailNavigation` event because we're loading the site from a local HTML file. In the event that we somehow do receive a `didFailNavigation` event, it will simply be handled gracefully by the timeout.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?