### PR TITLE
changed SwiftFormat `closingparen` setting to `balanced`

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -11,7 +11,7 @@
 # format options
 
 --exclude Sources/KlaviyoSwift/Vendor,Tests/KlaviyoSwiftTests/Vendor,Tests/KlaviyoSwiftTests/__Snapshots__
---closingparen same-line
+--closingparen balanced
 --commas inline
 --comments indent
 --decimalgrouping 3,5

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
@@ -26,7 +26,8 @@ class NotificationService: UNNotificationServiceExtension {
 
     override func didReceive(
         _ request: UNNotificationRequest,
-        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
         self.request = request
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
@@ -35,7 +36,8 @@ class NotificationService: UNNotificationServiceExtension {
             KlaviyoExtensionSDK.handleNotificationServiceDidReceivedRequest(
                 request: self.request,
                 bestAttemptContent: bestAttemptContent,
-                contentHandler: contentHandler)
+                contentHandler: contentHandler
+            )
         }
     }
 
@@ -47,7 +49,8 @@ class NotificationService: UNNotificationServiceExtension {
             KlaviyoExtensionSDK.handleNotificationServiceExtensionTimeWillExpireRequest(
                 request: request,
                 bestAttemptContent: bestAttemptContent,
-                contentHandler: contentHandler)
+                contentHandler: contentHandler
+            )
         }
     }
 }

--- a/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift
@@ -26,7 +26,8 @@ class NotificationService: UNNotificationServiceExtension {
 
     override func didReceive(
         _ request: UNNotificationRequest,
-        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
         self.request = request
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
@@ -35,7 +36,8 @@ class NotificationService: UNNotificationServiceExtension {
             KlaviyoExtensionSDK.handleNotificationServiceDidReceivedRequest(
                 request: self.request,
                 bestAttemptContent: bestAttemptContent,
-                contentHandler: contentHandler)
+                contentHandler: contentHandler
+            )
         }
     }
 
@@ -47,7 +49,8 @@ class NotificationService: UNNotificationServiceExtension {
             KlaviyoExtensionSDK.handleNotificationServiceExtensionTimeWillExpireRequest(
                 request: request,
                 bestAttemptContent: bestAttemptContent,
-                contentHandler: contentHandler)
+                contentHandler: contentHandler
+            )
         }
     }
 }

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -30,7 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = getFirstViewController
         window?.makeKeyAndVisible()
@@ -82,14 +83,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
-        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
         // STEP5: add the push device token to your Klaviyo user profile.
         KlaviyoSDK().set(pushToken: deviceToken)
     }
 
     func application(
         _ application: UIApplication,
-        didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
         if error._code == 3010 {
             print("push notifications are not supported in the iOS simulator")
         } else {
@@ -107,7 +110,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(
         _ app: UIApplication,
         open url: URL,
-        options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
         guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
               let host = components.host
         else {
@@ -184,7 +188,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void) {
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
         // If this notifiation is Klaviyo's notification we'll handle it
         // else pass it on to the next push notification service to which it may belong
         let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler)
@@ -197,7 +202,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
         if #available(iOS 14.0, *) {
             completionHandler([.list, .banner])
         } else {

--- a/Examples/KlaviyoSwiftExamples/Shared/Cart.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/Cart.swift
@@ -41,7 +41,8 @@ class Cart {
                         name: name,
                         id: 1, description: "Lightly battered & fried fresh cod and freshly cooked fries",
                         image: "battered_fish.jpg",
-                        price: 10.99)
+                        price: 10.99
+                    )
                 )
             case "Nicoise Salad":
                 cartItems.append(
@@ -49,7 +50,8 @@ class Cart {
                         name: name,
                         id: 2, description: "Delicious salad of mixed greens, tuna nicoise and balasamic vinagrette",
                         image: "nicoise_salad.jpg",
-                        price: 12.99)
+                        price: 12.99
+                    )
                 )
             case "Red Pork":
                 cartItems.append(
@@ -57,7 +59,8 @@ class Cart {
                         name: name,
                         id: 4, description: "Our take on the popular Chinese dish",
                         image: "red_pork.jpg",
-                        price: 11.99)
+                        price: 11.99
+                    )
                 )
             case "Beef Bolognese":
                 cartItems.append(
@@ -65,7 +68,8 @@ class Cart {
                         name: name,
                         id: 5, description: "Traditional Italian Bolognese",
                         image: "bolognese_meal.jpg",
-                        price: 10.99)
+                        price: 10.99
+                    )
                 )
             default:
                 break

--- a/Examples/KlaviyoSwiftExamples/Shared/CheckOutViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/CheckOutViewController.swift
@@ -69,14 +69,16 @@ class CheckOutViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Thank You!",
             message: "Thank you for your purchase! Your order is currently being processed and will be on its way shortly.",
-            preferredStyle: .alert)
+            preferredStyle: .alert
+        )
         let okAction = UIAlertAction(
             title: "OK",
             style: .default,
             handler: { _ in
                 // segue back to menu
                 self.performSegue(withIdentifier: "checkoutMenuSegue", sender: self)
-            })
+            }
+        )
         alertController.addAction(okAction)
         present(alertController, animated: true, completion: nil)
     }

--- a/Examples/KlaviyoSwiftExamples/Shared/MenuPageViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/MenuPageViewController.swift
@@ -58,13 +58,15 @@ class MenuPageViewController: UIViewController {
             UIImage(
                 named: cart.cartItems.isEmpty ? "emptyCart" : "FullCart"
             ),
-            for: UIControl.State())
+            for: UIControl.State()
+        )
 
         // Add observer for when the app enters background
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(saveCartItems),
-            name: UIApplication.didEnterBackgroundNotification, object: nil)
+            name: UIApplication.didEnterBackgroundNotification, object: nil
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -104,23 +106,26 @@ class MenuPageViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Add Email",
             message: "Please add your email",
-            preferredStyle: .alert)
+            preferredStyle: .alert
+        )
 
         let addEmailAction = UIAlertAction(
             title: "Submit",
-            style: .default) { _ in
-                let emailTextField = alertController.textFields![0] as UITextField
-                self.email = emailTextField.text
-                if let email = self.email {
-                    // EXAMPLE: of when the users changes or an existing user changes their email we update the SDK with the new email.
-                    KlaviyoSDK().set(email: email)
-                    self.emailLabel.text = "Email: \(email)"
-                }
+            style: .default
+        ) { _ in
+            let emailTextField = alertController.textFields![0] as UITextField
+            self.email = emailTextField.text
+            if let email = self.email {
+                // EXAMPLE: of when the users changes or an existing user changes their email we update the SDK with the new email.
+                KlaviyoSDK().set(email: email)
+                self.emailLabel.text = "Email: \(email)"
             }
+        }
 
         let cancelAction = UIAlertAction(
             title: "Cancel",
-            style: .cancel)
+            style: .cancel
+        )
 
         alertController.addTextField { textfield in
             textfield.placeholder = "email"
@@ -148,10 +153,12 @@ class MenuPageViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Log Out?",
             message: "Are you sure you want to log out? You will lose any items in your cart.",
-            preferredStyle: .actionSheet)
+            preferredStyle: .actionSheet
+        )
         let cancelAction = UIAlertAction(
             title: "Nevermind",
-            style: .cancel)
+            style: .cancel
+        )
 
         let logoutAction = UIAlertAction(
             title: "Log Out",
@@ -162,7 +169,8 @@ class MenuPageViewController: UIViewController {
                 defaults.removeObject(forKey: "zip")
                 defaults.removeObject(forKey: "cartItems")
                 self.performSegue(withIdentifier: "logoutSegue", sender: self)
-            })
+            }
+        )
 
         alertController.addAction(cancelAction)
         alertController.addAction(logoutAction)
@@ -174,7 +182,8 @@ class MenuPageViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Add Zipcode",
             message: "Please add your zipcode",
-            preferredStyle: .alert)
+            preferredStyle: .alert
+        )
 
         let addZipAction = UIAlertAction(
             title: "Update",
@@ -183,11 +192,13 @@ class MenuPageViewController: UIViewController {
                 let zipTextField = alertController.textFields![0] as UITextField
                 self.zip = zipTextField.text
                 self.zipcode.text = zipTextField.text
-            })
+            }
+        )
 
         let cancelAction = UIAlertAction(
             title: "Cancel",
-            style: .cancel)
+            style: .cancel
+        )
 
         alertController.addTextField { textfield in
             textfield.placeholder = "zip"
@@ -208,11 +219,13 @@ class MenuPageViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Your Cart",
             message: message,
-            preferredStyle: .alert)
+            preferredStyle: .alert
+        )
 
         let cancelAction = UIAlertAction(
             title: "Cancel",
-            style: .cancel)
+            style: .cancel
+        )
         alertController.addAction(cancelAction)
 
         let checkoutAction = UIAlertAction(
@@ -224,7 +237,8 @@ class MenuPageViewController: UIViewController {
                 } else {
                     alertController.message = "Please add items to your cart first"
                 }
-            })
+            }
+        )
         alertController.addAction(checkoutAction)
         present(alertController, animated: true, completion: nil)
     }
@@ -280,28 +294,32 @@ class MenuPageViewController: UIViewController {
                     name: "Fish & Chips",
                     id: 1, description: "Lightly battered & fried fresh cod and freshly cooked fries",
                     image: "battered_fish.jpg",
-                    price: 10.99)
+                    price: 10.99
+                )
             )
             menuItems.append(
                 MenuItem(
                     name: "Nicoise Salad",
                     id: 2, description: "Delicious salad of mixed greens, tuna nicoise and balasamic vinagrette",
                     image: "nicoise_salad.jpg",
-                    price: 12.99)
+                    price: 12.99
+                )
             )
             menuItems.append(
                 MenuItem(
                     name: "Red Pork",
                     id: 3, description: "Our take on the popular Chinese dish",
                     image: "red_pork.jpg",
-                    price: 11.99)
+                    price: 11.99
+                )
             )
             menuItems.append(
                 MenuItem(
                     name: "Beef Bolognese",
                     id: 4, description: "Traditional Italian Bolognese",
                     image: "bolognese_meal.jpg",
-                    price: 10.99)
+                    price: 10.99
+                )
             )
         }
     }

--- a/Examples/KlaviyoSwiftExamples/Shared/ViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/ViewController.swift
@@ -59,10 +59,12 @@ class ViewController: UIViewController {
         let alertController = UIAlertController(
             title: "Oh No!",
             message: "Please enter a zipcode or email",
-            preferredStyle: .alert)
+            preferredStyle: .alert
+        )
         let okAction = UIAlertAction(
             title: "OK",
-            style: .default)
+            style: .default
+        )
 
         alertController.addAction(okAction)
         present(alertController, animated: true, completion: nil)

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -4,4 +4,5 @@ import PackageDescription
 let package = Package(
     name: "Examples",
     products: [],
-    targets: [])
+    targets: []
+)

--- a/Package.swift
+++ b/Package.swift
@@ -9,19 +9,23 @@ let package = Package(
     products: [
         .library(
             name: "KlaviyoSwift",
-            targets: ["KlaviyoSwift"]),
+            targets: ["KlaviyoSwift"]
+        ),
         .library(
             name: "KlaviyoForms",
-            targets: ["KlaviyoForms"]),
+            targets: ["KlaviyoForms"]
+        ),
         .library(
             name: "KlaviyoSwiftExtension",
-            targets: ["KlaviyoSwiftExtension"])
+            targets: ["KlaviyoSwiftExtension"]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.10.0"),
         .package(
             url: "https://github.com/Flight-School/AnyCodable",
-            from: "0.6.0"),
+            from: "0.6.0"
+        ),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.1"),
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.10.0"),
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "0.9.1")
@@ -30,7 +34,8 @@ let package = Package(
         .target(
             name: "KlaviyoCore",
             dependencies: [.product(name: "AnyCodable", package: "AnyCodable")],
-            path: "Sources/KlaviyoCore"),
+            path: "Sources/KlaviyoCore"
+        ),
         .testTarget(
             name: "KlaviyoCoreTests",
             dependencies: [
@@ -38,12 +43,14 @@ let package = Package(
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
                 .product(name: "CustomDump", package: "swift-custom-dump"),
                 .product(name: "CasePaths", package: "swift-case-paths")
-            ]),
+            ]
+        ),
         .target(
             name: "KlaviyoSwift",
             dependencies: [.product(name: "AnyCodable", package: "AnyCodable"), "KlaviyoCore"],
             path: "Sources/KlaviyoSwift",
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        ),
         .testTarget(
             name: "KlaviyoSwiftTests",
             dependencies: [
@@ -56,7 +63,8 @@ let package = Package(
             ],
             exclude: [
                 "__Snapshots__"
-            ]),
+            ]
+        ),
         .target(
             name: "KlaviyoForms",
             dependencies: ["KlaviyoSwift"],
@@ -66,7 +74,8 @@ let package = Package(
                 .process("KlaviyoWebView/Resources"),
                 .process("KlaviyoWebView/Development Assets/Scripts"),
                 .process("KlaviyoWebView/Development Assets/HTML")
-            ]),
+            ]
+        ),
         .testTarget(
             name: "KlaviyoFormsTests",
             dependencies: [
@@ -76,9 +85,12 @@ let package = Package(
             ],
             resources: [
                 .process("Assets")
-            ]),
+            ]
+        ),
         .target(
             name: "KlaviyoSwiftExtension",
             dependencies: [],
-            path: "Sources/KlaviyoSwiftExtension")
-    ])
+            path: "Sources/KlaviyoSwiftExtension"
+        )
+    ]
+)

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -40,7 +40,8 @@ public struct KlaviyoEnvironment {
         klaviyoAPI: KlaviyoAPI,
         timer: @escaping (Double) -> AnyPublisher<Date, Never>,
         SDKName: @escaping () -> String,
-        SDKVersion: @escaping () -> String) {
+        SDKVersion: @escaping () -> String
+    ) {
         self.archiverClient = archiverClient
         self.fileClient = fileClient
         self.dataFromUrl = dataFromUrl
@@ -204,7 +205,8 @@ public struct KlaviyoEnvironment {
                 .eraseToAnyPublisher()
         },
         SDKName: KlaviyoEnvironment.getSDKName,
-        SDKVersion: KlaviyoEnvironment.getSDKVersion)
+        SDKVersion: KlaviyoEnvironment.getSDKVersion
+    )
 }
 
 public var networkSession: NetworkSession!

--- a/Sources/KlaviyoCore/Models/APIModels/CreateEventPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/CreateEventPayload.swift
@@ -66,7 +66,8 @@ public struct CreateEventPayload: Equatable, Codable {
                         email: email,
                         phoneNumber: phoneNumber,
                         externalId: externalId,
-                        anonymousId: anonymousId ?? "")
+                        anonymousId: anonymousId ?? ""
+                    )
                 )
             }
 
@@ -101,7 +102,8 @@ public struct CreateEventPayload: Equatable, Codable {
                 anonymousId: anonymousId,
                 value: value,
                 time: time,
-                uniqueId: uniqueId)
+                uniqueId: uniqueId
+            )
         }
     }
 

--- a/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
@@ -119,7 +119,8 @@ public struct ProfilePayload: Equatable, Codable {
             image: image,
             location: location,
             properties: properties,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
     }
 
     public init(attributes: Attributes) {

--- a/Sources/KlaviyoCore/Models/APIModels/PushTokenPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/PushTokenPayload.swift
@@ -22,7 +22,8 @@ public struct PushTokenPayload: Equatable, Codable {
                 pushToken: pushToken,
                 enablement: enablement,
                 background: background,
-                profile: profile)
+                profile: profile
+            )
         }
 
         public struct Attributes: Equatable, Codable {
@@ -123,6 +124,7 @@ public struct PushTokenPayload: Equatable, Codable {
             pushToken: pushToken,
             enablement: enablement,
             background: background,
-            profile: profile)
+            profile: profile
+        )
     }
 }

--- a/Sources/KlaviyoCore/Models/APIModels/UnregisterPushTokenPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/UnregisterPushTokenPayload.swift
@@ -24,7 +24,8 @@ public struct UnregisterPushTokenPayload: Equatable, Codable {
                 email: email,
                 phoneNumber: phoneNumber,
                 externalId: externalId,
-                anonymousId: anonymousId)
+                anonymousId: anonymousId
+            )
         }
 
         public struct Attributes: Equatable, Codable {
@@ -64,7 +65,8 @@ public struct UnregisterPushTokenPayload: Equatable, Codable {
                     image: image,
                     location: location,
                     properties: properties,
-                    anonymousId: anonymousId)
+                    anonymousId: anonymousId
+                )
             }
 
             public struct Profile: Equatable, Codable {
@@ -92,7 +94,8 @@ public struct UnregisterPushTokenPayload: Equatable, Codable {
                         image: image,
                         location: location,
                         properties: properties,
-                        anonymousId: anonymousId))
+                        anonymousId: anonymousId
+                    ))
                 }
             }
         }
@@ -108,6 +111,7 @@ public struct UnregisterPushTokenPayload: Equatable, Codable {
             email: email,
             phoneNumber: phoneNumber,
             externalId: externalId,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
     }
 }

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -15,7 +15,8 @@ public struct KlaviyoRequest: Equatable, Codable {
     public init(
         apiKey: String,
         endpoint: KlaviyoEndpoint,
-        uuid: String = environment.uuid().uuidString) {
+        uuid: String = environment.uuid().uuidString
+    ) {
         self.apiKey = apiKey
         self.endpoint = endpoint
         self.uuid = uuid

--- a/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
+++ b/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
@@ -54,14 +54,16 @@ public struct SDKRequest: Identifiable, Equatable {
                     email: payload.data.attributes.email,
                     phoneNumber: payload.data.attributes.phoneNumber,
                     externalId: payload.data.attributes.externalId,
-                    anonymousId: payload.data.attributes.anonymousId))
+                    anonymousId: payload.data.attributes.anonymousId
+                ))
             case let .createEvent(payload):
                 return .createEvent(
                     EventInfo(eventName: payload.data.attributes.metric.data.attributes.name),
                     ProfileInfo(email: payload.data.attributes.profile.data.attributes.email,
                                 phoneNumber: payload.data.attributes.profile.data.attributes.phoneNumber,
                                 externalId: payload.data.attributes.profile.data.attributes.externalId,
-                                anonymousId: payload.data.attributes.profile.data.attributes.anonymousId))
+                                anonymousId: payload.data.attributes.profile.data.attributes.anonymousId)
+                )
             case let .aggregateEvent(payload):
                 return .createAggregateEvent(payload)
             case let .registerPushToken(payload):

--- a/Sources/KlaviyoCore/Utils/ArchivalUtils.swift
+++ b/Sources/KlaviyoCore/Utils/ArchivalUtils.swift
@@ -10,7 +10,8 @@ import Foundation
 public struct ArchiverClient {
     public init(
         archivedData: @escaping (Any, Bool) throws -> Data,
-        unarchivedMutableArray: @escaping (Data) throws -> NSMutableArray?) {
+        unarchivedMutableArray: @escaping (Data) throws -> NSMutableArray?
+    ) {
         self.archivedData = archivedData
         self.unarchivedMutableArray = unarchivedMutableArray
     }
@@ -28,7 +29,8 @@ public struct ArchiverClient {
                                                                                              NSNumber.self,
                                                                                              NSURL.self],
                                                                                  from: data) as? NSMutableArray
-        })
+        }
+    )
 }
 
 public func archiveQueue(queue: NSArray, to fileURL: URL) {

--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -16,7 +16,8 @@ public struct FileClient {
         write: @escaping (Data, URL) throws -> Void,
         fileExists: @escaping (String) -> Bool,
         removeItem: @escaping (String) throws -> Void,
-        libraryDirectory: @escaping () -> URL) {
+        libraryDirectory: @escaping () -> URL
+    ) {
         self.write = write
         self.fileExists = fileExists
         self.removeItem = removeItem
@@ -32,7 +33,8 @@ public struct FileClient {
         write: write(data:url:),
         fileExists: FileManager.default.fileExists(atPath:),
         removeItem: FileManager.default.removeItem(atPath:),
-        libraryDirectory: { FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first! })
+        libraryDirectory: { FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first! }
+    )
 }
 
 /**

--- a/Sources/KlaviyoCore/Utils/LoggerClient.swift
+++ b/Sources/KlaviyoCore/Utils/LoggerClient.swift
@@ -25,7 +25,8 @@ func runtimeWarn(
     _ message: @autoclosure () -> String,
     category: String? = environment.sdkName(),
     file: StaticString? = nil,
-    line: UInt? = nil) {
+    line: UInt? = nil
+) {
     #if DEBUG
     let message = message()
     let category = category ?? "Runtime Warning"
@@ -34,7 +35,8 @@ func runtimeWarn(
         .fault,
         log: OSLog(subsystem: "com.apple.runtime-issues", category: category),
         "%@",
-        message)
+        message
+    )
     #endif
     #endif
 }

--- a/Sources/KlaviyoCore/Vendor/ReachabilitySwift.swift
+++ b/Sources/KlaviyoCore/Vendor/ReachabilitySwift.swift
@@ -62,7 +62,8 @@ public class Reachability {
             #endif
         }(),
         notifierRunning: Bool = false,
-        reachabilityRef: SCNetworkReachability? = nil) {
+        reachabilityRef: SCNetworkReachability? = nil
+    ) {
         self.whenReachable = whenReachable
         self.whenUnreachable = whenUnreachable
         self.reachableOnWWAN = reachableOnWWAN

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewGridViewController.swift
@@ -57,7 +57,8 @@ class PreviewGridViewController: UIViewController, UICollectionViewDataSource {
             red: .random(in: 0...1),
             green: .random(in: 0...1),
             blue: .random(in: 0...1),
-            alpha: 1.0)
+            alpha: 1.0
+        )
         cell.layer.cornerRadius = 12.0
         return cell
     }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -147,7 +147,8 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
             // Format as an immediately invoked function expression
             source: ";(\(consoleHandlerScript))('\(strHandoff)');",
             injectionTime: .atDocumentStart,
-            forMainFrameOnly: false)
+            forMainFrameOnly: false
+        )
 
         webView.configuration.userContentController.addUserScript(script)
         webView.configuration.userContentController.add(self, name: "consoleMessageHandler")

--- a/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
@@ -44,6 +44,7 @@ struct KlaviyoSwiftEnvironment {
                     }
                     userDefaults.set(count, forKey: "badgeCount")
                 }
-            })
+            }
+        )
     }()
 }

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -20,7 +20,8 @@ extension Profile {
         email: String? = nil,
         phoneNumber: String? = nil,
         externalId: String? = nil,
-        anonymousId: String) -> ProfilePayload {
+        anonymousId: String
+    ) -> ProfilePayload {
         ProfilePayload(
             email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
             phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
@@ -32,7 +33,8 @@ extension Profile {
             image: image,
             location: location?.toAPILocation,
             properties: properties,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
     }
 }
 
@@ -47,6 +49,7 @@ extension Profile.Location {
             longitude: longitude,
             region: region,
             zip: zip,
-            timezone: timezone)
+            timezone: timezone
+        )
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -52,7 +52,8 @@ private func parseError(_ data: Data) -> [InvalidField]? {
 func handleRequestError(
     request: KlaviyoRequest,
     error: KlaviyoAPIError,
-    retryInfo: RetryInfo) -> KlaviyoAction {
+    retryInfo: RetryInfo
+) -> KlaviyoAction {
     switch error {
     case let .httpError(statuscode, data):
         let responseString = String(data: data, encoding: .utf8) ?? "[Unknown]"
@@ -112,7 +113,9 @@ func handleRequestError(
             request, .retryWithBackoff(
                 requestCount: requestRetryCount,
                 totalRetryCount: totalRetryCount,
-                currentBackoff: retryAfter))
+                currentBackoff: retryAfter
+            )
+        )
 
     case .missingOrInvalidResponse:
         runtimeWarn("Missing or invalid response from api.")

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -113,12 +113,14 @@ struct KlaviyoState: Equatable, Codable {
                 apiKey: apiKey,
                 anonymousId: anonymousId,
                 pushToken: pushTokenData.pushToken,
-                enablement: pushTokenData.pushEnablement)
+                enablement: pushTokenData.pushEnablement
+            )
             enqueueRequest(request: request)
         } else {
             enqueueProfileRequest(
                 apiKey: apiKey,
-                anonymousId: anonymousId)
+                anonymousId: anonymousId
+            )
         }
     }
 
@@ -234,11 +236,13 @@ struct KlaviyoState: Equatable, Codable {
                     pushToken: tokenData.pushToken,
                     enablement: tokenData.pushEnablement.rawValue,
                     background: tokenData.pushBackground.rawValue,
-                    profile: Profile().toAPIModel(anonymousId: anonymousId))
+                    profile: Profile().toAPIModel(anonymousId: anonymousId)
+                )
 
                 let request = KlaviyoRequest(
                     apiKey: apiKey,
-                    endpoint: KlaviyoEndpoint.registerPushToken(payload))
+                    endpoint: KlaviyoEndpoint.registerPushToken(payload)
+                )
 
                 enqueueRequest(request: request)
             }
@@ -254,7 +258,8 @@ struct KlaviyoState: Equatable, Codable {
             pushToken: newToken,
             pushEnablement: enablement,
             pushBackground: environment.getBackgroundSetting(),
-            deviceData: currentDeviceMetadata)
+            deviceData: currentDeviceMetadata
+        )
 
         return pushTokenData != newPushTokenData
     }
@@ -265,7 +270,8 @@ struct KlaviyoState: Equatable, Codable {
             phoneNumber: phoneNumber,
             externalId: externalId,
             properties: properties,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
 
         let endpoint = KlaviyoEndpoint.createProfile(CreateProfilePayload(data: payload))
 
@@ -280,7 +286,8 @@ struct KlaviyoState: Equatable, Codable {
                 email: email,
                 phoneNumber: phoneNumber,
                 externalId: externalId,
-                dict: pendingProfile)
+                dict: pendingProfile
+            )
             self.pendingProfile = nil
         } else {
             profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
@@ -290,7 +297,8 @@ struct KlaviyoState: Equatable, Codable {
             pushToken: pushToken,
             enablement: enablement.rawValue,
             background: environment.getBackgroundSetting().rawValue,
-            profile: profile.toAPIModel(anonymousId: anonymousId))
+            profile: profile.toAPIModel(anonymousId: anonymousId)
+        )
         let endpoint = KlaviyoEndpoint.registerPushToken(payload)
         return KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
     }
@@ -301,7 +309,8 @@ struct KlaviyoState: Equatable, Codable {
             email: email,
             phoneNumber: phoneNumber,
             externalId: externalId,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
         let endpoint = KlaviyoEndpoint.unregisterPushToken(payload)
         return KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
     }
@@ -371,7 +380,8 @@ func loadKlaviyoStateFromDisk(apiKey: String) -> KlaviyoState {
         state = KlaviyoState(
             apiKey: apiKey,
             anonymousId: environment.uuid().uuidString,
-            queue: [])
+            queue: []
+        )
     }
     return state
 }
@@ -388,7 +398,8 @@ extension Profile {
         email: String? = nil,
         phoneNumber: String? = nil,
         externalId: String? = nil,
-        dict: [Profile.ProfileKey: AnyEncodable]) -> Self {
+        dict: [Profile.ProfileKey: AnyEncodable]
+    ) -> Self {
         var firstName: String?
         var lastName: String?
         var address1: String?
@@ -445,7 +456,8 @@ extension Profile {
             latitude: latitude,
             longitude: longitude,
             region: region,
-            zip: zip)
+            zip: zip
+        )
 
         let profile = Profile(
             email: email,
@@ -457,7 +469,8 @@ extension Profile {
             title: title,
             image: image,
             location: location,
-            properties: customProperties)
+            properties: customProperties
+        )
 
         return profile
     }

--- a/Sources/KlaviyoSwift/StateManagement/StateChangePublisher.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateChangePublisher.swift
@@ -53,7 +53,8 @@ public struct StateChangePublisher {
                     anonymousId: state.anonymousId,
                     phoneNumber: state.phoneNumber,
                     externalId: state.externalId,
-                    pushToken: state.pushTokenData?.pushToken)
+                    pushToken: state.pushTokenData?.pushToken
+                )
             }
             .eraseToAnyPublisher()
     }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -144,7 +144,8 @@ struct KlaviyoReducer: ReducerProtocol {
                     let request = state.buildUnregisterRequest(
                         apiKey: apiKey,
                         anonymousId: anonymousId,
-                        pushToken: tokenData.pushToken)
+                        pushToken: tokenData.pushToken
+                    )
                     state.enqueueRequest(request: request)
                 }
                 state.apiKey = apiKey
@@ -266,7 +267,8 @@ struct KlaviyoReducer: ReducerProtocol {
                     state.retryInfo = .retryWithBackoff(
                         requestCount: requestCount,
                         totalRetryCount: totalCount,
-                        currentBackoff: newBackOff)
+                        currentBackoff: newBackOff
+                    )
                     return .none
                 } else {
                     state.retryInfo = .retry(requestCount)
@@ -330,7 +332,8 @@ struct KlaviyoReducer: ReducerProtocol {
                     pushToken: requestData.token,
                     pushEnablement: enablement,
                     pushBackground: backgroundStatus,
-                    deviceData: requestData.deviceMetadata)
+                    deviceData: requestData.deviceMetadata
+                )
             }
             state.requestsInFlight.removeAll { inflightRequest in
                 completedRequest.uuid == inflightRequest.uuid
@@ -444,7 +447,8 @@ struct KlaviyoReducer: ReducerProtocol {
                     value: event.value,
                     time: event.time,
                     uniqueId: event.uniqueId,
-                    pushToken: state.pushTokenData?.pushToken))
+                    pushToken: state.pushTokenData?.pushToken
+                ))
 
             let endpoint = KlaviyoEndpoint.createEvent(payload)
             let request = KlaviyoRequest(apiKey: apiKey, endpoint: endpoint)
@@ -494,21 +498,25 @@ struct KlaviyoReducer: ReducerProtocol {
                 email: state.email,
                 phoneNumber: state.phoneNumber,
                 externalId: state.externalId,
-                anonymousId: anonymousId)
+                anonymousId: anonymousId
+            )
 
             if let tokenData = pushTokenData {
                 let payload = PushTokenPayload(
                     pushToken: tokenData.pushToken,
                     enablement: tokenData.pushEnablement.rawValue,
                     background: tokenData.pushBackground.rawValue,
-                    profile: profilePayload)
+                    profile: profilePayload
+                )
                 request = KlaviyoRequest(
                     apiKey: apiKey,
-                    endpoint: KlaviyoEndpoint.registerPushToken(payload))
+                    endpoint: KlaviyoEndpoint.registerPushToken(payload)
+                )
             } else {
                 request = KlaviyoRequest(
                     apiKey: apiKey,
-                    endpoint: KlaviyoEndpoint.createProfile(CreateProfilePayload(data: profilePayload)))
+                    endpoint: KlaviyoEndpoint.createProfile(CreateProfilePayload(data: profilePayload))
+                )
             }
             state.enqueueRequest(request: request)
 
@@ -564,7 +572,8 @@ struct KlaviyoReducer: ReducerProtocol {
 extension Store where State == KlaviyoState, Action == KlaviyoAction {
     static let production = Store(
         initialState: KlaviyoState(queue: [], requestsInFlight: []),
-        reducer: KlaviyoReducer())
+        reducer: KlaviyoReducer()
+    )
 }
 
 extension Event {
@@ -572,7 +581,8 @@ extension Event {
         let identifiers = Identifiers(
             email: state.email,
             phoneNumber: state.phoneNumber,
-            externalId: state.externalId)
+            externalId: state.externalId
+        )
         var properties = properties
         if metric.name == EventName._openedPush,
            let pushToken = state.pushTokenData?.pushToken {

--- a/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
@@ -39,7 +39,8 @@ public enum KlaviyoExtensionSDK {
         request: UNNotificationRequest,
         bestAttemptContent: UNMutableNotificationContent,
         contentHandler: @escaping (UNNotificationContent) -> Void,
-        fallbackMediaType: String = "jpeg") {
+        fallbackMediaType: String = "jpeg"
+    ) {
         // handle badge setting from the push notification payload
         handleBadge(bestAttemptContent: bestAttemptContent)
         // handle rich media setup
@@ -82,7 +83,8 @@ public enum KlaviyoExtensionSDK {
     private static func handleRichMedia(
         bestAttemptContent: UNMutableNotificationContent,
         contentHandler: @escaping (UNNotificationContent) -> Void,
-        fallbackMediaType: String = "jpeg") {
+        fallbackMediaType: String = "jpeg"
+    ) {
         // 1a. get the rich media url from the push notification payload
         guard let imageURLString = bestAttemptContent.userInfo["rich-media"] as? String else {
             contentHandler(bestAttemptContent)
@@ -104,24 +106,26 @@ public enum KlaviyoExtensionSDK {
             // 3. once we have the local file URL we will create an attachment
             createAttachment(
                 localFileURL: localFileURL,
-                localFilePathWithTypeString: localFilePathWithTypeString) { attachment in
-                    guard let attachment = attachment else {
-                        contentHandler(bestAttemptContent)
-                        return
-                    }
-
-                    // 4. assign the create attachement to the best attempt content attachment and call the content handler so that the notification with the
-                    //    media can be delivered to the user.
-                    bestAttemptContent.attachments = [attachment]
+                localFilePathWithTypeString: localFilePathWithTypeString
+            ) { attachment in
+                guard let attachment = attachment else {
                     contentHandler(bestAttemptContent)
+                    return
                 }
+
+                // 4. assign the create attachement to the best attempt content attachment and call the content handler so that the notification with the
+                //    media can be delivered to the user.
+                bestAttemptContent.attachments = [attachment]
+                contentHandler(bestAttemptContent)
+            }
         }
     }
 
     public static func handleNotificationServiceExtensionTimeWillExpireRequest(
         request: UNNotificationRequest,
         bestAttemptContent: UNMutableNotificationContent,
-        contentHandler: @escaping (UNNotificationContent) -> Void) {
+        contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
         contentHandler(bestAttemptContent)
     }
 
@@ -132,7 +136,8 @@ public enum KlaviyoExtensionSDK {
     ///                 note that in the case of failure the closure will still be called but with `nil`.
     private static func downloadMedia(
         for urlString: String,
-        completion: @escaping (URL?) -> Void) {
+        completion: @escaping (URL?) -> Void
+    ) {
         guard let imageURL = URL(string: urlString) else {
             completion(nil)
             return
@@ -163,7 +168,8 @@ public enum KlaviyoExtensionSDK {
     private static func createAttachment(
         localFileURL: URL,
         localFilePathWithTypeString: String,
-        completion: @escaping (UNNotificationAttachment?) -> Void) {
+        completion: @escaping (UNNotificationAttachment?) -> Void
+    ) {
         let localFileURLWithType: URL
         if #available(iOS 16.0, *) {
             localFileURLWithType = URL(filePath: localFilePathWithTypeString)
@@ -181,7 +187,8 @@ public enum KlaviyoExtensionSDK {
         guard let attachment = try? UNNotificationAttachment(
             identifier: "",
             url: localFileURLWithType,
-            options: nil)
+            options: nil
+        )
         else {
             completion(nil)
             return

--- a/Tests/KlaviyoCoreTests/EncodableTests.swift
+++ b/Tests/KlaviyoCoreTests/EncodableTests.swift
@@ -33,7 +33,8 @@ final class EncodableTests: XCTestCase {
             pushToken: "foo",
             enablement: "AUTHORIZED",
             background: "AVAILABLE",
-            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo"))
+            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo")
+        )
         assertSnapshot(matching: tokenPayload, as: .json(KlaviyoEnvironment.encoder))
     }
 
@@ -42,7 +43,8 @@ final class EncodableTests: XCTestCase {
             pushToken: "foo",
             email: "foo",
             phoneNumber: "foo",
-            anonymousId: "foo")
+            anonymousId: "foo"
+        )
         assertSnapshot(matching: tokenPayload, as: .json)
     }
 
@@ -51,7 +53,8 @@ final class EncodableTests: XCTestCase {
             pushToken: "foo",
             enablement: "AUTHORIZED",
             background: "AVAILABLE",
-            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo"))
+            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo")
+        )
         let request = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
         assertSnapshot(matching: request, as: .json)
     }

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -20,7 +20,8 @@ final class KlaviyoAPITests: XCTestCase {
 
         await sendAndAssert(with: KlaviyoRequest(
             apiKey: "foo",
-            endpoint: .createProfile(CreateProfilePayload(data: .test)))
+            endpoint: .createProfile(CreateProfilePayload(data: .test))
+        )
         ) { result in
             switch result {
             case let .failure(error):

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -71,7 +71,8 @@ let SAMPLE_PROPERTIES = [
 extension ArchiverClient {
     static let test = ArchiverClient(
         archivedData: { _, _ in ARCHIVED_RETURNED_DATA },
-        unarchivedMutableArray: { _ in SAMPLE_DATA })
+        unarchivedMutableArray: { _ in SAMPLE_DATA }
+    )
 }
 
 extension KlaviyoEnvironment {
@@ -105,7 +106,8 @@ extension KlaviyoEnvironment {
             klaviyoAPI: KlaviyoAPI.test(),
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
-            SDKVersion: { __klaviyoSwiftVersion })
+            SDKVersion: { __klaviyoSwiftVersion }
+        )
     }
 }
 
@@ -114,7 +116,8 @@ extension FileClient {
         write: { _, _ in },
         fileExists: { _ in true },
         removeItem: { _ in },
-        libraryDirectory: { TEST_URL })
+        libraryDirectory: { TEST_URL }
+    )
 }
 
 extension KlaviyoAPI {
@@ -172,7 +175,8 @@ extension PushTokenPayload {
         pushToken: "foo",
         enablement: "AUTHORIZED",
         background: "AVAILABLE",
-        profile: ProfilePayload(properties: [:], anonymousId: "anon-id"))
+        profile: ProfilePayload(properties: [:], anonymousId: "anon-id")
+    )
 }
 
 extension ProfilePayload {
@@ -184,7 +188,8 @@ extension ProfilePayload {
         latitude: 1,
         longitude: 1,
         region: "BL",
-        zip: "0BLOB")
+        zip: "0BLOB"
+    )
 
     static let test = ProfilePayload(
         email: "blobemail",
@@ -197,5 +202,6 @@ extension ProfilePayload {
         image: "foo",
         location: location,
         properties: [:],
-        anonymousId: "foo")
+        anonymousId: "foo"
+    )
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -21,7 +21,8 @@ final class IAFWebViewModelTests: XCTestCase {
         // FIXME: refactor the KlaviyoUI test suite so we can use the TCA tools to initialize a test Klaviyo environment and set the Company ID, similar to how we do it here: https://github.com/klaviyo/klaviyo-swift-sdk/blob/c9bdf25e65a9c575d1e30216dcfcaa156c2ac60b/Tests/KlaviyoSwiftTests/StateManagementTests.swift#L29. Until we're able to do this, the apiKey in the test suite will be nil, and IAFWebViewModel.initializeLoadScripts() will return without injecting the required scripts. Once this is fixed, we should remove the `XCTSkipIf` line.
         try XCTSkipIf(
             KlaviyoInternal.apiKey == nil,
-            "Skipping this test until the KlaviyoUI test suite is able to initialize a Company ID")
+            "Skipping this test until the KlaviyoUI test suite is able to initialize a Company ID"
+        )
 
         super.setUp()
 

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -44,7 +44,8 @@ class MockIAFWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
                             "formId": "abc123"
                           }
                         }
-                        """)
+                        """
+                    )
 
                     viewModel.handleScriptMessage(scriptMessage)
 

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -25,7 +25,8 @@ final class EncodableTests: XCTestCase {
             pushToken: "foo",
             enablement: "AUTHORIZED",
             background: "AVAILABLE",
-            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo"))
+            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo")
+        )
         let request = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload), uuid: KlaviyoEnvironment.test().uuid().uuidString)
         let klaviyoState = KlaviyoState(
             email: "foo",
@@ -35,9 +36,11 @@ final class EncodableTests: XCTestCase {
                 pushToken: "foo",
                 pushEnablement: .authorized,
                 pushBackground: .available,
-                deviceData: .init(context: KlaviyoEnvironment.test().appContextInfo())),
+                deviceData: .init(context: KlaviyoEnvironment.test().appContextInfo())
+            ),
             queue: [request],
-            requestsInFlight: [request])
+            requestsInFlight: [request]
+        )
         assertSnapshot(matching: klaviyoState, as: .json(KlaviyoEnvironment.encoder))
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -25,8 +25,10 @@ class KlaviyoModelsTest: XCTestCase {
                 city: "Albuquerque",
                 country: "USA",
                 zip: "42000",
-                timezone: "MDT"),
-            properties: ["order amount": "a lot of money"])
+                timezone: "MDT"
+            ),
+            properties: ["order amount": "a lot of money"]
+        )
         let anonymousId = "C10H15N"
         let apiProfile = profile.toAPIModel(anonymousId: anonymousId)
 
@@ -54,13 +56,15 @@ class KlaviyoModelsTest: XCTestCase {
     func testProfileWithNoIdsModelConvertsToAPIModel() {
         let profile = Profile(
             firstName: "Walter",
-            lastName: "White")
+            lastName: "White"
+        )
         let anonymousId = "C10H15N"
         let apiProfile = profile.toAPIModel(
             email: "walter.white@breakingbad.com",
             phoneNumber: "1800-better-call-saul",
             externalId: "999",
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
         XCTAssertNil(profile.email)
         XCTAssertNil(profile.phoneNumber)
         XCTAssertNil(profile.externalId)
@@ -78,7 +82,8 @@ class KlaviyoModelsTest: XCTestCase {
             phoneNumber: "",
             externalId: "",
             firstName: "Walter",
-            lastName: "White")
+            lastName: "White"
+        )
         let anonymousId = "C10H15N"
         let apiProfile = profile.toAPIModel(
             anonymousId: anonymousId)
@@ -97,13 +102,15 @@ class KlaviyoModelsTest: XCTestCase {
             phoneNumber: "",
             externalId: "",
             firstName: "Walter",
-            lastName: "White")
+            lastName: "White"
+        )
         let anonymousId = "C10H15N"
         let apiProfile = profile.toAPIModel(
             email: "test@blob.com    ",
             phoneNumber: "+12345678901    ",
             externalId: "a       ",
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
 
         XCTAssertEqual(apiProfile.attributes.email, "test@blob.com")
         XCTAssertEqual(apiProfile.attributes.phoneNumber, "+12345678901")

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -71,7 +71,8 @@ class KlaviyoSDKTests: XCTestCase {
             email: "john.smith@example.com",
             phoneNumber: "+15555551212",
             firstName: "John",
-            lastName: "Smith")
+            lastName: "Smith"
+        )
         let expectation = setupActionAssertion(expectedAction: .enqueueProfile(profile))
 
         klaviyo.set(profile: profile)

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -117,7 +117,8 @@ final class KlaviyoStateTests: XCTestCase {
                 apiKey: "foo",
                 anonymousId: environment.uuid().uuidString,
                 queue: [],
-                requestsInFlight: []))
+                requestsInFlight: []
+            ))
         }
 
         let state = loadKlaviyoStateFromDisk(apiKey: "foo")
@@ -137,7 +138,8 @@ final class KlaviyoStateTests: XCTestCase {
             pushToken: "foo",
             enablement: "AUTHORIZED",
             background: "AVAILABLE",
-            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo"))
+            profile: ProfilePayload(email: "foo", phoneNumber: "foo", anonymousId: "foo")
+        )
         let tokenRequest = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(tokenPayload))
 
         let state = KlaviyoState(apiKey: "key", queue: [tokenRequest, eventRequest, profileRequest])

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -16,7 +16,8 @@ let ARCHIVED_RETURNED_DATA = Data()
 extension ArchiverClient {
     static let test = ArchiverClient(
         archivedData: { _, _ in ARCHIVED_RETURNED_DATA },
-        unarchivedMutableArray: { _ in SAMPLE_DATA })
+        unarchivedMutableArray: { _ in SAMPLE_DATA }
+    )
 }
 
 extension AppLifeCycleEvents {
@@ -54,7 +55,8 @@ extension KlaviyoEnvironment {
             klaviyoAPI: KlaviyoAPI.test(),
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
-            SDKVersion: { __klaviyoSwiftVersion })
+            SDKVersion: { __klaviyoSwiftVersion }
+        )
     }
 }
 
@@ -91,7 +93,8 @@ extension FileClient {
         write: { _, _ in },
         fileExists: { _ in true },
         removeItem: { _ in },
-        libraryDirectory: { TEST_URL })
+        libraryDirectory: { TEST_URL }
+    )
 }
 
 extension KlaviyoAPI {
@@ -148,13 +151,15 @@ private final class KeyedArchiver: NSKeyedArchiver {
 extension UNNotificationResponse {
     static func with(
         userInfo: [AnyHashable: Any],
-        actionIdentifier: String = UNNotificationDefaultActionIdentifier) throws -> UNNotificationResponse {
+        actionIdentifier: String = UNNotificationDefaultActionIdentifier
+    ) throws -> UNNotificationResponse {
         let content = UNMutableNotificationContent()
         content.userInfo = userInfo
         let request = UNNotificationRequest(
             identifier: "",
             content: content,
-            trigger: nil)
+            trigger: nil
+        )
 
         let notification = try XCTUnwrap(UNNotification(coder: KeyedArchiver(requiringSecureCoding: false)))
         notification.setValue(request, forKey: "request")

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -476,7 +476,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
             queue: [],
             requestsInFlight: [],
             initalizationState: .initialized,
-            flushing: false)
+            flushing: false
+        )
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         // Impossible case really but we want coverage on it.
@@ -545,7 +546,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
             queue: [],
             requestsInFlight: [],
             initalizationState: .initialized,
-            flushing: true)
+            flushing: true
+        )
 
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -162,7 +162,8 @@ class StateManagementTests: XCTestCase {
             apiKey: initialState.apiKey!,
             anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
-            enablement: .authorized)
+            enablement: .authorized
+        )
 
         _ = await store.send(.setPushToken(initialState.pushTokenData!.pushToken, .authorized)) {
             $0.queue = [pushTokenRequest]
@@ -183,7 +184,8 @@ class StateManagementTests: XCTestCase {
                 pushToken: initialState.pushTokenData!.pushToken,
                 pushEnablement: .authorized,
                 pushBackground: initialState.pushTokenData!.pushBackground,
-                deviceData: initialState.pushTokenData!.deviceData)
+                deviceData: initialState.pushTokenData!.deviceData
+            )
         }
     }
 
@@ -237,7 +239,8 @@ class StateManagementTests: XCTestCase {
             apiKey: initialState.apiKey!,
             anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
-            enablement: .authorized)
+            enablement: .authorized
+        )
 
         _ = await store.send(.setPushEnablement(.authorized))
 
@@ -546,8 +549,10 @@ class StateManagementTests: XCTestCase {
                     pushToken: initialState.pushTokenData!.pushToken,
                     enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                     background: initialState.pushTokenData!.pushBackground.rawValue,
-                    profile: Profile.test.toAPIModel(anonymousId: initialState.anonymousId!))
-                ))
+                    profile: Profile.test.toAPIModel(anonymousId: initialState.anonymousId!)
+                )
+                )
+            )
             $0.queue = [request]
         }
     }
@@ -586,8 +591,10 @@ class StateManagementTests: XCTestCase {
                                 phoneNumber: $0.phoneNumber,
                                 anonymousId: initialState.anonymousId!,
                                 time: event.time,
-                                pushToken: initialState.pushTokenData!.pushToken)
-                        ))))
+                                pushToken: initialState.pushTokenData!.pushToken
+                            )
+                        ))
+                    ))
             }
 
             // if the event is opened push we want to flush immidietly, for all other events we flush during regular intervals set in code
@@ -622,8 +629,10 @@ class StateManagementTests: XCTestCase {
                             properties: event.properties,
                             phoneNumber: $0.phoneNumber,
                             anonymousId: initialState.anonymousId!,
-                            time: event.time)
-                    )))
+                            time: event.time
+                        )
+                    ))
+                )
             )
         }
 
@@ -645,7 +654,8 @@ class StateManagementTests: XCTestCase {
             try $0.enqueueRequest(
                 request: KlaviyoRequest(
                     apiKey: XCTUnwrap($0.apiKey),
-                    endpoint: .aggregateEvent(AggregateEventPayload(data)))
+                    endpoint: .aggregateEvent(AggregateEventPayload(data))
+                )
             )
         }
     }
@@ -669,7 +679,8 @@ class StateManagementTests: XCTestCase {
             try $0.enqueueRequest(
                 request: KlaviyoRequest(
                     apiKey: XCTUnwrap($0.apiKey),
-                    endpoint: .aggregateEvent(AggregateEventPayload(data)))
+                    endpoint: .aggregateEvent(AggregateEventPayload(data))
+                )
             )
         }
 

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -23,7 +23,8 @@ let INITIALIZED_TEST_STATE = {
         queue: [],
         requestsInFlight: [],
         initalizationState: .initialized,
-        flushing: true)
+        flushing: true
+    )
 }
 
 let INITILIZING_TEST_STATE = {
@@ -33,7 +34,8 @@ let INITILIZING_TEST_STATE = {
         queue: [],
         requestsInFlight: [],
         initalizationState: .initializing,
-        flushing: true)
+        flushing: true
+    )
 }
 
 let INITIALIZED_TEST_STATE_INVALID_PHONE = {
@@ -48,7 +50,8 @@ let INITIALIZED_TEST_STATE_INVALID_PHONE = {
         queue: [],
         requestsInFlight: [],
         initalizationState: .initialized,
-        flushing: true)
+        flushing: true
+    )
 }
 
 let INITIALIZED_TEST_STATE_INVALID_EMAIL = {
@@ -63,7 +66,8 @@ let INITIALIZED_TEST_STATE_INVALID_EMAIL = {
         queue: [],
         requestsInFlight: [],
         initalizationState: .initialized,
-        flushing: true)
+        flushing: true
+    )
 }
 
 extension Profile {
@@ -84,7 +88,8 @@ extension Profile {
         title: "Jelly",
         image: "foo",
         location: .test,
-        properties: [:])
+        properties: [:]
+    )
 }
 
 extension Profile.Location {
@@ -96,7 +101,8 @@ extension Profile.Location {
         latitude: 1,
         longitude: 1,
         region: "BL",
-        zip: "0BLOB")
+        zip: "0BLOB"
+    )
 }
 
 extension Event {
@@ -132,7 +138,8 @@ extension KlaviyoState {
                                        pushToken: "blob_token",
                                        pushEnablement: .authorized,
                                        pushBackground: .available,
-                                       deviceData: DeviceMetadata(context: environment.appContextInfo())),
+                                       deviceData: DeviceMetadata(context: environment.appContextInfo())
+                                   ),
                                    queue: [],
                                    requestsInFlight: [],
                                    initalizationState: .initialized,


### PR DESCRIPTION
# Description

This PR updates our .swiftformat settings to adjust the closing parentheses behavior. Prior to this PR, SwiftFormat would automatically change 

```
func foo(
    parameter1: String,
    parameter2: String
) {
    print("bar")
}
```
to
```
func foo(
    parameter1: String,
    parameter2: String) {
    print("bar")
}
```

Personally, I find that more difficult to read. It's also contrary to the default Xcode behavior for handling the closing parenthesis on multiline function signature; if you were to highlight the 2nd code block above in Xcode and hit control-m, Xcode would automatically reformat it to look like the 1st code block. In general, I prefer to adhere to Xcode's default recommended code style because I think it does a pretty good job and because I don't think we should be "fighting the system".

This PR changes the SwiftFormat rule so that SwiftFormat will format a multiline function signature to look like the 1st code block above, not the 2nd.