### PR TITLE
Prevent double calls to constructWebview

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -54,6 +54,13 @@ class IAFPresentationManager {
             return
         }
 
+        guard viewController == nil else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.log("Webview is already set up; ignoring request.")
+            }
+            return
+        }
+
         guard let fileUrl = indexHtmlFileUrl else { return }
 
         isLoading = true


### PR DESCRIPTION
# Description
Prevent `registerForInAppForms` from creating a new webview if there is already one active


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Add a guard check that there is not already an active viewController when `registerForInAppForms` is called

## Test Plan

https://github.com/user-attachments/assets/925e4468-0381-476a-8ec4-92ddc240e806



## Related Issues/Tickets
Slack discussion [here](https://klaviyo.slack.com/archives/C08GN96SF1B/p1748638808354229)