### PR TITLE
fix memory leak on cancellable

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -25,6 +25,7 @@ package struct KlaviyoInternal {
                 .removeDuplicates()
                 .sink(receiveValue: {
                     completion($0)
+                    cancellable = nil
                 })
         }
     }


### PR DESCRIPTION
# Description

When trying to test calling `registerForInAppForms` on every app foreground, I was receiving the error `SWIFT TASK CONTINUATION MISUSE: presentIAF(assetSource:) leaked its continuation!`so it would only work once (on launch) and was unable to present the form any further. This fixes the memory leak and works on every foreground event/multiple calls.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.

https://github.com/user-attachments/assets/345dd27f-4999-4162-a4c9-838af34ec949




# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
