### PR TITLE
Make api key package method async

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -6,7 +6,9 @@
 //  Copyright (c) 2015 Katy Keuper. All rights reserved.
 //
 
-// STEP1: Importing klaviyo SDK into your app code
+import KlaviyoForms
+// STEP1: Importing klaviyo SDK modules into your app code
+// `KlaviyoSwift` is for analytics and push notifications and `KlaviyoForms` is for presenting marketing in app forms/messages
 import KlaviyoSwift
 import UIKit
 
@@ -34,7 +36,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         // STEP2: Setup Klaviyo SDK with api key
-        KlaviyoSDK().initialize(with: "magpcN")
+        KlaviyoSDK()
+            .initialize(with: "ABC123")
+            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
 
         // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import KlaviyoCore
+import KlaviyoSwift
 import OSLog
 import UIKit
 
@@ -32,21 +33,25 @@ class IAFPresentationManager {
             return
         }
 
-        guard let fileUrl = indexHtmlFileUrl else {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("URL for local HTML file is nil; unable to present In-App Form.")
-            }
-            return
-        }
+        guard let fileUrl = indexHtmlFileUrl else { return }
 
         isLoading = true
 
-        let viewModel = IAFWebViewModel(url: fileUrl, assetSource: assetSource)
-        let viewController = KlaviyoWebViewController(viewModel: viewModel)
-        viewController.modalPresentationStyle = .overCurrentContext
-
         Task {
             defer { isLoading = false }
+
+            guard let companyId = await withCheckedContinuation({ continuation in
+                KlaviyoInternal.apiKey { apiKey in
+                    continuation.resume(returning: apiKey)
+                }
+            }) else {
+                environment.emitDeveloperWarning("124 SDK must be initialized before usage.")
+                return
+            }
+
+            let viewModel = IAFWebViewModel(url: fileUrl, companyId: companyId, assetSource: assetSource)
+            let viewController = KlaviyoWebViewController(viewModel: viewModel)
+            viewController.modalPresentationStyle = .overCurrentContext
 
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -25,21 +25,14 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     var loadScripts: Set<WKUserScript>? = Set<WKUserScript>()
     var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
-    let assetSource: String?
+    private let companyId: String?
+    private let assetSource: String?
 
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
 
     // MARK: - Scripts
 
     private var klaviyoJsWKScript: WKUserScript? {
-        guard let companyId = KlaviyoInternal.apiKey else {
-            environment.emitDeveloperWarning("SDK must be initialized before usage.")
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Unable to initialize KlaviyoJS script on In-App Form HTML due to missing API key.")
-            }
-            return nil
-        }
-
         var apiURL = environment.cdnURL()
         apiURL.path = "/onsite/js/klaviyo.js"
         apiURL.queryItems = [
@@ -83,8 +76,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Initializer
 
-    init(url: URL, assetSource: String? = nil) {
+    init(url: URL, companyId: String, assetSource: String? = nil) {
         self.url = url
+        self.companyId = companyId
         self.assetSource = assetSource
         initializeLoadScripts()
     }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -266,7 +266,7 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
     let companyId: String = "9BX3wh" // ⬅️ use a company ID that has a live form
     _ = klaviyoSwiftEnvironment.send(.initialize(companyId))
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "InAppFormsTemplate", type: "html")
-    let viewModel = IAFWebViewModel(url: indexHtmlFileUrl)
+    let viewModel = IAFWebViewModel(url: indexHtmlFileUrl, companyId: companyId)
     return createKlaviyoWebPreview(viewModel: viewModel)
 }
 

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -5,14 +5,29 @@
 //  Created by Andrew Balmer on 2/4/25.
 //
 
+import Combine
+import Foundation
 import KlaviyoCore
 
 /// The internal interface for the Klaviyo SDK.
 ///
 /// - Note: Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
 package struct KlaviyoInternal {
+    static var cancellable: Cancellable?
     /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
-    package static var apiKey: String? { klaviyoSwiftEnvironment.state().apiKey }
+    /// - Parameter completion: completion hanlder that will be called when apiKey is avaialble after SDK is initilized
+    package static func apiKey(completion: @escaping ((String?) -> Void)) {
+        if cancellable == nil {
+            cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
+                .receive(on: DispatchQueue.main)
+                .filter { $0.initalizationState == .initialized }
+                .compactMap(\.apiKey)
+                .removeDuplicates()
+                .sink(receiveValue: {
+                    completion($0)
+                })
+        }
+    }
 
     /// Create and send an aggregate event.
     /// - Parameter event: the event to be tracked in Klaviyo


### PR DESCRIPTION
# Description

During testing @belleklaviyo noticed that when `.registerForInAppForms` is chained to `initialize` method of `KlaviyoSwift` in app forms isn't loading since `companyId` is not yet available since `initialize` is async. This PR makes the package method async. Belle already in #298 made `registerForInAppForms` async. This will be merged in that PR.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
