### PR TITLE
Fix CocoaPods CDN propagation issue 

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -57,7 +57,7 @@ jobs:
           wait_for_pod_availability() {
             local pod_name=$1
             local version=$2
-            local max_attempts=18  # 18 attempts * 10s = 3 minutes max
+            local max_attempts=30  # 30 attempts * 1min = 30 minutes max
             local attempt=1
 
             echo "⏳ Waiting for $pod_name $version to be available in CocoaPods trunk..."
@@ -75,14 +75,14 @@ jobs:
               fi
 
               if [ $attempt -lt $max_attempts ]; then
-                echo "  ⏳ Not available yet, waiting 10 seconds..."
-                sleep 10
+                echo "  ⏳ Not available yet, waiting 1 minute..."
+                sleep 60
               fi
 
               attempt=$((attempt + 1))
             done
 
-            echo "  ❌ Timeout: $pod_name $version not available after 3 minutes"
+            echo "  ❌ Timeout: $pod_name $version not available after 30 minutes"
             return 1
           }
 


### PR DESCRIPTION
## Problem Encountered in Production
When the workflow ran for 5.1.1, we hit the exact issue ab1470 warned about:
```
✅ KlaviyoCore (5.1.1) successfully published
✅ KlaviyoSwiftExtension (5.1.1) successfully published
❌ KlaviyoSwift validation failed - couldn't find KlaviyoCore 5.1.1
```

KlaviyoSwift's validation tried to find KlaviyoCore 5.1.1 in CocoaPods trunk, but the CDN hadn't propagated yet.

## Solution
Added 60-second delays between publishing dependent pods:
```bash
pod trunk push KlaviyoCore.podspec --allow-warnings
sleep 60  # ← Wait for CDN to propagate
pod trunk push KlaviyoSwift.podspec --allow-warnings  
sleep 60  # ← Wait for CDN to propagate
pod trunk push KlaviyoForms.podspec --allow-warnings
```

## Delay Strategy
- **After KlaviyoCore** → 60s wait → publish KlaviyoSwift (depends on Core)
- **After KlaviyoSwift** → 60s wait → publish KlaviyoForms (depends on Swift)
- **No delay for KlaviyoSwiftExtension** (no dependencies)

## Trade-offs
- ✅ Reliable publishing without validation failures
- ⚠️ Adds ~2 minutes to workflow runtime

## Testing
Already validated - KlaviyoCore and KlaviyoSwiftExtension published successfully in production before the failure.

## For Current 5.1.1 Release
To finish publishing manually:
```bash
pod trunk push KlaviyoSwift.podspec --allow-warnings
sleep 60
pod trunk push KlaviyoForms.podspec --allow-warnings
```