### PR TITLE
Enable toggling web/in-app data env

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -40,7 +40,8 @@ public struct KlaviyoEnvironment {
         klaviyoAPI: KlaviyoAPI,
         timer: @escaping (Double) -> AnyPublisher<Date, Never>,
         SDKName: @escaping () -> String,
-        SDKVersion: @escaping () -> String
+        SDKVersion: @escaping () -> String,
+        formsDataEnvironment: @escaping () -> String
     ) {
         self.archiverClient = archiverClient
         self.fileClient = fileClient
@@ -70,6 +71,7 @@ public struct KlaviyoEnvironment {
         self.timer = timer
         sdkName = SDKName
         sdkVersion = SDKVersion
+        self.formsDataEnvironment = formsDataEnvironment
     }
 
     static let productionHost: URLComponents = {
@@ -133,6 +135,7 @@ public struct KlaviyoEnvironment {
     public var appContextInfo: () -> AppContextInfo
     public var klaviyoAPI: KlaviyoAPI
     public var timer: (Double) -> AnyPublisher<Date, Never>
+    public var formsDataEnvironment: () -> String
 
     public var sdkName: () -> String
     public var sdkVersion: () -> String
@@ -224,7 +227,8 @@ public struct KlaviyoEnvironment {
                 .eraseToAnyPublisher()
         },
         SDKName: KlaviyoEnvironment.getSDKName,
-        SDKVersion: KlaviyoEnvironment.getSDKVersion
+        SDKVersion: KlaviyoEnvironment.getSDKVersion,
+        formsDataEnvironment: { "in-app" }
     )
 }
 

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -41,7 +41,7 @@ public struct KlaviyoEnvironment {
         timer: @escaping (Double) -> AnyPublisher<Date, Never>,
         SDKName: @escaping () -> String,
         SDKVersion: @escaping () -> String,
-        formsDataEnvironment: @escaping () -> String
+        formsDataEnvironment: @escaping () -> String?
     ) {
         self.archiverClient = archiverClient
         self.fileClient = fileClient
@@ -135,7 +135,7 @@ public struct KlaviyoEnvironment {
     public var appContextInfo: () -> AppContextInfo
     public var klaviyoAPI: KlaviyoAPI
     public var timer: (Double) -> AnyPublisher<Date, Never>
-    public var formsDataEnvironment: () -> String
+    public var formsDataEnvironment: () -> String?
 
     public var sdkName: () -> String
     public var sdkVersion: () -> String
@@ -228,7 +228,7 @@ public struct KlaviyoEnvironment {
         },
         SDKName: KlaviyoEnvironment.getSDKName,
         SDKVersion: KlaviyoEnvironment.getSDKVersion,
-        formsDataEnvironment: { "in-app" }
+        formsDataEnvironment: { nil }
     )
 }
 

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -41,7 +41,7 @@ public struct KlaviyoEnvironment {
         timer: @escaping (Double) -> AnyPublisher<Date, Never>,
         SDKName: @escaping () -> String,
         SDKVersion: @escaping () -> String,
-        formsDataEnvironment: @escaping () -> String?
+        formsDataEnvironment: @escaping () -> FormEnvironment?
     ) {
         self.archiverClient = archiverClient
         self.fileClient = fileClient
@@ -135,7 +135,7 @@ public struct KlaviyoEnvironment {
     public var appContextInfo: () -> AppContextInfo
     public var klaviyoAPI: KlaviyoAPI
     public var timer: (Double) -> AnyPublisher<Date, Never>
-    public var formsDataEnvironment: () -> String?
+    public var formsDataEnvironment: () -> FormEnvironment?
 
     public var sdkName: () -> String
     public var sdkVersion: () -> String
@@ -242,6 +242,11 @@ public func createNetworkSession() -> NetworkSession {
 
 public enum KlaviyoDecodingError: Error {
     case invalidType
+}
+
+public enum FormEnvironment: String, Equatable, Codable, CaseIterable {
+    case inApp = "in-app"
+    case web
 }
 
 public struct DataDecoder {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -109,8 +109,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         loadScripts?.insert(sdkNameWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
-        guard let dataEnvironmentWKScript else { return }
-        loadScripts?.insert(dataEnvironmentWKScript)
+        if let dataEnvironmentWKScript { 
+            loadScripts?.insert(dataEnvironmentWKScript)
+        }
     }
 
     // MARK: - Loading

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -74,6 +74,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     }
 
     @MainActor
+    private var dataEnvironmentWKScript: WKUserScript {
+        var environment = environment.formsDataEnvironment()
+        let sdkVersionScript = "document.head.setAttribute('data-forms-data-environment', '\(environment)');"
+        return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
+    @MainActor
     private var handshakeWKScript: WKUserScript {
         let handshakeStringified = IAFNativeBridgeEvent.handshake
         let handshakeScript = "document.head.setAttribute('data-native-bridge-handshake', '\(handshakeStringified)');"
@@ -100,6 +107,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         guard let klaviyoJsWKScript else { return }
         loadScripts?.insert(klaviyoJsWKScript)
         loadScripts?.insert(sdkNameWKScript)
+        loadScripts?.insert(dataEnvironmentWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -74,10 +74,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     }
 
     @MainActor
-    private var dataEnvironmentWKScript: WKUserScript {
-        guard let formsEnv = environment.formsDataEnvironment() else {
-            return WKUserScript(source: "", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-        }
+    private var dataEnvironmentWKScript: WKUserScript? {
+        guard let formsEnv = environment.formsDataEnvironment() else { return nil }
         let sdkVersionScript = "document.head.setAttribute('data-forms-data-environment', '\(formsEnv)');"
         return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
@@ -109,9 +107,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         guard let klaviyoJsWKScript else { return }
         loadScripts?.insert(klaviyoJsWKScript)
         loadScripts?.insert(sdkNameWKScript)
-        loadScripts?.insert(dataEnvironmentWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
+        guard let dataEnvironmentWKScript else { return }
+        loadScripts?.insert(dataEnvironmentWKScript)
     }
 
     // MARK: - Loading

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -75,8 +75,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     @MainActor
     private var dataEnvironmentWKScript: WKUserScript {
-        var environment = environment.formsDataEnvironment()
-        let sdkVersionScript = "document.head.setAttribute('data-forms-data-environment', '\(environment)');"
+        guard let formsEnv = environment.formsDataEnvironment() else {
+            return WKUserScript(source: "", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+        }
+        let sdkVersionScript = "document.head.setAttribute('data-forms-data-environment', '\(formsEnv)');"
         return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -75,7 +75,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     @MainActor
     private var dataEnvironmentWKScript: WKUserScript? {
-        guard let formsEnv = environment.formsDataEnvironment() else { return nil }
+        guard let formsEnv = environment.formsDataEnvironment()?.rawValue else { return nil }
         let sdkVersionScript = "document.head.setAttribute('data-forms-data-environment', '\(formsEnv)');"
         return WKUserScript(source: sdkVersionScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
@@ -109,7 +109,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         loadScripts?.insert(sdkNameWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
-        if let dataEnvironmentWKScript { 
+        if let dataEnvironmentWKScript {
             loadScripts?.insert(dataEnvironmentWKScript)
         }
     }

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -106,7 +106,8 @@ extension KlaviyoEnvironment {
             klaviyoAPI: KlaviyoAPI.test(),
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
-            SDKVersion: { __klaviyoSwiftVersion }
+            SDKVersion: { __klaviyoSwiftVersion },
+            formsDataEnvironment: { nil }
         )
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -89,6 +89,45 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertEqual(resultString, "0.0.1")
     }
 
+    func testInjectFormsDataEnvironmentAttribute() async throws {
+        // This test has been flaky when running on CI. It seems to have something to do with instability when
+        // running a WKWebView in a CI test environment. Until we find a fix for this, we'll skip running this test on CI.
+        let isRunningOnCI = Bool(ProcessInfo.processInfo.environment["GITHUB_CI"] ?? "false") ?? false
+        try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
+
+        // Given
+        try await viewModel.establishHandshake(timeout: 3.0)
+
+        // When
+        let script = "document.head.getAttribute('data-forms-data-environment');"
+        let delegate = try XCTUnwrap(viewModel.delegate)
+        let result = try await delegate.evaluateJavaScript(script)
+        let resultString = try XCTUnwrap(result as? String)
+
+        // Then
+        XCTAssertNil(resultString)
+    }
+
+    func testInjectFormsDataEnvironmentSetToWeb() async throws {
+        // This test has been flaky when running on CI. It seems to have something to do with instability when
+        // running a WKWebView in a CI test environment. Until we find a fix for this, we'll skip running this test on CI.
+        let isRunningOnCI = Bool(ProcessInfo.processInfo.environment["GITHUB_CI"] ?? "false") ?? false
+        try XCTSkipIf(isRunningOnCI, "Skipping test in Github CI environment")
+
+        // Given
+        environment.formsDataEnvironment = { "web" }
+        try await viewModel.establishHandshake(timeout: 3.0)
+
+        // When
+        let script = "document.head.getAttribute('data-forms-data-environment');"
+        let delegate = try XCTUnwrap(viewModel.delegate)
+        let result = try await delegate.evaluateJavaScript(script)
+        let resultString = try XCTUnwrap(result as? String)
+
+        // Then
+        XCTAssertEqual(resultString, "web")
+    }
+
     func testInjectHandshakeAttribute() async throws {
         // This test has been flaky when running on CI. It seems to have something to do with instability when
         // running a WKWebView in a CI test environment. Until we find a fix for this, we'll skip running this test on CI.

--- a/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
@@ -107,7 +107,8 @@ extension KlaviyoEnvironment {
             klaviyoAPI: KlaviyoAPI.test(),
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
-            SDKVersion: { __klaviyoSwiftVersion }
+            SDKVersion: { __klaviyoSwiftVersion },
+            formsDataEnvironment: { nil }
         )
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -55,7 +55,8 @@ extension KlaviyoEnvironment {
             klaviyoAPI: KlaviyoAPI.test(),
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
-            SDKVersion: { __klaviyoSwiftVersion }
+            SDKVersion: { __klaviyoSwiftVersion },
+            formsDataEnvironment: { nil }
         )
     }
 }


### PR DESCRIPTION
# Description
Enables us to inject a `data-forms-data-environment` attribute that is either set to `in-app` explicitly or `web`. By default, if we do not inject it we will load the in-app forms data. This is toggle-able in the test app updated [here](https://github.com/klaviyo/klaviyo-ios-test-app/pull/78). In production we are defaulting this value to nil so it is never injected as we only care about in-app forms right now.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Added `formsDataEnvironment` on the `KlaviyoEnvironment` that when populated will inject a `data-forms-data-environment` attribute to target different forms data.


## Test Plan
By default, no `data-forms-data-environment` is injected. In-app forms appear when triggered.

When explicitly set (via toggled) to web, `data-forms-data-environment = web` is injected. Web forms appear when triggered.

When explicitly set (via toggled) to in-app, `data-forms-data-environment = in-app` is injected. In-app forms appear when triggered.

https://github.com/user-attachments/assets/a4771f4c-f29e-40a1-9cb9-02a6b049cb81



## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-20018
