### PR TITLE
[CHNL-22083] address duplicate webviews

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -225,7 +225,7 @@ class IAFPresentationManager {
 
     func handleLifecycleEvent(_ event: String) async throws {
         if #available(iOS 14.0, *) {
-            Logger.webViewLogger.info("Attempting to dispatch '\(event)' lifecycle event via Klaviyo.JS")
+            Logger.webViewLogger.info("Attempting to dispatch '\(event, privacy: .public)' lifecycle event via Klaviyo.JS")
         }
 
         do {
@@ -241,6 +241,9 @@ class IAFPresentationManager {
     }
 
     private func handleFormEvent(_ event: IAFLifecycleEvent) {
+        if #available(iOS 14.0, *) {
+            Logger.webViewLogger.info("Handling '\(event.rawValue, privacy: .public)' form lifecycle event")
+        }
         switch event {
         case .present:
             presentForm()

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -313,7 +313,6 @@ class IAFPresentationManager {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
             }
-            destroyWebView()
         } else {
             topController.present(viewController, animated: false, completion: nil)
         }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -263,7 +263,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
         case let .abort(reason):
             if #available(iOS 14.0, *) {
-                Logger.webViewLogger.info("Aborting webview: \(reason)")
+                Logger.webViewLogger.info("Aborting webview: \(reason, privacy: .public)")
             }
             formLifecycleContinuation.yield(.abort)
         case .handShook:


### PR DESCRIPTION
# Description
This PR removes a `destroyWebView()` call if `presentForm()` is called when a form is already presented. It resolves a bug identified here: [CHNL-22083](https://klaviyo.atlassian.net/browse/CHNL-22083?isEligibleForUserSurvey=true).


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
