### PR TITLE
Trim whitespace for create profile path

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -22,9 +22,9 @@ extension Profile {
         externalId: String? = nil,
         anonymousId: String) -> ProfilePayload {
         ProfilePayload(
-            email: self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            phoneNumber: self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            externalId: self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
             firstName: firstName,
             lastName: lastName,
             organization: organization,

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -9,7 +9,7 @@ import Foundation
 import KlaviyoCore
 
 extension String {
-    fileprivate func returnNilIfEmpty() -> String? {
+    fileprivate func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
         let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedString.isEmpty ? nil : trimmedString
     }
@@ -22,9 +22,9 @@ extension Profile {
         externalId: String? = nil,
         anonymousId: String) -> ProfilePayload {
         ProfilePayload(
-            email: email ?? self.email?.returnNilIfEmpty(),
-            phoneNumber: phoneNumber ?? self.phoneNumber?.returnNilIfEmpty(),
-            externalId: externalId ?? self.externalId?.returnNilIfEmpty(),
+            email: self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            phoneNumber: self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            externalId: self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
             firstName: firstName,
             lastName: lastName,
             organization: organization,

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -90,4 +90,26 @@ class KlaviyoModelsTest: XCTestCase {
         XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
         XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
     }
+
+    func testWhitespaceIsTrimmedForProfileParameters() {
+        let profile = Profile(
+            email: "",
+            phoneNumber: "",
+            externalId: "",
+            firstName: "Walter",
+            lastName: "White")
+        let anonymousId = "C10H15N"
+        let apiProfile = profile.toAPIModel(
+            email: "test@blob.com    ",
+            phoneNumber: "+12345678901    ",
+            externalId: "a       ",
+            anonymousId: anonymousId)
+
+        XCTAssertEqual(apiProfile.attributes.email, "test@blob.com")
+        XCTAssertEqual(apiProfile.attributes.phoneNumber, "+12345678901")
+        XCTAssertEqual(apiProfile.attributes.externalId, "a")
+        XCTAssertEqual(apiProfile.attributes.firstName, profile.firstName)
+        XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
+        XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
+    }
 }


### PR DESCRIPTION
# Description

#314 only fixed if we were making a token request w/ an identifier, but it didn't actually trim the whitespace for the create profile path. This ensures the identifiers are always trimmed.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [ ] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
