### PR TITLE
Fix opened push js event

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
@@ -14,13 +14,13 @@
                     }));
                 };
                 window.dispatchProfileEvent = function(metric, properties) {
-                    console.log('Dispatching profile event:', metric);
                     document.head.dispatchEvent(new CustomEvent('profileEvent', {
                         detail: {
                             metric: metric,
                             properties: properties
                         }
                     }));
+                    return true;
                 };
             </script>
             <link rel="stylesheet" type="text/css" href="https://static-forms.klaviyo.com/fonts/api/v1/in-app-web-fonts/websafe_fonts.css"/>


### PR DESCRIPTION
# Description
Had to make a few updates to the IAF logic in our event sending. We have to pull the message title out of the body and put it back at the top level to match the onsite trigger expectation. Tried adding a test for this case as well.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
^ TODO but I'll do this on the release branch merge
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview

https://github.com/user-attachments/assets/99db90dc-fb3e-4cf7-acbf-b14e08b2d340



## Test Plan
- add the necessary feature flags to web for IAF trigger by opened push (under mobile editors)
- publish a form with an opened push trigger
- send yourself a legit campaign so that the 'opened_push' event triggers

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-24359