### PR TITLE
Refactor KlaviyoWebViewController deinitialization

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -32,6 +32,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Scripts
 
+    @MainActor
     private var klaviyoJsWKScript: WKUserScript? {
         var apiURL = environment.cdnURL()
         apiURL.path = "/onsite/js/klaviyo.js"
@@ -56,18 +57,21 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         return WKUserScript(source: klaviyoJsScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    @MainActor
     private var sdkNameWKScript: WKUserScript {
         let sdkName = environment.sdkName()
         let sdkNameScript = "document.head.setAttribute('data-sdk-name', '\(sdkName)');"
         return WKUserScript(source: sdkNameScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    @MainActor
     private var sdkVersionWKScript: WKUserScript {
         let sdkVersion = environment.sdkVersion()
         let sdkVersionScript = "document.head.setAttribute('data-sdk-version', '\(sdkVersion)');"
         return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    @MainActor
     private var handshakeWKScript: WKUserScript {
         let handshakeStringified = IAFNativeBridgeEvent.handshake
         let handshakeScript = "document.head.setAttribute('data-native-bridge-handshake', '\(handshakeStringified)');"
@@ -76,6 +80,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Initializer
 
+    @MainActor
     init(url: URL, companyId: String, assetSource: String? = nil) {
         self.url = url
         self.companyId = companyId
@@ -83,6 +88,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         initializeLoadScripts()
     }
 
+    @MainActor
     func initializeLoadScripts() {
         guard let klaviyoJsWKScript else { return }
         loadScripts?.insert(klaviyoJsWKScript)

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -23,7 +23,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     let url: URL
     var loadScripts: Set<WKUserScript>? = Set<WKUserScript>()
-    var messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
+    let messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 
     private let companyId: String?
     private let assetSource: String?

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -35,6 +35,7 @@ private func createDefaultWebView() -> WKWebView {
 
 class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDelegate {
     private let webView: WKWebView
+    private lazy var scriptDelegateWrapper: ScriptDelegateWrapper = .init(delegate: self)
 
     private var viewModel: KlaviyoWebViewModeling
 
@@ -117,7 +118,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         }
 
         viewModel.messageHandlers?.forEach {
-            webView.configuration.userContentController.add(ScriptDelegateWrapper(delegate: self), name: $0)
+            webView.configuration.userContentController.add(scriptDelegateWrapper, name: $0)
         }
 
         #if DEBUG
@@ -143,7 +144,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
             forMainFrameOnly: false)
 
         webView.configuration.userContentController.addUserScript(script)
-        webView.configuration.userContentController.add(ScriptDelegateWrapper(delegate: self), name: "consoleMessageHandler")
+        webView.configuration.userContentController.add(scriptDelegateWrapper, name: "consoleMessageHandler")
     }
     #endif
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -34,24 +34,22 @@ private func createDefaultWebView() -> WKWebView {
 }
 
 class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDelegate {
-    private lazy var webView: WKWebView = {
-        let webView = createWebView()
-        webView.customUserAgent = NetworkSession.defaultUserAgent
-        webView.navigationDelegate = self
-        webView.uiDelegate = self
-        return webView
-    }()
+    private let webView: WKWebView
 
     private var viewModel: KlaviyoWebViewModeling
-    private let createWebView: () -> WKWebView
 
     // MARK: - Initializers
 
-    init(viewModel: KlaviyoWebViewModeling, webViewFactory: @escaping () -> WKWebView = createDefaultWebView) {
+    init(viewModel: KlaviyoWebViewModeling, webViewFactory: () -> WKWebView = createDefaultWebView) {
         self.viewModel = viewModel
-        createWebView = webViewFactory
+        webView = webViewFactory()
         super.init(nibName: nil, bundle: nil)
         self.viewModel.delegate = self
+
+        // Set up the web view
+        webView.customUserAgent = NetworkSession.defaultUserAgent
+        webView.navigationDelegate = self
+        webView.uiDelegate = self
     }
 
     deinit {

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -54,6 +54,17 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         self.viewModel.delegate = self
     }
 
+    deinit {
+        viewModel.messageHandlers?.forEach {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: $0)
+        }
+        #if DEBUG
+        if webConsoleLoggingEnabled {
+            webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
+        }
+        #endif
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -77,14 +88,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         loadUrl()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
-        viewModel.messageHandlers?.forEach {
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: $0)
-        }
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         dismiss()
@@ -104,14 +107,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     @MainActor
     func dismiss() {
-        viewModel.messageHandlers?.forEach {
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: $0)
-        }
-        #if DEBUG
-        if webConsoleLoggingEnabled {
-            webView.configuration.userContentController.removeScriptMessageHandler(forName: "consoleMessageHandler")
-        }
-        #endif
         dismiss(animated: false)
     }
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -119,7 +119,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         }
 
         viewModel.messageHandlers?.forEach {
-            webView.configuration.userContentController.add(self, name: $0)
+            webView.configuration.userContentController.add(ScriptDelegateWrapper(delegate: self), name: $0)
         }
 
         #if DEBUG
@@ -145,7 +145,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
             forMainFrameOnly: false)
 
         webView.configuration.userContentController.addUserScript(script)
-        webView.configuration.userContentController.add(self, name: "consoleMessageHandler")
+        webView.configuration.userContentController.add(ScriptDelegateWrapper(delegate: self), name: "consoleMessageHandler")
     }
     #endif
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -16,6 +16,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     var viewModel: IAFWebViewModel!
     var delegate: MockIAFWebViewDelegate!
 
+    @MainActor
     override func setUp() {
         super.setUp()
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -17,20 +17,20 @@ final class IAFWebViewModelTests: XCTestCase {
     var viewModel: IAFWebViewModel!
     var viewController: KlaviyoWebViewController!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         // FIXME: refactor the KlaviyoUI test suite so we can use the TCA tools to initialize a test Klaviyo environment and set the Company ID, similar to how we do it here: https://github.com/klaviyo/klaviyo-swift-sdk/blob/c9bdf25e65a9c575d1e30216dcfcaa156c2ac60b/Tests/KlaviyoSwiftTests/StateManagementTests.swift#L29. Until we're able to do this, the apiKey in the test suite will be nil, and IAFWebViewModel.initializeLoadScripts() will return without injecting the required scripts. Once this is fixed, we should remove the `XCTSkipIf` line.
         try XCTSkipIf(
             KlaviyoInternal.apiKey == nil,
             "Skipping this test until the KlaviyoUI test suite is able to initialize a Company ID")
 
-        super.setUp()
+        try await super.setUp()
 
         environment.sdkName = { "swift" }
         environment.sdkVersion = { "0.0.1" }
 
         let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
 
-        viewModel = IAFWebViewModel(url: fileUrl, companyId: "abc123")
+        viewModel = await IAFWebViewModel(url: fileUrl, companyId: "abc123")
         viewController = KlaviyoWebViewController(viewModel: viewModel, webViewFactory: {
             let configuration = WKWebViewConfiguration()
             configuration.processPool = WKProcessPool() // Ensures a fresh WebKit process

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -1,0 +1,72 @@
+@testable import KlaviyoForms
+import OSLog
+import UIKit
+import WebKit
+import XCTest
+
+/// A mock ``WKUserContentController`` that stores the removed script message handlers as a property.
+///
+/// When we try to deallocate an instance of a ``WKWebView``, we need to ensure that any ``WKScriptMessageHandler``s
+/// assigned to its ``WKUserContentController`` get removed. If this doesn't happen, the ``WKWebView`` may not get
+/// deallocated, and we will likely get a memory leak.
+///
+/// To unit test that the ``KlaviyoWebViewController`` successfully removes the script message handlers from
+/// its ``WKWebView``'s ``WKUserContentController`` when the ``KlaviyoWebViewController`` gets
+/// deallocated, we need a way to keep track of the message handlers that get removed. This class stores the removed
+/// message handlers, so that we can `XCTAssert` that the removed message handlers are what we expect.
+private final class MockWKUserContentController: WKUserContentController {
+    var removedMessageHandlers = Set<String>()
+
+    override func removeScriptMessageHandler(forName name: String) {
+        removedMessageHandlers.insert(name)
+        super.removeScriptMessageHandler(forName: name)
+    }
+
+    override func removeAllUserScripts() {
+        userScripts.forEach { removedMessageHandlers.insert($0.description) }
+        super.removeAllUserScripts()
+    }
+}
+
+private final class MockIAFWebViewModel: KlaviyoWebViewModeling {
+    var messageHandlers: Set<String>?
+
+    var url: URL
+    weak var delegate: KlaviyoWebViewDelegate?
+    var loadScripts: Set<WKUserScript>?
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    func preloadWebsite(timeout: UInt64) async throws {}
+    func handleNavigationEvent(_ event: KlaviyoForms.WKNavigationEvent) {}
+    func handleScriptMessage(_ message: WKScriptMessage) {}
+}
+
+final class KlaviyoWebViewControllerTests: XCTestCase {
+    /// Test to validate that the ``KlaviyoWebViewController`` removes any script message handlers
+    /// from its ``WKWebView``'s ``WKUserContentController`` when it gets deallocated.
+    @MainActor
+    func testScriptMessageHandlersAreRemovedOnDeallocation() async throws {
+        // Given
+        let config = WKWebViewConfiguration()
+        let mockController = MockWKUserContentController()
+        config.userContentController = mockController
+
+        let url = URL(string: "https://www.google.com")!
+        let viewModel = MockIAFWebViewModel(url: url)
+        let messageHandlers = Set(["handler1", "handler2"])
+        viewModel.messageHandlers = messageHandlers
+
+        var viewController: KlaviyoWebViewController? = KlaviyoWebViewController(viewModel: viewModel) {
+            WKWebView(frame: .zero, configuration: config)
+        }
+
+        // When
+        viewController = nil
+
+        // Then
+        XCTAssertEqual(mockController.removedMessageHandlers, messageHandlers, "All message handlers should be removed when the KlaviyoWebViewController is deallocated")
+    }
+}


### PR DESCRIPTION
# Description

This PR refactors the `KlaviyoWebViewController`'s deinitialization so that we call `removeScriptMessageHandler()` in the `deinit` method rather than in the `viewDidDisappear` and `dismiss` methods. We need to call `removeScriptMessageHandler()` to avoid a retain cycle when we deallocate the `KlaviyoWebViewController`.

This change is necessary for upcoming work on maintaining a persistent web view. For our MVP IAF release, it was okay for us to remove the script message handlers when the `KlaviyoWebViewController` was dismissed/removed from the view hierarchy. This approach will not work with persistent web views, however, because we need to be able to dismiss the `KlaviyoWebViewController` from the view hierarchy without deallocating it entirely, and the view controller needs to remain alive and listening for script messages so that it can re-present itself if and when it receives another `formWillAppear` event.

I wanted to make these changes prior to working on [CHNL-18661](https://klaviyo.atlassian.net/browse/CHNL-18661) because that ticket will involve some refactoring of the same parts of the codebase that the changes in this PR touches, and I didn't want to make changes for 18661 that will need to be changed again for the work on persistent web views.

Even if, for whatever reason, we don't end up implementing persistent web views (or we employ a different approach than the one we've been discussing), I think the changes in this PR are still valid and an improvement because I think it's better to remove the script message handlers on the viewController's deinitialization, rather than rely on dismiss and viewDidDisappear to handle it.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

In addition to the unit tests that I added as part of this PR to validate the changes are working as expected, I also ran the test app and displayed/dismissed a form and validated that the `KlaviyoWebViewController` is successfully getting deinitialized when the form is dismissed.

[CHNL-18661]: https://klaviyo.atlassian.net/browse/CHNL-18661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ