### PR TITLE
Explicitly return trimmed string

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -10,7 +10,8 @@ import KlaviyoCore
 
 extension String {
     fileprivate func returnNilIfEmpty() -> String? {
-        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedString.isEmpty ? nil : trimmedString
     }
 }
 

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -106,6 +106,28 @@ class APIRequestErrorHandlingTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testEmailWhitespaceIsTrimmedBeforeSendingRequest() async throws {
+        var initialState = INITIALIZED_TEST_STATE_INVALID_EMAIL()
+
+        initialState.email = "foo@blob.com      "
+
+        let request = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: initialState.pushTokenData?.pushToken ?? "", enablement: .authorized)
+        initialState.requestsInFlight = [request]
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        environment.klaviyoAPI.send = { _, _ in .success(Data()) }
+        _ = await store.send(.sendRequest)
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+            $0.requestsInFlight = []
+            $0.flushing = false
+            $0.email = "foo@blob.com      "
+            if case let .registerPushToken(payload) = request.endpoint {
+                XCTAssertEqual(payload.data.attributes.profile.data.attributes.email, "foo@blob.com", "Email should be trimmed of whitespace before being sent.")
+            }
+        }
+    }
+
     // MARK: - network error
 
     @MainActor


### PR DESCRIPTION
# Description

Before, we were just checking if there was whitespace but still returning the original string. This actually returns the trimmed string.

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

https://github.com/user-attachments/assets/9df369f1-8bd7-4bf6-959e-639c52c185a2

