### PR TITLE
[CHNL-19677] publish company id changes

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -12,7 +12,7 @@ import KlaviyoCore
 /// The internal interface for the Klaviyo SDK.
 ///
 /// - Note: Can only be accessed from other modules within the Klaviyo-Swift-SDK package; cannot be accessed from the host app.
-package struct KlaviyoInternal {
+package enum KlaviyoInternal {
     static var cancellable: Cancellable?
     /// the apiKey (a.k.a. CompanyID) for the current SDK instance.
     /// - Parameter completion: completion hanlder that will be called when apiKey is avaialble after SDK is initilized

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -66,7 +66,7 @@ package enum KlaviyoInternal {
                     // If we get a valid key, emit it immediately and cancel any pending timer
                     return Just(apiKey).eraseToAnyPublisher()
                 } else {
-                    // If we get nil or empty string, start a timer that will emit nil after 10 seconds
+                    // If we get nil or empty string, start a timer that will emit a warning after 10 seconds
                     return Just(nil)
                         .delay(for: .seconds(10), scheduler: DispatchQueue.main)
                         .handleEvents(receiveOutput: { _ in

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -52,4 +52,32 @@ package enum KlaviyoInternal {
     package static func create(aggregateEvent: AggregateEventPayload) {
         dispatchOnMainThread(action: .enqueueAggregateEvent(aggregateEvent))
     }
+
+    /// A publisher that monitors the API key (aka Company ID) and emits valid API keys.
+    ///
+    /// If a nil or empty string is received, it will start a 10-second timer and log a warning if no valid key is received before the timer elapses.
+    /// - Returns: A publisher that emits valid API keys (non-nil, non-empty strings)
+    package static func apiKeyPublisher() -> AnyPublisher<String, Never> {
+        profileChangePublisher()
+            .map(\.apiKey)
+            .removeDuplicates()
+            .map { apiKey -> AnyPublisher<String?, Never> in
+                if let apiKey = apiKey, !apiKey.isEmpty {
+                    // If we get a valid key, emit it immediately and cancel any pending timer
+                    return Just(apiKey).eraseToAnyPublisher()
+                } else {
+                    // If we get nil or empty string, start a timer that will emit nil after 10 seconds
+                    return Just(nil)
+                        .delay(for: .seconds(10), scheduler: DispatchQueue.main)
+                        .handleEvents(receiveOutput: { _ in
+                            environment.emitDeveloperWarning("SDK must be initialized before usage.")
+                        })
+                        .eraseToAnyPublisher()
+                }
+            }
+            .switchToLatest()
+            .compactMap { $0 } // Only emit non-nil values
+            .filter { !$0.isEmpty }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -36,6 +36,7 @@ package struct KlaviyoInternal {
             .removeDuplicates()
             .map {
                 ProfileData(
+                    apiKey: $0.apiKey,
                     email: $0.email,
                     anonymousId: $0.anonymousId,
                     phoneNumber: $0.phoneNumber,

--- a/Sources/KlaviyoSwift/Models/ProfileData.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileData.swift
@@ -6,6 +6,7 @@
 //
 
 package struct ProfileData: Equatable, CustomDebugStringConvertible {
+    package var apiKey: String?
     package var email: String?
     package var anonymousId: String?
     package var phoneNumber: String?
@@ -13,6 +14,7 @@ package struct ProfileData: Equatable, CustomDebugStringConvertible {
 
     package var debugDescription: String {
         """
+        apiKey: \t\t\t\(apiKey ?? "<no API key>")
         email: \t\t\t\(email ?? "<no email>")
         phoneNumber: \t\(phoneNumber ?? "<no phoneNumber>")
         anonymousId: \t\(anonymousId ?? "<no anonymousId>")


### PR DESCRIPTION
# Description

This PR adds a publisher to emit API Key (aka Company ID) changes from KlaviyoSwift. If the upstream publisher emits a `nil` or empty value for the API key, this publisher will kick off a 10-second timer, after which it will emit a developer warning that the API needs to be initialized. The stream will not get cancelled after emitting the warning, however; it will continue to listen for API Key changes from KlaviyoSwift and emit them to any subscribers.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Have you tested this change on real device?
- [x] Are your changes backwards compatible with previous SDK Versions?
- [x] Have you added unit test coverage for your changes?
- [x] Have you verified that your changes are compatible with all the operating system version this SDK currently supports?