### PR TITLE
[CHNL-22883] resolve tracking link destination

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -73,7 +73,16 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
             return url
         case let .resolveDestinationURL(trackingLink, _):
-            return trackingLink
+            var urlComponents = URLComponents()
+
+            urlComponents.scheme = trackingLink.scheme
+            urlComponents.host = trackingLink.host
+
+            guard let url = urlComponents.url else {
+                throw KlaviyoAPIError.internalError("Failed to build valid URL from URLComponents '\(urlComponents)'")
+            }
+
+            return url
         }
     }
 
@@ -89,8 +98,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
             return "/client/push-token-unregister/"
         case .aggregateEvent:
             return "/onsite/track-analytics"
-        case .resolveDestinationURL:
-            return ""
+        case let .resolveDestinationURL(trackingLink, _):
+            return trackingLink.path
         }
     }
 

--- a/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
+++ b/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
@@ -46,6 +46,7 @@ public struct SDKRequest: Identifiable, Equatable {
         case createProfile(ProfileInfo)
         case saveToken(token: String, info: ProfileInfo)
         case unregisterToken(token: String, info: ProfileInfo)
+        case resolveDestinationURL(trackingLink: URL)
 
         fileprivate static func fromEndpoint(request: KlaviyoRequest) -> RequestType {
             switch request.endpoint {
@@ -78,6 +79,8 @@ public struct SDKRequest: Identifiable, Equatable {
                                 phoneNumber: payload.data.attributes.profile.data.attributes.phoneNumber,
                                 externalId: payload.data.attributes.profile.data.attributes.externalId,
                                 anonymousId: payload.data.attributes.profile.data.attributes.anonymousId))
+            case let .resolveDestinationURL(trackingLink: trackingLink):
+                return .resolveDestinationURL(trackingLink: trackingLink)
             }
         }
     }

--- a/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
+++ b/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
@@ -79,7 +79,7 @@ public struct SDKRequest: Identifiable, Equatable {
                                 phoneNumber: payload.data.attributes.profile.data.attributes.phoneNumber,
                                 externalId: payload.data.attributes.profile.data.attributes.externalId,
                                 anonymousId: payload.data.attributes.profile.data.attributes.anonymousId))
-            case let .resolveDestinationURL(trackingLink: trackingLink):
+            case let .resolveDestinationURL(trackingLink, _):
                 return .resolveDestinationURL(trackingLink: trackingLink)
             }
         }

--- a/Sources/KlaviyoSwift/Models/TrackingLinkDestinationResponse.swift
+++ b/Sources/KlaviyoSwift/Models/TrackingLinkDestinationResponse.swift
@@ -1,0 +1,41 @@
+//
+//  TrackingLinkDestinationResponse.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 7/31/25.
+//
+
+import Foundation
+import OSLog
+
+/// A struct to decode the response from a tracking link resolution request
+///
+/// When an API call is made to a tracking link URL, the engtrack service will
+/// respond JSON including the canonical universal link URL. This model allows
+/// us to decode that JSON so we can access the universal link URL.
+struct TrackingLinkDestinationResponse: Decodable {
+    /// The canonical universal link URL indicating the tracking link's ultimate destination.
+    let destinationLink: URL
+
+    private enum CodingKeys: String, CodingKey {
+        case destinationLink = "original_destination"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let urlString = try container.decode(String.self, forKey: .destinationLink)
+
+        guard let url = URL(string: urlString) else {
+            let errorMessage = "Unable to initialize URL from string '\(urlString)'"
+            if #available(iOS 14.0, *) {
+                Logger.codableLogger.warning("\(errorMessage)")
+            }
+            throw DecodingError.dataCorruptedError(
+                forKey: .destinationLink,
+                in: container,
+                debugDescription: errorMessage
+            )
+        }
+        destinationLink = url
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -17,6 +17,8 @@ extension KlaviyoEndpoint {
         switch self {
         case .createProfile, .registerPushToken, .unregisterPushToken, .createEvent, .aggregateEvent:
             return 50
+        case .resolveDestinationURL:
+            return 1
         }
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -15,6 +15,7 @@ import AnyCodable
 import Combine
 import Foundation
 import KlaviyoCore
+import OSLog
 import UIKit
 import UserNotifications
 
@@ -596,6 +597,10 @@ struct KlaviyoReducer: ReducerProtocol {
             return .task { .deQueueCompletedResults(request) }
 
         case let .resolveTrackingLinkDestination(from: trackingLinkURL):
+            if #available(iOS 14.0, *) {
+                Logger.stateLogger.info("Attempting to resolve tracking link destination from URL '\(trackingLinkURL.absoluteString)'")
+            }
+
             guard case .initialized = state.initalizationState else {
                 return .none
             }
@@ -622,13 +627,23 @@ struct KlaviyoReducer: ReducerProtocol {
                         let response: TrackingLinkDestinationResponse = try environment.decoder.decode(data)
                         let destinationURL = response.destinationLink
 
+                        if #available(iOS 14.0, *) {
+                            Logger.stateLogger.info("Successfully resolved tracking link destination. Destination URL: '\(destinationURL.absoluteString)'")
+                        }
+
                     // TODO: handle destination URL
                     // example:
                     // await send(.navigateToDestinationURL(destinationURL))
                     case let .failure(error):
+                        if #available(iOS 14.0, *) {
+                            Logger.stateLogger.warning("Unable to resolve tracking link destination; error: '\(error)'")
+                        }
                         // TODO: handle error
                     }
                 } catch {
+                    if #available(iOS 14.0, *) {
+                        Logger.stateLogger.warning("Unable to resolve tracking link destination; error: '\(error)'")
+                    }
                     // TODO: handle error
                 }
             }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -594,6 +594,10 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
             return .task { .deQueueCompletedResults(request) }
+
+        case let .resolveTrackingLinkDestination(from: from):
+            // TODO: implement this
+            return .none
         }
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -598,7 +598,7 @@ struct KlaviyoReducer: ReducerProtocol {
 
         case let .resolveTrackingLinkDestination(from: trackingLinkURL):
             if #available(iOS 14.0, *) {
-                Logger.stateLogger.info("Attempting to resolve tracking link destination from URL '\(trackingLinkURL.absoluteString)'")
+                Logger.stateLogger.info("Attempting to resolve tracking link destination from tracking URL '\(trackingLinkURL.absoluteString)'")
             }
 
             guard case .initialized = state.initalizationState else {

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -120,13 +120,14 @@ enum KlaviyoAction: Equatable {
     /// the data that was passed to the client endpoint
     case resetStateAndDequeue(KlaviyoRequest, [InvalidField])
 
+    case resolveTrackingLinkDestination(from: URL)
+
     var requiresInitialization: Bool {
         switch self {
         // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
         case let .enqueueEvent(event) where event.metric.name == ._openedPush:
             return false
-
-        case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setBadgeCount, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
+        case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setBadgeCount, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken, .resolveTrackingLinkDestination:
             return true
 
         case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .syncBadgeCount:

--- a/Sources/KlaviyoSwift/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoSwift/Utilities/Logger+Ext.swift
@@ -22,4 +22,7 @@ extension Logger {
 extension Logger {
     /// Logger for ``Codable`` events (JSON encoding & decoding)
     static let codableLogger = Logger(category: "Encoding/Decoding Logger")
+
+    /// Logger for state events that run through the reducer
+    static let stateLogger = Logger(category: "State logger")
 }

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -90,6 +90,30 @@ final class KlaviyoEndpointTests: XCTestCase {
         XCTAssertEqual(request.httpBody, payload)
     }
 
+    func testResolveDestinationURLEndpointUrlRequest() throws {
+        // Given
+        let trackingLink = URL(string: "https://email.klaviyo.com/tracking/link")!
+        let profileInfo = ProfilePayload(email: "test@example.com", phoneNumber: "+15551234567", externalId: "user-123", anonymousId: "anon-456")
+        let endpoint = KlaviyoEndpoint.resolveDestinationURL(trackingLink: trackingLink, profileInfo: profileInfo)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.absoluteString, trackingLink.absoluteString)
+        XCTAssertNil(request.url?.query) // No query items for this endpoint
+        XCTAssertNil(request.httpBody) // No body for this endpoint
+
+        // Test headers
+        if let profileData = try? environment.encodeJSON(profileInfo),
+           let profileDataString = String(data: profileData, encoding: .utf8) {
+            XCTAssertEqual(request.allHTTPHeaderFields?["X-Klaviyo-Profile-Info"], profileDataString)
+        } else {
+            XCTFail("Failed to encode profile info for header")
+        }
+    }
+
     func testPathValidation() throws {
         // Given
         environment.apiURL = {

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -1,0 +1,107 @@
+//
+//  ResolveTrackingLinkTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Claude on 8/4/25.
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import Combine
+import XCTest
+
+final class ResolveTrackingLinkTests: XCTestCase {
+    @MainActor
+    override func setUpWithError() throws {
+        environment = KlaviyoEnvironment.test()
+        klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+    }
+
+    @MainActor
+    func testResolveTrackingLinkDestinationWithSuccess() async throws {
+        // Given
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let trackingLinkURL = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
+        let destinationURL = try XCTUnwrap(URL(string: "https://example.com/destination"))
+
+        // Mock successful API response
+        let responseJSON = """
+        {
+            "original_destination": "\(destinationURL.absoluteString)"
+        }
+        """
+        let responseData = try XCTUnwrap(responseJSON.data(using: .utf8))
+
+        environment.decoder = DataDecoder(jsonDecoder: JSONDecoder())
+
+        environment.klaviyoAPI.send = { request, _ in
+            XCTAssertEqual(request.endpoint, KlaviyoEndpoint.resolveDestinationURL(
+                trackingLink: trackingLinkURL,
+                profileInfo: ProfilePayload(
+                    email: initialState.email,
+                    phoneNumber: initialState.phoneNumber,
+                    externalId: initialState.externalId,
+                    anonymousId: initialState.anonymousId ?? ""
+                )
+            ))
+            return .success(responseData)
+        }
+
+        // When/Then
+        await store.send(.resolveTrackingLinkDestination(from: trackingLinkURL))
+
+        // TODO: Validate that
+    }
+
+    @MainActor
+    func testResolveTrackingLinkDestinationWithError() async throws {
+        // Given
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let trackingLinkURL = URL(string: "https://email.klaviyo.com/tracking/link")!
+
+        // Mock API failure
+        environment.klaviyoAPI.send = { _, _ in
+            .failure(.networkError(NSError(domain: "foo", code: NSURLErrorCancelled)))
+        }
+
+        // When/Then
+        await store.send(.resolveTrackingLinkDestination(from: trackingLinkURL))
+
+        // TODO: validate that error is handled properly
+    }
+
+    @MainActor
+    func testResolveTrackingLinkDestinationWhenNotInitialized() async throws {
+        // Given
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.initalizationState = .uninitialized
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let trackingLinkURL = URL(string: "https://email.klaviyo.com/tracking/link")!
+
+        // When/Then - Should do nothing when not initialized
+        await store.send(.resolveTrackingLinkDestination(from: trackingLinkURL))
+
+        // No state changes or API calls should happen
+    }
+
+    @MainActor
+    func testResolveTrackingLinkDecodingError() async throws {
+        // Given
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let trackingLinkURL = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
+
+        environment.decoder = DataDecoder(jsonDecoder: InvalidJSONDecoder())
+
+        // When/Then
+        await store.send(.resolveTrackingLinkDestination(from: trackingLinkURL))
+
+        // TODO: validate that error is handled properly
+    }
+}

--- a/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
+++ b/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
@@ -1,0 +1,80 @@
+//
+//  TrackingLinkDestinationResponseTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Claude on 8/4/25.
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+final class TrackingLinkDestinationResponseTests: XCTestCase {
+    override func setUpWithError() throws {
+        environment = KlaviyoEnvironment.test()
+    }
+
+    func testDecodingValidResponse() throws {
+        // Given
+        let json = """
+        {
+            "original_destination": "https://example.com/destination"
+        }
+        """
+        let jsonData = try XCTUnwrap(json.data(using: .utf8))
+
+        // When
+        let response = try JSONDecoder().decode(TrackingLinkDestinationResponse.self, from: jsonData)
+
+        // Then
+        XCTAssertEqual(response.destinationLink.absoluteString, "https://example.com/destination")
+    }
+
+    func testDecodingInvalidURL() throws {
+        // Given
+        let json = """
+        {
+            "original_destination": ""
+        }
+        """
+        let jsonData = json.data(using: .utf8)!
+
+        // When/Then
+        XCTAssertThrowsError(try JSONDecoder().decode(TrackingLinkDestinationResponse.self, from: jsonData)) { error in
+            guard let decodingError = error as? DecodingError else {
+                XCTFail("Expected DecodingError")
+                return
+            }
+
+            switch decodingError {
+            case .dataCorrupted:
+                // This is the expected error type
+                break
+            default:
+                XCTFail("Expected .dataCorrupted error")
+            }
+        }
+    }
+
+    func testDecodingMissingField() throws {
+        // Given
+        let json = "{}"
+        let jsonData = json.data(using: .utf8)!
+
+        // When/Then
+        XCTAssertThrowsError(try JSONDecoder().decode(TrackingLinkDestinationResponse.self, from: jsonData)) { error in
+            guard let decodingError = error as? DecodingError else {
+                XCTFail("Expected DecodingError")
+                return
+            }
+
+            switch decodingError {
+            case .keyNotFound:
+                // This is the expected error type
+                break
+            default:
+                XCTFail("Expected .keyNotFound error")
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
This PR adds the logic to resolve a tracking link URL into a destination URL. This is necessary for our work on universal linking


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Test Plan

1. I used Proxyman's "Map Local" function to mock a response to the url `https://track.local.com/*`:

<img width="712" alt="Screenshot 2025-08-04 at 17 03 35" src="https://github.com/user-attachments/assets/87dbcecc-164e-488d-a89e-411bfd335b5a" />

2.  I wired up the iOS test app to execute the `resolveTrackingLinkDestination` action, passing in the URL `https://track.local.com/u/slug`. 
3. I validated that the API request gets made and includes the proper values for all headers:

<img width="837" alt="Screenshot 2025-08-04 at 17 09 09" src="https://github.com/user-attachments/assets/d659e1fa-2dec-4604-add7-ac0bff6d97f4" />


