### PR TITLE
ios26 open URL fix

### DIFF
--- a/KlaviyoCore.podspec
+++ b/KlaviyoCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoCore"
-  s.version          = "4.2.1"
+  s.version          = "4.2.2"
   s.summary          = "Core functionalities for the Klaviyo SDK"
   s.description      = <<-DESC
                         Core functionalities and utilities for the Klaviyo SDK.

--- a/KlaviyoForms.podspec
+++ b/KlaviyoForms.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoForms"
-  s.version          = "4.2.1"
+  s.version          = "4.2.2"
   s.summary          = "Klaviyo forms is a new way to engage with your app users"
   s.description      = <<-DESC
                         Use Klaviyo forms to include in app forms in your app and engage user with marketing content
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
     ]
   }
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
-  s.dependency     'KlaviyoSwift', '~> 4.2.1'
+  s.dependency     'KlaviyoSwift', '~> 4.2.2'
 end

--- a/KlaviyoSwift.podspec
+++ b/KlaviyoSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwift"
-  s.version          = "4.2.1"
+  s.version          = "4.2.2"
   s.summary          = "Incorporate Klaviyo's event and person tracking and push notifications functionality into iOS applications"
 
   s.description      = <<-DESC
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/KlaviyoSwift/**/*.swift'
   s.resource_bundles = {"KlaviyoSwift" => ["Sources/KlaviyoSwift/PrivacyInfo.xcprivacy"]}
   s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-package-name KlaviyoSwift' }
-  s.dependency     'KlaviyoCore', '~> 4.2.1'
+  s.dependency     'KlaviyoCore', '~> 4.2.2'
   s.dependency     'AnyCodable-FlightSchool'
 end

--- a/KlaviyoSwiftExtension.podspec
+++ b/KlaviyoSwiftExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KlaviyoSwiftExtension"
-  s.version          = "4.2.1"
+  s.version          = "4.2.2"
   s.summary          = "Incorporate Klaviyo's rich push notifications functionality into your iOS applications"
 
   s.description      = <<-DESC

--- a/Sources/KlaviyoCore/Utils/Version.swift
+++ b/Sources/KlaviyoCore/Utils/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 public let __klaviyoSwiftName = "swift"
-public let __klaviyoSwiftVersion = "4.2.1"
+public let __klaviyoSwiftVersion = "4.2.2"

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -189,11 +189,19 @@ extension KlaviyoWebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         if let url = navigationAction.request.url,
-           await UIApplication.shared.open(url) {
-            return .cancel
-        } else {
-            return .allow
+           !(url.lastPathComponent == "InAppFormsTemplate.html") {
+            let didOpenURL = await UIApplication.shared.open(url)
+
+            if #available(iOS 14.0, *) {
+                if didOpenURL {
+                    Logger.webViewLogger.info("'UIApplication.shared.open(_:)' successfully opened URL '\(url.absoluteString)'")
+                } else {
+                    Logger.webViewLogger.info("'UIApplication.shared.open(_:)' did not open the URL '\(url.absoluteString)'")
+                }
+            }
         }
+
+        return .allow
     }
 }
 

--- a/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testEventPayload.1.json
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testEventPayload.1.json
@@ -36,7 +36,7 @@
         "OS Version" : "1.1.1",
         "Push Token" : "",
         "SDK Name" : "swift",
-        "SDK Version" : "4.2.1",
+        "SDK Version" : "4.2.2",
         "Stuff" : 2
       },
       "time" : "2009-02-13T23:31:30Z",

--- a/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testKlaviyoRequest.1.json
@@ -18,7 +18,7 @@
               "manufacturer" : "Orange",
               "os_name" : "iOS",
               "os_version" : "1.1.1",
-              "sdk_version" : "4.2.1"
+              "sdk_version" : "4.2.2"
             },
             "enablement_status" : "AUTHORIZED",
             "platform" : "ios",

--- a/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/EncodableTests/testTokenPayload.1.json
@@ -14,7 +14,7 @@
         "manufacturer" : "Orange",
         "os_name" : "iOS",
         "os_version" : "1.1.1",
-        "sdk_version" : "4.2.1"
+        "sdk_version" : "4.2.2"
       },
       "enablement_status" : "AUTHORIZED",
       "platform" : "ios",

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithEvent.1.txt
@@ -16,4 +16,3 @@
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true
-  - httpShouldUsePipelining: false

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithProfile.1.txt
@@ -16,4 +16,3 @@
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true
-  - httpShouldUsePipelining: false

--- a/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/KlaviyoAPITests/testSuccessfulResponseWithStoreToken.1.txt
@@ -16,4 +16,3 @@
   - httpBody: Optional<Data>.none
   - httpBodyStream: Optional<NSInputStream>.none
   - httpShouldHandleCookies: true
-  - httpShouldUsePipelining: false

--- a/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testCreateEmphemeralSesionHeaders.1.txt
@@ -8,7 +8,7 @@
         - "deflate"
     ▿ (2 elements)
       - key: "User-Agent"
-      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.2.1"
+      - value: "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.2.2"
     ▿ (2 elements)
       - key: "X-Klaviyo-Mobile"
       - value: "1"

--- a/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
+++ b/Tests/KlaviyoCoreTests/__Snapshots__/NetworkSessionTests/testDefaultUserAgent.1.txt
@@ -1,1 +1,1 @@
-- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.2.1"
+- "FooApp/1.2.3 (com.klaviyo.fooapp; build:1; iOS 1.1.1) klaviyo-swift/4.2.2"

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -15,7 +15,7 @@
       "manufacturer" : "Orange",
       "os_name" : "iOS",
       "os_version" : "1.1.1",
-      "sdk_version" : "4.2.1"
+      "sdk_version" : "4.2.2"
     },
     "pushBackground" : "AVAILABLE",
     "pushEnablement" : "AUTHORIZED",
@@ -42,7 +42,7 @@
                   "manufacturer" : "Orange",
                   "os_name" : "iOS",
                   "os_version" : "1.1.1",
-                  "sdk_version" : "4.2.1"
+                  "sdk_version" : "4.2.2"
                 },
                 "enablement_status" : "AUTHORIZED",
                 "platform" : "ios",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -28,7 +28,7 @@
         - manufacturer: "Orange"
         - osName: "iOS"
         - osVersion: "1.1.1"
-        - sdkVersion: "4.2.1"
+        - sdkVersion: "4.2.2"
       - pushBackground: PushBackground.available
       - pushEnablement: PushEnablement.authorized
       - pushToken: "blob_token"


### PR DESCRIPTION
# Description
This branch fixes the [iOS 26 issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues/405) in which an in-app form could trigger an external app to open. It parallels the fix that's going into the 5.0.3 release