### PR TITLE
Changed SwiftFormat settings to put function and type attributes on their own lines

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -29,3 +29,4 @@
 --wrapcollections preserve
 --wrapparameters preserve
 --funcattributes prev-line
+--typeattributes prev-line

--- a/.swiftformat
+++ b/.swiftformat
@@ -28,3 +28,4 @@
 --wraparguments preserve
 --wrapcollections preserve
 --wrapparameters preserve
+--funcattributes prev-line

--- a/Examples/KlaviyoSwiftExamples/Shared/CheckOutViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/CheckOutViewController.swift
@@ -47,7 +47,8 @@ class CheckOutViewController: UIViewController {
      Check out button action
      Triggers checkout completed event & empties the cart
      */
-    @IBAction func checkOutButton(_ sender: UIButton) {
+    @IBAction
+    func checkOutButton(_ sender: UIButton) {
         if cart.cartItems.isEmpty {
             return
         }
@@ -83,7 +84,8 @@ class CheckOutViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    @IBAction func removeItemButton(_ sender: AnyObject) {
+    @IBAction
+    func removeItemButton(_ sender: AnyObject) {
         if cart.cartItems.isEmpty {
             return
         }

--- a/Examples/KlaviyoSwiftExamples/Shared/MenuPageViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/MenuPageViewController.swift
@@ -101,7 +101,8 @@ class MenuPageViewController: UIViewController {
 
     // MARK: IB Action
 
-    @IBAction func addEmail(_ sender: AnyObject) {
+    @IBAction
+    func addEmail(_ sender: AnyObject) {
         // present user with text box to add email & save
         let alertController = UIAlertController(
             title: "Add Email",
@@ -138,7 +139,8 @@ class MenuPageViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    @IBAction func removeItem(_ sender: AnyObject) {
+    @IBAction
+    func removeItem(_ sender: AnyObject) {
         if cart.cartItems.isEmpty {
             cartIcon.setImage(UIImage(named: "emptyCart"), for: UIControl.State())
             return
@@ -148,7 +150,8 @@ class MenuPageViewController: UIViewController {
         tableView.reloadData()
     }
 
-    @IBAction func logOut(_ sender: AnyObject) {
+    @IBAction
+    func logOut(_ sender: AnyObject) {
         // Present an action sheet to ask if they are sure
         let alertController = UIAlertController(
             title: "Log Out?",
@@ -178,7 +181,8 @@ class MenuPageViewController: UIViewController {
     }
 
     // Add a modal popup that lets users add their zip code: Can't add text to action sheet so this currently uses the alert controlelr
-    @IBAction func addZipcode(_ sender: UIButton) {
+    @IBAction
+    func addZipcode(_ sender: UIButton) {
         let alertController = UIAlertController(
             title: "Add Zipcode",
             message: "Please add your zipcode",
@@ -211,7 +215,8 @@ class MenuPageViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    @IBAction func viewCart(_ sender: UIButton) {
+    @IBAction
+    func viewCart(_ sender: UIButton) {
         let message = cart.cartItems.isEmpty ?
             "Your cart is empty! Please add some items before you check out." :
             "You have \(cart.cartItems.count) item(s) in your cart. Are you ready to check out?"
@@ -243,7 +248,8 @@ class MenuPageViewController: UIViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    @IBAction func addToCart(_ sender: UIButton) {
+    @IBAction
+    func addToCart(_ sender: UIButton) {
         if !cart.cartItems.isEmpty {
             cartIcon.setImage(UIImage(named: "FullCart"), for: UIControl.State())
         }
@@ -262,7 +268,8 @@ class MenuPageViewController: UIViewController {
         tableView.reloadData()
     }
 
-    @IBAction func unwindToMenuPageViewController(_ segue: UIStoryboardSegue) {
+    @IBAction
+    func unwindToMenuPageViewController(_ segue: UIStoryboardSegue) {
         print("Successfully unwound. Items in cart: \(cart.cartItems.count)")
     }
 

--- a/Examples/KlaviyoSwiftExamples/Shared/ViewController.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/ViewController.swift
@@ -20,7 +20,8 @@ class ViewController: UIViewController {
     @IBOutlet var zipcodeTextField: UITextField!
     @IBOutlet var rememberMeSwitch: UISwitch!
 
-    @IBAction func login(_ sender: UIButton) {
+    @IBAction
+    func login(_ sender: UIButton) {
         if checkForZipAndEmail {
             performSegue(withIdentifier: "loginSegue", sender: sender)
         } else {

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -13,7 +13,8 @@ import Foundation
 import Testing
 
 struct IAFNativeBridgeEventTests {
-    @Test func testHandshakeCreated() async throws {
+    @Test
+    func testHandshakeCreated() async throws {
         struct TestableHandshakeData: Codable, Equatable {
             var type: String
             var version: Int
@@ -30,7 +31,8 @@ struct IAFNativeBridgeEventTests {
         #expect(actualHandshakeData == expectedHandshakeData)
     }
 
-    @Test func testHandShook() async throws {
+    @Test
+    func testHandShook() async throws {
         let json = """
         {
           "type": "handShook",
@@ -43,7 +45,8 @@ struct IAFNativeBridgeEventTests {
         #expect(event == .handShook)
     }
 
-    @Test func testAbort() async throws {
+    @Test
+    func testAbort() async throws {
         let json = """
         {
           "type": "abort",
@@ -63,7 +66,8 @@ struct IAFNativeBridgeEventTests {
         #expect(reason == "because")
     }
 
-    @Test func testDecodeOpenDeepLink() async throws {
+    @Test
+    func testDecodeOpenDeepLink() async throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -85,7 +89,8 @@ struct IAFNativeBridgeEventTests {
         #expect(url == expectedUrl)
     }
 
-    @Test func testDecodeFormWillAppear() async throws {
+    @Test
+    func testDecodeFormWillAppear() async throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -100,7 +105,8 @@ struct IAFNativeBridgeEventTests {
         #expect(event == .formWillAppear)
     }
 
-    @Test func testDecodeFormDisappeared() async throws {
+    @Test
+    func testDecodeFormDisappeared() async throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -115,7 +121,8 @@ struct IAFNativeBridgeEventTests {
         #expect(event == .formDisappeared)
     }
 
-    @Test func testDecodeTrackProfileEvent() async throws {
+    @Test
+    func testDecodeTrackProfileEvent() async throws {
         let json = """
         {
           "type": "trackProfileEvent",
@@ -152,7 +159,8 @@ struct IAFNativeBridgeEventTests {
         #expect(profileEventDataDecoded == associatedValueDataDecoded)
     }
 
-    @Test func testDecodeAggregateEvent() async throws {
+    @Test
+    func testDecodeAggregateEvent() async throws {
         let json = """
         {
           "type": "trackAggregateEvent",

--- a/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
@@ -63,7 +63,8 @@ final class StateChangePublisherTests: XCTestCase {
         }
 
         testScheduler.run()
-        @MainActor func runDebouncedEffect() {
+        @MainActor
+        func runDebouncedEffect() {
             _ = klaviyoSwiftEnvironment.send(.initialize("foo"))
             testScheduler.run()
             // This should not trigger a save since in our reducer it does not change the state.
@@ -108,7 +109,8 @@ final class StateChangePublisherTests: XCTestCase {
             test.state.eraseToAnyPublisher()
         }
 
-        @MainActor func runDebouncedEffect() {
+        @MainActor
+        func runDebouncedEffect() {
             _ = klaviyoSwiftEnvironment.send(.initialize("foo"))
             _ = klaviyoSwiftEnvironment.send(.flushQueue)
             _ = klaviyoSwiftEnvironment.send(.flushQueue)


### PR DESCRIPTION
# Description

This PR updates our .swiftformat rules to put function and type attributes on their own lines. For example, this rule update will modify this:
```
@MainActor func foo() { ... }
```
to this:
```
@MainActor
func foo() { ... }
```

I wanted to make this update because of (1) personal preference (I think it looks cleaner), and (2) [Apple's developer documentation](https://developer.apple.com/documentation/swift/updating_an_app_to_use_swift_concurrency#4099730) shows it this way.