### PR TITLE
fix podspecs to account for new package-level code

### DIFF
--- a/KlaviyoCore.podspec
+++ b/KlaviyoCore.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   s.swift_version    = '5.7'
   s.platform         = :ios, '13.0'
   s.source_files     = 'Sources/KlaviyoCore/**/*.swift'
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoCore' }
   s.dependency       'AnyCodable-FlightSchool'
 end

--- a/KlaviyoForms.podspec
+++ b/KlaviyoForms.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
       'Tests/KlaviyoFormsTests/Assets/*.{html}'
     ]
   }
-  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift -package-name KlaviyoCore' }
   s.dependency     'KlaviyoSwift', '~> 4.2.1'
 end

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
-  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
+  s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift -package-name KlaviyoCore' }
   s.dependency     'KlaviyoCore', '~> 4.2.1'
   s.dependency     'AnyCodable-FlightSchool'
 end


### PR DESCRIPTION
# Description

PRs #329 and #330 added new package-access-level code to KlaviyoCore ([1](https://github.com/klaviyo/klaviyo-swift-sdk/pull/329/files#diff-17c1ed8c8cc1ec70a9ffa8a0d9ddc7a420d4e342c533e68848354f20b769c736R10), [2](https://github.com/klaviyo/klaviyo-swift-sdk/pull/330/files#diff-3ee4ab2bc41e7192fd3ff60033503a9a621bc7340f4730dac9c48167560020e4R8)). This was working fine for apps that host the SDK using SPM, but it was broken on apps that host the SDK using Cocoapods. This PR fixes that issue.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

I tested these changes in the React Native test app, which imports our SDK using Cocoapods. The app compiles and runs as expected.