### PR TITLE
Add unregisterFromInAppForms

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -52,6 +52,18 @@ class IAFPresentationManager {
         }
     }
 
+    func destroyWebviewAndListeners() {
+        destroyWebView()
+        isLoading = false
+        UserDefaults.standard.removeObject(forKey: "lastBackgrounded")
+        lifecycleCancellable?.cancel()
+        lifecycleCancellable = nil
+        apiKeyCancellable?.cancel()
+        apiKeyCancellable = nil
+        formEventTask?.cancel()
+        formEventTask = nil
+    }
+
     func setupLifecycleEvents(configuration: IAFConfiguration) {
         lifecycleCancellable = environment.appLifeCycle.lifeCycleEvents()
             .sink { [weak self] event in

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -52,18 +52,6 @@ class IAFPresentationManager {
         }
     }
 
-    func destroyWebviewAndListeners() {
-        destroyWebView()
-        isLoading = false
-        UserDefaults.standard.removeObject(forKey: "lastBackgrounded")
-        lifecycleCancellable?.cancel()
-        lifecycleCancellable = nil
-        apiKeyCancellable?.cancel()
-        apiKeyCancellable = nil
-        formEventTask?.cancel()
-        formEventTask = nil
-    }
-
     func setupLifecycleEvents(configuration: IAFConfiguration) {
         lifecycleCancellable = environment.appLifeCycle.lifeCycleEvents()
             .sink { [weak self] event in
@@ -219,6 +207,21 @@ class IAFPresentationManager {
         viewController.dismiss(animated: false) { [weak self] in
             self?.viewController = nil
         }
+    }
+
+    func destroyWebviewAndListeners() {
+        if #available(iOS 14.0, *) {
+            Logger.webViewLogger.info("UnregisterFromInAppForms; destroying webview and listeners")
+        }
+        isLoading = false
+        UserDefaults.standard.removeObject(forKey: "lastBackgrounded")
+        lifecycleCancellable?.cancel()
+        apiKeyCancellable?.cancel()
+        formEventTask?.cancel()
+        lifecycleCancellable = nil
+        apiKeyCancellable = nil
+        formEventTask = nil
+        destroyWebView()
     }
 }
 

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -20,6 +20,15 @@ extension KlaviyoSDK {
     }
 
     @MainActor
+    public func unregisterFromInAppForms() {
+        Task {
+            await MainActor.run {
+                IAFPresentationManager.shared.destroyWebviewAndListeners()
+            }
+        }
+    }
+
+    @MainActor
     @_spi(KlaviyoPrivate)
     @available(*, deprecated, message: "This function is for internal use only, and should not be used in production applications")
     public func registerForInAppForms(configuration: IAFConfiguration = IAFConfiguration(), assetSource: String) {

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -9,6 +9,14 @@ import Foundation
 import KlaviyoSwift
 
 extension KlaviyoSDK {
+    /// Registers app to receive and display in-app forms from Klaviyo.
+    ///
+    /// This method sets up the necessary lifecycle event handlers and constructs the web view
+    /// that will be used to display in-app forms. The forms will be displayed based on your
+    /// Klaviyo form display settings.
+    ///
+    /// - Parameter configuration: Configuration options for in-app forms, including session timeout duration.
+    ///   Defaults to a 1-hour session timeout.
     @MainActor
     public func registerForInAppForms(configuration: IAFConfiguration = IAFConfiguration()) {
         Task {
@@ -19,6 +27,7 @@ extension KlaviyoSDK {
         }
     }
 
+    /// Unregisters app from receiving in-app forms and cleans up resources associated with in-app forms (e.g. web view resources, subscriptions, state)
     @MainActor
     public func unregisterFromInAppForms() {
         Task {
@@ -28,6 +37,16 @@ extension KlaviyoSDK {
         }
     }
 
+    /// Registers app to receive and display in-app forms from Klaviyo with a custom asset source.
+    ///
+    /// This method is for internal use only and should not be used in production applications.
+    /// It provides the same functionality as ``registerForInAppForms(configuration:)`` but allows
+    /// specifying a custom asset source for testing purposes.
+    ///
+    /// - Parameters:
+    ///   - configuration: Configuration options for in-app forms, including session timeout duration.
+    ///     Defaults to a 1-hour session timeout.
+    ///   - assetSource: A custom source URL for the form assets.
     @MainActor
     @_spi(KlaviyoPrivate)
     @available(*, deprecated, message: "This function is for internal use only, and should not be used in production applications")


### PR DESCRIPTION
# Description
Kills webview, removes listeners, resets state + added tests

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Adds `unregisterFromInAppForms` method

## Test Plan
- [ ] Open the test app and trigger registerForInAppForms
- [ ] Observe form appears/lifecycle listeners begin listening and printing events with backgrounding/foregrounding. You can use the Safari developer window to confirm the webview being alive
- [ ] Trigger unregisterForInAppForms and observe the Safari developer window closes as there is no more webview. Observe backgrounding/foregrounding produces no logs of injected events


https://github.com/user-attachments/assets/d4bb6159-c92f-4a4b-bc42-c26edf41492e

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-19954
