### PR TITLE
Possible retain cycle fix for webview <-> view controller

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -56,6 +56,7 @@ class IAFPresentationManager {
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
             } catch {
+                await viewController.dismiss()
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")
                 }
@@ -63,10 +64,12 @@ class IAFPresentationManager {
             }
 
             guard let topController = UIApplication.shared.topMostViewController else {
+                await viewController.dismiss()
                 return
             }
 
             if topController.isKlaviyoVC || topController.hasKlaviyoVCInStack {
+                await viewController.dismiss()
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -50,6 +50,8 @@ class IAFPresentationManager {
             }
 
             let viewModel = IAFWebViewModel(url: fileUrl, companyId: companyId, assetSource: assetSource)
+            let viewController = KlaviyoWebViewController(viewModel: viewModel)
+            viewController.modalPresentationStyle = .overCurrentContext
 
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
@@ -69,8 +71,6 @@ class IAFPresentationManager {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }
             } else {
-                let viewController = KlaviyoWebViewController(viewModel: viewModel)
-                viewController.modalPresentationStyle = .overCurrentContext
                 topController.present(viewController, animated: true, completion: nil)
             }
         }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -102,6 +102,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     @MainActor
     func dismiss() {
+        viewModel.messageHandlers?.forEach {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: $0)
+        }
         #if DEBUG
         if webConsoleLoggingEnabled {
             webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")


### PR DESCRIPTION
# Description
I'm baaaack

The script message handler injected into the webview holds a strong reference. In our case, that means the view has a strong reference to the VC and the VC of course has a strong ref to the view. 

Tested this with the scenario where this abort occurs:
> Aborting webview: No formWillAppear event detected

Without removing script message handlers, safari still shows the webview as inspectable and this is the memory graph post-abort:
![Screenshot 2025-03-05 at 16 18 27](https://github.com/user-attachments/assets/d5fbbb01-85f8-4923-973b-a9e79a4c2f30)
I'm not 100% sure i'm reading it right, but I think the fact that we see View -> View Controller -> View is a bad sign.

Once I remove the script message handlers in our `dismiss` function, post-abort safari no longer lists the webview as inspectable, and i can’t find KlaviyoWebViewController or IAFWebViewModel in the memory graph

# Check List

- [] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
