### PR TITLE
[CHNL-17060] fix react native user-agent

### DIFF
--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -69,13 +69,22 @@ public func removeFile(at url: URL) -> Bool {
     return false
 }
 
-/// load any plist from app main bundle
+/// load any plist from app main bundle or React Native framework bundle
 /// - Parameter name: the name of the plist
 /// - Returns: the contents of the plist in `[String: AnyObject]` or nil if not found
 func loadPlist(named name: String) -> [String: AnyObject]? {
+    // Try loading from main bundle first
     if let path = Bundle.main.path(forResource: name, ofType: "plist"),
        let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
         return dict
     }
+
+    // If not found in main bundle, try loading from React Native framework bundle
+    if let reactNativeBundle = Bundle(identifier: "org.cocoapods.klaviyo-react-native-sdk"),
+       let path = reactNativeBundle.path(forResource: name, ofType: "plist"),
+       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
+        return dict
+    }
+
     return nil
 }

--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -73,18 +73,23 @@ public func removeFile(at url: URL) -> Bool {
 /// - Parameter name: the name of the plist
 /// - Returns: the contents of the plist in `[String: AnyObject]` or nil if not found
 func loadPlist(named name: String) -> [String: AnyObject]? {
-    // Try loading from main bundle first
-    if let path = Bundle.main.path(forResource: name, ofType: "plist"),
-       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
-        return dict
-    }
+    let plistPath: String? = {
+        if let path = Bundle.main.path(forResource: name, ofType: "plist") {
+            // Try loading from main bundle first
+            return path
+        } else if let reactNativeBundle = Bundle(identifier: "org.cocoapods.klaviyo-react-native-sdk"),
+                  let path = reactNativeBundle.path(forResource: name, ofType: "plist") {
+            // If not found in main bundle, try loading from React Native framework bundle
+            return path
+        } else {
+            return nil
+        }
+    }()
 
-    // If not found in main bundle, try loading from React Native framework bundle
-    if let reactNativeBundle = Bundle(identifier: "org.cocoapods.klaviyo-react-native-sdk"),
-       let path = reactNativeBundle.path(forResource: name, ofType: "plist"),
-       let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
+    if let plistPath,
+       let dict = NSDictionary(contentsOfFile: plistPath) as? [String: AnyObject] {
         return dict
+    } else {
+        return nil
     }
-
-    return nil
 }


### PR DESCRIPTION
# Description

We had a bug in which API calls made using the React Native SDK would show the incorrect user agent if the SDK was imported dynamically. This happened because we were attempting to access the `klaviyo-sdk-configuration.plist` file, which we use to set the user agent, from `Bundle.main`, but that file does not exist in the main bundle when the SDK is imported dynamically. This PR fixes that by searching for the file specifically within the react native framework if it's unable to find it in the main app bundle.

[CHNL-17060](https://klaviyo.atlassian.net/browse/CHNL-17060)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [ ] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

# Manual Test Plan

With the changes in this PR, I validated that the user agents are correct when the frameworks are linked statically and dynamically. To reproduce, I:

1. pointed the React Native Test App to consume the local React Native SDK (commit 9fddd58) and the local Swift SDK (this branch)
2. ran `pod install`, built and ran the RN test app, triggered an event, and inspected the user agent in Proxyman to validate that it's what we expect
3. set the `klaviyo-react-native-test-app/iOS/Podfile`'s `use_frameworks!` setting to `dynamic`
4. repeated step 2

User-agent when podfile includes `use_frameworks! :linkage => :static`:
`KlaviyoRNTestApp/1.4.0 (com.klaviyo.rntest; build:1; iOS 18.2.0) klaviyo-react_native/1.2.0`

User-agent when podfile includes `use_frameworks! :linkage => :dynamic`:
`KlaviyoRNTestApp/1.4.0 (com.klaviyo.rntest; build:1; iOS 18.2.0) klaviyo-react_native/1.2.0`

[CHNL-17060]: https://klaviyo.atlassian.net/browse/CHNL-17060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ