### PR TITLE
[CHNL-18661] remove `dismiss` from delegate

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -14,6 +14,8 @@ import UIKit
 class IAFPresentationManager {
     static let shared = IAFPresentationManager()
 
+    let animateDismissal = false
+
     lazy var indexHtmlFileUrl: URL? = {
         do {
             return try ResourceLoader.getResourceUrl(path: "InAppFormsTemplate", type: "html")
@@ -56,7 +58,7 @@ class IAFPresentationManager {
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
             } catch {
-                viewController.dismiss(animated: false)
+                viewController.dismiss(animated: animateDismissal)
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")
                 }
@@ -64,12 +66,12 @@ class IAFPresentationManager {
             }
 
             guard let topController = UIApplication.shared.topMostViewController else {
-                viewController.dismiss(animated: false)
+                viewController.dismiss(animated: animateDismissal)
                 return
             }
 
             if topController.isKlaviyoVC || topController.hasKlaviyoVCInStack {
-                viewController.dismiss(animated: false)
+                viewController.dismiss(animated: animateDismissal)
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -14,7 +14,7 @@ import UIKit
 class IAFPresentationManager {
     static let shared = IAFPresentationManager()
 
-    let animateDismissal = false
+    private let animateDismissal = false
 
     lazy var indexHtmlFileUrl: URL? = {
         do {

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -56,7 +56,7 @@ class IAFPresentationManager {
             do {
                 try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
             } catch {
-                viewController.dismiss()
+                viewController.dismiss(animated: false)
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error preloading In-App Form: \(error).")
                 }
@@ -64,12 +64,12 @@ class IAFPresentationManager {
             }
 
             guard let topController = UIApplication.shared.topMostViewController else {
-                viewController.dismiss()
+                viewController.dismiss(animated: false)
                 return
             }
 
             if topController.isKlaviyoVC || topController.hasKlaviyoVCInStack {
-                viewController.dismiss()
+                viewController.dismiss(animated: false)
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -178,7 +178,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             formWillAppearContinuation.finish()
         case .formDisappeared:
             Task {
-                await delegate?.dismiss()
+                await delegate?.dismiss(animated: false)
             }
         case let .trackProfileEvent(data):
             if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
@@ -196,7 +196,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 Logger.webViewLogger.info("Aborting webview: \(reason)")
             }
             Task {
-                await delegate?.dismiss()
+                await delegate?.dismiss(animated: false)
             }
         case .handShook:
             if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -145,7 +145,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
             }
         case .closeMessageHandler:
             Task {
-                await delegate?.dismiss()
+                await delegate?.dismiss(animated: false)
             }
         }
     }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -89,7 +89,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        dismiss()
+        dismiss(animated: false)
     }
 
     @MainActor
@@ -102,11 +102,6 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     @MainActor
     func preloadUrl() {
         loadUrl()
-    }
-
-    @MainActor
-    func dismiss() {
-        dismiss(animated: false)
     }
 
     // MARK: - Scripts

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewDelegate.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewDelegate.swift
@@ -9,13 +9,10 @@ import Combine
 import Foundation
 import WebKit
 
-protocol KlaviyoWebViewDelegate: AnyObject {
+protocol KlaviyoWebViewDelegate: UIViewController {
     @MainActor
     func preloadUrl()
 
     @MainActor
     func evaluateJavaScript(_ script: String) async throws -> Any
-
-    @MainActor
-    func dismiss()
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -35,6 +35,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     // MARK: - tests
 
     /// Tests scenario in which a `formWillAppear` event is emitted before the timeout is reached.
+    @MainActor
     func testPreloadWebsiteSuccess() async throws {
         // Given
         delegate.preloadResult = .formWillAppear(delay: 100_000_000) // 0.1 second in nanoseconds
@@ -54,6 +55,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     }
 
     /// Tests scenario in which the timeout is reached before the `formWillAppear` event is emitted.
+    @MainActor
     func testPreloadWebsiteTimeout() async {
         // Given
         delegate.preloadResult = .formWillAppear(delay: 1_000_000_000) // 1 second in nanoseconds
@@ -75,6 +77,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     }
 
     /// Tests scenario in which the delegate does nothing and emits no events after `preloadUrl()` is called.
+    @MainActor
     func testPreloadWebsiteNoActionTimeout() async {
         // Given
         delegate.preloadResult = MockIAFWebViewDelegate.PreloadResult.none

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     enum PreloadResult {
         case formWillAppear(delay: UInt64)

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -7,8 +7,9 @@
 
 @testable import KlaviyoForms
 import Foundation
+import UIKit
 
-class MockIAFWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
+class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     enum PreloadResult {
         case formWillAppear(delay: UInt64)
         case didFailNavigation(delay: UInt64)
@@ -23,6 +24,12 @@ class MockIAFWebViewDelegate: NSObject, KlaviyoWebViewDelegate {
 
     init(viewModel: IAFWebViewModel) {
         self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     func preloadUrl() {


### PR DESCRIPTION
# Description

This PR removes the `dismiss()` requirement from the `KlaviyoWebViewDelegate`. With #326, [the logic within the `KlaviyoWebViewController`'s `dismiss` method was moved to the `deinit` method](https://github.com/klaviyo/klaviyo-swift-sdk/pull/326/commits/9e700274e190e3b45ce33fdd9ecb73fc731a0c9b), leaving the view controller's `dismiss` method not really doing anything, so we no longer need the delegate to implement its own `dismiss` logic. 

This PR is part of the work that I'm doing for [CHNL-18661](https://klaviyo.atlassian.net/browse/CHNL-18661).

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I ran the test app and validated that the In-App Form is behaving as expected. The form dismisses successfully, and the KlaviyoWebViewController is deinitialized after the form is dismissed.

[CHNL-18661]: https://klaviyo.atlassian.net/browse/CHNL-18661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ