### PR TITLE
Conditional console log relay

### DIFF
--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -10,6 +10,10 @@ import OSLog
 import UIKit
 import WebKit
 
+private var webConsoleLoggingEnabled: Bool {
+    ProcessInfo.processInfo.environment["WEB_CONSOLE_LOGGING"] == "1"
+}
+
 private func createDefaultWebView() -> WKWebView {
     let config = WKWebViewConfiguration()
     // Required to allow localStorage data to be retained between webview instances
@@ -94,7 +98,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     @MainActor
     func dismiss() {
         #if DEBUG
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
+        if webConsoleLoggingEnabled {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
+        }
         #endif
         dismiss(animated: true)
     }
@@ -112,7 +118,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         }
 
         #if DEBUG
-        injectConsoleLoggingScript()
+        if webConsoleLoggingEnabled {
+            injectConsoleLoggingScript()
+        }
         #endif
     }
 


### PR DESCRIPTION
# Description

This PR puts the Web View console log relay behind an environment variable, so the developer will only see the console log messages if they set an environment variable WEB_CONSOLE_LOGGING to "1". To do this:

1. Go to "Edit Scheme" in the host app:

<img width="600" alt="Screenshot 2025-02-24 at 16 51 19" src="https://github.com/user-attachments/assets/bdf3c7aa-947c-4f7e-8131-68bcb0365252" />

2. Go to **Run → Arguments → Environment Variables**.
3. Add WEB_CONSOLE_LOGGING = 1.

<img width="600" alt="Screenshot 2025-02-24 at 16 47 32" src="https://github.com/user-attachments/assets/58498174-c711-4a5e-a6de-f8cad56df922" />

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
