### PR TITLE
Dismiss should not cancel formEventTask

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -99,7 +99,6 @@ class IAFPresentationManager {
             presentForm()
         case .dismiss:
             dismissForm()
-            formEventTask?.cancel()
         case .abort:
             formEventTask?.cancel()
         }


### PR DESCRIPTION
# Description
While testing [this](https://klaviyo.atlassian.net/browse/CHNL-21071) -- realized if we receive multiple formWillAppear messages and at any point we dismiss it, the sustaining web view will not present it because `dismiss` cancels the formEventTask. This is part of the webview-should-not-be-fully-destroyed-when-dismissed work but got left out


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Remove canceling the formEventTask on dismiss

## Test Plan

We are able to trigger forms in the same webview after dismissing in the Safari Developer console via:
```
window._klOnsite = window._klOnsite || [];
window._klOnsite.push(['openForm', 'SOME_FORM_ID]);
```

https://github.com/user-attachments/assets/cd917bae-2fcd-4f74-9395-9338d31989b5



## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
