### PR TITLE
Cocoapods | handling swift package level access modifier 

### DIFF
--- a/KlaviyoForms.podspec
+++ b/KlaviyoForms.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoForms"
   s.version          = "4.2.0"
-  s.summary          = "UI components for the Klaviyo"
+  s.summary          = "Klaviyo forms is a new way to engage with your app users"
   s.description      = <<-DESC
-                        UI components and utilities for the Klaviyo SDK.
+                        Use Klaviyo forms to include in app forms in your app and engage user with marketing content
                        DESC
   s.homepage         = "https://github.com/klaviyo/klaviyo-swift-sdk"
   s.license          = { :type => "MIT", :file => "LICENSE" }
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
       'Tests/KlaviyoFormsTests/Assets/*.{html}'
     ]
   }
-  # update once modularization changes are merged in.
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
   s.dependency     'KlaviyoSwift', '~> 4.2.0'
 end

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
   s.dependency     'KlaviyoCore', '~> 4.2.0'
   s.dependency     'AnyCodable-FlightSchool'
 end


### PR DESCRIPTION
# Description

Using `package` access modifier to expose APIs in `KlaviyoSwift` wasn't working with cocoapods since package is a SPM construct. While digging online, it seemed like you need to include a build setting using cocoapods - 

`s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }`

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

<!--
Describe how you tested this change.
-->

1.


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
