### PR TITLE
Remove session from lifecycleEvent

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
@@ -5,12 +5,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover">
             <title>Klaviyo In-App Form Template</title>
             <script type="text/javascript">
-                window.dispatchLifecycleEvent = function(type, session) {
-                    console.log('Dispatching lifecycle event:', { type, session });
+                window.dispatchLifecycleEvent = function(type) {
+                    console.log('Dispatching lifecycle event:', type);
                     document.head.dispatchEvent(new CustomEvent('lifecycleEvent', {
                         detail: {
-                            type: type,
-                            session: session
+                            type: type
                         }
                     }));
                 };

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
@@ -83,12 +83,12 @@ final class IAFPresentationManagerTests: XCTestCase {
         }
 
         // When
-        try await presentationManager.handleLifecycleEvent("test", "test")
+        try await presentationManager.handleLifecycleEvent("test")
 
         // Then
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('test', 'test')")
+            script.contains("dispatchLifecycleEvent('test')")
         })
     }
 
@@ -113,7 +113,7 @@ final class IAFPresentationManagerTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('background', 'persist')")
+            script.contains("dispatchLifecycleEvent('background')")
         })
     }
 
@@ -155,7 +155,7 @@ final class IAFPresentationManagerTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('foreground', 'restore')")
+            script.contains("dispatchLifecycleEvent('foreground')")
         })
     }
 
@@ -198,7 +198,7 @@ final class IAFPresentationManagerTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('foreground', 'purge')")
+            script.contains("dispatchLifecycleEvent('foreground')")
         })
     }
 
@@ -237,7 +237,7 @@ final class IAFPresentationManagerTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 3.0)
         XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('foreground', 'restore')")
+            script.contains("dispatchLifecycleEvent('foreground')")
         })
     }
 
@@ -253,34 +253,6 @@ final class IAFPresentationManagerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mockManager.constructWebviewCalled, "constructWebview should be called when foregrounding in new session")
-    }
-
-    @MainActor
-    func testSubsequentApiKeyChangesPurgeEventInjected() async throws {
-        // Given
-        let expectation = XCTestExpectation(description: "Lifecycle event script is injected")
-        presentationManager.setupLifecycleEvents(configuration: IAFConfiguration())
-
-        var evaluatedScripts: [String] = []
-        mockViewController.evaluateJavaScriptCallback = { script in
-            evaluatedScripts.append(script)
-            if script.contains("dispatchLifecycleEvent") && script.contains("purge") {
-                expectation.fulfill()
-            }
-            return true
-        }
-
-        // When
-        // First send initializes the API key
-        mockApiKeyPublisher.send("ABC123")
-        try await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-        mockApiKeyPublisher.send("ABC321")
-
-        // Then
-        await fulfillment(of: [expectation], timeout: 1.0)
-        XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("dispatchLifecycleEvent('foreground', 'purge')")
-        })
     }
 
     @MainActor

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -102,7 +102,7 @@ final class IAFWebViewModelTests: XCTestCase {
         let script = "document.head.getAttribute('data-forms-data-environment');"
         let delegate = try XCTUnwrap(viewModel.delegate)
         let result = try await delegate.evaluateJavaScript(script)
-        let resultString = try XCTUnwrap(result as? String)
+        let resultString = result as? String
 
         // Then
         XCTAssertNil(resultString)
@@ -196,7 +196,7 @@ final class IAFWebViewModelTests: XCTestCase {
                 document.head.addEventListener('lifecycleEvent', function(e) {
                     eventDetails = e.detail;
                 });
-                window.dispatchLifecycleEvent('foreground', 'purge');
+                window.dispatchLifecycleEvent('foreground');
                 return eventDetails;
             })();
         """
@@ -206,6 +206,5 @@ final class IAFWebViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(resultDict["type"] as? String, "foreground", "Event type should be 'foreground'")
-        XCTAssertEqual(resultDict["session"] as? String, "purge", "Session should be 'purge'")
     }
 }


### PR DESCRIPTION
# Description
- Removes `session` field from `lifeCycleEvent`
- Removes injection of event when company ID is changed
- Updated tests

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Removes `session` field from `lifeCycleEvent` and removes injection of event when company ID is changed.


## Test Plan
Events now look like this in the console:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/aa4bb3cc-5e5b-42e2-b640-c00b35753901" />



## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-21197
