### PR TITLE
Add automated CocoaPods publishing workflow

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || github.ref }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -40,11 +40,11 @@ jobs:
 
       - name: Validate podspecs
         run: |
-          echo "Validating all podspecs..."
+          echo "Validating all podspecs in dependency order..."
           pod lib lint KlaviyoCore.podspec --allow-warnings
-          pod lib lint KlaviyoForms.podspec --allow-warnings
           pod lib lint KlaviyoSwiftExtension.podspec --allow-warnings
           pod lib lint KlaviyoSwift.podspec --allow-warnings
+          pod lib lint KlaviyoForms.podspec --allow-warnings
           echo "✅ All podspecs are valid"
 
       - name: Publish to CocoaPods Trunk
@@ -84,11 +84,11 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "*Version:* `${{ github.event.release.tag_name || github.event.inputs.version }}`\n*Repository:* ${{ github.repository }}\n*Published Podspecs:*\n• KlaviyoCore\n• KlaviyoSwiftExtension\n• KlaviyoSwift\n• KlaviyoForms"
+                  text: "*Version:* `${{ github.event.release.tag_name || github.event.inputs.version }}`\n*Repository:* ${{ github.repository }}\n*Trigger:* ${{ github.event_name == 'release' && 'Automatic (GitHub Release)' || 'Manual (Workflow Dispatch)' }}\n*Published Podspecs:*\n• KlaviyoCore\n• KlaviyoSwiftExtension\n• KlaviyoSwift\n• KlaviyoForms"
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "*Release:* <${{ github.event.release.html_url }}|View Release>\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+                  text: "${{ github.event.release.html_url && format('*Release:* <{0}|View Release>\n', github.event.release.html_url) || '' }}*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
 
       - name: Send Slack notification on failure
         if: failure()


### PR DESCRIPTION
## Summary
Automates CocoaPods publishing when a GitHub release is created. Eliminates manual `pod trunk push` commands and ensures all four podspecs are published in correct dependency order.

## What This Does
- ✅ Automatically triggers when you publish a GitHub release
- ✅ Validates all podspecs before publishing
- ✅ Publishes in dependency order: Core → Extension/Swift → Forms
- ✅ Sends Slack notifications on success/failure
- ✅ Supports manual trigger via workflow_dispatch

## Setup Required

**You need to add the CocoaPods token as a GitHub secret:**

1. Get your CocoaPods trunk token:
   ```bash
   cat ~/.netrc | grep -A 2 cocoapods.org
   ```
   Look for the `password` value after `cocoapods.org`

2. Add to GitHub Secrets:
   - Go to: https://github.com/klaviyo/klaviyo-swift-sdk/settings/secrets/actions
   - Click "New repository secret"
   - Name: `COCOAPODS_TRUNK_TOKEN`
   - Value: <paste token from step 1>
   - Click "Add secret"

## Testing

After merging and adding the secret, the workflow will automatically run on the next GitHub release. You can also test it manually:
1. Go to Actions tab
2. Select "Publish to CocoaPods" workflow
3. Click "Run workflow"
4. Enter version number (e.g., 5.1.1)

## Benefits
- No more manual `pod trunk push` for 4 podspecs
- Guaranteed correct publish order
- Immediate Slack notification on success/failure
- Consistent release process
- Can re-run if CocoaPods fails temporarily