### PR TITLE
Make invalid field sourcePointer check more inclusive

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -23,10 +23,10 @@ enum InvalidField: Equatable {
     /// - Parameter sourcePointer: pointers to the source of the error
     /// - Returns: the field that is invalid else `nil`
     static func getInvalidField(sourcePointer: String) -> InvalidField? {
-        if sourcePointer == "/data/attributes/phone_number" {
+        if sourcePointer.contains("/attributes/phone_number") {
             return .phone
         }
-        if sourcePointer == "/data/attributes/email" {
+        if sourcePointer.contains("/attributes/email") {
             return .email
         }
 

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -83,6 +83,29 @@ class APIRequestErrorHandlingTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testSendRequestHttpFailureForPhoneNumberForDifferentErrorPathResetsStateAndDequesRequest() async throws {
+        var initialState = INITIALIZED_TEST_STATE_INVALID_PHONE()
+        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        initialState.requestsInFlight = [request]
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        environment.klaviyoAPI.send = { _, _ in .failure(.httpError(400, TEST_FAILURE_JSON_INVALID_PHONE_NUMBER_DIFFERENT_SOURCE_POINTER.data(using: .utf8)!)) }
+
+        _ = await store.send(.sendRequest)
+
+        await store.receive(.resetStateAndDequeue(request, [InvalidField.phone]), timeout: TIMEOUT_NANOSECONDS) {
+            $0.phoneNumber = nil
+        }
+
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+            $0.flushing = false
+            $0.queue = []
+            $0.requestsInFlight = []
+            $0.retryInfo = .retry(1)
+        }
+    }
+
     // MARK: - network error
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -167,6 +167,24 @@ let TEST_FAILURE_JSON_INVALID_PHONE_NUMBER = """
 }
 """
 
+let TEST_FAILURE_JSON_INVALID_PHONE_NUMBER_DIFFERENT_SOURCE_POINTER = """
+{
+    "errors": [
+      {
+        "id": "9997bd4f-7d5f-4f01-bbd1-df0065ef4faa",
+        "status": 400,
+        "code": "invalid",
+        "title": "Invalid input.",
+        "detail": "Invalid phone number format (Example of a valid format: +12345678901)",
+        "source": {
+          "pointer": "/data/attributes/profile/data/attributes/phone_number"
+        },
+        "meta": {}
+      }
+    ]
+}
+"""
+
 let TEST_FAILURE_JSON_INVALID_EMAIL = """
 {
   "errors": [


### PR DESCRIPTION
# Description

Changing how we are checking the error path to be more accommodating to breaking changes

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

Now when an invalid identifier is submitted, the state is properly reset


https://github.com/user-attachments/assets/f21bb209-441f-4ac8-be78-8a15e4a42d61



# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
