### PR TITLE
Remove analyticsEvent from handshake

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -118,7 +118,6 @@ extension IAFNativeBridgeEvent {
             .trackAggregateEvent(Data()),
             .openDeepLink(URL(string: "https://example.com")!),
             .abort(""),
-            .analyticsEvent,
             .lifecycleEvent
         ]
     }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1},{"type":"analyticsEvent","version":1},{"type":"lifecycleEvent","version":1}]
+        [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -112,7 +112,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1},{"type":"analyticsEvent","version":1},{"type":"lifecycleEvent","version":1}]
+            [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)


### PR DESCRIPTION
# Description
Removing since it is not really supported yet. Keeping the scaffolding in though as it is coming. Updated unit tests.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
Removed `analyticsEvent` from handshake with JS.

## Test Plan
Ran unit tests checking expected handshake events

## Related Issues/Tickets
https://klaviyo.slack.com/archives/C08GN96SF1B/p1747665584208909?thread_ts=1747663887.299139&cid=C08GN96SF1B
