### PR TITLE
[CHNL-25156] conditionally show "register deep link handler" warning

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -234,6 +234,11 @@ public struct KlaviyoEnvironment {
         formsDataEnvironment: { nil },
         linkHandler: DeepLinkHandler()
     )
+
+    /// Returns `true` if the SDK is currently running in a React Native host app.
+    package static var isReactNative: Bool {
+        NSClassFromString("RCTBridge") != nil
+    }
 }
 
 public var networkSession: NetworkSession!

--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -58,8 +58,10 @@ public class DeepLinkHandler {
                 customDeepLinkHandler(url)
             }
         } else {
-            if #available(iOS 14.0, *) {
-                Logger.navigation.info("A deep link handler has not been registered.\nHandling URL: '\(url.absoluteString, privacy: .public)' using fallback deep link handler")
+            if !KlaviyoEnvironment.isReactNative {
+                if #available(iOS 14.0, *) {
+                    Logger.navigation.info("A deep link handler has not been registered.\nHandling URL: '\(url.absoluteString, privacy: .public)' using fallback deep link handler")
+                }
             }
 
             if ["http", "https"].contains(url.scheme?.lowercased()) {
@@ -72,13 +74,15 @@ public class DeepLinkHandler {
 
     @MainActor
     private static func openWithFallbackHandler(url: URL) async {
-        if #available(iOS 14.0, *) {
-            Logger.navigation.warning("""
-            Attempting to handle universal link via a fallback mechanism.
-            For improved stability and future-proofing, please provide your own
-            deep link handler logic by calling `KlaviyoSDK().registerDeepLinkHandler(_:)`
-            on application launch. Refer to the Klaviyo Swift SDK's README for more details.
-            """)
+        if !KlaviyoEnvironment.isReactNative {
+            if #available(iOS 14.0, *) {
+                Logger.navigation.warning("""
+                Attempting to handle universal link via a fallback mechanism.
+                For improved stability and future-proofing, please provide your own
+                deep link handler logic by calling `KlaviyoSDK().registerDeepLinkHandler(_:)`
+                on application launch. Refer to the Klaviyo Swift SDK's README for more details.
+                """)
+            }
         }
 
         // First try to route with the App Delegate


### PR DESCRIPTION
# Description
After discussing with @evan-masseau, we decided to remove the `registerDeepLinkHandler` method from the React Native SDK, because React Native has a pretty good built-in method for handling deep links and universal links. This means that the warning we display to consumers of our Swift SDK is not relevant to consumers of our React Native SDK. This PR suppresses that warning.