### PR TITLE
encode profile header as Base64-encoded string

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -183,7 +183,7 @@ extension ProfilePayload {
     fileprivate func asJSONString() throws -> String {
         do {
             let profileData = try environment.encodeJSON(self)
-            return String(decoding: profileData, as: UTF8.self)
+            return profileData.base64EncodedString()
         } catch {
             if #available(iOS 14.0, *) {
                 Logger.codable.warning("Unable to encode ProfilePayload into JSON string; error: \(error)")

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -109,9 +109,16 @@ final class KlaviyoEndpointTests: XCTestCase {
         if let profileData = try? environment.encodeJSON(profileInfo),
            let profileDataString = String(data: profileData, encoding: .utf8),
            let headerValue = request.allHTTPHeaderFields?["X-Klaviyo-Profile-Info"] {
+            // Decode Base64 header value back to JSON string
+            guard let decodedData = Data(base64Encoded: headerValue),
+                  let decodedJsonString = String(data: decodedData, encoding: .utf8) else {
+                XCTFail("Failed to decode Base64 header value")
+                return
+            }
+
             // Compare JSON objects instead of string representations to avoid order issues
             let profileJson = try JSONSerialization.jsonObject(with: Data(profileDataString.utf8), options: []) as! [String: Any]
-            let headerJson = try JSONSerialization.jsonObject(with: Data(headerValue.utf8), options: []) as! [String: Any]
+            let headerJson = try JSONSerialization.jsonObject(with: Data(decodedJsonString.utf8), options: []) as! [String: Any]
 
             // Compare the type
             XCTAssertEqual(profileJson["type"] as? String, headerJson["type"] as? String)


### PR DESCRIPTION
# Description
This PR encodes the `profileInfo` header as a Base64-encoded string


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Test Plan

1. I added `print(profileData.base64EncodedString())` to the `asJSONString()` method in KlaviyoEndpoint.swift
2. In the iOS test app, I added code to call `KlaviyoSDK().handleUniversalTrackingLink(_:)` with a Klaviyo click-tracking url (`https://evancmasseau.com/u/settings`) when the app launches
3. After the test app launched, I copied the Base64-encoded string that was printed in the console (as a result of step 1)
4. I converted the Base64-encoded string to a human-readable string and validated that the contents were correct