### PR TITLE
Reduce significant location changes monitoring

### DIFF
--- a/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
+++ b/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
@@ -17,6 +17,7 @@ class KlaviyoLocationManager: NSObject {
 
     private var locationManager: LocationManagerProtocol
     private var apiKeyCancellable: AnyCancellable?
+    private var lifecycleCancellable: AnyCancellable?
     internal let cooldownTracker = GeofenceCooldownTracker()
 
     init(locationManager: LocationManagerProtocol? = nil) {
@@ -29,7 +30,6 @@ class KlaviyoLocationManager: NSObject {
     func monitorGeofencesFromBackground() {
         locationManager.delegate = self
         locationManager.allowsBackgroundLocationUpdates = true
-        locationManager.startMonitoringSignificantLocationChanges()
     }
 
     @MainActor
@@ -52,6 +52,7 @@ class KlaviyoLocationManager: NSObject {
         await syncGeofences()
 
         startObservingAPIKeyChanges()
+        startObservingAppLifecycle()
     }
 
     func syncGeofences() async {
@@ -100,6 +101,7 @@ class KlaviyoLocationManager: NSObject {
     @MainActor
     func stopGeofenceMonitoring() async {
         stopObservingAPIKeyChanges()
+        stopObservingAppLifecycle()
         let klaviyoRegions = locationManager.monitoredRegions
             .compactMap { $0 as? CLCircularRegion }
             .filter(\.isKlaviyoGeofence)
@@ -142,5 +144,30 @@ class KlaviyoLocationManager: NSObject {
     private func stopObservingAPIKeyChanges() {
         apiKeyCancellable?.cancel()
         apiKeyCancellable = nil
+    }
+
+    // MARK: - App Lifecycle Observation
+
+    private func startObservingAppLifecycle() {
+        guard lifecycleCancellable == nil else { return }
+
+        lifecycleCancellable = environment.appLifeCycle.lifeCycleEvents()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                switch event {
+                case .terminated:
+                    self.locationManager.startMonitoringSignificantLocationChanges()
+                case .foregrounded, .backgrounded:
+                    self.locationManager.stopMonitoringSignificantLocationChanges()
+                default:
+                    break
+                }
+            }
+    }
+
+    private func stopObservingAppLifecycle() {
+        lifecycleCancellable?.cancel()
+        lifecycleCancellable = nil
     }
 }


### PR DESCRIPTION
# Description
We can't prevent Apple from popping up the alert every 3 days about how often an app has accessed a user's background location, but we can try to make the number associated with it less scary!

I'm pretty sure the number of times an app is monitoring the user's location is related to our usage of `startMonitoringSignificantLocationChanges` -- this is necessary in order to ensure geofence events can trigger in terminated states. However, maybe we don't need to monitor it always and can stop monitoring for significant location changes when we know we already have the user's location and app processes running to support firing the events.

Hard to tell how much this will help cut down on that number (guess we will see in 3 ish days) but this overall seems like good cleanup.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
Only monitor significant location changes in the terminated state. Reduce unnecessary monitoring.

## Test Plan
Tested this IRL. Loaded geofences near me and with this code change on my physical device and walked around testing different types of terminated states from manually closing from the app switcher to shutting down the phone and restarting it. All events were received as expected.

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
