### PR TITLE
[CHNL-18661] change timeout type

### DIFF
--- a/Sources/KlaviyoCore/Utils/UInt64+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/UInt64+Ext.swift
@@ -1,0 +1,15 @@
+//
+//  UInt64+Ext.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 4/10/25.
+//
+
+import Foundation
+
+package extension UInt64 {
+    var seconds: TimeInterval { Double(self) / 1_000_000_000 }
+    var milliseconds: TimeInterval { Double(self) / 1_000_000 }
+    var microseconds: TimeInterval { Double(self) / 1000 }
+    var nanoseconds: TimeInterval { Double(self) }
+}

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -56,7 +56,7 @@ class IAFPresentationManager {
             viewController.modalPresentationStyle = .overCurrentContext
 
             do {
-                try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout)
+                try await viewModel.preloadWebsite(timeout: Double(NetworkSession.networkTimeout) / 1_000_000_000)
             } catch {
                 viewController.dismiss(animated: animateDismissal)
                 if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -56,7 +56,7 @@ class IAFPresentationManager {
             viewController.modalPresentationStyle = .overCurrentContext
 
             do {
-                try await viewModel.preloadWebsite(timeout: Double(NetworkSession.networkTimeout) / 1_000_000_000)
+                try await viewModel.preloadWebsite(timeout: NetworkSession.networkTimeout.seconds)
             } catch {
                 viewController.dismiss(animated: animateDismissal)
                 if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -99,7 +99,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: - Loading
 
-    func preloadWebsite(timeout: UInt64) async throws {
+    func preloadWebsite(timeout: TimeInterval) async throws {
         guard let delegate else { return }
 
         await delegate.preloadUrl()
@@ -112,7 +112,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 }
 
                 group.addTask {
-                    try await Task.sleep(nanoseconds: timeout)
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                     throw PreloadError.timeout
                 }
 
@@ -127,7 +127,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
         } catch let error as PreloadError {
             if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Loading time exceeded specified timeout of \(Float(timeout / 1_000_000_000), format: .fixed(precision: 1)) seconds.")
+                Logger.webViewLogger.warning("Loading time exceeded specified timeout of \(timeout, format: .fixed(precision: 1)) seconds.")
             }
             throw error
         } catch {

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -54,7 +54,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
     ///
     /// The caller of this method should `await` completion of this method, then present the ViewController.
     /// - Parameter timeout: the amount of time, in milliseconds, to wait before throwing a `timeout` error.
-    public func preloadWebsite(timeout: UInt64) async throws {
+    public func preloadWebsite(timeout: TimeInterval) async throws {
         guard let delegate else { return }
 
         await delegate.preloadUrl()
@@ -62,7 +62,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
         do {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    try await Task.sleep(nanoseconds: timeout)
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                     throw PreloadError.timeout
                 }
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -18,7 +18,7 @@ protocol KlaviyoWebViewModeling: AnyObject {
     var loadScripts: Set<WKUserScript>? { get }
     var messageHandlers: Set<String>? { get }
 
-    func preloadWebsite(timeout: UInt64) async throws
+    func preloadWebsite(timeout: TimeInterval) async throws
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)
 }

--- a/Tests/KlaviyoCoreTests/UInt64+ExtTests.swift
+++ b/Tests/KlaviyoCoreTests/UInt64+ExtTests.swift
@@ -1,0 +1,98 @@
+//
+//  UInt64+ExtTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 4/10/25.
+//
+
+import XCTest
+
+class UInt64ExtensionTests: XCTestCase {
+    func testNanosecondsToSeconds() {
+        // 1 second
+        let oneSecond: UInt64 = 1_000_000_000
+        XCTAssertEqual(oneSecond.seconds, 1.0)
+
+        // 1.5 seconds
+        let oneAndHalfSeconds: UInt64 = 1_500_000_000
+        XCTAssertEqual(oneAndHalfSeconds.seconds, 1.5)
+
+        // 0.5 seconds
+        let halfSecond: UInt64 = 500_000_000
+        XCTAssertEqual(halfSecond.seconds, 0.5)
+
+        // 2 seconds
+        let twoSeconds: UInt64 = 2_000_000_000
+        XCTAssertEqual(twoSeconds.seconds, 2.0)
+    }
+
+    func testNanosecondsToMilliseconds() {
+        // 1 millisecond = 1,000,000 nanoseconds
+        let oneMillisecond: UInt64 = 1_000_000
+        XCTAssertEqual(oneMillisecond.milliseconds, 1.0)
+
+        // 1.5 milliseconds
+        let oneAndHalfMilliseconds: UInt64 = 1_500_000
+        XCTAssertEqual(oneAndHalfMilliseconds.milliseconds, 1.5)
+
+        // 0.5 milliseconds
+        let halfMillisecond: UInt64 = 500_000
+        XCTAssertEqual(halfMillisecond.milliseconds, 0.5)
+
+        // 2 milliseconds
+        let twoMilliseconds: UInt64 = 2_000_000
+        XCTAssertEqual(twoMilliseconds.milliseconds, 2.0)
+    }
+
+    func testNanosecondsToMicroseconds() {
+        // 1 microsecond = 1,000 nanoseconds
+        let oneMicrosecond: UInt64 = 1000
+        XCTAssertEqual(oneMicrosecond.microseconds, 1.0)
+
+        // 1.5 microseconds
+        let oneAndHalfMicroseconds: UInt64 = 1500
+        XCTAssertEqual(oneAndHalfMicroseconds.microseconds, 1.5)
+
+        // 0.5 microseconds
+        let halfMicrosecond: UInt64 = 500
+        XCTAssertEqual(halfMicrosecond.microseconds, 0.5)
+
+        // 2 microseconds
+        let twoMicroseconds: UInt64 = 2000
+        XCTAssertEqual(twoMicroseconds.microseconds, 2.0)
+    }
+
+    func testNanosecondsToNanoseconds() {
+        let nanos: UInt64 = 1500
+        XCTAssertEqual(nanos.nanoseconds, 1500.0)
+    }
+
+    func testLargeValues() {
+        // Test a large value: 1 hour = 3600 seconds = 3,600,000,000,000 nanoseconds
+        let oneHour: UInt64 = 3_600_000_000_000
+        XCTAssertEqual(oneHour.seconds, 3600.0)
+    }
+
+    func testSmallValues() {
+        // Test very small values
+        let singleNano: UInt64 = 1
+        XCTAssertEqual(singleNano.seconds, 1e-9)
+        XCTAssertEqual(singleNano.milliseconds, 1e-6)
+        XCTAssertEqual(singleNano.microseconds, 1e-3)
+        XCTAssertEqual(singleNano.nanoseconds, 1.0)
+    }
+
+    func testZeroValue() {
+        let zero: UInt64 = 0
+        XCTAssertEqual(zero.seconds, 0.0)
+        XCTAssertEqual(zero.milliseconds, 0.0)
+        XCTAssertEqual(zero.microseconds, 0.0)
+        XCTAssertEqual(zero.nanoseconds, 0.0)
+    }
+
+    func testPrecision() {
+        // Test that we maintain precision for small fractional values
+        let preciseValue: UInt64 = 1_234_567_890
+        XCTAssertEqual(preciseValue.seconds, 1.23456789)
+    }
+}

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -38,7 +38,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     @MainActor
     func testPreloadWebsiteSuccess() async throws {
         // Given
-        delegate.preloadResult = .formWillAppear(delay: 100_000_000) // 0.1 second in nanoseconds
+        delegate.preloadResult = .formWillAppear(delay: 0.1)
         let expectation = XCTestExpectation(description: "Preloading website succeeds")
 
         // When
@@ -58,7 +58,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     @MainActor
     func testPreloadWebsiteTimeout() async {
         // Given
-        delegate.preloadResult = .formWillAppear(delay: 1_000_000_000) // 1 second in nanoseconds
+        delegate.preloadResult = .formWillAppear(delay: 1.0)
         let expectation = XCTestExpectation(description: "Preloading website times out")
 
         // When

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -43,7 +43,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 1_000_000_000) // 1 second in nanoseconds
+            try await viewModel.preloadWebsite(timeout: 1.0)
             expectation.fulfill()
         } catch {
             XCTFail("Expected success, but got error: \(error)")
@@ -63,7 +63,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 100_000_000) // 0.1 second in nanoseconds
+            try await viewModel.preloadWebsite(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch PreloadError.timeout {
             expectation.fulfill()
@@ -85,7 +85,7 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 100_000_000) // 0.1 second in nanoseconds
+            try await viewModel.preloadWebsite(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch PreloadError.timeout {
             expectation.fulfill()

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -39,7 +39,7 @@ private final class MockIAFWebViewModel: KlaviyoWebViewModeling {
         self.url = url
     }
 
-    func preloadWebsite(timeout: UInt64) async throws {}
+    func preloadWebsite(timeout: TimeInterval) async throws {}
     func handleNavigationEvent(_ event: KlaviyoForms.WKNavigationEvent) {}
     func handleScriptMessage(_ message: WKScriptMessage) {}
 }

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 @MainActor
 class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     enum PreloadResult {
-        case formWillAppear(delay: UInt64)
+        case formWillAppear(delay: TimeInterval)
         case none
     }
 
@@ -40,7 +40,7 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
             if let result = preloadResult {
                 switch result {
                 case let .formWillAppear(delay):
-                    try? await Task.sleep(nanoseconds: delay)
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
 
                     let scriptMessage = MockWKScriptMessage(
                         name: "KlaviyoNativeBridge",

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -13,7 +13,6 @@ import UIKit
 class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     enum PreloadResult {
         case formWillAppear(delay: UInt64)
-        case didFailNavigation(delay: UInt64)
         case none
     }
 
@@ -56,10 +55,6 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
                     )
 
                     viewModel.handleScriptMessage(scriptMessage)
-
-                case let .didFailNavigation(delay):
-                    try? await Task.sleep(nanoseconds: delay)
-                    viewModel.handleNavigationEvent(.didFailNavigation)
 
                 case .none:
                     // don't do anything


### PR DESCRIPTION
# Description

This PR changes the `preloadWebsite(timeout:)` method to take a `TimeInterval` instead of a `UInt64` as a parameter. I think it's more readable this way, and it's aligned with some of Apple's APIs that use a timer (like `Timer.scheduledTimer(timeInterval: TimeInterval, <...>)`, `Date(timeInterval: TimeInterval, <...>)`, etc).

This PR is part of the work that I'm doing for [CHNL-18661](https://klaviyo.atlassian.net/browse/CHNL-18661).

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

In addition to updating the unit tests, I also ran the iOS test app and validated that the In-App Forms are behaving as expected. I also simulated a timeout scenario in the test app and validated that the timeout is working as expected.

[CHNL-18661]: https://klaviyo.atlassian.net/browse/CHNL-18661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ