### PR TITLE
Check viewController for unofficial backgrounding events

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -117,11 +117,14 @@ class IAFPresentationManager {
                                 try await self.createFormAndAwaitFormEvents(apiKey: apiKey)
                             }
                         } else {
-                            // launching
                             try await self.handleLifecycleEvent("foreground")
-
-                            let apiKey = try await KlaviyoInternal.fetchAPIKey()
-                            try await self.createFormAndAwaitFormEvents(apiKey: apiKey)
+                            // to prevent case when app is reforegrounded from opening the notification/control center
+                            // no backgrounded lifecycle event is dispatched in that case, only foregrounded event
+                            if self.viewController == nil {
+                                // fresh launch
+                                let apiKey = try await KlaviyoInternal.fetchAPIKey()
+                                try await self.createFormAndAwaitFormEvents(apiKey: apiKey)
+                            }
                         }
                     case .backgrounded:
                         self.lastBackgrounded = Date()


### PR DESCRIPTION
# Description
When we pull down on the notification/control center or slightly slide up on the home bar (not fully backgrounding the app) -- we do not receive a backgrounded lifecycle event. We do however, upon closing the notification/control center or releasing the home bar so we return to the app, receive a foregrounded lifecycle event. We only receive a backgrounded lifecycle event when we actually fully background the app.

This was causing an issue where since we did not have any previous backgrounded time stamp for these cases, the resuming foregrounded event would be treated as a fresh launch and create a new webview. This change checks if there is already a viewController making the conditions for launching a new webview more strict and accurate. It also means we are definitely not considering opening the notification/control center as a backgrounding event (a previous assumption)

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Adds a check if a viewController already exists or not to account for unofficial backgrounding events like opening the notification/control center.

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
Addresses bugs reported [here](https://klaviyo.enterprise.slack.com/lists/T029KGL8E/F090YAV31JT?record_id=Rec091EQ1NC3W) and [here](https://klaviyo.enterprise.slack.com/lists/T029KGL8E/F090YAV31JT?record_id=Rec091CKG9LJH)

https://klaviyo.atlassian.net/browse/CHNL-22084
