### PR TITLE
Align iOS with Android meta tags + prevent zoom

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
-<head data-native-bridge-name="KlaviyoNativeBridge"
-      data-support-event-types='test1,test2'
->
+<head data-native-bridge-name="KlaviyoNativeBridge">
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Klaviyo In-App Form Test - 1</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover">
+        <title>Klaviyo In-App Form Template</title>
 </head>
 <body></body>
 </html>


### PR DESCRIPTION
# Description

Per Slack [discussion](https://klaviyo.slack.com/archives/C064QGU3BCG/p1740003048313169) and comment in [CHNL-17594](https://klaviyo.atlassian.net/browse/CHNL-17594?focusedCommentId=627807) aligned the tags as much as I could while iOS is still injecting the data tags while [Android](https://github.com/klaviyo/klaviyo-android-sdk/blob/feat/iaf/sdk/forms/src/main/assets/InAppFormsTemplate.html) is string replacing. 

The added meta properties prevent zoom.

(Tested this change on sim and confirmed zoom is prevented, a screen recording would just be pointless here)

[CHNL-17594]: https://klaviyo.atlassian.net/browse/CHNL-17594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ