### PR TITLE
[CHNL-18661] update timeout

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -29,6 +29,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let assetSource: String?
 
     private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
+    let formLifecycleStream: AsyncStream<IAFLifecycleEvent>
+    private let formLifecycleContinuation: AsyncStream<IAFLifecycleEvent>.Continuation
     private let (handshakeStream, handshakeContinuation) = AsyncStream.makeStream(of: Void.self)
 
     // MARK: - Scripts
@@ -86,6 +88,11 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         self.url = url
         self.companyId = companyId
         self.assetSource = assetSource
+
+        let (stream, continuation) = AsyncStream.makeStream(of: IAFLifecycleEvent.self)
+        formLifecycleStream = stream
+        formLifecycleContinuation = continuation
+
         initializeLoadScripts()
     }
 
@@ -179,15 +186,14 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private func handleNativeBridgeEvent(_ event: IAFNativeBridgeEvent) {
         switch event {
         case .formsDataLoaded:
-            // TODO: handle formsDataLoaded
             ()
         case .formWillAppear:
-            formWillAppearContinuation.yield()
-            formWillAppearContinuation.finish()
-        case .formDisappeared:
-            Task {
-                await delegate?.dismiss(animated: false)
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Received `formWillAppear` event from KlaviyoJS")
             }
+            formLifecycleContinuation.yield(.present)
+        case .formDisappeared:
+            formLifecycleContinuation.yield(.dismiss)
         case let .trackProfileEvent(data):
             if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                let metricName = jsonEventData["metric"] as? String {
@@ -203,9 +209,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Aborting webview: \(reason)")
             }
-            Task {
-                await delegate?.dismiss(animated: false)
-            }
+            formLifecycleContinuation.yield(.abort)
         case .handShook:
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Successful handshake with JS")

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -129,29 +129,6 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         }
     }
 
-    func preloadWebsite(timeout: TimeInterval) async throws {
-        guard let delegate else { return }
-
-        await delegate.preloadUrl()
-
-        do {
-            try await withTimeout(seconds: timeout) { [weak self] in
-                guard let self else { throw ObjectStateError.objectDeallocated }
-                await self.formWillAppearStream.first { _ in true }
-            }
-        } catch let error as TimeoutError {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Loading time exceeded specified timeout of \(timeout, format: .fixed(precision: 1)) seconds.")
-            }
-            throw error
-        } catch {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("Error preloading URL: \(error)")
-            }
-            throw error
-        }
-    }
-
     // MARK: - handle WKWebView events
 
     func handleNavigationEvent(_ event: WKNavigationEvent) {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -218,4 +218,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             handshakeContinuation.finish()
         }
     }
+
+    // MARK: - handle view events
+
+    func handleViewTransition() {
+        formLifecycleContinuation.yield(.dismiss)
+    }
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -28,7 +28,6 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let companyId: String?
     private let assetSource: String?
 
-    private let (formWillAppearStream, formWillAppearContinuation) = AsyncStream.makeStream(of: Void.self)
     let formLifecycleStream: AsyncStream<IAFLifecycleEvent>
     private let formLifecycleContinuation: AsyncStream<IAFLifecycleEvent>.Continuation
     private let (handshakeStream, handshakeContinuation) = AsyncStream.makeStream(of: Void.self)

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFLifecycleEvent.swift
@@ -1,0 +1,12 @@
+//
+//  IAFLifecycleEvent.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 4/11/25.
+//
+
+enum IAFLifecycleEvent: String {
+    case present
+    case dismiss
+    case abort
+}

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -132,5 +132,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
             }
         }
     }
+
+    func handleViewTransition() {}
 }
 #endif

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -89,7 +89,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        dismiss(animated: false)
+        viewModel.handleViewTransition()
     }
 
     @MainActor

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -21,4 +21,5 @@ protocol KlaviyoWebViewModeling: AnyObject {
     func preloadWebsite(timeout: TimeInterval) async throws
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)
+    func handleViewTransition()
 }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -18,7 +18,6 @@ protocol KlaviyoWebViewModeling: AnyObject {
     var loadScripts: Set<WKUserScript>? { get }
     var messageHandlers: Set<String>? { get }
 
-    func preloadWebsite(timeout: TimeInterval) async throws
     func handleNavigationEvent(_ event: WKNavigationEvent)
     func handleScriptMessage(_ message: WKScriptMessage)
     func handleViewTransition()

--- a/Tests/KlaviyoFormsTests/Assets/IAFUnitTest.html
+++ b/Tests/KlaviyoFormsTests/Assets/IAFUnitTest.html
@@ -9,10 +9,8 @@
                 <script>
                     document.addEventListener("DOMContentLoaded", function () {
                         const message = JSON.stringify({
-                            type: "formWillAppear",
-                            data: {
-                                formId: "abc123"
-                            }
+                            type: "handShook",
+                            data: {}
                         });
 
                         window.webkit.messageHandlers.KlaviyoNativeBridge.postMessage(message);

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -38,12 +38,12 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     @MainActor
     func testPreloadWebsiteSuccess() async throws {
         // Given
-        delegate.preloadResult = .formWillAppear(delay: 0.1)
+        delegate.handshakeResult = .handshakeEstablished(delay: 0.1)
         let expectation = XCTestExpectation(description: "Preloading website succeeds")
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 1.0)
+            try await viewModel.establishHandshake(timeout: 1.0)
             expectation.fulfill()
         } catch {
             XCTFail("Expected success, but got error: \(error)")
@@ -57,12 +57,12 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     @MainActor
     func testPreloadWebsiteTimeout() async {
         // Given
-        delegate.preloadResult = .formWillAppear(delay: 1.0)
+        delegate.handshakeResult = .handshakeEstablished(delay: 1.0)
         let expectation = XCTestExpectation(description: "Preloading website times out")
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 0.1)
+            try await viewModel.establishHandshake(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch TimeoutError.timeout {
             expectation.fulfill()
@@ -78,12 +78,12 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     @MainActor
     func testPreloadWebsiteNoActionTimeout() async {
         // Given
-        delegate.preloadResult = MockIAFWebViewDelegate.PreloadResult.none
+        delegate.handshakeResult = MockIAFWebViewDelegate.HandshakeResult.none
         let expectation = XCTestExpectation(description: "Preloading website times out")
 
         // When
         do {
-            try await viewModel.preloadWebsite(timeout: 0.1)
+            try await viewModel.establishHandshake(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch TimeoutError.timeout {
             expectation.fulfill()

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -50,7 +50,6 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(delegate.preloadUrlCalled, "preloadUrl should be called on delegate")
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
@@ -72,7 +71,6 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(delegate.preloadUrlCalled, "preloadUrl should be called on delegate")
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
@@ -94,7 +92,6 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(delegate.preloadUrlCalled, "preloadUrl should be called on delegate")
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -57,7 +57,7 @@ final class IAFWebViewModelTests: XCTestCase {
         try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
 
         // Given
-        try await viewModel.preloadWebsite(timeout: 3_000_000_000)
+        try await viewModel.establishHandshake(timeout: 3.0)
 
         // When
         let script = "document.head.getAttribute('data-sdk-name');"
@@ -76,7 +76,7 @@ final class IAFWebViewModelTests: XCTestCase {
         try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
 
         // Given
-        try await viewModel.preloadWebsite(timeout: 3_000_000_000)
+        try await viewModel.establishHandshake(timeout: 3.0)
 
         // When
         let script = "document.head.getAttribute('data-sdk-version');"
@@ -95,7 +95,7 @@ final class IAFWebViewModelTests: XCTestCase {
         try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
 
         // Given
-        try await viewModel.preloadWebsite(timeout: 3_000_000_000)
+        try await viewModel.establishHandshake(timeout: 3.0)
 
         // When
         let script = "document.head.getAttribute('data-native-bridge-handshake');"
@@ -128,7 +128,7 @@ final class IAFWebViewModelTests: XCTestCase {
         try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
 
         // Given
-        try await viewModel.preloadWebsite(timeout: 3_000_000_000)
+        try await viewModel.establishHandshake(timeout: 3.0)
 
         // When
         let script = "document.getElementById('klaviyoJS').getAttribute('src');"

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -42,6 +42,7 @@ private final class MockIAFWebViewModel: KlaviyoWebViewModeling {
     func preloadWebsite(timeout: TimeInterval) async throws {}
     func handleNavigationEvent(_ event: KlaviyoForms.WKNavigationEvent) {}
     func handleScriptMessage(_ message: WKScriptMessage) {}
+    func handleViewTransition() {}
 }
 
 final class KlaviyoWebViewControllerTests: XCTestCase {

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -39,7 +39,6 @@ private final class MockIAFWebViewModel: KlaviyoWebViewModeling {
         self.url = url
     }
 
-    func preloadWebsite(timeout: TimeInterval) async throws {}
     func handleNavigationEvent(_ event: KlaviyoForms.WKNavigationEvent) {}
     func handleScriptMessage(_ message: WKScriptMessage) {}
     func handleViewTransition() {}

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -19,7 +19,6 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     let viewModel: IAFWebViewModel
 
     var preloadResult: PreloadResult?
-    var preloadUrlCalled = false
     var evaluateJavaScriptCalled = false
 
     init(viewModel: IAFWebViewModel) {
@@ -34,7 +33,6 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
 
     func preloadUrl() {
         viewModel.handleNavigationEvent(.didCommitNavigation)
-        preloadUrlCalled = true
 
         Task {
             if let result = preloadResult {

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -43,12 +43,7 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
                     let scriptMessage = MockWKScriptMessage(
                         name: "KlaviyoNativeBridge",
                         body: """
-                        {
-                          "type": "formWillAppear",
-                          "data": {
-                            "formId": "abc123"
-                          }
-                        }
+                        {"type":"handShook","data":{}}
                         """
                     )
 

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -11,14 +11,14 @@ import UIKit
 
 @MainActor
 class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
-    enum PreloadResult {
-        case formWillAppear(delay: TimeInterval)
+    enum HandshakeResult {
+        case handshakeEstablished(delay: TimeInterval)
         case none
     }
 
     let viewModel: IAFWebViewModel
 
-    var preloadResult: PreloadResult?
+    var handshakeResult: HandshakeResult?
     var evaluateJavaScriptCalled = false
 
     init(viewModel: IAFWebViewModel) {
@@ -35,9 +35,9 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
         viewModel.handleNavigationEvent(.didCommitNavigation)
 
         Task {
-            if let result = preloadResult {
+            if let result = handshakeResult {
                 switch result {
-                case let .formWillAppear(delay):
+                case let .handshakeEstablished(delay):
                     try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
 
                     let scriptMessage = MockWKScriptMessage(


### PR DESCRIPTION
# Description

This PR updates the timeout logic for In-App Forms so that it waits for the handshake, rather than formWillAppear, before canceling the timeout timer. As part of this work, I also moved the responsibility for dismissing the `KlaviyoWebViewController` solely within the `IAFPresentationManager`. This allows us to better manage the full view lifecycle and deallocation of the `KlaviyoWebViewController` in a single place, which is important for upcoming work on persistent web views.

[CHNL-18661](https://klaviyo.atlassian.net/browse/CHNL-18661)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

- I ran the test app and validated that In-App Forms are working as expected
- I simulated triggering the timeout in the test app, and validated that the app worked as expected
- I simulated an "abort" message in the test app, and validated that the app worked as expected

[CHNL-18661]: https://klaviyo.atlassian.net/browse/CHNL-18661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ