### PR TITLE
ViewController presentation animation clashes with form animation

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -74,7 +74,7 @@ class IAFPresentationManager {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }
             } else {
-                topController.present(viewController, animated: true, completion: nil)
+                topController.present(viewController, animated: false, completion: nil)
             }
         }
     }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -110,7 +110,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
             webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
         }
         #endif
-        dismiss(animated: true)
+        dismiss(animated: false)
     }
 
     // MARK: - Scripts

--- a/Sources/KlaviyoForms/KlaviyoWebViewOverlayManager.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebViewOverlayManager.swift
@@ -40,7 +40,7 @@ class KlaviyoWebViewOverlayManager {
             guard let topController = UIApplication.shared.topMostViewController else {
                 return
             }
-            topController.present(viewController, animated: true, completion: nil)
+            topController.present(viewController, animated: false, completion: nil)
         }
     }
 }


### PR DESCRIPTION
# Description
Certainly subjective, but IMO it is jarring to have the fade-in of the onsite forms animation simultaneously with the native view slide-in animation. It is also inconsistent cross platform. 

| before | after |
|---|---|
|<video src="https://github.com/user-attachments/assets/e61fa7d2-6599-4bbe-841a-a14b9c136e4c"/>|<video src="https://github.com/user-attachments/assets/216d3c9f-eb6b-4073-8247-d6e1d020b618"/>|


# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
