### PR TITLE
[CHNL-24581] Sending properties as a json instead of string

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -264,7 +264,17 @@ class IAFPresentationManager {
         }
 
         do {
-            let result = try await viewController?.evaluateJavaScript("dispatchProfileEvent('\(event.metric.name.value)', '\(event.properties)')")
+            // Convert properties to JSON string to ensure proper object serialization
+            let propertiesJSON: String
+            if let propertiesData = try? JSONSerialization.data(withJSONObject: event.properties),
+               let propertiesString = String(data: propertiesData, encoding: .utf8) {
+                propertiesJSON = propertiesString
+            } else {
+                // Fallback to empty object if serialization fails
+                propertiesJSON = "{}"
+            }
+
+            let result = try await viewController?.evaluateJavaScript("dispatchProfileEvent('\(event.metric.name.value)', \(propertiesJSON))")
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Successfully dispatched event via Klaviyo.JS\(result != nil ? "; message: \(result.debugDescription)" : "")")
             }

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
@@ -445,9 +445,20 @@ final class IAFPresentationManagerTests: XCTestCase {
         XCTAssertTrue(evaluatedScripts.contains { script in
             script.contains("dispatchProfileEvent") && script.contains("Added to Cart")
         }, "Event should be dispatched with correct event name")
-        XCTAssertTrue(evaluatedScripts.contains { script in
-            script.contains("amount") && script.contains("currency")
-        }, "Event should include properties")
+
+        // Verify properties are passed as JSON object (not string)
+        let scriptWithProperties = evaluatedScripts.first { script in
+            script.contains("dispatchProfileEvent") && script.contains("Added to Cart")
+        }
+        XCTAssertNotNil(scriptWithProperties, "Should find script with dispatchProfileEvent")
+
+        if let script = scriptWithProperties {
+            // Properties should be passed as JSON object, not quoted string
+            XCTAssertTrue(script.contains("\"amount\":"), "Properties should include amount key")
+            XCTAssertTrue(script.contains("\"currency\":"), "Properties should include currency key")
+            XCTAssertTrue(script.contains("USD"), "Properties should include USD value")
+            XCTAssertFalse(script.contains("'{\"amount\":99.99,\"currency\":\"USD\"}'"), "Properties should not be wrapped in quotes")
+        }
     }
 
     @MainActor


### PR DESCRIPTION
# Description
Had to make a small change to the iaf trigger by event logic so we're sending properties as a map rather than a string. This aligns to what I have on Android and Fender, but open to discussion if people don't think it's the right play.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview


## Test Plan
Tested locally, attaching vid:

https://github.com/user-attachments/assets/4d7dc7c5-3cdf-48f1-bcfb-94a997d2f7b0



## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-24581