### PR TITLE
fixed profile data keys

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileData.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileData.swift
@@ -28,6 +28,8 @@ extension ProfileData: Encodable {
     package func toHtmlString() throws -> String {
         do {
             let encoder = JSONEncoder()
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+
             let jsonData = try encoder.encode(self)
             let jsonString = String(data: jsonData, encoding: .utf8)
             return jsonString ?? ""

--- a/Tests/KlaviyoSwiftTests/ProfileDataTests.swift
+++ b/Tests/KlaviyoSwiftTests/ProfileDataTests.swift
@@ -14,9 +14,9 @@ final class ProfileDataTests: XCTestCase {
 
         XCTAssertFalse(htmlString.isEmpty)
         XCTAssertTrue(htmlString.contains("\"email\":\"test@example.com\""))
-        XCTAssertTrue(htmlString.contains("\"anonymousId\":\"anon-123\""))
-        XCTAssertTrue(htmlString.contains("\"phoneNumber\":\"+1234567890\""))
-        XCTAssertTrue(htmlString.contains("\"externalId\":\"ext-456\""))
+        XCTAssertTrue(htmlString.contains("\"anonymous_id\":\"anon-123\""))
+        XCTAssertTrue(htmlString.contains("\"phone_number\":\"+1234567890\""))
+        XCTAssertTrue(htmlString.contains("\"external_id\":\"ext-456\""))
     }
 
     func testToHtmlStringWithEmptyData() throws {


### PR DESCRIPTION
# Description
When encoding the profile data to an HTML string to inject into the web view, we had been using camelCase for the keys, when we should have been using snake_case. This PR fixes that issue.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
