### PR TITLE
[CHNL-22919] allow injection of deep link handler

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -41,7 +41,8 @@ public struct KlaviyoEnvironment {
         timer: @escaping (Double) -> AnyPublisher<Date, Never>,
         SDKName: @escaping () -> String,
         SDKVersion: @escaping () -> String,
-        formsDataEnvironment: @escaping () -> FormEnvironment?
+        formsDataEnvironment: @escaping () -> FormEnvironment?,
+        openURL: @escaping (URL) async -> Void
     ) {
         self.archiverClient = archiverClient
         self.fileClient = fileClient
@@ -72,6 +73,7 @@ public struct KlaviyoEnvironment {
         sdkName = SDKName
         sdkVersion = SDKVersion
         self.formsDataEnvironment = formsDataEnvironment
+        self.openURL = openURL
     }
 
     static let productionHost: URLComponents = {
@@ -136,6 +138,7 @@ public struct KlaviyoEnvironment {
     public var klaviyoAPI: KlaviyoAPI
     public var timer: (Double) -> AnyPublisher<Date, Never>
     public var formsDataEnvironment: () -> FormEnvironment?
+    public var openURL: (URL) async -> Void
 
     public var sdkName: () -> String
     public var sdkVersion: () -> String
@@ -228,7 +231,12 @@ public struct KlaviyoEnvironment {
         },
         SDKName: KlaviyoEnvironment.getSDKName,
         SDKVersion: KlaviyoEnvironment.getSDKVersion,
-        formsDataEnvironment: { nil }
+        formsDataEnvironment: { nil },
+        openURL: { url in
+            await MainActor.run {
+                UIApplication.shared.open(url)
+            }
+        }
     )
 }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -268,7 +268,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
                 }
-                UIApplication.shared.open(url)
+                KlaviyoInternal.handleDeepLink(url: url)
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL’s scheme, or b) you haven’t declared the URL’s scheme in your Info.plist file")

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -171,17 +171,17 @@ public struct KlaviyoSDK {
         }
 
         create(event: Event(name: ._openedPush, properties: properties))
-        Task {
-            await MainActor.run {
-                if let url = notificationResponse.klaviyoDeepLinkURL {
-                    if let deepLinkHandler = deepLinkHandler {
-                        deepLinkHandler(url)
-                    } else {
-                        UIApplication.shared.open(url)
-                    }
+        if let url = notificationResponse.klaviyoDeepLinkURL {
+            if let deepLinkHandler = deepLinkHandler {
+                Task { @MainActor in
+                    deepLinkHandler(url)
                 }
-                completionHandler()
+            } else {
+                dispatchOnMainThread(action: .openDeepLink(url))
             }
+        }
+        Task { @MainActor in
+            completionHandler()
         }
         return true
     }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -141,14 +141,14 @@ public struct KlaviyoSDK {
         dispatchOnMainThread(action: .enqueueEvent(event))
     }
 
-    /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
+    /// Set the current user's push token. This will be associated with profile and can be used to send them push notifications.
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {
         let apnDeviceToken = pushToken.map { String(format: "%02.2hhx", $0) }.joined()
         set(pushToken: apnDeviceToken)
     }
 
-    /// Set the current user's push token. This will be associated with profile and can be used to send them push notificaitons.
+    /// Set the current user's push token. This will be associated with profile and can be used to send them push notifications.
     /// - Parameter pushToken: String formatted push token.
     public func set(pushToken: String) {
         Task {
@@ -174,9 +174,9 @@ public struct KlaviyoSDK {
 
     /// Track a notificationResponse open event in Klaviyo. NOTE: all callbacks will be made on the main thread.
     /// - Parameters:
-    ///   - remoteNotification: the remote notificaiton that was opened
+    ///   - remoteNotification: the remote notification that was opened
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
-    /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
+    /// - Returns: true if the notification originated from Klaviyo, false otherwise.
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) -> Bool {
         guard notificationResponse.isKlaviyoNotification,
               let properties = notificationResponse.klaviyoProperties else {
@@ -196,10 +196,10 @@ public struct KlaviyoSDK {
 
     /// Track a notificationResponse open event in Klaviyo. NOTE: all callbacks will be made on the main thread.
     /// - Parameters:
-    ///   - remoteNotification: the remote notificaiton that was opened
+    ///   - remoteNotification: the remote notification that was opened
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
     ///   - deepLinkHandler: a completion handler that will be called when a notification contains a deep link.
-    /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
+    /// - Returns: true if the notification originated from Klaviyo, false otherwise.
     @available(*, deprecated, message: "This will be removed in v6.0; use `handle(notificationResponse:withCompletionHandler:)` instead")
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {
         guard notificationResponse.isKlaviyoNotification,

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -200,6 +200,7 @@ public struct KlaviyoSDK {
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
     ///   - deepLinkHandler: a completion handler that will be called when a notification contains a deep link.
     /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
+    @available(iOS, deprecated: 5.1.0, obsoleted: 6.0, message: "This will be removed in v6.0; use `handle(notificationResponse:withCompletionHandler:)` instead")
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {
         guard notificationResponse.isKlaviyoNotification,
               let properties = notificationResponse.klaviyoProperties else {

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -157,6 +157,21 @@ public struct KlaviyoSDK {
         }
     }
 
+    /// Register a custom deep link handler to be used by the SDK when opening Klaviyo deep links.
+    ///
+    /// If set, this handler will be invoked instead of the default URL opener.
+    /// - Parameter handler: a closure receiving the deep link `URL` to handle.
+    /// - Returns: a KlaviyoSDK instance for chaining.
+    @discardableResult
+    public func registerDeepLinkHandler(_ handler: @escaping (URL) -> Void) -> KlaviyoSDK {
+        environment.openURL = { url in
+            await MainActor.run {
+                handler(url)
+            }
+        }
+        return self
+    }
+
     /// Track a notificationResponse open event in Klaviyo. NOTE: all callbacks will be made on the main thread.
     /// - Parameters:
     ///   - remoteNotification: the remote notificaiton that was opened

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -176,6 +176,28 @@ public struct KlaviyoSDK {
     /// - Parameters:
     ///   - remoteNotification: the remote notificaiton that was opened
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
+    /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
+    public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) -> Bool {
+        guard notificationResponse.isKlaviyoNotification,
+              let properties = notificationResponse.klaviyoProperties else {
+            dispatchOnMainThread(action: .syncBadgeCount)
+            return false
+        }
+
+        create(event: Event(name: ._openedPush, properties: properties))
+        if let url = notificationResponse.klaviyoDeepLinkURL {
+            dispatchOnMainThread(action: .openDeepLink(url))
+        }
+        Task { @MainActor in
+            completionHandler()
+        }
+        return true
+    }
+
+    /// Track a notificationResponse open event in Klaviyo. NOTE: all callbacks will be made on the main thread.
+    /// - Parameters:
+    ///   - remoteNotification: the remote notificaiton that was opened
+    ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
     ///   - deepLinkHandler: a completion handler that will be called when a notification contains a deep link.
     /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -200,7 +200,7 @@ public struct KlaviyoSDK {
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
     ///   - deepLinkHandler: a completion handler that will be called when a notification contains a deep link.
     /// - Returns: true if the notificaiton originated from Klaviyo, false otherwise.
-    @available(iOS, deprecated: 5.1.0, obsoleted: 6.0, message: "This will be removed in v6.0; use `handle(notificationResponse:withCompletionHandler:)` instead")
+    @available(*, deprecated, message: "This will be removed in v6.0; use `handle(notificationResponse:withCompletionHandler:)` instead")
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {
         guard notificationResponse.isKlaviyoNotification,
               let properties = notificationResponse.klaviyoProperties else {

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -159,4 +159,12 @@ package enum KlaviyoInternal {
     package static func create(aggregateEvent: AggregateEventPayload) {
         dispatchOnMainThread(action: .enqueueAggregateEvent(aggregateEvent))
     }
+
+    // MARK: - Deep link handling
+
+    /// Handles a deep link according to the handler configured in `klaviyoSwiftEnvironment`
+    /// - Parameter url: the URL of the deep link to be handled
+    package static func handleDeepLink(url: URL) {
+        dispatchOnMainThread(action: .openDeepLink(url))
+    }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -123,6 +123,9 @@ enum KlaviyoAction: Equatable {
 
     case resolveTrackingLinkDestination(from: URL)
 
+    /// open a deep link URL originating from a Klaviyo notification
+    case openDeepLink(URL)
+
     var requiresInitialization: Bool {
         switch self {
         // if event metric is opened push we DON'T require initilization in all other event metric cases we DO.
@@ -131,7 +134,7 @@ enum KlaviyoAction: Equatable {
         case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setBadgeCount, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
             return true
 
-        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .syncBadgeCount, .resolveTrackingLinkDestination:
+        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .syncBadgeCount, .resolveTrackingLinkDestination, .openDeepLink:
             return false
         }
     }
@@ -642,6 +645,11 @@ struct KlaviyoReducer: ReducerProtocol {
                     }
                     // TODO: [CHNL-22886] handle error
                 }
+            }
+
+        case let .openDeepLink(url):
+            return .run { _ in
+                await environment.openURL(url)
             }
         }
     }

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -107,7 +107,8 @@ extension KlaviyoEnvironment {
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
             SDKVersion: { __klaviyoSwiftVersion },
-            formsDataEnvironment: { nil }
+            formsDataEnvironment: { nil },
+            openURL: { _ in }
         )
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
@@ -230,7 +230,7 @@ final class IAFPresentationManagerTests: XCTestCase {
         try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
 
         // Then
-        XCTAssertFalse(mockManager.createFormAndAwaitFormEventsCalled, "createFormAndAwaitFormEvents should not be called when foregrounding in existing instance (such as opening the notificaiton/control center)")
+        XCTAssertFalse(mockManager.createFormAndAwaitFormEventsCalled, "createFormAndAwaitFormEvents should not be called when foregrounding in existing instance (such as opening the notification/control center)")
     }
 
     @MainActor

--- a/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
@@ -108,7 +108,8 @@ extension KlaviyoEnvironment {
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
             SDKVersion: { __klaviyoSwiftVersion },
-            formsDataEnvironment: { nil }
+            formsDataEnvironment: { nil },
+            openURL: { _ in }
         )
     }
 }

--- a/Tests/KlaviyoSwiftTests/AppLifeCycleEventsTests.swift
+++ b/Tests/KlaviyoSwiftTests/AppLifeCycleEventsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 class AppLifeCycleEventsTests: XCTestCase {
     let passThroughSubject = PassthroughSubject<Notification, Never>()
 
-    func getFilteredNotificaitonPublished(name: Notification.Name) -> (Notification.Name) -> AnyPublisher<Notification, Never> {
+    func getFilteredNotificationPublished(name: Notification.Name) -> (Notification.Name) -> AnyPublisher<Notification, Never> {
         // returns passthrough if it's match other return nothing
         { [weak self] notificationName in
             if name == notificationName {
@@ -52,7 +52,7 @@ class AppLifeCycleEventsTests: XCTestCase {
     }
 
     func testAppTerminateGetsStopAction() {
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: UIApplication.willTerminateNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: UIApplication.willTerminateNotification)
         let stopActionExpection = XCTestExpectation(description: "Stop action is received.")
         stopActionExpection.assertForOverFulfill = true
         var receivedAction: KlaviyoAction?
@@ -88,7 +88,7 @@ class AppLifeCycleEventsTests: XCTestCase {
     }
 
     func testAppBackgroundGetsStopAction() {
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: UIApplication.didEnterBackgroundNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: UIApplication.didEnterBackgroundNotification)
         let stopActionExpection = XCTestExpectation(description: "Stop action is received.")
         stopActionExpection.assertForOverFulfill = true
         var receivedAction: KlaviyoAction?
@@ -124,7 +124,7 @@ class AppLifeCycleEventsTests: XCTestCase {
     }
 
     func testAppBecomeActiveGetsStartAction() {
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: UIApplication.didBecomeActiveNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: UIApplication.didBecomeActiveNotification)
         let stopActionExpection = XCTestExpectation(description: "Stop action is received.")
         stopActionExpection.assertForOverFulfill = true
         var receivedAction: KlaviyoAction?
@@ -167,7 +167,7 @@ class AppLifeCycleEventsTests: XCTestCase {
 
     func testReachabilityNotificationStatusHandled() {
         let expection = XCTestExpectation(description: "Reachability status is accessed")
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: ReachabilityChangedNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: ReachabilityChangedNotification)
         environment.reachabilityStatus = {
             expection.fulfill()
             return .reachableViaWWAN
@@ -182,7 +182,7 @@ class AppLifeCycleEventsTests: XCTestCase {
 
     func testReachabilityStatusNilThenNotNil() {
         let expection = XCTestExpectation(description: "Reachability status is accessed")
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: ReachabilityChangedNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: ReachabilityChangedNotification)
         var count = 0
         environment.reachabilityStatus = {
             if count == 0 {
@@ -205,7 +205,7 @@ class AppLifeCycleEventsTests: XCTestCase {
 
     func testReachaibilityNotificationGetsRightAction() {
         environment.reachabilityStatus = { .reachableViaWWAN }
-        environment.notificationCenterPublisher = getFilteredNotificaitonPublished(name: ReachabilityChangedNotification)
+        environment.notificationCenterPublisher = getFilteredNotificationPublished(name: ReachabilityChangedNotification)
         let reachabilityAction = XCTestExpectation(description: "Reachabilty changed is received.")
         var receivedAction: KlaviyoAction?
         let cancellable = AppLifeCycleEvents().lifeCycleEvents().sink { action in

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -1,0 +1,115 @@
+//
+//  DeepLinkHandlingTests.swift
+//
+//  Created by Cursor AI on 8/11/25.
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import Combine
+import Foundation
+import XCTest
+
+final class DeepLinkHandlingTests: XCTestCase {
+    @MainActor
+    override func setUp() async throws {
+        environment = KlaviyoEnvironment.test()
+        klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+    }
+
+    @MainActor
+    func testOpenDeepLinkActionCallsEnvironmentOpenURL() async throws {
+        let expectedURL = URL(string: "https://example.com/path")!
+        let called = expectation(description: "environment.openURL called")
+
+        environment.openURL = { url in
+            XCTAssertEqual(url, expectedURL)
+            called.fulfill()
+        }
+
+        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
+
+        _ = await store.send(.openDeepLink(expectedURL))
+        await fulfillment(of: [called], timeout: 1.0)
+    }
+
+    @MainActor
+    func testRegisterDeepLinkHandlerOverridesEnvironmentOpenURL() async throws {
+        let expectedURL = URL(string: "https://example.com/override")!
+
+        let defaultCalled = XCTestExpectation(description: "default openURL should NOT be called")
+        defaultCalled.isInverted = true
+        environment.openURL = { _ in
+            defaultCalled.fulfill()
+        }
+
+        let customCalled = expectation(description: "custom handler called")
+        let sdk = KlaviyoSDK().registerDeepLinkHandler { url in
+            XCTAssertEqual(url, expectedURL)
+            customCalled.fulfill()
+        }
+        _ = sdk // silence unused warning; method is @discardableResult but we still keep consistency
+
+        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
+        _ = await store.send(.openDeepLink(expectedURL))
+
+        await fulfillment(of: [customCalled], timeout: 1.0)
+        await fulfillment(of: [defaultCalled], timeout: 0.2)
+    }
+
+    @MainActor
+    func testHandleNotificationResponseUsesInjectedDeepLinkHandler() async throws {
+        let urlString = "https://example.com/deeplink"
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        // If environment.openURL gets called here, we want to know (it should not be)
+        let envCalled = XCTestExpectation(description: "environment.openURL should not be called")
+        envCalled.isInverted = true
+        environment.openURL = { _ in envCalled.fulfill() }
+
+        let handlerCalled = expectation(description: "injected deep link handler called")
+        let completionCalled = expectation(description: "completion handler called")
+
+        let sdk = KlaviyoSDK()
+        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        }, deepLinkHandler: { url in
+            XCTAssertEqual(url.absoluteString, urlString)
+            handlerCalled.fulfill()
+        })
+
+        XCTAssertTrue(result)
+        await fulfillment(of: [handlerCalled, completionCalled], timeout: 1.0)
+        await fulfillment(of: [envCalled], timeout: 0.2)
+    }
+
+    @MainActor
+    func testHandleNotificationResponseDispatchesOpenDeepLinkWhenNoHandler() async throws {
+        let urlString = "https://example.com/deeplink2"
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        let openCalled = expectation(description: "environment.openURL called via reducer effect")
+        environment.openURL = { url in
+            XCTAssertEqual(url.absoluteString, urlString)
+            openCalled.fulfill()
+        }
+
+        let completionCalled = expectation(description: "completion handler called")
+
+        let sdk = KlaviyoSDK()
+        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        })
+
+        XCTAssertTrue(result)
+        await fulfillment(of: [openCalled, completionCalled], timeout: 1.0)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -56,7 +56,8 @@ extension KlaviyoEnvironment {
             timer: { _ in Just(Date()).eraseToAnyPublisher() },
             SDKName: { __klaviyoSwiftName },
             SDKVersion: { __klaviyoSwiftVersion },
-            formsDataEnvironment: { nil }
+            formsDataEnvironment: { nil },
+            openURL: { _ in }
         )
     }
 }


### PR DESCRIPTION
# Description
This PR adds the ability to register a deep link handler by calling `KlavyioSDK().registerDeepLinkHandler()`. We will use the registered deep link handler with our universal linking feature, and we'll also call the registered handler when a deep link is called from an In-App Form. 


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
I tested this using the iOS test app and validated that the deep link handler is called when a deep link is opened. 


## Related Issues/Tickets
[CHNL-22919](https://klaviyo.atlassian.net/browse/CHNL-22919)

[CHNL-22919]: https://klaviyo.atlassian.net/browse/CHNL-22919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ