### PR TITLE
Clean up: Remove redundant internal keywords from KlaviyoLocation

### DIFF
--- a/Sources/KlaviyoLocation/GeofenceService.swift
+++ b/Sources/KlaviyoLocation/GeofenceService.swift
@@ -10,12 +10,12 @@ import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 
-internal protocol GeofenceServiceProvider {
+protocol GeofenceServiceProvider {
     func fetchGeofences() async -> Set<Geofence>
 }
 
-internal struct GeofenceService: GeofenceServiceProvider {
-    internal func fetchGeofences() async -> Set<Geofence> {
+struct GeofenceService: GeofenceServiceProvider {
+    func fetchGeofences() async -> Set<Geofence> {
         do {
             let data = try await fetchGeofenceData()
             return try await parseGeofences(from: data)
@@ -50,7 +50,7 @@ internal struct GeofenceService: GeofenceServiceProvider {
     }
 
     /// Parses raw geofence data and transforms it into Geofence objects with the companyId prepended to the id
-    internal func parseGeofences(from data: Data) async throws -> Set<Geofence> {
+    func parseGeofences(from data: Data) async throws -> Set<Geofence> {
         do {
             let response = try JSONDecoder().decode(GeofenceJSONResponse.self, from: data)
             let companyId = try await KlaviyoInternal.fetchAPIKey()

--- a/Sources/KlaviyoLocation/KlaviyoGeofenceManager.swift
+++ b/Sources/KlaviyoLocation/KlaviyoGeofenceManager.swift
@@ -10,14 +10,14 @@ import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 
-internal class KlaviyoGeofenceManager {
+class KlaviyoGeofenceManager {
     private let locationManager: LocationManagerProtocol
 
-    internal init(locationManager: LocationManagerProtocol) {
+    init(locationManager: LocationManagerProtocol) {
         self.locationManager = locationManager
     }
 
-    internal func setupGeofencing() {
+    func setupGeofencing() {
         guard CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self) else {
             if #available(iOS 14.0, *) {
                 Logger.geoservices.warning("Geofencing is not supported on this device")
@@ -44,7 +44,7 @@ internal class KlaviyoGeofenceManager {
         }
     }
 
-    internal func destroyGeofencing() {
+    func destroyGeofencing() {
         if #available(iOS 14.0, *) {
             if !locationManager.monitoredRegions.isEmpty {
                 Logger.geoservices.info("Stop monitoring for all regions")
@@ -99,7 +99,7 @@ internal class KlaviyoGeofenceManager {
 extension Geofence {
     /// Converts this geofence to a Core Location circular region
     /// - Returns: A CLCircularRegion instance
-    internal func toCLCircularRegion() -> CLCircularRegion {
+    func toCLCircularRegion() -> CLCircularRegion {
         let region = CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
             radius: radius,
@@ -110,11 +110,11 @@ extension Geofence {
 }
 
 extension CLCircularRegion {
-    internal func toKlaviyoGeofence() throws -> Geofence {
+    func toKlaviyoGeofence() throws -> Geofence {
         try Geofence(id: identifier, longitude: center.longitude, latitude: center.latitude, radius: radius)
     }
 
-    internal var klaviyoLocationId: String? {
+    var klaviyoLocationId: String? {
         do {
             return try toKlaviyoGeofence().locationId
         } catch {

--- a/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
+++ b/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
@@ -12,13 +12,13 @@ import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 
-public class KlaviyoLocationManager: NSObject {
-    internal static let shared = KlaviyoLocationManager()
+class KlaviyoLocationManager: NSObject {
+    static let shared = KlaviyoLocationManager()
 
     private var locationManager: LocationManagerProtocol
     private let geofenceManager: KlaviyoGeofenceManager
 
-    internal init(locationManager: LocationManagerProtocol? = nil, geofenceManager: KlaviyoGeofenceManager? = nil) {
+    init(locationManager: LocationManagerProtocol? = nil, geofenceManager: KlaviyoGeofenceManager? = nil) {
         self.locationManager = locationManager ?? CLLocationManager()
         self.geofenceManager = geofenceManager ?? KlaviyoGeofenceManager(locationManager: self.locationManager)
 
@@ -36,14 +36,14 @@ public class KlaviyoLocationManager: NSObject {
     }
 
     @MainActor
-    internal func setupGeofencing() {
+    func setupGeofencing() {
         if environment.getLocationAuthorizationStatus() == .authorizedAlways {
             geofenceManager.setupGeofencing()
         }
     }
 
     @MainActor
-    internal func destroyGeofencing() {
+    func destroyGeofencing() {
         geofenceManager.destroyGeofencing()
     }
 }

--- a/Sources/KlaviyoLocation/Models/Geofence.swift
+++ b/Sources/KlaviyoLocation/Models/Geofence.swift
@@ -11,26 +11,26 @@ import KlaviyoCore
 import KlaviyoSwift
 
 /// Represents a Klaviyo geofence
-internal struct Geofence: Equatable, Hashable, Codable {
+struct Geofence: Equatable, Hashable, Codable {
     /// The geofence ID is a combination of the company ID and location ID from Klaviyo, separated by a colon.
-    internal let id: String
+    let id: String
 
     /// Longitude of the geofence center
-    internal let longitude: Double
+    let longitude: Double
 
     /// Latitude of the geofence center
-    internal let latitude: Double
+    let latitude: Double
 
     /// Radius of the geofence in meters
-    internal let radius: Double
+    let radius: Double
 
     /// Company ID to which this geofence belongs, extracted from the geofence ID.
-    internal var companyId: String {
+    var companyId: String {
         id.split(separator: ":").first.map(String.init) ?? ""
     }
 
     /// Location UUID to which this geofence belongs, extracted from the geofence ID.
-    internal var locationId: String {
+    var locationId: String {
         let components = id.split(separator: ":", maxSplits: 1)
         return components.count > 1 ? String(components[1]) : ""
     }
@@ -42,7 +42,7 @@ internal struct Geofence: Equatable, Hashable, Codable {
     ///   - latitude: Latitude coordinate of the geofence center
     ///   - radius: Radius of the geofence in meters
     /// - Throws: `GeofenceError.invalidIdFormat` if the ID doesn't match the expected format
-    internal init(
+    init(
         id: String,
         longitude: Double,
         latitude: Double,
@@ -68,6 +68,6 @@ internal struct Geofence: Equatable, Hashable, Codable {
 }
 
 /// Errors that can occur when working with geofences
-internal enum GeofenceError: Error {
+enum GeofenceError: Error {
     case invalidIdFormat(String)
 }

--- a/Sources/KlaviyoLocation/Utilities/CLAuthorizationStatus+Ext.swift
+++ b/Sources/KlaviyoLocation/Utilities/CLAuthorizationStatus+Ext.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 
 extension CLAuthorizationStatus {
-    internal var description: String {
+    var description: String {
         switch self {
         case .notDetermined:
             "not determined"

--- a/Sources/KlaviyoLocation/Utilities/CLLocationManager+LocationManagerProtocol.swift
+++ b/Sources/KlaviyoLocation/Utilities/CLLocationManager+LocationManagerProtocol.swift
@@ -9,7 +9,7 @@ import CoreLocation
 
 // MARK: - Location Manager Protocol
 
-internal protocol LocationManagerProtocol {
+protocol LocationManagerProtocol {
     var delegate: CLLocationManagerDelegate? { get set }
     var allowsBackgroundLocationUpdates: Bool { get set }
     var currentAuthorizationStatus: CLAuthorizationStatus { get }

--- a/Sources/KlaviyoLocation/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoLocation/Utilities/Logger+Ext.swift
@@ -12,5 +12,5 @@ extension Logger {
     private static var subsystem = Bundle.main.bundleIdentifier ?? ""
 
     /// Logs events related to location services.
-    internal static let geoservices = Logger(subsystem: subsystem, category: "geoservices")
+    static let geoservices = Logger(subsystem: subsystem, category: "geoservices")
 }


### PR DESCRIPTION
## Summary
Removes redundant `internal` access control keywords from the KlaviyoLocation module for cleaner, more idiomatic Swift code.

## Changes
- Changed `KlaviyoLocationManager` from `public` to `internal` (was unnecessarily public)
- Removed `internal` keywords from type declarations (classes, structs, protocols, enums)
- Removed `internal` keywords from all members (methods, properties, initializers)
- Types now rely on Swift's default internal access level

## Testing
- All 13 KlaviyoLocationTests passing
- Build successful