### PR TITLE
Fix flaky test in IAFPresentationManagerTests

### DIFF
--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTests.swift
@@ -210,9 +210,9 @@ final class IAFPresentationManagerTests: XCTestCase {
 
         // When
         mockLifecycleEvents.send(.foregrounded)
-        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
 
         // Then
+        await fulfillment(of: [createExpectation], timeout: 2.0)
         XCTAssertTrue(presentationManager.createFormWebViewAndListenCalled, "Web view should be recreated when foregrounding in new session")
     }
 


### PR DESCRIPTION
## Summary
Fixes a flaky test in `IAFPresentationManagerTests` by replacing unreliable `Task.sleep` with proper expectation fulfillment.

## Problem
The test `testIntializeSessionTimeoutCreatesNewViewController` was using `Task.sleep(nanoseconds: 1_000_000_000)` to wait for the web view creation, which is unreliable and can cause intermittent test failures.

## Solution
Replace the sleep with proper async expectation handling using `await fulfillment(of: [createExpectation], timeout: 2.0)`.

## Changes
- **Removed:** `try await Task.sleep(nanoseconds: 1_000_000_000)`
- **Added:** `await fulfillment(of: [createExpectation], timeout: 2.0)`

This ensures the test properly waits for the expectation to be fulfilled before asserting, making it more reliable and less flaky.

## Testing
- Test now waits for the actual event to occur rather than an arbitrary time
- Timeout increased from 1s to 2s to provide more buffer
- Expectation is properly awaited before assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)