### PR TITLE
CHNL-22957: Inject profile events into webview

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
@@ -13,6 +13,15 @@
                         }
                     }));
                 };
+                window.dispatchProfileEvent = function(metric, properties) {
+                    console.log('Dispatching profile event:', metric);
+                    document.head.dispatchEvent(new CustomEvent('profileEvent', {
+                        detail: {
+                            metric: metric,
+                            properties: properties
+                        }
+                    }));
+                };
             </script>
             <link rel="stylesheet" type="text/css" href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/websafe_fonts.css"/>
 </head>

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -289,6 +289,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             ()
         case .lifecycleEvent:
             ()
+        case .profileEvent:
+            ()
         case .profileMutation:
             ()
         }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -20,6 +20,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case handShook
     case analyticsEvent
     case lifecycleEvent
+    case profileEvent
     case profileMutation
 
     private enum CodingKeys: String, CodingKey {
@@ -38,6 +39,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case handShook
         case analyticsEvent
         case lifecycleEvent
+        case profileEvent
         case profileMutation
     }
 
@@ -72,6 +74,8 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .analyticsEvent
         case .lifecycleEvent:
             self = .lifecycleEvent
+        case .profileEvent:
+            self = .profileEvent
         case .profileMutation:
             self = .profileMutation
         }
@@ -123,6 +127,7 @@ extension IAFNativeBridgeEvent {
             .openDeepLink(URL(string: "https://example.com")!),
             .abort(""),
             .lifecycleEvent,
+            .profileEvent,
             .profileMutation
         ]
     }
@@ -139,6 +144,7 @@ extension IAFNativeBridgeEvent {
         case .handShook: return 1
         case .analyticsEvent: return 1
         case .lifecycleEvent: return 1
+        case .profileEvent: return 1
         case .profileMutation: return 1
         }
     }
@@ -155,6 +161,7 @@ extension IAFNativeBridgeEvent {
         case .handShook: return "handShook"
         case .analyticsEvent: return "analyticsEvent"
         case .lifecycleEvent: return "lifecycleEvent"
+        case .profileEvent: return "profileEvent"
         case .profileMutation: return "profileMutation"
         }
     }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -25,9 +25,11 @@ package enum KlaviyoInternal {
 
     private static var profileDataCancellable: Cancellable?
     private static var apiKeyCancellable: Cancellable?
+    private static var profileEventCancellable: Cancellable?
 
     private static let profileDataSubject = CurrentValueSubject<ProfileDataResult, Never>(.failure(.notInitialized))
     private static let apiKeySubject = CurrentValueSubject<APIKeyResult, Never>(.failure(.notInitialized))
+    private static let profileEventSubject = PassthroughSubject<Event, Never>()
 
     // MARK: - API Key methods
 
@@ -149,6 +151,28 @@ package enum KlaviyoInternal {
         profileDataCancellable?.cancel()
         profileDataCancellable = nil
         profileDataSubject.send(.failure(.notInitialized))
+    }
+
+    // MARK: - Profile Event methods
+
+    /// Publishes an event to subscribers.
+    ///
+    /// - Parameter event: the profile event to publish
+    package static func publishEvent(_ event: Event) {
+        profileEventSubject.send(event)
+    }
+
+    /// A publisher that emits events when they are created.
+    ///
+    /// - Returns: A publisher that emits profile events
+    package static func eventPublisher() -> AnyPublisher<Event, Never> {
+        profileEventSubject.eraseToAnyPublisher()
+    }
+
+    /// Resets the profile event subject to its initial state.
+    package static func resetEventSubject() {
+        profileEventCancellable?.cancel()
+        profileEventCancellable = nil
     }
 
     // MARK: - Aggregate Events methods

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -158,7 +158,7 @@ package enum KlaviyoInternal {
     /// Publishes an event to subscribers.
     ///
     /// - Parameter event: the profile event to publish
-    package static func publishEvent(_ event: Event) {
+    internal static func publishEvent(_ event: Event) {
         profileEventSubject.send(event)
     }
 

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -437,6 +437,9 @@ struct KlaviyoReducer: ReducerProtocol {
 
             event = event.updateEventWithState(state: &state)
 
+            // Publish the event to subscribers
+            KlaviyoInternal.publishEvent(event)
+
             let payload = CreateEventPayload(
                 data: CreateEventPayload.Event(
                     name: event.metric.name.value,

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":1},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -413,6 +413,40 @@ final class KlaviyoInternalTests: XCTestCase {
 //        XCTAssertNoThrow(KlaviyoInternal.create(aggregateEvent: testEvent))
 //    }
 
+    // MARK: - Event Publishing Tests
+
+    @MainActor
+    func testEventPublisher_emitsEventWithProperties() throws {
+        // Given: Set up a mock to capture published events
+        var publishedEvents: [Event] = []
+        let initialState = KlaviyoState(
+            apiKey: "test-api-key",
+            anonymousId: "test-anonymous-id",
+            queue: [],
+            initalizationState: .initialized
+        )
+        let testStore = Store(initialState: initialState, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+        KlaviyoInternal.eventPublisher()
+            .sink { event in
+                publishedEvents.append(event)
+            }
+            .store(in: &cancellables)
+
+        // When
+        let testEvent = Event(
+            name: .addedToCartMetric,
+            properties: ["amount": 99.99, "currency": "USD"]
+        )
+        _ = testStore.send(.enqueueEvent(testEvent))
+
+        // Then
+        XCTAssertEqual(publishedEvents.count, 1, "Should have published exactly one event")
+        XCTAssertEqual(publishedEvents.first?.metric.name, .addedToCartMetric, "Should have published the correct event name")
+        XCTAssertEqual(publishedEvents.first?.properties["amount"] as? Double, 99.99, "Should have published the correct properties")
+        XCTAssertEqual(publishedEvents.first?.properties["currency"] as? String, "USD", "Should have published the correct properties")
+    }
+
     // MARK: - Integration Tests
 
     @MainActor


### PR DESCRIPTION
# Description
This adds support for injecting profile events into the webview. This adds a publisher to KlaviyoInternal to publish profile events that hook into where we are enqueuing events. Then IAFPresentationManager subscribes to these events and injects the metric along with its properties.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Added profileEvent to handshake
- Added support to inject profile events into the webview

## Test Plan
<img width="1266" height="962" alt="image" src="https://github.com/user-attachments/assets/1b375e5d-b5c1-491a-a2c1-1a19d190cb34" />



## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-22957
