### PR TITLE
Trim whitespace upstream

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -9,9 +9,8 @@ import Foundation
 import KlaviyoCore
 
 extension String {
-    fileprivate func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
-        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedString.isEmpty ? nil : trimmedString
+    fileprivate func returnNilIfEmpty() -> String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
     }
 }
 
@@ -22,9 +21,9 @@ extension Profile {
         externalId: String? = nil,
         anonymousId: String) -> ProfilePayload {
         ProfilePayload(
-            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            email: email ?? self.email?.returnNilIfEmpty(),
+            phoneNumber: phoneNumber ?? self.phoneNumber?.returnNilIfEmpty(),
+            externalId: externalId ?? self.externalId?.returnNilIfEmpty(),
             firstName: firstName,
             lastName: lastName,
             organization: organization,

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -9,8 +9,9 @@ import Foundation
 import KlaviyoCore
 
 extension String {
-    fileprivate func returnNilIfEmpty() -> String? {
-        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    internal func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
+        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedString.isEmpty ? nil : trimmedString
     }
 }
 
@@ -21,9 +22,9 @@ extension Profile {
         externalId: String? = nil,
         anonymousId: String) -> ProfilePayload {
         ProfilePayload(
-            email: email ?? self.email?.returnNilIfEmpty(),
-            phoneNumber: phoneNumber ?? self.phoneNumber?.returnNilIfEmpty(),
-            externalId: externalId ?? self.externalId?.returnNilIfEmpty(),
+            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
             firstName: firstName,
             lastName: lastName,
             organization: organization,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -78,7 +78,6 @@ struct KlaviyoState: Equatable, Codable {
         queue.append(request)
     }
 
-    // used when setEmail is called (separate from Create Profile)
     mutating func updateEmail(email: String) {
         if email.isNotEmptyOrSame(as: self.email, identifier: "email") {
             self.email = email.trimWhiteSpaceOrReturnNilIfEmpty()

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -78,23 +78,24 @@ struct KlaviyoState: Equatable, Codable {
         queue.append(request)
     }
 
+    // used when setEmail is called (separate from Create Profile)
     mutating func updateEmail(email: String) {
         if email.isNotEmptyOrSame(as: self.email, identifier: "email") {
-            self.email = email
+            self.email = email.trimWhiteSpaceOrReturnNilIfEmpty()
             enqueueProfileOrTokenRequest()
         }
     }
 
     mutating func updateExternalId(externalId: String) {
         if externalId.isNotEmptyOrSame(as: self.externalId, identifier: "external Id") {
-            self.externalId = externalId
+            self.externalId = externalId.trimWhiteSpaceOrReturnNilIfEmpty()
             enqueueProfileOrTokenRequest()
         }
     }
 
     mutating func updatePhoneNumber(phoneNumber: String) {
         if phoneNumber.isNotEmptyOrSame(as: self.phoneNumber, identifier: "phone number") {
-            self.phoneNumber = phoneNumber
+            self.phoneNumber = phoneNumber.trimWhiteSpaceOrReturnNilIfEmpty()
             enqueueProfileOrTokenRequest()
         }
     }
@@ -134,20 +135,20 @@ struct KlaviyoState: Equatable, Codable {
         }
     }
 
-    mutating func updateStateWithProfile(profile: Profile) {
+    mutating func updateStateWithProfile(profile: Profile) { // Create Profile
         if let profileEmail = profile.email,
            profileEmail.isNotEmptyOrSame(as: self.email, identifier: "email") {
-            email = profileEmail
+            email = profileEmail.trimWhiteSpaceOrReturnNilIfEmpty() // needed here to actually update state
         }
 
         if let profilePhoneNumber = profile.phoneNumber,
            profilePhoneNumber.isNotEmptyOrSame(as: self.phoneNumber, identifier: "phone number") {
-            phoneNumber = profilePhoneNumber
+            phoneNumber = profilePhoneNumber.trimWhiteSpaceOrReturnNilIfEmpty()
         }
 
         if let profileExternalId = profile.externalId,
            profileExternalId.isNotEmptyOrSame(as: self.externalId, identifier: "external id") {
-            externalId = profileExternalId
+            externalId = profileExternalId.trimWhiteSpaceOrReturnNilIfEmpty()
         }
     }
 
@@ -471,5 +472,10 @@ extension String {
         }
 
         return !incoming.isEmpty && incoming != state
+    }
+
+    fileprivate func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
+        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedString.isEmpty ? nil : trimmedString
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -472,9 +472,4 @@ extension String {
 
         return !incoming.isEmpty && incoming != state
     }
-
-    fileprivate func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
-        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedString.isEmpty ? nil : trimmedString
-    }
 }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -134,7 +134,7 @@ struct KlaviyoState: Equatable, Codable {
         }
     }
 
-    mutating func updateStateWithProfile(profile: Profile) { // Create Profile
+    mutating func updateStateWithProfile(profile: Profile) {
         if let profileEmail = profile.email,
            profileEmail.isNotEmptyOrSame(as: self.email, identifier: "email") {
             email = profileEmail.trimWhiteSpaceOrReturnNilIfEmpty() // needed here to actually update state

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -137,7 +137,7 @@ struct KlaviyoState: Equatable, Codable {
     mutating func updateStateWithProfile(profile: Profile) {
         if let profileEmail = profile.email,
            profileEmail.isNotEmptyOrSame(as: self.email, identifier: "email") {
-            email = profileEmail.trimWhiteSpaceOrReturnNilIfEmpty() // needed here to actually update state
+            email = profileEmail.trimWhiteSpaceOrReturnNilIfEmpty()
         }
 
         if let profilePhoneNumber = profile.phoneNumber,

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -106,6 +106,29 @@ class APIRequestErrorHandlingTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testEmailWhitespaceIsTrimmedBeforeSendingRequest() async throws {
+        var initialState = INITIALIZED_TEST_STATE_INVALID_EMAIL()
+
+        // in the case of state loaded from old sdk where email was stored with whitespaces
+        initialState.email = "foo@blob.com      "
+
+        let request = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: initialState.pushTokenData?.pushToken ?? "", enablement: .authorized)
+        initialState.requestsInFlight = [request]
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        environment.klaviyoAPI.send = { _, _ in .success(Data()) }
+        _ = await store.send(.sendRequest)
+        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+            $0.requestsInFlight = []
+            $0.flushing = false
+            $0.email = "foo@blob.com      "
+            if case let .registerPushToken(payload) = request.endpoint {
+                XCTAssertEqual(payload.data.attributes.profile.data.attributes.email, "foo@blob.com", "Email should be trimmed of whitespace before being sent.")
+            }
+        }
+    }
+
     // MARK: - network error
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -90,26 +90,4 @@ class KlaviyoModelsTest: XCTestCase {
         XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
         XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
     }
-
-    func testWhitespaceIsTrimmedForProfileParameters() {
-        let profile = Profile(
-            email: "",
-            phoneNumber: "",
-            externalId: "",
-            firstName: "Walter",
-            lastName: "White")
-        let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
-            email: "test@blob.com    ",
-            phoneNumber: "+12345678901    ",
-            externalId: "a       ",
-            anonymousId: anonymousId)
-
-        XCTAssertEqual(apiProfile.attributes.email, "test@blob.com")
-        XCTAssertEqual(apiProfile.attributes.phoneNumber, "+12345678901")
-        XCTAssertEqual(apiProfile.attributes.externalId, "a")
-        XCTAssertEqual(apiProfile.attributes.firstName, profile.firstName)
-        XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
-        XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
-    }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -90,4 +90,26 @@ class KlaviyoModelsTest: XCTestCase {
         XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
         XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
     }
+
+    func testWhitespaceIsTrimmedForProfileParameters() {
+        let profile = Profile(
+            email: "",
+            phoneNumber: "",
+            externalId: "",
+            firstName: "Walter",
+            lastName: "White")
+        let anonymousId = "C10H15N"
+        let apiProfile = profile.toAPIModel(
+            email: "test@blob.com    ",
+            phoneNumber: "+12345678901    ",
+            externalId: "a       ",
+            anonymousId: anonymousId)
+
+        XCTAssertEqual(apiProfile.attributes.email, "test@blob.com")
+        XCTAssertEqual(apiProfile.attributes.phoneNumber, "+12345678901")
+        XCTAssertEqual(apiProfile.attributes.externalId, "a")
+        XCTAssertEqual(apiProfile.attributes.firstName, profile.firstName)
+        XCTAssertEqual(apiProfile.attributes.lastName, profile.lastName)
+        XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
+    }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -171,6 +171,20 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.setEmail("        "))
     }
 
+    @MainActor
+    func testSetEmailWithTrailingWhiteSpace() async throws {
+        let apiKey = "fake-key"
+        let initialState = KlaviyoState(apiKey: apiKey,
+                                        queue: [],
+                                        requestsInFlight: [],
+                                        initalizationState: .initialized,
+                                        flushing: false)
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        _ = await store.send(.setEmail("test@blob.com        ")) {
+            $0.email = "test@blob.com"
+        }
+    }
+
     // MARK: - Set External Id
 
     @MainActor
@@ -215,7 +229,21 @@ class StateManagementEdgeCaseTests: XCTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setExternalId(""))
+        _ = await store.send(.setExternalId("      "))
+    }
+
+    @MainActor
+    func testSetExternalIdWithTrailingWhiteSpace() async throws {
+        let apiKey = "fake-key"
+        let initialState = KlaviyoState(apiKey: apiKey,
+                                        queue: [],
+                                        requestsInFlight: [],
+                                        initalizationState: .initialized,
+                                        flushing: false)
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        _ = await store.send(.setExternalId("external-blob-id        ")) {
+            $0.externalId = "external-blob-id"
+        }
     }
 
     // MARK: - Set Phone number
@@ -261,7 +289,21 @@ class StateManagementEdgeCaseTests: XCTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        _ = await store.send(.setPhoneNumber(""))
+        _ = await store.send(.setPhoneNumber("       "))
+    }
+
+    @MainActor
+    func testSetPhoneNumberWithTrailingWhiteSpace() async throws {
+        let initialState = KlaviyoState(anonymousId: environment.uuid().uuidString,
+                                        queue: [],
+                                        requestsInFlight: [],
+                                        initalizationState: .initialized,
+                                        flushing: false)
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.setPhoneNumber("1-800-Blobs4u        ")) {
+            $0.phoneNumber = "1-800-Blobs4u"
+        }
     }
 
     // MARK: - Set Push Token

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -552,6 +552,19 @@ class StateManagementTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testCreateProfileWithTrailingWhitespaceProperties() async throws {
+        let store = TestStore(initialState: INITIALIZED_TEST_STATE(), reducer: KlaviyoReducer())
+
+        _ = await store.send(.enqueueProfile(Profile(email: "foo@blob.com ", phoneNumber: "+19999999999     ", externalId: "abcdefg    "))) {
+            $0.phoneNumber = "+19999999999"
+            $0.email = "foo@blob.com"
+            $0.externalId = "abcdefg"
+            $0.enqueueProfileOrTokenRequest()
+            $0.pushTokenData = nil
+        }
+    }
+
     // MARK: - Test enqueue event
 
     @MainActor


### PR DESCRIPTION
# Description

This should be the last whitespace change (I hope) -- @ab1470 ran into a path where if you create a profile with a identifier with trailling whitespace, that request itself has the identifier trimmed, but then when firing an event, that still holds the old identifier with trailing whitespace. There are several places where these identifiers are being pulled from state and then trimmed, but to avoid duplicating it everywhere we should just trim it upstream wherever it is being set and stored in state.

`updateStateWithProfile` is called when create profile is called
`updateEmail/PhoneNumber/ExternalId` is called when setEmail/PhoneNumber/ExternalId is called

Removed some tests that were no longer relevant as they tested things that would never happen.

# Check List

- [ ] Are you changing anything with the public API?
- [x] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [ ] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan


https://github.com/user-attachments/assets/8f4ff697-82bd-4257-b588-58842bfa1fc3


# Supporting Materials

<!--
Please include any support materials like screenshots or other evidence that shows your changes works as intended.
-->
