### PR TITLE
[CHNL-20505] Plugin user-agent value appending

### DIFF
--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -35,8 +35,8 @@ public struct NetworkSession {
 
     public static let networkTimeout: UInt64 = 10_000_000_000 // in nanoseconds (10 seconds)
 
-    private static func getPluginConfiguration() -> (name: String, version: String)? {
-        guard let plistURL = Bundle.main.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist") else {
+    static func getPluginConfiguration(bundle: Bundle = .main) -> (name: String, version: String)? {
+        guard let plistURL = bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist") else {
             return nil
         }
 

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -35,40 +35,38 @@ public struct NetworkSession {
 
     public static let networkTimeout: UInt64 = 10_000_000_000 // in nanoseconds (10 seconds)
 
-    static func getPluginConfiguration(bundle: Bundle = .main) -> (name: String, version: String)? {
-        guard let plistURL = bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist") else {
+    private static func getPluginConfiguration(bundle: Bundle = .main) -> (name: String, version: String)? {
+        print(type(of: bundle))
+        print(bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist"))
+        guard let plistURL = bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist"),
+              let plistData = try? Data(contentsOf: plistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any]
+        else {
             return nil
         }
 
-        guard let plistData = try? Data(contentsOf: plistURL) else {
-            return nil
-        }
-
-        guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any] else {
-            return nil
-        }
-
-        guard let pluginName = plist["klaviyo_sdk_plugin_name_override"] as? String else {
-            return nil
-        }
-        guard let pluginVersion = plist["klaviyo_sdk_plugin_version_override"] as? String else {
+        guard let pluginName = plist["klaviyo_sdk_plugin_name_override"] as? String,
+              let pluginVersion = plist["klaviyo_sdk_plugin_version_override"] as? String
+        else {
             return nil
         }
 
         return (name: pluginName, version: pluginVersion)
     }
 
-    public static let defaultUserAgent = { () -> String in
+    public static var defaultUserAgent: String = defaultUserAgent(bundle: .main)
+
+    internal static func defaultUserAgent(bundle: Bundle) -> String {
         let appContext = environment.appContextInfo()
         let klaivyoSDKVersion = "klaviyo-\(environment.sdkName())/\(environment.sdkVersion())"
         var userAgent = "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
-        
-        if let pluginConfig = getPluginConfiguration() {
+        // checks if we're using a react native framework (ex. Expo) to assemble, and appending to user agent
+        if let pluginConfig = getPluginConfiguration(bundle: bundle) {
             userAgent += " (\(pluginConfig.name)/\(pluginConfig.version))"
         }
-        
+
         return userAgent
-    }()
+    }
 
     public static let production = { () -> NetworkSession in
         let session = createEmphemeralSession()

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -36,8 +36,6 @@ public struct NetworkSession {
     public static let networkTimeout: UInt64 = 10_000_000_000 // in nanoseconds (10 seconds)
 
     private static func getPluginConfiguration(bundle: Bundle = .main) -> (name: String, version: String)? {
-        print(type(of: bundle))
-        print(bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist"))
         guard let plistURL = bundle.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist"),
               let plistData = try? Data(contentsOf: plistURL),
               let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any]

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -35,10 +35,48 @@ public struct NetworkSession {
 
     public static let networkTimeout: UInt64 = 10_000_000_000 // in nanoseconds (10 seconds)
 
+    private static func getPluginConfiguration() -> (name: String, version: String)? {
+        guard let plistURL = Bundle.main.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist") else {
+            print("❌ [Klaviyo] klaviyo-plugin-configuration.plist not found in bundle")
+            return nil
+        }
+        print("✅ [Klaviyo] Found klaviyo-plugin-configuration.plist at \(plistURL)")
+
+        guard let plistData = try? Data(contentsOf: plistURL) else {
+            print("❌ [Klaviyo] Could not read data from plist")
+            return nil
+        }
+
+        guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any] else {
+            print("❌ [Klaviyo] Could not deserialize plist data")
+            return nil
+        }
+
+        print("✅ [Klaviyo] Plist contents: \(plist)")
+
+        guard let pluginName = plist["klaviyo_sdk_plugin_name_override"] as? String else {
+            print("❌ [Klaviyo] klaviyo_sdk_plugin_name_override not found in plist")
+            return nil
+        }
+        guard let pluginVersion = plist["klaviyo_sdk_plugin_version_override"] as? String else {
+            print("❌ [Klaviyo] klaviyo_sdk_plugin_version_override not found in plist")
+            return nil
+        }
+
+        print("✅ [Klaviyo] Plugin name: \(pluginName), version: \(pluginVersion)")
+        return (name: pluginName, version: pluginVersion)
+    }
+
     public static let defaultUserAgent = { () -> String in
         let appContext = environment.appContextInfo()
         let klaivyoSDKVersion = "klaviyo-\(environment.sdkName())/\(environment.sdkVersion())"
-        return "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
+        var userAgent = "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
+        
+        if let pluginConfig = getPluginConfiguration() {
+            userAgent += " (\(pluginConfig.name)/\(pluginConfig.version))"
+        }
+        
+        return userAgent
     }()
 
     public static let production = { () -> NetworkSession in

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -37,33 +37,24 @@ public struct NetworkSession {
 
     private static func getPluginConfiguration() -> (name: String, version: String)? {
         guard let plistURL = Bundle.main.url(forResource: "klaviyo-plugin-configuration", withExtension: "plist") else {
-            print("❌ [Klaviyo] klaviyo-plugin-configuration.plist not found in bundle")
             return nil
         }
-        print("✅ [Klaviyo] Found klaviyo-plugin-configuration.plist at \(plistURL)")
 
         guard let plistData = try? Data(contentsOf: plistURL) else {
-            print("❌ [Klaviyo] Could not read data from plist")
             return nil
         }
 
         guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any] else {
-            print("❌ [Klaviyo] Could not deserialize plist data")
             return nil
         }
 
-        print("✅ [Klaviyo] Plist contents: \(plist)")
-
         guard let pluginName = plist["klaviyo_sdk_plugin_name_override"] as? String else {
-            print("❌ [Klaviyo] klaviyo_sdk_plugin_name_override not found in plist")
             return nil
         }
         guard let pluginVersion = plist["klaviyo_sdk_plugin_version_override"] as? String else {
-            print("❌ [Klaviyo] klaviyo_sdk_plugin_version_override not found in plist")
             return nil
         }
 
-        print("✅ [Klaviyo] Plugin name: \(pluginName), version: \(pluginVersion)")
         return (name: pluginName, version: pluginVersion)
     }
 

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -52,7 +52,6 @@ class NetworkSessionTests: XCTestCase {
                 options: 0
             )
             try plistData.write(to: plistURL)
-            print(plistURL)
             // Create a mock bundle that returns our temporary plist
             let mockBundle = MockBundle(plistURL: plistURL)
 

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 11/18/22.
 //
 
-import KlaviyoCore
+@testable import KlaviyoCore
 import SnapshotTesting
 import XCTest
 
@@ -31,5 +31,97 @@ class NetworkSessionTests: XCTestCase {
 
         assertSnapshot(matching: data, as: .dump)
         assertSnapshot(matching: response, as: .dump)
+    }
+
+    func testGetPluginConfigurationWithValidPlist() {
+        // Create a temporary plist file
+        let tempDir = FileManager.default.temporaryDirectory
+        let plistURL = tempDir.appendingPathComponent("klaviyo-plugin-configuration.plist")
+        
+        // Create plist content
+        let plistContent: [String: Any] = [
+            "klaviyo_sdk_plugin_name_override": "test-plugin",
+            "klaviyo_sdk_plugin_version_override": "1.0.0"
+        ]
+        
+        do {
+            // Write plist to temporary location
+            let plistData = try PropertyListSerialization.data(
+                fromPropertyList: plistContent,
+                format: .xml,
+                options: 0
+            )
+            try plistData.write(to: plistURL)
+            
+            // Create a mock bundle that returns our temporary plist
+            let mockBundle = MockBundle(plistURL: plistURL)
+            
+            // Call the function with our mock bundle
+            let result = NetworkSession.getPluginConfiguration(bundle: mockBundle)
+            
+            // Verify the result
+            XCTAssertNotNil(result)
+            XCTAssertEqual(result?.name, "test-plugin")
+            XCTAssertEqual(result?.version, "1.0.0")
+            
+            // Clean up
+            try FileManager.default.removeItem(at: plistURL)
+        } catch {
+            XCTFail("Failed to create test plist: \(error)")
+        }
+    }
+    
+    func testGetPluginConfigurationWithMissingPlist() {
+        // Create a mock bundle that returns nil for the plist URL
+        let mockBundle = MockBundle(plistURL: nil)
+        
+        // Call the function with our mock bundle
+        let result = NetworkSession.getPluginConfiguration(bundle: mockBundle)
+        
+        // Verify the result is nil
+        XCTAssertNil(result)
+    }
+    
+    func testGetPluginConfigurationWithInvalidPlist() {
+        // Create a temporary plist file with invalid content
+        let tempDir = FileManager.default.temporaryDirectory
+        let plistURL = tempDir.appendingPathComponent("klaviyo-plugin-configuration.plist")
+        
+        do {
+            // Write invalid data to the plist
+            let invalidData = "invalid plist data".data(using: .utf8)!
+            try invalidData.write(to: plistURL)
+            
+            // Create a mock bundle that returns our temporary plist
+            let mockBundle = MockBundle(plistURL: plistURL)
+            
+            // Call the function with our mock bundle
+            let result = NetworkSession.getPluginConfiguration(bundle: mockBundle)
+            
+            // Verify the result is nil
+            XCTAssertNil(result)
+            
+            // Clean up
+            try FileManager.default.removeItem(at: plistURL)
+        } catch {
+            XCTFail("Failed to create test plist: \(error)")
+        }
+    }
+}
+
+// Mock Bundle class for testing
+private class MockBundle: Bundle {
+    private let mockPlistURL: URL?
+    
+    init(plistURL: URL?) {
+        self.mockPlistURL = plistURL
+        super.init()
+    }
+    
+    override func url(forResource name: String?, withExtension ext: String?) -> URL? {
+        if name == "klaviyo-plugin-configuration" && ext == "plist" {
+            return mockPlistURL
+        }
+        return nil
     }
 }


### PR DESCRIPTION
# Description
We want more visibility into when customers are using the react native SDK in a traditional workflow, or using a framework like expo. This logic checks for the added plist ([which we add to the built ios project with this ticket](https://github.com/klaviyo/klaviyo-expo-plugin/pull/8)) and appends it to the user agent if it's included in the app bundle. 

Definitely have a low confidence level in swift so please feel free to rip this apart - I also took a shot at a unit test for validation.

Here is a screenshot from local setup to show it appending:
![image](https://github.com/user-attachments/assets/1b68255c-cad3-479c-aaa3-f55cb74774ea)
`User-Agent: klaviyopluginexample/1.0.0 (com.klaviyo.expoexample; build:1; iOS 18.1.0) klaviyo-react_native/1.2.0 (klaviyo-expo/0.0.2)`

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
this is a pain to setup but if you'd like to test locally:
- checkout both this branch and the expo plugin version linked above
- link expo example app the local react native SDK and validate it runs ([instructions on this in the expo pr](https://github.com/klaviyo/klaviyo-expo-plugin/pull/7))
- link local swift SDK to the react native SDK 
- from the expo example directory, run 'npm run clean-ios' and stop it after it get's to the 'installing pods' step. You should now see an 'ios' folder under the example directory
- then, in the Podfile of that directory add the following code change:
```
# Local Swift SDK dependencies
pod 'KlaviyoSwift', :path => '/Users/daniel.peluso/Klaviyo/Repos/klaviyo-swift-sdk'
pod 'KlaviyoForms', :path => '/Users/daniel.peluso/Klaviyo/Repos/klaviyo-swift-sdk'
pod 'KlaviyoCore', :path => '/Users/daniel.peluso/Klaviyo/Repos/klaviyo-swift-sdk'
```
it should now look like this:
![image](https://github.com/user-attachments/assets/5350a525-ea7b-4111-8946-c6ed3fd92021)
- run `pod install` from the example/ios folder
- run `npx expo start` from the `example` dir and then type 's' to move away from an expo go build (should say development build). This needs to be running in a terminal or else you will get a white screen on the app.
- run `expo run:ios` from the example folder. *do not* run 'npm run clean-ios' or you will delete your ios folder entirely, which will wipe your podfile changes.

Sorry running this locally is a pain in the ass, I do think it's important for testing though so please reach out if you'd like some assistance.

Then you can either run the expo ios example app by opening the xcworkspace and running from xcode, or by running

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-20505