### PR TITLE
Configure stale bot for label-driven approach

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         only-labels: 'awaiting-reporter-response,missing-details'
+        remove-stale-when-updated: true
         days-before-issue-stale: 14
         days-before-issue-close: 14
         stale-issue-label: 'stale'


### PR DESCRIPTION
## Summary
This PR configures the stale bot to use a label-driven approach for managing stale issues. The bot will now only process issues that are specifically marked as awaiting information from the reporter.

## Changes
- Added `only-labels` parameter to restrict bot to issues labeled `awaiting-reporter-response` or `missing-details`
- Updated exempt labels to `evergreen`, `investigating`, and `awaiting-team` (removed auto-applied `bug` and `feature-request` labels)
- Changed timing: issues marked stale after 14 days, closed after additional 14 days (28 days total)
- Updated cron schedule to run at noon Eastern (5pm UTC)
- Kept original message copy with corrected timing references

## Benefits
- **More targeted approach**: Only issues awaiting reporter response are affected
- **Protected important issues**: Issues under investigation or awaiting team action won't be automatically closed
- **Clear communication**: Messages accurately reflect the timing and reason for closure
- **Prevents false positives**: Maintainers must explicitly mark issues before bot processes them

## How It Works
1. Maintainer requests info from reporter and adds `awaiting-reporter-response` or `missing-details` label
2. After 14 days of inactivity, bot marks issue as stale
3. After 14 more days without response (28 days total), issue is automatically closed
4. If reporter responds at any time, remove the label to stop the stale countdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates stale bot to act only on specific labeled issues, adjust timing/messages, add exemptions, auto-unstale on updates, and add an extra cron run.
> 
> - **CI/GitHub Actions**: Update `/.github/workflows/stale.yml`
>   - **Label-driven processing**: `only-labels: 'awaiting-reporter-response,missing-details'`
>   - **Auto-unstale on activity**: `remove-stale-when-updated: true`
>   - **Timing**:
>     - `days-before-issue-close` changed from `10` to `14`
>     - Issue messages updated to reflect 14-day stale and 28-day close windows
>   - **Exemptions**: expand `exempt-issue-labels` to `evergreen,investigating,awaiting-team`
>   - **Scheduling**: add cron `0 17 * * *` alongside existing schedule
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f09a42cd4d0551be515540b2f9c6d5ae2db4e12d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->