### PR TITLE
JS bridge observers suggestions

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
@@ -11,7 +11,6 @@ import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 
-@MainActor
 class CompanyObserver: JSBridgeObserver {
     enum Event { case apiKeyUpdated(String), error(SDKError) }
 

--- a/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
@@ -26,7 +26,7 @@ class CompanyObserver: JSBridgeObserver {
     func startObserving() {
         apiKeyCancellable = KlaviyoInternal.apiKeyPublisher()
             .receive(on: DispatchQueue.main)
-            .sink { @MainActor [weak self] result in
+            .sink { [weak self] result in
                 guard let self else { return }
 
                 switch result {
@@ -37,7 +37,7 @@ class CompanyObserver: JSBridgeObserver {
 
                     initializationWarningTask?.cancel()
                     initializationWarningTask = nil
-                    Task { [weak self] in
+                    Task { @MainActor [weak self] in
                         guard let self else { return }
                         self.manager.reinitializeIAFForNewAPIKey(apiKey, configuration: self.configuration)
                     }

--- a/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/CompanyObserver.swift
@@ -39,7 +39,7 @@ class CompanyObserver: JSBridgeObserver {
                     initializationWarningTask = nil
                     Task { [weak self] in
                         guard let self else { return }
-                        await self.manager.reinitializeIAFForNewAPIKey(apiKey, configuration: self.configuration)
+                        self.manager.reinitializeIAFForNewAPIKey(apiKey, configuration: self.configuration)
                     }
                 case let .failure(sdkError):
                     handleAPIKeyError(sdkError)


### PR DESCRIPTION
This PR is a suggested implementation for `CompanyObserver` that removes the dependency on `IAFPresentationManager`. 

Caution: I wrote it with ChatGPT's assistance and haven't yet tested it, and it doesn't currently compile because of a TODO that needs to be resolved. That said, it may be a good starting point