### PR TITLE
changed `handleTrackingLink` to `handleUniversalTrackingLink`

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -157,7 +157,7 @@ public struct KlaviyoSDK {
         }
     }
 
-    public func handleTrackingLink(_ url: URL) {
+    public func handleUniversalTrackingLink(_ url: URL) {
         dispatchOnMainThread(action: .trackingLinkReceived(url))
     }
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -180,11 +180,11 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: tracking link handling
 
-    func testHandleTrackingLinkDispatchesTrackingLinkReceived() throws {
+    func testHandleUniversalTrackingLinkDispatchesTrackingLinkReceived() throws {
         let url = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
         let expectation = setupActionAssertion(expectedAction: .trackingLinkReceived(url))
 
-        klaviyo.handleTrackingLink(url)
+        klaviyo.handleUniversalTrackingLink(url)
 
         wait(for: [expectation], timeout: 1.0)
     }


### PR DESCRIPTION
# Description
This PR changes `handleTrackingLink` to `handleUniversalTrackingLink`, following a discussion with @evan-masseau on Slack.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.