### PR TITLE
make registerForInAppForms async

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -6,7 +6,9 @@
 //  Copyright (c) 2015 Katy Keuper. All rights reserved.
 //
 
-// STEP1: Importing klaviyo SDK into your app code
+import KlaviyoForms
+// STEP1: Importing klaviyo SDK modules into your app code
+// `KlaviyoSwift` is for analytics and push notifications and `KlaviyoForms` is for presenting marketing in app forms/messages
 import KlaviyoSwift
 import UIKit
 
@@ -34,7 +36,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         // STEP2: Setup Klaviyo SDK with api key
-        KlaviyoSDK().initialize(with: "magpcN")
+        KlaviyoSDK()
+            .initialize(with: "ABC123")
+            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
 
         // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import KlaviyoCore
+import KlaviyoSwift
 import OSLog
 import UIKit
 
@@ -32,21 +33,25 @@ class IAFPresentationManager {
             return
         }
 
-        guard let fileUrl = indexHtmlFileUrl else {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("URL for local HTML file is nil; unable to present In-App Form.")
-            }
-            return
-        }
+        guard let fileUrl = indexHtmlFileUrl else { return }
 
         isLoading = true
 
-        let viewModel = IAFWebViewModel(url: fileUrl, assetSource: assetSource)
-        let viewController = KlaviyoWebViewController(viewModel: viewModel)
-        viewController.modalPresentationStyle = .overCurrentContext
-
         Task {
             defer { isLoading = false }
+
+            guard let companyId = await withCheckedContinuation({ continuation in
+                KlaviyoInternal.apiKey { apiKey in
+                    continuation.resume(returning: apiKey)
+                }
+            }) else {
+                environment.emitDeveloperWarning("124 SDK must be initialized before usage.")
+                return
+            }
+
+            let viewModel = IAFWebViewModel(url: fileUrl, companyId: companyId, assetSource: assetSource)
+            let viewController = KlaviyoWebViewController(viewModel: viewModel)
+            viewController.modalPresentationStyle = .overCurrentContext
 
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -25,21 +25,14 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     var loadScripts: Set<WKUserScript>? = Set<WKUserScript>()
     var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
-    let assetSource: String?
+    private let companyId: String?
+    private let assetSource: String?
 
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
     // MARK: - Scripts
 
     private var klaviyoJsWKScript: WKUserScript? {
-        guard let companyId = KlaviyoInternal.apiKey else {
-            environment.emitDeveloperWarning("SDK must be initialized before usage.")
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Unable to initialize KlaviyoJS script on In-App Form HTML due to missing API key.")
-            }
-            return nil
-        }
-
         var apiURL = environment.cdnURL()
         apiURL.path = "/onsite/js/klaviyo.js"
         apiURL.queryItems = [
@@ -83,8 +76,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Initializer
 
-    init(url: URL, assetSource: String? = nil) {
+    init(url: URL, companyId: String, assetSource: String? = nil) {
         self.url = url
+        self.companyId = companyId
         self.assetSource = assetSource
         initializeLoadScripts()
     }

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -11,13 +11,21 @@ import KlaviyoSwift
 extension KlaviyoSDK {
     @MainActor
     public func registerForInAppForms() {
-        IAFPresentationManager.shared.presentIAF()
+        Task {
+            await MainActor.run {
+                IAFPresentationManager.shared.presentIAF()
+            }
+        }
     }
 
     @MainActor
     @_spi(KlaviyoPrivate)
     @available(*, deprecated, message: "This function is for internal use only, and should not be used in production applications")
     public func registerForInAppForms(assetSource: String) {
-        IAFPresentationManager.shared.presentIAF(assetSource: assetSource)
+        Task {
+            await MainActor.run {
+                IAFPresentationManager.shared.presentIAF(assetSource: assetSource)
+            }
+        }
     }
 }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -266,7 +266,7 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
     let companyId: String = "9BX3wh" // ⬅️ use a company ID that has a live form
     _ = klaviyoSwiftEnvironment.send(.initialize(companyId))
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "InAppFormsTemplate", type: "html")
-    let viewModel = IAFWebViewModel(url: indexHtmlFileUrl)
+    let viewModel = IAFWebViewModel(url: indexHtmlFileUrl, companyId: companyId)
     return createKlaviyoWebPreview(viewModel: viewModel)
 }
 

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -5,14 +5,29 @@
 //  Created by Andrew Balmer on 2/4/25.
 //
 
+import Combine
+import Foundation
 import KlaviyoCore
 
 /// The internal interface for the Klaviyo SDK.
 ///
 /// - Note: Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
 package struct KlaviyoInternal {
+    static var cancellable: Cancellable?
     /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
-    package static var apiKey: String? { klaviyoSwiftEnvironment.state().apiKey }
+    /// - Parameter completion: completion hanlder that will be called when apiKey is avaialble after SDK is initilized
+    package static func apiKey(completion: @escaping ((String?) -> Void)) {
+        if cancellable == nil {
+            cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
+                .receive(on: DispatchQueue.main)
+                .filter { $0.initalizationState == .initialized }
+                .compactMap(\.apiKey)
+                .removeDuplicates()
+                .sink(receiveValue: {
+                    completion($0)
+                })
+        }
+    }
 
     /// Create and send an aggregate event.
     /// - Parameter event: the event to be tracked in Klaviyo

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -19,7 +19,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        viewModel = IAFWebViewModel(url: URL(string: "https://example.com")!)
+        viewModel = IAFWebViewModel(url: URL(string: "https://example.com")!, companyId: "abc123")
         delegate = MockIAFWebViewDelegate(viewModel: viewModel)
         viewModel.delegate = delegate
     }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -30,7 +30,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
 
-        viewModel = IAFWebViewModel(url: fileUrl)
+        viewModel = IAFWebViewModel(url: fileUrl, companyId: "abc123")
         viewController = KlaviyoWebViewController(viewModel: viewModel, webViewFactory: {
             let configuration = WKWebViewConfiguration()
             configuration.processPool = WKProcessPool() // Ensures a fresh WebKit process


### PR DESCRIPTION
# Description
The getter for companyId is sync however the setter using `.initialize()` goes through `dispatchOnMainThread` which is async. Therefore, `registerForInAppForms()` needs to be async as well or it may not pick up the companyId in the (assumed) most common use case of calling it right after initialize on launch.


# Manual Test Plan

Only was able to test in the SPM Example app (in the SDK Repo examples) as the Test App itself does not initialize on launch. The SPM Example App is a better model though in this case as this is what most devs might do instead (versus in the test app we initialize on tapping Start and only call forms on button tap)

# Supporting Materials
Video shows before with `registerForInAppForms` being sync and after making it async


https://github.com/user-attachments/assets/1cd55472-326a-46b3-b9ef-a9ea618f257b

