### PR TITLE
Fix: Do not try to open url for InAppFormsTemplate.html

### DIFF
--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -204,11 +204,10 @@ extension KlaviyoWebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         if let url = navigationAction.request.url,
-           await UIApplication.shared.open(url) {
-            return .cancel
-        } else {
-            return .allow
+           !url.absoluteString.contains("InAppFormsTemplate.html") {
+            await UIApplication.shared.open(url)
         }
+        return .allow
     }
 }
 


### PR DESCRIPTION
# Description
Previously we were attempting to open all intercepted urls, but we should not do this for our `InAppFormsTemplate.html` as a change in iOS26 can cause this to be opened in a separate app if the app is the device's default document reader. Another change in iOS26 seems to require us to always return `.allow` when we intercept as `.cancel` causes a (non-fatal) web kit crash. The crash is logged but doesn't _seem_ to affect the webkit functionality but should still probably be avoided

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
