### PR TITLE
Fix memory leak + cancellable issue

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -54,10 +54,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        KlaviyoSDK().registerForInAppForms()
-    }
-
     // MARK: Push Notification implementation
 
     private func howToSetupPushNotifications() {

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -37,8 +37,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // STEP2: Setup Klaviyo SDK with api key
         KlaviyoSDK()
-            .initialize(with: "XNhKEQ")
-//            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
+            .initialize(with: "ABC123")
+            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
 
         // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -37,8 +37,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // STEP2: Setup Klaviyo SDK with api key
         KlaviyoSDK()
-            .initialize(with: "ABC123")
-            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
+            .initialize(with: "XNhKEQ")
+//            .registerForInAppForms() // STEP2A: register for in app forms (currently only one us supported in a session)
 
         // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))
@@ -52,6 +52,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         howToSetupPushNotifications()
 
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        KlaviyoSDK().registerForInAppForms()
     }
 
     // MARK: Push Notification implementation

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -50,8 +50,6 @@ class IAFPresentationManager {
             }
 
             let viewModel = IAFWebViewModel(url: fileUrl, companyId: companyId, assetSource: assetSource)
-            let viewController = KlaviyoWebViewController(viewModel: viewModel)
-            viewController.modalPresentationStyle = .overCurrentContext
 
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
@@ -71,6 +69,8 @@ class IAFPresentationManager {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }
             } else {
+                let viewController = KlaviyoWebViewController(viewModel: viewModel)
+                viewController.modalPresentationStyle = .overCurrentContext
                 topController.present(viewController, animated: true, completion: nil)
             }
         }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -45,7 +45,7 @@ class IAFPresentationManager {
                     continuation.resume(returning: apiKey)
                 }
             }) else {
-                environment.emitDeveloperWarning("124 SDK must be initialized before usage.")
+                environment.emitDeveloperWarning("SDK must be initialized before usage.")
                 return
             }
 

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -17,15 +17,18 @@ package struct KlaviyoInternal {
     /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
     /// - Parameter completion: completion hanlder that will be called when apiKey is avaialble after SDK is initilized
     package static func apiKey(completion: @escaping ((String?) -> Void)) {
-        cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
-            .receive(on: DispatchQueue.main)
-            .filter { $0.initalizationState == .initialized }
-            .compactMap(\.apiKey)
-            .removeDuplicates()
-            .prefix(1)
-            .sink(receiveValue: {
-                completion($0)
-            })
+        if cancellable == nil {
+            cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
+                .receive(on: DispatchQueue.main)
+                .filter { $0.initalizationState == .initialized }
+                .compactMap(\.apiKey)
+                .removeDuplicates()
+                .prefix(1)
+                .sink(receiveValue: {
+                    completion($0)
+                    cancellable = nil
+                })
+        }
     }
 
     /// Create and send an aggregate event.

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -17,16 +17,16 @@ package struct KlaviyoInternal {
     /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
     /// - Parameter completion: completion hanlder that will be called when apiKey is avaialble after SDK is initilized
     package static func apiKey(completion: @escaping ((String?) -> Void)) {
-        if cancellable == nil {
-            cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
-                .receive(on: DispatchQueue.main)
-                .filter { $0.initalizationState == .initialized }
-                .compactMap(\.apiKey)
-                .removeDuplicates()
-                .sink(receiveValue: {
+        cancellable = KlaviyoSwiftEnvironment.production.statePublisher()
+            .receive(on: DispatchQueue.main)
+            .filter { $0.initalizationState == .initialized }
+            .compactMap(\.apiKey)
+            .removeDuplicates()
+            .prefix(1)
+            .sink(
+                receiveValue: {
                     completion($0)
                 })
-        }
     }
 
     /// Create and send an aggregate event.

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -23,10 +23,9 @@ package struct KlaviyoInternal {
             .compactMap(\.apiKey)
             .removeDuplicates()
             .prefix(1)
-            .sink(
-                receiveValue: {
-                    completion($0)
-                })
+            .sink(receiveValue: {
+                completion($0)
+            })
     }
 
     /// Create and send an aggregate event.


### PR DESCRIPTION
# Description

Changing where we are creating the KlaviyoWebViewController to only when we absolutely know we are presenting something fixes a memory leak. And using `.prefix(1)` helps us avoid having to manually cancel or check for nil of the cancellable.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
