### PR TITLE
[CHNL-19677] share profile data changes

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -31,6 +31,21 @@ package struct KlaviyoInternal {
         }
     }
 
+    package static func profileChangePublisher() -> AnyPublisher<ProfileData, Never> {
+        klaviyoSwiftEnvironment.statePublisher()
+            .removeDuplicates()
+            .map {
+                ProfileData(
+                    email: $0.email,
+                    anonymousId: $0.anonymousId,
+                    phoneNumber: $0.phoneNumber,
+                    externalId: $0.externalId
+                )
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     /// Create and send an aggregate event.
     /// - Parameter event: the event to be tracked in Klaviyo
     package static func create(aggregateEvent: AggregateEventPayload) {

--- a/Sources/KlaviyoSwift/Models/ProfileData.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileData.swift
@@ -1,0 +1,22 @@
+//
+//  ProfileData.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 4/21/25.
+//
+
+package struct ProfileData: Equatable, CustomDebugStringConvertible {
+    package var email: String?
+    package var anonymousId: String?
+    package var phoneNumber: String?
+    package var externalId: String?
+
+    package var debugDescription: String {
+        """
+        email: \t\t\t\(email ?? "<no email>")
+        phoneNumber: \t\(phoneNumber ?? "<no phoneNumber>")
+        anonymousId: \t\(anonymousId ?? "<no anonymousId>")
+        externalId: \t\(externalId ?? "<no externalId>")
+        """
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -1,0 +1,91 @@
+//
+//  KlaviyoInternalTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 4/22/25.
+//
+
+import Combine
+import XCTest
+@_spi(KlaviyoPrivate) @testable import KlaviyoSwift
+import KlaviyoCore
+
+final class KlaviyoInternalTests: XCTestCase {
+    var cancellables = Set<AnyCancellable>()
+
+    @MainActor
+    override func setUpWithError() throws {
+        environment = KlaviyoEnvironment.test()
+    }
+
+    @MainActor
+    override func tearDownWithError() throws {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+    }
+
+    @MainActor
+    func testProfileChangePublisherEmitsCorrectData() throws {
+        let expectation = XCTestExpectation(description: "Profile data is emitted")
+        var receivedProfile: ProfileData?
+
+        // Set up test environment
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        // Subscribe to the publisher
+        KlaviyoInternal.profileChangePublisher()
+            .sink { profile in
+                receivedProfile = profile
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // Trigger a profile change
+        _ = testStore.send(.setEmail("a@b.com"))
+        _ = testStore.send(.setPhoneNumber("+15555555555"))
+        _ = testStore.send(.setExternalId("test123"))
+
+        // Wait for the expectation
+        wait(for: [expectation], timeout: 1.0)
+
+        // Verify the emitted profile data
+        XCTAssertEqual(receivedProfile?.email, "a@b.com")
+        XCTAssertEqual(receivedProfile?.phoneNumber, "+15555555555")
+        XCTAssertEqual(receivedProfile?.externalId, "test123")
+    }
+
+    @MainActor
+    func testRemoveDuplicates() throws {
+        let expectation = XCTestExpectation(description: "Profile data is emitted")
+        var receiveValueCount = 0
+
+        // Set up test environment
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        let initialEmail = try XCTUnwrap(KlaviyoState.test.email)
+
+        // Subscribe to the publisher
+        KlaviyoInternal.profileChangePublisher()
+            .sink { _ in
+                receiveValueCount += 1
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        // receiveValueCount should be 1 at this point because `profileChangePublisher`
+        // will get an initial value when it receives a subscription.
+        XCTAssertEqual(receiveValueCount, 1)
+
+        // Trigger a profile change
+        _ = testStore.send(.setEmail(initialEmail))
+
+        // receiveValueCount should stay at 1 because we
+        // set the email to the same as its initial value
+        XCTAssertEqual(receiveValueCount, 1)
+
+        // Wait for the expectation
+        wait(for: [expectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
# Description

This PR creates a package-access-level publisher that will emit profile data when one of the user's profile attributes changes. In the future, we will subscribe do this so that we can pass profile data changes into KlaviyoJS.

[CHNL-19425](https://klaviyo.atlassian.net/browse/CHNL-19425)

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?

[CHNL-19425]: https://klaviyo.atlassian.net/browse/CHNL-19425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ