### PR TITLE
[CHNL-23448] allow endpoint-specific max retries

### DIFF
--- a/Sources/KlaviyoCore/Models/RequestAttemptInfo.swift
+++ b/Sources/KlaviyoCore/Models/RequestAttemptInfo.swift
@@ -1,0 +1,23 @@
+//
+//  RequestAttemptInfo.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 7/23/25.
+//
+
+/// Represents the retry metadata for a single network request attempt.
+public struct RequestAttemptInfo: Equatable {
+    /// The ordinal number of the current attempt (starts at `1`).
+    public let attemptNumber: Int
+
+    /// The maximum number of attempts allowed for the request.
+    public let maxAttempts: Int
+
+    /// - Parameters:
+    ///   - attemptNumber: The current attempt count (must be `>= 1`).
+    ///   - maxAttempts: The maximum attempts permitted (must be `>= attemptNumber`).
+    public init(attemptNumber: Int, maxAttempts: Int) {
+        self.attemptNumber = attemptNumber
+        self.maxAttempts = maxAttempts
+    }
+}

--- a/Sources/KlaviyoCore/Models/RequestAttemptInfo.swift
+++ b/Sources/KlaviyoCore/Models/RequestAttemptInfo.swift
@@ -13,10 +13,20 @@ public struct RequestAttemptInfo: Equatable {
     /// The maximum number of attempts allowed for the request.
     public let maxAttempts: Int
 
+    /// Error cases thrown by ``RequestAttemptInfo``'s initializer.
+    public enum InitializationError: Error, Equatable {
+        /// The provided values are outside of the valid range.
+        case invalidRange(attemptNumber: Int, maxAttempts: Int)
+    }
+
+    /// Creates a new instance or throws ``InitializationError`` if the supplied values are invalid.
     /// - Parameters:
-    ///   - attemptNumber: The current attempt count (must be `>= 1`).
-    ///   - maxAttempts: The maximum attempts permitted (must be `>= attemptNumber`).
-    public init(attemptNumber: Int, maxAttempts: Int) {
+    ///   - attemptNumber: The current attempt count. Must be **≥ 1**.
+    ///   - maxAttempts: The maximum attempts permitted. Must be **≥ attemptNumber**.
+    public init(attemptNumber: Int, maxAttempts: Int) throws {
+        guard attemptNumber >= 1, maxAttempts >= attemptNumber else {
+            throw InitializationError.invalidRange(attemptNumber: attemptNumber, maxAttempts: maxAttempts)
+        }
         self.attemptNumber = attemptNumber
         self.maxAttempts = maxAttempts
     }

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -9,16 +9,16 @@ import AnyCodable
 import Foundation
 
 public struct KlaviyoAPI {
-    public var send: (KlaviyoRequest, Int) async -> Result<Data, KlaviyoAPIError>
+    public var send: (KlaviyoRequest, (attemptNumber: Int, maxAttempts: Int)) async -> Result<Data, KlaviyoAPIError>
 
-    public init(send: @escaping (KlaviyoRequest, Int) async -> Result<Data, KlaviyoAPIError> = { request, attemptNumber in
+    public init(send: @escaping (KlaviyoRequest, (attemptNumber: Int, maxAttempts: Int)) async -> Result<Data, KlaviyoAPIError> = { request, retryInfo in
         let start = environment.date()
 
         var urlRequest: URLRequest
         do {
             urlRequest = try request.urlRequest(
-                currentAttempt: attemptNumber,
-                maxAttempts: 50
+                currentAttempt: retryInfo.attemptNumber,
+                maxAttempts: retryInfo.maxAttempts
             )
         } catch {
             requestHandler(request, nil, .error(.requestFailed(error)))
@@ -44,7 +44,7 @@ public struct KlaviyoAPI {
         }
 
         if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-            let exponentialBackOff = Int(pow(2.0, Double(attemptNumber)))
+            let exponentialBackOff = Int(pow(2.0, Double(retryInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             if let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After") {
                 nextBackoff = Int(retryAfter) ?? exponentialBackOff

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -9,16 +9,16 @@ import AnyCodable
 import Foundation
 
 public struct KlaviyoAPI {
-    public var send: (KlaviyoRequest, (attemptNumber: Int, maxAttempts: Int)) async -> Result<Data, KlaviyoAPIError>
+    public var send: (KlaviyoRequest, RequestAttemptInfo) async -> Result<Data, KlaviyoAPIError>
 
-    public init(send: @escaping (KlaviyoRequest, (attemptNumber: Int, maxAttempts: Int)) async -> Result<Data, KlaviyoAPIError> = { request, retryInfo in
+    public init(send: @escaping (KlaviyoRequest, RequestAttemptInfo) async -> Result<Data, KlaviyoAPIError> = { request, requestAttemptInfo in
         let start = environment.date()
 
         var urlRequest: URLRequest
         do {
             urlRequest = try request.urlRequest(
-                currentAttempt: retryInfo.attemptNumber,
-                maxAttempts: retryInfo.maxAttempts
+                currentAttempt: requestAttemptInfo.attemptNumber,
+                maxAttempts: requestAttemptInfo.maxAttempts
             )
         } catch {
             requestHandler(request, nil, .error(.requestFailed(error)))
@@ -44,7 +44,7 @@ public struct KlaviyoAPI {
         }
 
         if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-            let exponentialBackOff = Int(pow(2.0, Double(retryInfo.attemptNumber)))
+            let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             if let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After") {
                 nextBackoff = Int(retryAfter) ?? exponentialBackOff

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -16,7 +16,10 @@ public struct KlaviyoAPI {
 
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.urlRequest(attemptNumber)
+            urlRequest = try request.urlRequest(
+                currentAttempt: attemptNumber,
+                maxAttempts: 50
+            )
         } catch {
             requestHandler(request, nil, .error(.requestFailed(error)))
             return .failure(.internalRequestError(error))

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct KlaviyoRequest: Equatable, Codable {
-    public let apiKey: String
+    private let apiKey: String
     public let endpoint: KlaviyoEndpoint
     public var uuid: String
 

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -22,7 +22,7 @@ public struct KlaviyoRequest: Equatable, Codable {
         self.uuid = uuid
     }
 
-    public func urlRequest(_ attemptNumber: Int = 1) throws -> URLRequest {
+    public func urlRequest(currentAttempt: Int = 1, maxAttempts: Int) throws -> URLRequest {
         guard let url = url else {
             throw KlaviyoAPIError.internalError("Invalid url string. API URL: \(environment.apiURL())")
         }
@@ -38,7 +38,7 @@ public struct KlaviyoRequest: Equatable, Codable {
         }
 
         request.httpMethod = endpoint.httpMethod.rawValue
-        request.setValue("\(attemptNumber)/50", forHTTPHeaderField: "X-Klaviyo-Attempt-Count")
+        request.setValue("\(currentAttempt)/\(maxAttempts)", forHTTPHeaderField: "X-Klaviyo-Attempt-Count")
 
         return request
     }

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -9,7 +9,6 @@ import Foundation
 import KlaviyoCore
 
 enum ErrorHandlingConstants {
-    static let maxRetries = 50
     static let maxBackoff = 60 * 3 // 3 minutes
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -60,7 +60,7 @@ private func parseError(_ data: Data) -> [InvalidField]? {
 func handleRequestError(
     request: KlaviyoRequest,
     error: KlaviyoAPIError,
-    retryInfo: RetryInfo
+    retryState: RetryState
 ) -> KlaviyoAction {
     switch error {
     case let .httpError(statuscode, data):
@@ -76,7 +76,7 @@ func handleRequestError(
 
     case let .networkError(error):
         environment.logger.error("A network error occurred: \(error)")
-        switch retryInfo {
+        switch retryState {
         case let .retry(count):
             let requestRetryCount = count + 1
             return .requestFailed(request, .retry(requestRetryCount))
@@ -107,7 +107,7 @@ func handleRequestError(
     case let .rateLimitError(retryAfter):
         var requestRetryCount = 0
         var totalRetryCount = 0
-        switch retryInfo {
+        switch retryState {
         case let .retry(count):
             requestRetryCount = count + 1
             totalRetryCount = requestRetryCount

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -13,6 +13,15 @@ enum ErrorHandlingConstants {
     static let maxBackoff = 60 * 3 // 3 minutes
 }
 
+extension KlaviyoEndpoint {
+    var maxRetries: Int {
+        switch self {
+        case .createProfile, .registerPushToken, .unregisterPushToken, .createEvent, .aggregateEvent:
+            return 50
+        }
+    }
+}
+
 enum InvalidField: Equatable {
     case email
     case phone

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -57,7 +57,7 @@ struct KlaviyoState: Equatable, Codable {
     var initalizationState = InitializationState.uninitialized
     var flushing = false
     var flushInterval = StateManagementConstants.wifiFlushInterval
-    var retryInfo = RetryInfo.retry(StateManagementConstants.initialAttempt)
+    var retryState = RetryState.retry(StateManagementConstants.initialAttempt)
     var pendingRequests: [PendingRequest] = []
     var pendingProfile: [Profile.ProfileKey: AnyEncodable]?
 

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -382,7 +382,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
             return .run { [numAttempts] send in
-                let result = await environment.klaviyoAPI.send(request, (attemptNumber: numAttempts, maxAttempts: request.endpoint.maxRetries))
+                let requestAttemptInfo = RequestAttemptInfo(attemptNumber: numAttempts, maxAttempts: request.endpoint.maxRetries)
+                let result = await environment.klaviyoAPI.send(request, requestAttemptInfo)
                 switch result {
                 case .success:
                     await send(.deQueueCompletedResults(request))

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -365,7 +365,7 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
             return .run { [numAttempts] send in
-                let result = await environment.klaviyoAPI.send(request, numAttempts)
+                let result = await environment.klaviyoAPI.send(request, (attemptNumber: numAttempts, maxAttempts: request.endpoint.maxRetries))
                 switch result {
                 case .success:
                     await send(.deQueueCompletedResults(request))
@@ -410,10 +410,10 @@ struct KlaviyoReducer: ReducerProtocol {
             var exceededRetries = false
             switch retryInfo {
             case let .retry(count):
-                exceededRetries = count > ErrorHandlingConstants.maxRetries
+                exceededRetries = count > request.endpoint.maxRetries
                 state.retryInfo = .retry(exceededRetries ? 1 : count)
             case let .retryWithBackoff(requestCount, totalCount, backOff):
-                exceededRetries = requestCount > ErrorHandlingConstants.maxRetries
+                exceededRetries = requestCount > request.endpoint.maxRetries
                 state.retryInfo = .retryWithBackoff(requestCount: exceededRetries ? 0 : requestCount, totalRetryCount: totalCount, currentBackoff: backOff)
             }
             if exceededRetries {

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -26,7 +26,7 @@ enum StateManagementConstants {
 }
 
 /// Describes how the state machine should handle retrying a request after a failure.
-enum RetryInfo: Equatable {
+enum RetryState: Equatable {
     /// Indicates that the request should be retried immediately (subject to
     /// the regular flush cadence).
     ///
@@ -101,7 +101,7 @@ enum KlaviyoAction: Equatable {
     case cancelInFlightRequests
 
     /// called when there is a network or rate limit error
-    case requestFailed(KlaviyoRequest, RetryInfo)
+    case requestFailed(KlaviyoRequest, RetryState)
 
     /// when there is an event to be sent to klaviyo it's added to the queue
     case enqueueEvent(Event)
@@ -279,17 +279,17 @@ struct KlaviyoReducer: ReducerProtocol {
             if state.flushing {
                 return .none
             }
-            if case let .retryWithBackoff(requestCount, totalCount, backOff) = state.retryInfo {
+            if case let .retryWithBackoff(requestCount, totalCount, backOff) = state.retryState {
                 let newBackOff = max(backOff - Int(state.flushInterval), 0)
                 if newBackOff > 0 {
-                    state.retryInfo = .retryWithBackoff(
+                    state.retryState = .retryWithBackoff(
                         requestCount: requestCount,
                         totalRetryCount: totalCount,
                         currentBackoff: newBackOff
                     )
                     return .none
                 } else {
-                    state.retryInfo = .retry(requestCount)
+                    state.retryState = .retry(requestCount)
                 }
             }
             if state.pendingProfile != nil {
@@ -356,7 +356,7 @@ struct KlaviyoReducer: ReducerProtocol {
             state.requestsInFlight.removeAll { inflightRequest in
                 completedRequest.uuid == inflightRequest.uuid
             }
-            state.retryInfo = RetryInfo.retry(StateManagementConstants.initialAttempt)
+            state.retryState = RetryState.retry(StateManagementConstants.initialAttempt)
             if state.requestsInFlight.isEmpty {
                 state.flushing = false
                 return .none
@@ -375,9 +375,9 @@ struct KlaviyoReducer: ReducerProtocol {
                 state.flushing = false
                 return .none
             }
-            let retryInfo = state.retryInfo
+            let retryState = state.retryState
             var numAttempts = 1
-            if case let .retry(attempts) = retryInfo {
+            if case let .retry(attempts) = retryState {
                 numAttempts = attempts
             }
 
@@ -387,7 +387,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 case .success:
                     await send(.deQueueCompletedResults(request))
                 case let .failure(error):
-                    await send(handleRequestError(request: request, error: error, retryInfo: retryInfo))
+                    await send(handleRequestError(request: request, error: error, retryState: retryState))
                 }
             } catch: { error, send in
                 // For now assuming this is cancellation since nothing else can throw AFAICT
@@ -423,15 +423,15 @@ struct KlaviyoReducer: ReducerProtocol {
                 }.eraseToEffect()
                 .cancellable(id: FlushTimer.self, cancelInFlight: true)
 
-        case let .requestFailed(request, retryInfo):
+        case let .requestFailed(request, retryState):
             var exceededRetries = false
-            switch retryInfo {
+            switch retryState {
             case let .retry(count):
                 exceededRetries = count > request.endpoint.maxRetries
-                state.retryInfo = .retry(exceededRetries ? 1 : count)
+                state.retryState = .retry(exceededRetries ? 1 : count)
             case let .retryWithBackoff(requestCount, totalCount, backOff):
                 exceededRetries = requestCount > request.endpoint.maxRetries
-                state.retryInfo = .retryWithBackoff(requestCount: exceededRetries ? 0 : requestCount, totalRetryCount: totalCount, currentBackoff: backOff)
+                state.retryState = .retryWithBackoff(requestCount: exceededRetries ? 0 : requestCount, totalRetryCount: totalCount, currentBackoff: backOff)
             }
             if exceededRetries {
                 state.requestsInFlight.removeAll { inflightRequest in

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -25,8 +25,25 @@ enum StateManagementConstants {
     static let initialAttempt = 1
 }
 
+/// Describes how the state machine should handle retrying a request after a failure.
 enum RetryInfo: Equatable {
-    case retry(Int) // Int is current count for first request
+    /// Indicates that the request should be retried immediately (subject to
+    /// the regular flush cadence).
+    ///
+    /// - Parameter currentCount: The attempt number for the *current* request.
+    ///   The value should start at `1` for the very first send and is incremented each
+    ///   time a transient failure (such as a network error) occurs.
+    case retry(_ currentCount: Int)
+
+    /// Indicates that the request should be retried after waiting for a
+    /// server-specified back-off interval. This path is typically triggered by
+    /// an HTTP 429 "Too Many Requests" response that includes a `Retry-After`
+    /// header.
+    ///
+    /// - Parameters:
+    ///   - requestCount: The number of attempts made for this specific request.
+    ///   - totalRetryCount: The total number of attempts made for this request across all retry strategies.
+    ///   - currentBackoff: The remaining time in seconds to wait before the next retry attempt.
     case retryWithBackoff(requestCount: Int, totalRetryCount: Int, currentBackoff: Int)
 }
 

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -131,7 +131,7 @@ final class KlaviyoAPITests: XCTestCase {
 
     func sendAndAssert(with request: KlaviyoRequest,
                        assertion: (Result<Data, KlaviyoAPIError>) -> Void) async {
-        let result = await KlaviyoAPI().send(request, 0)
+        let result = await KlaviyoAPI().send(request, (0, 50))
         assertion(result)
     }
 }

--- a/Tests/KlaviyoCoreTests/KlaviyoRequestTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoRequestTests.swift
@@ -1,0 +1,11 @@
+@testable import KlaviyoCore
+import XCTest
+
+final class KlaviyoRequestTests: XCTestCase {
+    func testURLRequestSetsAttemptHeader() throws {
+        let request = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(.test))
+        let urlRequest = try request.urlRequest(currentAttempt: 3, maxAttempts: 7)
+        let header = urlRequest.value(forHTTPHeaderField: "X-Klaviyo-Attempt-Count")
+        XCTAssertEqual(header, "3/7")
+    }
+}

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -27,7 +27,7 @@ class NetworkSessionTests: XCTestCase {
         URLProtocolOverrides.protocolClasses = [SimpleMockURLProtocol.self]
         let session = NetworkSession.production
         let sampleRequest = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(.test))
-        let (data, response) = try await session.data(sampleRequest.urlRequest(maxAttempts: 50))
+        let (data, response) = try await session.data(sampleRequest.urlRequest(currentAttempt: 1, maxAttempts: 50))
 
         assertSnapshot(matching: data, as: .dump)
         assertSnapshot(matching: response, as: .dump)

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -27,7 +27,7 @@ class NetworkSessionTests: XCTestCase {
         URLProtocolOverrides.protocolClasses = [SimpleMockURLProtocol.self]
         let session = NetworkSession.production
         let sampleRequest = KlaviyoRequest(apiKey: "foo", endpoint: .registerPushToken(.test))
-        let (data, response) = try await session.data(sampleRequest.urlRequest())
+        let (data, response) = try await session.data(sampleRequest.urlRequest(maxAttempts: 50))
 
         assertSnapshot(matching: data, as: .dump)
         assertSnapshot(matching: response, as: .dump)

--- a/Tests/KlaviyoCoreTests/RequestAttemptInfoTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestAttemptInfoTests.swift
@@ -1,0 +1,30 @@
+@testable import KlaviyoCore
+import XCTest
+
+final class RequestAttemptInfoTests: XCTestCase {
+    func testInitializerSucceedsWithValidParameters() throws {
+        let info = try RequestAttemptInfo(attemptNumber: 1, maxAttempts: 3)
+        XCTAssertEqual(info.attemptNumber, 1)
+        XCTAssertEqual(info.maxAttempts, 3)
+    }
+
+    func testInitializerThrowsWhenAttemptNumberIsZero() throws {
+        XCTAssertThrowsError(try RequestAttemptInfo(attemptNumber: 0, maxAttempts: 3)) { error in
+            guard case let .invalidRange(attempt, max) = error as? RequestAttemptInfo.InitializationError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(attempt, 0)
+            XCTAssertEqual(max, 3)
+        }
+    }
+
+    func testInitializerThrowsWhenAttemptNumberExceedsMax() throws {
+        XCTAssertThrowsError(try RequestAttemptInfo(attemptNumber: 4, maxAttempts: 3)) { error in
+            guard case let .invalidRange(attempt, max) = error as? RequestAttemptInfo.InitializationError else {
+                return XCTFail("Unexpected error type: \(error)")
+            }
+            XCTAssertEqual(attempt, 4)
+            XCTAssertEqual(max, 3)
+        }
+    }
+}

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
@@ -12,7 +12,7 @@
     ▿ some: 1 key/value pair
       ▿ (2 elements)
         - key: "X-Klaviyo-Attempt-Count"
-        - value: "0/50"
+        - value: "1/50"
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
@@ -12,7 +12,7 @@
     ▿ some: 1 key/value pair
       ▿ (2 elements)
         - key: "X-Klaviyo-Attempt-Count"
-        - value: "0/50"
+        - value: "1/50"
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
@@ -12,7 +12,7 @@
     ▿ some: 1 key/value pair
       ▿ (2 elements)
         - key: "X-Klaviyo-Attempt-Count"
-        - value: "0/50"
+        - value: "1/50"
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -56,7 +56,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -79,7 +79,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -102,7 +102,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -147,14 +147,14 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request, request2]
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(2)
+            $0.retryState = .retry(2)
         }
     }
 
     @MainActor
     func testSendRequestFailureWithBackoff() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        initialState.retryInfo = .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 1)
+        initialState.retryState = .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 1)
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "new_token", enablement: .authorized)
         initialState.requestsInFlight = [request, request2]
@@ -168,14 +168,14 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request, request2]
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(2)
+            $0.retryState = .retry(2)
         }
     }
 
     @MainActor
     func testSendRequestMaxRetries() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        initialState.retryInfo = .retry(ErrorHandlingConstants.maxRetries)
+        initialState.retryState = .retry(ErrorHandlingConstants.maxRetries)
 
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         var request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "new_token", enablement: .authorized)
@@ -191,7 +191,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request2]
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -214,7 +214,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -236,7 +236,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -258,7 +258,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -279,7 +279,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -300,7 +300,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 
@@ -321,14 +321,14 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
-            $0.retryInfo = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 30)
+            $0.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 30)
         }
     }
 
     @MainActor
     func testRateLimitErrorWithExistingBackoffRetry() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        initialState.retryInfo = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
+        initialState.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -341,14 +341,14 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
-            $0.retryInfo = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 30)
+            $0.retryState = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 30)
         }
     }
 
     @MainActor
     func testRetryWithRetryAfter() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        initialState.retryInfo = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 4)
+        initialState.retryState = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 4)
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -361,7 +361,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = [request]
             $0.requestsInFlight = []
-            $0.retryInfo = .retryWithBackoff(requestCount: 4, totalRetryCount: 4, currentBackoff: 20)
+            $0.retryState = .retryWithBackoff(requestCount: 4, totalRetryCount: 4, currentBackoff: 20)
         }
     }
 
@@ -370,7 +370,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testMissingOrInvalidResponse() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        initialState.retryInfo = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
+        initialState.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -383,7 +383,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
             $0.flushing = false
             $0.queue = []
             $0.requestsInFlight = []
-            $0.retryInfo = .retry(1)
+            $0.retryState = .retry(1)
         }
     }
 }

--- a/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
+++ b/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
@@ -1,0 +1,33 @@
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+@MainActor
+final class AttemptNumberTests: XCTestCase {
+    func testFirstRequestStartsAtOne() async throws {
+        var capturedAttempt: Int?
+        environment.klaviyoAPI.send = { _, attemptInfo in
+            capturedAttempt = attemptInfo.attemptNumber
+            return .success(Data())
+        }
+
+        // Build a minimal request and pre-populate state with it in flight.
+        let request = KlaviyoRequest(apiKey: "foo", endpoint: .createEvent(.init(data: .init(name: "foo"))))
+        let initialState = KlaviyoState(
+            apiKey: "foo",
+            anonymousId: environment.uuid().uuidString,
+            queue: [],
+            requestsInFlight: [request],
+            initalizationState: .initialized,
+            flushing: true
+        )
+
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off // We only care about the sendRequest action.
+
+        // Trigger sendRequest which should invoke our mock API.
+        await store.send(.sendRequest)
+
+        XCTAssertEqual(capturedAttempt, 1, "The first request should have an attempt number of 1")
+    }
+}

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -14,5 +14,5 @@
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements
-  ▿ retryInfo: RetryInfo
+  ▿ retryState: RetryState
     - retry: 1

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -14,5 +14,5 @@
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements
-  ▿ retryInfo: RetryInfo
+  ▿ retryState: RetryState
     - retry: 1

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -14,5 +14,5 @@
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements
-  ▿ retryInfo: RetryInfo
+  ▿ retryState: RetryState
     - retry: 1

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -34,5 +34,5 @@
       - pushToken: "blob_token"
   - queue: 0 elements
   - requestsInFlight: 0 elements
-  ▿ retryInfo: RetryInfo
+  ▿ retryState: RetryState
     - retry: 1


### PR DESCRIPTION
# Description
This PR modifies our networking logic to allow for endpoint-specific max retries. It also passes the number of max retries into the `X-Klaviyo-Attempt-Count` header; before this PR we were just hard-coding the max retries to 50, regardless of the actual number of max retries.

This is some prerequisite work for the universal linking feature. For that, we have an API call that we want to try only once; if it fails, we give up and don't try again. 


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<table>
    <tr><th>Scenario</th><th>Result</th></tr>
    <tr>
        <td>Max retries set to 2</td>
        <td>
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 10 21 51" src="https://github.com/user-attachments/assets/2870beaa-eaed-4e14-88b8-f62fe03f4a10" />
        </td>
    </tr>
    <tr>
        <td>Max retries set to 10</td>
        <td>
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 10 22 36" src="https://github.com/user-attachments/assets/d44225f0-5c92-4915-b50c-6b9e128782b2" />
        </td>
    </tr>
    <tr>
        <td>Max retries set to 1</td>
        <td>
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 10 23 18" src="https://github.com/user-attachments/assets/98b5fc94-e4b1-4123-a9e5-4e15f9984358" />
</td>
    </tr>
    <tr>
        <td>Max retries set to 2; API call is failing</td>
        <td>
<img width="1728" height="1117" alt="Screenshot 2025-07-24 at 10 24 18" src="https://github.com/user-attachments/assets/c652828f-079c-4e7e-87ea-ff1f085926e0"/> Although the first two calls have failed, we've already reached the max number of attempts. I validated that the SDK did not try the call again.
        </td>
    </tr>
</table>


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
