### PR TITLE
Feature/dynamic push action buttons

### DIFF
--- a/PUSH_ACTION_BUTTONS_PAYLOAD_SPEC.md
+++ b/PUSH_ACTION_BUTTONS_PAYLOAD_SPEC.md
@@ -1,0 +1,632 @@
+# Push Action Buttons - APNs Payload Specification
+
+This document specifies the APNs payload format for dynamic push action buttons in the Klaviyo iOS SDK.
+
+## Overview
+
+The Klaviyo iOS SDK supports two approaches for push notification action buttons:
+
+1. **Dynamic Action Buttons** (Recommended) - Fully customizable button labels and actions per notification
+2. **Predefined Categories** (Fallback) - 4 fixed button combinations for backwards compatibility
+
+## Dynamic Action Buttons (Primary Format)
+
+### Requirements
+
+- **`mutable-content: 1`** must be set in the `aps` dictionary
+- Notification Service Extension (NSE) must be implemented
+- iOS 10.0+ required (iOS 15+ for button icons)
+
+### Payload Structure
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Flash Sale!",
+      "body": "50% off everything - today only!"
+    },
+    "mutable-content": 1,
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "unique_notification_id_12345",
+    "url": "myapp://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.action.shop",
+        "label": "Shop Now",
+        "url": "myapp://sale/flash",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.action.later",
+        "label": "Remind Later",
+        "url": "myapp://reminders"
+      }
+    ]
+  }
+}
+```
+
+### Field Specifications
+
+#### `aps.mutable-content`
+- **Type**: Number
+- **Required**: Yes
+- **Value**: `1`
+- **Purpose**: Triggers Notification Service Extension to process dynamic buttons
+
+#### `body._k`
+- **Type**: String
+- **Required**: Yes
+- **Purpose**: Unique identifier for the notification, used to generate category ID
+- **Format**: Any unique string (UUID recommended)
+- **Example**: `"notif_abc123_xyz789"`
+
+#### `body.url`
+- **Type**: String
+- **Required**: No
+- **Purpose**: Default deep link URL when user taps notification body (not a button)
+- **Format**: Valid URL string (universal link or custom scheme)
+- **Examples**:
+  - `"myapp://home"`
+  - `"https://example.com/products"`
+
+#### `body.action_buttons`
+- **Type**: Array of Objects
+- **Required**: Yes (for dynamic buttons)
+- **Min Length**: 1
+- **Max Length**: 4 (iOS limit, recommend 2-3 for better UX)
+- **Purpose**: Defines the action buttons to display
+
+### Action Button Object
+
+Each object in `action_buttons` array has these fields:
+
+#### `id`
+- **Type**: String
+- **Required**: Yes
+- **Purpose**: Unique identifier for this action (used in analytics)
+- **Format**: Reverse domain notation recommended
+- **Examples**:
+  - `"com.klaviyo.action.shop"`
+  - `"com.company.action.view_order"`
+- **Used In**: `$opened_push_action` event as `action_id` property
+
+#### `label`
+- **Type**: String
+- **Required**: Yes
+- **Purpose**: Button text displayed to user
+- **Max Length**: ~30 characters (iOS truncates longer text)
+- **Localization**: Server should send localized text based on user's locale
+- **Examples**:
+  - `"Shop Now"` (English)
+  - `"Comprar ahora"` (Spanish)
+  - `"Jetzt einkaufen"` (German)
+
+#### `url`
+- **Type**: String
+- **Required**: No
+- **Purpose**: Deep link URL when this specific button is tapped
+- **Format**: Valid URL string
+- **Fallback**: If omitted, uses `body.url` as fallback
+- **Examples**:
+  - `"myapp://product/12345"`
+  - `"https://example.com/cart"`
+  - `"myapp://reminders/create"`
+
+#### `icon`
+- **Type**: String
+- **Required**: No
+- **Purpose**: SF Symbol name for button icon (iOS 15+ only)
+- **Format**: Valid SF Symbol name
+- **Availability**: iOS 15.0+. Ignored on older iOS versions.
+- **Examples**:
+  - `"cart.fill"` - Shopping cart
+  - `"heart.fill"` - Favorite/like
+  - `"bell.fill"` - Reminder
+  - `"eye.fill"` - View
+- **Resources**: [SF Symbols Browser](https://developer.apple.com/sf-symbols/)
+
+### Button Ordering
+
+**iOS Convention (Applied Automatically by SDK):**
+- **2 buttons**: Reversed (confirmatory action appears on right)
+  - Sent: `["Decline", "Accept"]` → Displayed: `[Accept] [Decline]`
+- **1 or 3+ buttons**: Original order preserved
+
+**Recommendation:** Send buttons in logical order; SDK handles iOS conventions.
+
+---
+
+## Predefined Categories (Fallback Format)
+
+For pushes without NSE or `mutable-content`, use predefined categories.
+
+### Available Categories
+
+| Category ID | Button 1 | Button 2 | Use Case |
+|-------------|----------|----------|----------|
+| `com.klaviyo.category.acceptDecline` | Accept | Decline | Invitations, requests |
+| `com.klaviyo.category.yesNo` | Yes | No | Simple questions |
+| `com.klaviyo.category.confirmCancel` | Confirm | Cancel | Confirmations |
+| `com.klaviyo.category.viewDismiss` | View | Dismiss | Content, updates |
+
+### Payload Structure
+
+```json
+{
+  "aps": {
+    "alert": "Your order has shipped!",
+    "category": "com.klaviyo.category.viewDismiss",
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "unique_notification_id",
+    "url": "myapp://orders",
+    "actions": {
+      "com.klaviyo.action.view": {
+        "url": "myapp://orders/12345"
+      },
+      "com.klaviyo.action.dismiss": {}
+    }
+  }
+}
+```
+
+### Field Specifications
+
+#### `aps.category`
+- **Type**: String
+- **Required**: Yes (for predefined categories)
+- **Values**: One of the category IDs above
+- **Note**: Apps must call `KlaviyoSDK().registerPushCategories(.automatic)` at launch
+
+#### `body.actions`
+- **Type**: Object (dictionary)
+- **Required**: No
+- **Purpose**: Per-button deep link URLs
+- **Keys**: Action identifiers (e.g., `"com.klaviyo.action.view"`)
+- **Values**: Objects with optional `url` field
+
+---
+
+## Event Tracking
+
+### Regular Notification Tap (Body Tap)
+
+**Event**: `$opened_push`
+
+**Properties**:
+```json
+{
+  "event": "$opened_push",
+  "properties": {
+    "_k": "unique_notification_id",
+    "url": "myapp://home",
+    // ... other notification properties
+  }
+}
+```
+
+### Action Button Tap
+
+**Event**: `$opened_push_action`
+
+**Properties**:
+```json
+{
+  "event": "$opened_push_action",
+  "properties": {
+    "_k": "unique_notification_id",
+    "action_id": "com.klaviyo.action.shop",
+    "action_label": "Shop Now",
+    "url": "myapp://sale/flash",
+    // ... other notification properties
+  }
+}
+```
+
+**Additional Properties**:
+- `action_id`: The button's identifier
+- `action_label`: The button's label text (dynamic buttons only)
+
+---
+
+## Validation Rules
+
+### Dynamic Buttons
+
+✅ **Valid:**
+```json
+{
+  "aps": { "alert": "...", "mutable-content": 1 },
+  "body": {
+    "_k": "notif123",
+    "action_buttons": [
+      { "id": "action1", "label": "Button 1" }
+    ]
+  }
+}
+```
+
+❌ **Invalid - Missing mutable-content:**
+```json
+{
+  "aps": { "alert": "..." },  // ← Missing mutable-content: 1
+  "body": {
+    "action_buttons": [...]
+  }
+}
+```
+
+❌ **Invalid - Missing required fields:**
+```json
+{
+  "body": {
+    "action_buttons": [
+      { "id": "action1" }  // ← Missing "label"
+    ]
+  }
+}
+```
+
+❌ **Invalid - Missing notification ID:**
+```json
+{
+  "body": {
+    // ← Missing "_k"
+    "action_buttons": [...]
+  }
+}
+```
+
+### Predefined Categories
+
+✅ **Valid:**
+```json
+{
+  "aps": {
+    "alert": "...",
+    "category": "com.klaviyo.category.viewDismiss"
+  },
+  "body": { "_k": "notif123" }
+}
+```
+
+❌ **Invalid - Unknown category:**
+```json
+{
+  "aps": {
+    "category": "unknown.category"  // ← Not registered
+  }
+}
+```
+
+---
+
+## Examples by Use Case
+
+### E-commerce: Flash Sale
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "⚡ Flash Sale Alert",
+      "body": "50% off everything for 2 hours only!"
+    },
+    "mutable-content": 1,
+    "badge": 1
+  },
+  "body": {
+    "_k": "flash_sale_2024_12_05",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.action.shop",
+        "label": "Shop Now",
+        "url": "klaviyo://sale/flash",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.action.remind",
+        "label": "Remind in 1hr",
+        "url": "klaviyo://reminders/create?in=1h"
+      }
+    ]
+  }
+}
+```
+
+### E-commerce: Abandoned Cart
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Your cart is waiting!",
+      "body": "Complete your purchase and get free shipping."
+    },
+    "mutable-content": 1
+  },
+  "body": {
+    "_k": "abandon_cart_user123_cart456",
+    "url": "klaviyo://cart",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.action.checkout",
+        "label": "Complete Purchase",
+        "url": "klaviyo://checkout",
+        "icon": "creditcard.fill"
+      },
+      {
+        "id": "com.klaviyo.action.browse",
+        "label": "Browse More",
+        "url": "klaviyo://shop"
+      }
+    ]
+  }
+}
+```
+
+### E-commerce: Order Update
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Package Delivered!",
+      "body": "Your order #12345 was delivered."
+    },
+    "mutable-content": 1
+  },
+  "body": {
+    "_k": "order_12345_delivered",
+    "url": "klaviyo://orders/12345",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.action.track",
+        "label": "View Details",
+        "url": "klaviyo://orders/12345/tracking",
+        "icon": "shippingbox.fill"
+      },
+      {
+        "id": "com.klaviyo.action.support",
+        "label": "Contact Support",
+        "url": "klaviyo://support/order/12345"
+      }
+    ]
+  }
+}
+```
+
+### E-commerce: Back in Stock
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Good news!",
+      "body": "The Nike Air Max you wanted is back in stock."
+    },
+    "mutable-content": 1
+  },
+  "body": {
+    "_k": "restock_product_abc123",
+    "url": "klaviyo://product/abc123",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.action.buy",
+        "label": "Buy Now",
+        "url": "klaviyo://product/abc123/quick-buy",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.action.view",
+        "label": "View Product",
+        "url": "klaviyo://product/abc123"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Testing Payloads
+
+### Using apns-cli
+
+```bash
+# Install if needed
+npm install -g apns-cli
+
+# Send test notification
+apns-cli send \
+  --token YOUR_DEVICE_TOKEN \
+  --bundle-id com.your.app \
+  --team-id YOUR_TEAM_ID \
+  --key-id YOUR_KEY_ID \
+  --key-path /path/to/AuthKey_XXXXX.p8 \
+  --payload payload.json
+```
+
+### Sample Test Payload (payload.json)
+
+```json
+{
+  "aps": {
+    "alert": "Test notification with action buttons",
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_notification_001",
+    "url": "klaviyo://test",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.action1",
+        "label": "Action 1",
+        "url": "klaviyo://test/action1",
+        "icon": "star.fill"
+      },
+      {
+        "id": "com.klaviyo.test.action2",
+        "label": "Action 2",
+        "url": "klaviyo://test/action2"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Best Practices
+
+### Button Labels
+
+✅ **Good**:
+- "Shop Now" - Clear call-to-action
+- "View Details" - Specific action
+- "Track Order" - User benefit clear
+
+❌ **Avoid**:
+- "Click Here" - Vague
+- "Learn More About Our Amazing Products" - Too long
+- "Button 1" - Not descriptive
+
+### Button Count
+
+- **Recommended**: 2 buttons
+  - Clean UI, easy to tap
+  - Works well on all device sizes
+- **Acceptable**: 1 or 3 buttons
+  - 1 button: Simple yes/no scenarios
+  - 3 buttons: Rare, ensure labels are short
+- **Avoid**: 4 buttons
+  - Crowded interface
+  - Small tap targets
+
+### Deep Link URLs
+
+✅ **Good**:
+- Specific screens: `"myapp://product/12345"`
+- With context: `"myapp://sale/flash?source=push"`
+- Fallback handling: Always set `body.url` as default
+
+❌ **Avoid**:
+- Generic: `"myapp://"`
+- Invalid URLs: `"not a url"`
+- External links without handling: `"https://example.com"` (opens Safari)
+
+### Localization
+
+- **Server-side**: Send localized button labels based on user's locale
+- **A/B Testing**: Test different button labels for engagement
+- **Icon Consistency**: Use same icons across locales for visual consistency
+
+### Category IDs
+
+- **Dynamic**: Auto-generated as `com.klaviyo.dynamic.<notification_id>`
+- **Namespace**: Always use `com.klaviyo.*` prefix
+- **Avoid Conflicts**: Don't use `com.klaviyo.*` for custom app categories
+
+---
+
+## Migration from Predefined to Dynamic
+
+### Step 1: Update Backend
+Add support for `action_buttons` array in payload
+
+### Step 2: Enable mutable-content
+Set `"mutable-content": 1` in all pushes with action buttons
+
+### Step 3: Gradual Rollout
+- Continue sending predefined category as fallback
+- New pushes use dynamic format
+- Monitor `$opened_push_action` events for adoption
+
+### Example Migration Payload
+
+```json
+{
+  "aps": {
+    "alert": "Order shipped!",
+    "category": "com.klaviyo.category.viewDismiss",  // Fallback
+    "mutable-content": 1  // New
+  },
+  "body": {
+    "_k": "order_123",
+    "url": "klaviyo://orders/123",
+    "action_buttons": [  // New
+      {
+        "id": "com.klaviyo.action.view",
+        "label": "Track Order",
+        "url": "klaviyo://orders/123/track"
+      },
+      {
+        "id": "com.klaviyo.action.dismiss",
+        "label": "Dismiss"
+      }
+    ],
+    "actions": {  // Fallback
+      "com.klaviyo.action.view": {
+        "url": "klaviyo://orders/123"
+      }
+    }
+  }
+}
+```
+
+**Behavior**:
+- iOS with NSE: Uses dynamic `action_buttons` (custom labels)
+- iOS without NSE: Falls back to predefined `category` (fixed labels)
+
+---
+
+## Troubleshooting
+
+### Buttons Don't Appear
+
+**Check**:
+1. ✅ `mutable-content: 1` is set
+2. ✅ NSE is implemented and calls `KlaviyoExtensionSDK.handleNotificationServiceDidReceivedRequest(...)`
+3. ✅ `body._k` exists
+4. ✅ `body.action_buttons` is an array with valid objects
+5. ✅ Each button has `id` and `label`
+
+### Button Taps Not Tracked
+
+**Check**:
+1. ✅ App delegate implements `userNotificationCenter(_:didReceive:withCompletionHandler:)`
+2. ✅ Calls `KlaviyoSDK().handle(notificationResponse:withCompletionHandler:)`
+3. ✅ Check Klaviyo events dashboard for `$opened_push_action` events
+
+### Deep Links Not Working
+
+**Check**:
+1. ✅ URL scheme registered in Info.plist
+2. ✅ Universal links configured (if using https://)
+3. ✅ App implements deep link handling via `action: .openDeepLink(url)`
+4. ✅ Button `url` field is valid URL string
+
+### Icons Not Showing
+
+**Check**:
+1. ✅ Device is iOS 15.0 or later
+2. ✅ Icon name is valid SF Symbol (check [SF Symbols app](https://developer.apple.com/sf-symbols/))
+3. ✅ `icon` field contains symbol name only (e.g., `"cart.fill"`, not `"SFSymbol.cart.fill"`)
+
+---
+
+## Support
+
+For issues or questions:
+- SDK Issues: [GitHub Issues](https://github.com/klaviyo/klaviyo-swift-sdk/issues)
+- Integration Help: Klaviyo Support
+- Payload Testing: Use `apns-cli` from `/Users/ajay.subramanya/Klaviyo/Repos/apns-cli`

--- a/Sources/KlaviyoSwift/Models/Event.swift
+++ b/Sources/KlaviyoSwift/Models/Event.swift
@@ -20,6 +20,10 @@ public struct Event: Equatable {
         internal static var _openedPush: EventName {
             EventName.customEvent("_openedPush")
         }
+
+        internal static var _openedPushAction: EventName {
+            EventName.customEvent("_openedPushAction")
+        }
     }
 
     public struct Metric: Equatable {
@@ -91,6 +95,7 @@ extension Event.EventName {
     public var value: String {
         switch self {
         case ._openedPush: return "$opened_push"
+        case ._openedPushAction: return "$opened_push_action"
         case .openedAppMetric: return "Opened App"
         case .viewedProductMetric: return "Viewed Product"
         case .addedToCartMetric: return "Added to Cart"

--- a/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
@@ -1,0 +1,231 @@
+//
+//  KlaviyoActionButtonParser.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created for Klaviyo
+//
+//  Copyright (c) 2025 Klaviyo
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import Foundation
+import UserNotifications
+
+/// Represents a parsed action button definition from a push notification payload.
+struct ActionButtonDefinition {
+    let id: String
+    let label: String
+    let url: String?
+    let icon: String?  // SF Symbol name for iOS 15+
+}
+
+/// Parses action button definitions from push notification payloads and creates UNNotificationAction instances.
+///
+/// This parser handles the dynamic action button format:
+/// ```json
+/// {
+///   "body": {
+///     "action_buttons": [
+///       {
+///         "id": "com.klaviyo.action.shop",
+///         "label": "Shop Now",
+///         "url": "myapp://sale",
+///         "icon": "cart.fill"
+///       }
+///     ]
+///   }
+/// }
+/// ```
+class KlaviyoActionButtonParser {
+
+    // MARK: - Public Methods
+
+    /// Parses action button definitions from a push notification payload.
+    ///
+    /// - Parameter userInfo: The notification's userInfo dictionary
+    /// - Returns: Array of parsed button definitions, or nil if none found
+    static func parseActionButtons(from userInfo: [AnyHashable: Any]) -> [ActionButtonDefinition]? {
+        // Extract body dictionary
+        guard let body = userInfo["body"] as? [String: Any],
+              let actionButtonsArray = body["action_buttons"] as? [[String: Any]],
+              !actionButtonsArray.isEmpty else {
+            return nil
+        }
+
+        // Parse each button definition
+        var definitions: [ActionButtonDefinition] = []
+
+        for buttonData in actionButtonsArray {
+            guard let id = buttonData["id"] as? String,
+                  let label = buttonData["label"] as? String else {
+                continue  // Skip invalid button definitions
+            }
+
+            let url = buttonData["url"] as? String
+            let icon = buttonData["icon"] as? String
+
+            definitions.append(ActionButtonDefinition(
+                id: id,
+                label: label,
+                url: url,
+                icon: icon
+            ))
+        }
+
+        return definitions.isEmpty ? nil : definitions
+    }
+
+    /// Creates an array of UNNotificationAction instances from button definitions.
+    ///
+    /// Button reversal logic (iOS convention):
+    /// - 2 buttons: Reversed (confirmatory action on right)
+    /// - 1 or 3+ buttons: Original order
+    ///
+    /// - Parameter definitions: Array of parsed button definitions
+    /// - Returns: Array of UNNotificationAction instances
+    static func createActions(from definitions: [ActionButtonDefinition]) -> [UNNotificationAction] {
+        var actions: [UNNotificationAction] = []
+
+        for definition in definitions {
+            let action = createAction(from: definition)
+            actions.append(action)
+        }
+
+        // Apply iOS button reversal convention for 2-button layouts
+        if actions.count == 2 {
+            return actions.reversed()
+        }
+
+        return actions
+    }
+
+    // MARK: - Private Methods
+
+    /// Creates a single UNNotificationAction from a button definition.
+    ///
+    /// - Parameter definition: The button definition to convert
+    /// - Returns: A configured UNNotificationAction
+    private static func createAction(from definition: ActionButtonDefinition) -> UNNotificationAction {
+        // Try to create action with icon support (iOS 15+)
+        if #available(iOS 15.0, *), let icon = definition.icon {
+            return createActionWithIcon(
+                id: definition.id,
+                label: definition.label,
+                icon: icon
+            )
+        }
+
+        // Fallback to standard action without icon
+        return UNNotificationAction(
+            identifier: definition.id,
+            title: definition.label,
+            options: .foreground  // Opens app when tapped
+        )
+    }
+
+    /// Creates a UNNotificationAction with an icon (iOS 15+).
+    ///
+    /// Uses NSInvocation reflection to call iOS 15+ icon APIs dynamically,
+    /// similar to OneSignal's approach. This allows the SDK to run on older
+    /// iOS versions while supporting icons when available.
+    ///
+    /// - Parameters:
+    ///   - id: The action identifier
+    ///   - label: The button label text
+    ///   - icon: SF Symbol name (e.g., "cart.fill")
+    /// - Returns: A UNNotificationAction with icon if successful, plain action otherwise
+    @available(iOS 15.0, *)
+    private static func createActionWithIcon(
+        id: String,
+        label: String,
+        icon: String
+    ) -> UNNotificationAction {
+        // Attempt to create icon using UNNotificationActionIcon.iconWithSystemImageName:
+        guard let iconClass = NSClassFromString("UNNotificationActionIcon") else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Get the iconWithSystemImageName: selector
+        let iconSelector = NSSelectorFromString("iconWithSystemImageName:")
+        guard iconClass.responds(to: iconSelector) else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Create the icon instance using performSelector
+        guard let iconObject = iconClass.perform(iconSelector, with: icon)?.takeUnretainedValue() else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Get the actionWithIdentifier:title:options:icon: selector
+        let actionClass: AnyClass = UNNotificationAction.self
+        let actionSelector = NSSelectorFromString("actionWithIdentifier:title:options:icon:")
+        guard actionClass.responds(to: actionSelector) else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Create NSMethodSignature
+        guard let method = class_getClassMethod(actionClass, actionSelector),
+              let signature = method_getTypeEncoding(method) else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Create NSInvocation (using reflection to avoid direct API usage)
+        let invocationClass = NSClassFromString("NSInvocation")
+        let invocationSelector = NSSelectorFromString("invocationWithMethodSignature:")
+
+        guard let invocationClass = invocationClass,
+              let signatureObject = NSMethodSignature(cString: signature) else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        guard let invocation = invocationClass.perform(invocationSelector, with: signatureObject)?.takeUnretainedValue() as? NSObject else {
+            return createFallbackAction(id: id, label: label)
+        }
+
+        // Set up the invocation
+        invocation.setValue(actionSelector, forKey: "selector")
+        invocation.setValue(actionClass, forKey: "target")
+
+        // Set arguments (indexes 0 and 1 are self and _cmd)
+        var idArg: NSString = id as NSString
+        var labelArg: NSString = label as NSString
+        var optionsArg: UNNotificationActionOptions = .foreground
+        var iconArg = iconObject
+
+        withUnsafePointer(to: &idArg) { invocation.setArgument($0, at: 2) }
+        withUnsafePointer(to: &labelArg) { invocation.setArgument($0, at: 3) }
+        withUnsafePointer(to: &optionsArg) { invocation.setArgument($0, at: 4) }
+        withUnsafePointer(to: &iconArg) { invocation.setArgument($0, at: 5) }
+
+        // Invoke
+        invocation.perform(NSSelectorFromString("invoke"))
+
+        // Get return value
+        var returnValue: Unmanaged<AnyObject>?
+        withUnsafeMutablePointer(to: &returnValue) { pointer in
+            invocation.perform(NSSelectorFromString("getReturnValue:"), with: pointer)
+        }
+
+        if let action = returnValue?.takeUnretainedValue() as? UNNotificationAction {
+            return action
+        }
+
+        // Fallback if reflection fails
+        return createFallbackAction(id: id, label: label)
+    }
+
+    /// Creates a standard action without icon (fallback).
+    ///
+    /// - Parameters:
+    ///   - id: The action identifier
+    ///   - label: The button label text
+    /// - Returns: A UNNotificationAction without icon
+    private static func createFallbackAction(id: String, label: String) -> UNNotificationAction {
+        return UNNotificationAction(
+            identifier: id,
+            title: label,
+            options: .foreground
+        )
+    }
+}

--- a/Sources/KlaviyoSwiftExtension/KlaviyoCategoryController.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoCategoryController.swift
@@ -1,0 +1,198 @@
+//
+//  KlaviyoCategoryController.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created for Klaviyo
+//
+//  Copyright (c) 2025 Klaviyo
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import Foundation
+import UserNotifications
+
+/// Manages the lifecycle of dynamically registered notification categories.
+///
+/// This controller handles:
+/// - Dynamic category registration per notification
+/// - FIFO pruning to maintain 128 category limit
+/// - Persistence across app restarts via UserDefaults
+/// - Smart merging to avoid overwriting existing categories
+class KlaviyoCategoryController {
+    static let shared = KlaviyoCategoryController()
+
+    // MARK: - Constants
+
+    /// Maximum number of categories to keep registered (iOS limit is higher, but 128 is plenty)
+    private let maxCategories = 128
+
+    /// UserDefaults key for storing registered category IDs
+    private let storageKey = "com.klaviyo.registered_categories"
+
+    /// Prefix for all Klaviyo dynamic category IDs
+    private let categoryPrefix = "com.klaviyo.dynamic."
+
+    // MARK: - Private Properties
+
+    /// UserDefaults instance (app group aware for badge handling compatibility)
+    private var userDefaults: UserDefaults? {
+        if let appGroup = Bundle.main.object(forInfoDictionaryKey: "klaviyo_app_group") as? String {
+            return UserDefaults(suiteName: appGroup)
+        }
+        return UserDefaults.standard
+    }
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// Registers a notification category with the given notification ID and actions.
+    ///
+    /// This method:
+    /// 1. Generates a unique category ID based on the notification ID
+    /// 2. Creates a UNNotificationCategory with the provided actions
+    /// 3. Merges with existing categories (without overwriting)
+    /// 4. Saves the category ID for persistence
+    /// 5. Prunes old categories if limit exceeded
+    ///
+    /// - Parameters:
+    ///   - notificationId: Unique identifier for this notification (from `_k` field)
+    ///   - actions: Array of notification actions to include in the category
+    /// - Returns: The generated category ID
+    func registerCategory(notificationId: String, actions: [UNNotificationAction]) -> String {
+        let categoryId = generateCategoryId(notificationId: notificationId)
+
+        // Create the category
+        let category = UNNotificationCategory(
+            identifier: categoryId,
+            actions: actions,
+            intentIdentifiers: [],
+            options: .customDismissAction
+        )
+
+        // Get existing categories
+        let semaphore = DispatchSemaphore(value: 0)
+        var existingCategories: Set<UNNotificationCategory> = []
+
+        UNUserNotificationCenter.current().getNotificationCategories { categories in
+            existingCategories = categories
+            semaphore.signal()
+        }
+
+        // Wait for categories to be fetched (NSE has tight time constraints)
+        _ = semaphore.wait(timeout: .now() + 1.0)
+
+        // Merge categories
+        let mergedCategories = mergeCategories(existing: existingCategories, new: category)
+
+        // Register the merged set
+        UNUserNotificationCenter.current().setNotificationCategories(mergedCategories)
+
+        // Force iOS to refresh its internal category cache
+        // This is necessary because iOS caches categories and may not recognize new ones immediately
+        UNUserNotificationCenter.current().getNotificationCategories { _ in
+            // No-op, just forcing the refresh
+        }
+
+        // Save category ID for persistence and pruning
+        saveCategoryId(categoryId)
+
+        return categoryId
+    }
+
+    /// Generates a unique category ID for the given notification ID.
+    ///
+    /// Format: `com.klaviyo.dynamic.<notificationId>`
+    ///
+    /// - Parameter notificationId: The notification's unique identifier
+    /// - Returns: A category identifier string
+    func generateCategoryId(notificationId: String) -> String {
+        return categoryPrefix + notificationId
+    }
+
+    // MARK: - Private Methods
+
+    /// Merges a new category with existing categories without overwriting.
+    ///
+    /// - Parameters:
+    ///   - existing: Set of currently registered categories
+    ///   - new: New category to add
+    /// - Returns: Merged set of categories
+    private func mergeCategories(
+        existing: Set<UNNotificationCategory>,
+        new: UNNotificationCategory
+    ) -> Set<UNNotificationCategory> {
+        var merged = existing
+
+        // Remove any existing category with the same ID (update case)
+        merged = merged.filter { $0.identifier != new.identifier }
+
+        // Add the new category
+        merged.insert(new)
+
+        return merged
+    }
+
+    /// Saves a category ID to persistent storage and triggers pruning if needed.
+    ///
+    /// - Parameter categoryId: The category ID to save
+    private func saveCategoryId(_ categoryId: String) {
+        guard let defaults = userDefaults else { return }
+
+        // Get existing category IDs
+        var categoryIds = getRegisteredCategoryIds()
+
+        // Remove if already exists (to update position in FIFO queue)
+        categoryIds.removeAll { $0 == categoryId }
+
+        // Add to end (most recent)
+        categoryIds.append(categoryId)
+
+        // Prune if over limit
+        if categoryIds.count > maxCategories {
+            let idsToRemove = Array(categoryIds.prefix(categoryIds.count - maxCategories))
+            pruneCategories(idsToRemove)
+            categoryIds = Array(categoryIds.suffix(maxCategories))
+        }
+
+        // Save updated list
+        defaults.set(categoryIds, forKey: storageKey)
+        defaults.synchronize()
+    }
+
+    /// Retrieves the list of registered category IDs from persistent storage.
+    ///
+    /// - Returns: Array of category ID strings (oldest to newest)
+    func getRegisteredCategoryIds() -> [String] {
+        guard let defaults = userDefaults else { return [] }
+        return defaults.stringArray(forKey: storageKey) ?? []
+    }
+
+    /// Removes the specified category IDs from the notification center.
+    ///
+    /// This method fetches all categories, filters out the ones to remove,
+    /// and re-registers the remaining categories.
+    ///
+    /// - Parameter categoryIds: Array of category IDs to remove
+    private func pruneCategories(_ categoryIds: [String]) {
+        guard !categoryIds.isEmpty else { return }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var existingCategories: Set<UNNotificationCategory> = []
+
+        UNUserNotificationCenter.current().getNotificationCategories { categories in
+            existingCategories = categories
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 1.0)
+
+        // Filter out categories to remove
+        let categoryIdsSet = Set(categoryIds)
+        let filteredCategories = existingCategories.filter { !categoryIdsSet.contains($0.identifier) }
+
+        // Re-register without the pruned categories
+        UNUserNotificationCenter.current().setNotificationCategories(filteredCategories)
+    }
+}

--- a/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
@@ -210,9 +210,8 @@ public enum KlaviyoExtensionSDK {
         bestAttemptContent: UNMutableNotificationContent
     ) {
         // Respect developer-set categories (don't override non-Klaviyo categories)
-        if let existingCategory = request.content.categoryIdentifier,
-           !existingCategory.isEmpty,
-           !existingCategory.hasPrefix("com.klaviyo.") {
+        let existingCategory = request.content.categoryIdentifier
+        if !existingCategory.isEmpty && !existingCategory.hasPrefix("com.klaviyo.") {
             return
         }
 

--- a/TEST_PAYLOADS.md
+++ b/TEST_PAYLOADS.md
@@ -1,0 +1,559 @@
+# Test Payloads for Dynamic Push Action Buttons
+
+This document contains ready-to-use APNs payloads for testing the dynamic push action button feature.
+
+## Prerequisites
+
+### Using apns-cli
+
+```bash
+# Navigate to apns-cli directory
+cd /Users/ajay.subramanya/Klaviyo/Repos/apns-cli
+
+# Send a test notification
+apns-cli send \
+  --token YOUR_DEVICE_TOKEN \
+  --bundle-id YOUR_BUNDLE_ID \
+  --team-id YOUR_TEAM_ID \
+  --key-id YOUR_KEY_ID \
+  --key-path /path/to/AuthKey_XXXXX.p8 \
+  --payload payload.json
+```
+
+---
+
+## Test Payload 1: Basic 2-Button Dynamic
+
+**Scenario**: Flash sale with Shop Now and Remind Later buttons
+
+**File**: `test-payload-1-basic.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "⚡ Flash Sale!",
+      "body": "50% off everything - 2 hours only!"
+    },
+    "mutable-content": 1,
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "test_flash_sale_001",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.shop",
+        "label": "Shop Now",
+        "url": "klaviyo://sale/flash"
+      },
+      {
+        "id": "com.klaviyo.test.later",
+        "label": "Remind Later",
+        "url": "klaviyo://reminders"
+      }
+    ]
+  }
+}
+```
+
+**Expected Behavior**:
+- 2 buttons appear: [Remind Later] [Shop Now] (reversed per iOS convention)
+- Tapping "Shop Now" → opens `klaviyo://sale/flash`
+- Tapping "Remind Later" → opens `klaviyo://reminders`
+- Event `$opened_push_action` tracked with `action_id` and `action_label`
+
+---
+
+## Test Payload 2: With SF Symbols Icons (iOS 15+)
+
+**Scenario**: Order shipped notification with icons
+
+**File**: `test-payload-2-icons.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "📦 Package Delivered",
+      "body": "Your order #12345 was delivered today"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_order_delivered_002",
+    "url": "klaviyo://orders/12345",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.track",
+        "label": "View Details",
+        "url": "klaviyo://orders/12345/tracking",
+        "icon": "shippingbox.fill"
+      },
+      {
+        "id": "com.klaviyo.test.support",
+        "label": "Contact Support",
+        "url": "klaviyo://support",
+        "icon": "message.fill"
+      }
+    ]
+  }
+}
+```
+
+**Expected Behavior** (iOS 15+):
+- 2 buttons with icons appear
+- Icons display as SF Symbols
+- On iOS <15: buttons appear without icons (graceful fallback)
+
+---
+
+## Test Payload 3: Three Buttons
+
+**Scenario**: Product recommendation with 3 options
+
+**File**: `test-payload-3-three-buttons.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "New Arrivals Just for You",
+      "body": "Check out our latest collection"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_new_arrivals_003",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.view",
+        "label": "Browse All",
+        "url": "klaviyo://new-arrivals",
+        "icon": "eye.fill"
+      },
+      {
+        "id": "com.klaviyo.test.favorites",
+        "label": "Favorites",
+        "url": "klaviyo://favorites",
+        "icon": "heart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.dismiss",
+        "label": "Not Now"
+      }
+    ]
+  }
+}
+```
+
+**Expected Behavior**:
+- 3 buttons appear in original order (no reversal for 3+ buttons)
+- "Not Now" button has no URL (dismisses notification)
+
+---
+
+## Test Payload 4: Single Button
+
+**Scenario**: Simple call-to-action
+
+**File**: `test-payload-4-single-button.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Don't Miss Out!",
+      "body": "Your cart items are selling fast"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_single_button_004",
+    "url": "klaviyo://cart",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.checkout",
+        "label": "Complete Purchase",
+        "url": "klaviyo://checkout",
+        "icon": "creditcard.fill"
+      }
+    ]
+  }
+}
+```
+
+**Expected Behavior**:
+- 1 button appears
+- Tapping button opens checkout
+- Tapping notification body opens cart
+
+---
+
+## Test Payload 5: Abandoned Cart Recovery
+
+**Scenario**: E-commerce abandoned cart with compelling CTAs
+
+**File**: `test-payload-5-abandoned-cart.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Your Cart is Waiting 🛒",
+      "body": "Complete your purchase now and get free shipping!"
+    },
+    "mutable-content": 1,
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "test_abandoned_cart_005",
+    "url": "klaviyo://cart",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.checkout",
+        "label": "Checkout",
+        "url": "klaviyo://checkout?source=push",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.browse",
+        "label": "Keep Shopping",
+        "url": "klaviyo://shop",
+        "icon": "square.grid.2x2.fill"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Test Payload 6: Back in Stock Alert
+
+**Scenario**: Product availability notification
+
+**File**: `test-payload-6-back-in-stock.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Good News! 🎉",
+      "body": "The Nike Air Max you wanted is back in stock"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_back_in_stock_006",
+    "url": "klaviyo://product/nike-air-max-123",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.buy",
+        "label": "Buy Now",
+        "url": "klaviyo://product/nike-air-max-123/quick-buy",
+        "icon": "cart.fill.badge.plus"
+      },
+      {
+        "id": "com.klaviyo.test.view",
+        "label": "View Product",
+        "url": "klaviyo://product/nike-air-max-123",
+        "icon": "eye.fill"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Test Payload 7: Fallback to Predefined Category
+
+**Scenario**: Test backwards compatibility with predefined categories
+
+**File**: `test-payload-7-predefined-fallback.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Order Shipped",
+      "body": "Your order is on its way"
+    },
+    "category": "com.klaviyo.category.viewDismiss",
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_predefined_007",
+    "url": "klaviyo://orders/12345",
+    "actions": {
+      "com.klaviyo.action.view": {
+        "url": "klaviyo://orders/12345/track"
+      },
+      "com.klaviyo.action.dismiss": {}
+    }
+  }
+}
+```
+
+**Note**: This payload does NOT have `mutable-content: 1`, so it will use predefined categories if registered. Useful for testing fallback behavior.
+
+---
+
+## Test Payload 8: Hybrid (Both Dynamic and Predefined)
+
+**Scenario**: Maximum compatibility - works with or without NSE
+
+**File**: `test-payload-8-hybrid.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Special Offer Inside",
+      "body": "Exclusive deal just for you"
+    },
+    "category": "com.klaviyo.category.viewDismiss",
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_hybrid_008",
+    "url": "klaviyo://offers",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.claim",
+        "label": "Claim Offer",
+        "url": "klaviyo://offers/claim",
+        "icon": "gift.fill"
+      },
+      {
+        "id": "com.klaviyo.test.dismiss",
+        "label": "No Thanks"
+      }
+    ],
+    "actions": {
+      "com.klaviyo.action.view": {
+        "url": "klaviyo://offers"
+      },
+      "com.klaviyo.action.dismiss": {}
+    }
+  }
+}
+```
+
+**Expected Behavior**:
+- With NSE: Uses dynamic buttons ("Claim Offer" / "No Thanks")
+- Without NSE: Uses predefined buttons ("View" / "Dismiss")
+
+---
+
+## Test Payload 9: Localization Test
+
+**Scenario**: Spanish language buttons
+
+**File**: `test-payload-9-spanish.json`
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "¡Venta Relámpago!",
+      "body": "50% de descuento en todo"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_localization_009",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.shop",
+        "label": "Comprar Ahora",
+        "url": "klaviyo://sale",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.later",
+        "label": "Recordar Después",
+        "url": "klaviyo://reminders"
+      }
+    ]
+  }
+}
+```
+
+**Purpose**: Demonstrates server-side localization of button labels
+
+---
+
+## Test Payload 10: Error Cases
+
+**Scenario**: Invalid payload to test error handling
+
+**File**: `test-payload-10-invalid.json`
+
+```json
+{
+  "aps": {
+    "alert": "Missing mutable-content",
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_invalid_010",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.action",
+        "label": "Test Button"
+      }
+    ]
+  }
+}
+```
+
+**Expected Behavior**:
+- Notification displays WITHOUT buttons (missing `mutable-content: 1`)
+- Should fallback gracefully
+
+---
+
+## Quick Test Script
+
+Save this as `test-push.sh`:
+
+```bash
+#!/bin/bash
+
+# Configuration
+DEVICE_TOKEN="YOUR_DEVICE_TOKEN_HERE"
+BUNDLE_ID="YOUR_BUNDLE_ID_HERE"
+TEAM_ID="YOUR_TEAM_ID_HERE"
+KEY_ID="YOUR_KEY_ID_HERE"
+KEY_PATH="/path/to/AuthKey_XXXXX.p8"
+
+# Test payload number
+PAYLOAD_NUM=${1:-1}
+
+# Send notification
+cd /Users/ajay.subramanya/Klaviyo/Repos/apns-cli
+
+apns-cli send \
+  --token "$DEVICE_TOKEN" \
+  --bundle-id "$BUNDLE_ID" \
+  --team-id "$TEAM_ID" \
+  --key-id "$KEY_ID" \
+  --key-path "$KEY_PATH" \
+  --payload "test-payload-${PAYLOAD_NUM}.json"
+
+echo "Sent test payload #${PAYLOAD_NUM}"
+```
+
+**Usage**:
+```bash
+chmod +x test-push.sh
+./test-push.sh 1  # Send payload 1
+./test-push.sh 2  # Send payload 2
+```
+
+---
+
+## Verification Checklist
+
+After sending a test payload, verify:
+
+### Visual Verification
+- [ ] Notification appears in notification center
+- [ ] Long-press or swipe shows action buttons
+- [ ] Button labels are correct
+- [ ] Icons appear (iOS 15+) or gracefully absent
+- [ ] Button count matches expected (1-4 buttons)
+- [ ] 2-button order is reversed (confirmatory action on right)
+
+### Functional Verification
+- [ ] Tapping notification body opens default URL
+- [ ] Tapping each button opens correct deep link
+- [ ] App launches or brings to foreground
+- [ ] Deep link routes to correct screen
+
+### Analytics Verification
+Check Klaviyo events dashboard for:
+- [ ] `$opened_push` event (when body is tapped)
+- [ ] `$opened_push_action` event (when button is tapped)
+- [ ] `action_id` property contains button identifier
+- [ ] `action_label` property contains button label text (dynamic only)
+
+### Edge Cases
+- [ ] Test without NSE implemented → fallback graceful
+- [ ] Test on iOS 14 with icons → fallback to no icons
+- [ ] Test with invalid payload → notification still displays
+- [ ] Test with 128+ notifications → category pruning works
+
+---
+
+## Common SF Symbols for E-commerce
+
+Use these icon names in the `icon` field:
+
+| Icon Name | Symbol | Use Case |
+|-----------|--------|----------|
+| `cart.fill` | 🛒 | Shopping, Add to cart |
+| `cart.fill.badge.plus` | 🛒+ | Add item |
+| `creditcard.fill` | 💳 | Checkout, Payment |
+| `shippingbox.fill` | 📦 | Shipping, Delivery |
+| `gift.fill` | 🎁 | Offers, Promotions |
+| `heart.fill` | ❤️ | Favorites, Wishlist |
+| `star.fill` | ⭐ | Featured, Popular |
+| `eye.fill` | 👁 | View, Browse |
+| `bell.fill` | 🔔 | Reminders, Alerts |
+| `message.fill` | 💬 | Support, Chat |
+| `tag.fill` | 🏷 | Deals, Discounts |
+| `percent` | % | Sale, Discount |
+| `bag.fill` | 👜 | Products, Shop |
+| `square.grid.2x2.fill` | ▦ | Browse, Catalog |
+
+**Find More**: [SF Symbols Browser](https://developer.apple.com/sf-symbols/)
+
+---
+
+## Troubleshooting
+
+### Buttons Don't Appear
+
+1. Check `mutable-content: 1` is set
+2. Verify NSE is configured correctly
+3. Check console logs for parsing errors
+4. Ensure `body._k` exists and is unique
+
+### Events Not Tracked
+
+1. Verify SDK is initialized
+2. Check notification delegate is set
+3. Look for events in Klaviyo dashboard (may have delay)
+4. Check console logs for event creation
+
+### Deep Links Don't Work
+
+1. Verify URL scheme in Info.plist
+2. Check deep link handler is implemented
+3. Test URL in Safari first
+4. Look for routing errors in console
+
+---
+
+## Next Steps
+
+1. Copy desired payload to a JSON file
+2. Update configuration in `test-push.sh`
+3. Run the script to send notification
+4. Verify behavior on device
+5. Check analytics dashboard
+
+For detailed payload specifications, see `PUSH_ACTION_BUTTONS_PAYLOAD_SPEC.md`.

--- a/test-payloads/1-basic-two-buttons.json
+++ b/test-payloads/1-basic-two-buttons.json
@@ -1,0 +1,27 @@
+{
+  "aps": {
+    "alert": {
+      "title": "⚡ Flash Sale!",
+      "body": "50% off everything - 2 hours only!"
+    },
+    "mutable-content": 1,
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "test_flash_sale_001",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.shop",
+        "label": "Shop Now",
+        "url": "klaviyo://sale/flash"
+      },
+      {
+        "id": "com.klaviyo.test.later",
+        "label": "Remind Later",
+        "url": "klaviyo://reminders"
+      }
+    ]
+  }
+}

--- a/test-payloads/10-error-case.json
+++ b/test-payloads/10-error-case.json
@@ -1,0 +1,15 @@
+{
+  "aps": {
+    "alert": "Missing mutable-content flag",
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_invalid_010",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.action",
+        "label": "Test Button"
+      }
+    ]
+  }
+}

--- a/test-payloads/2-with-icons.json
+++ b/test-payloads/2-with-icons.json
@@ -1,0 +1,28 @@
+{
+  "aps": {
+    "alert": {
+      "title": "📦 Package Delivered",
+      "body": "Your order #12345 was delivered today"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_order_delivered_002",
+    "url": "klaviyo://orders/12345",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.track",
+        "label": "View Details",
+        "url": "klaviyo://orders/12345/tracking",
+        "icon": "shippingbox.fill"
+      },
+      {
+        "id": "com.klaviyo.test.support",
+        "label": "Contact Support",
+        "url": "klaviyo://support",
+        "icon": "message.fill"
+      }
+    ]
+  }
+}

--- a/test-payloads/3-three-buttons.json
+++ b/test-payloads/3-three-buttons.json
@@ -1,0 +1,32 @@
+{
+  "aps": {
+    "alert": {
+      "title": "New Arrivals Just for You",
+      "body": "Check out our latest collection"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_new_arrivals_003",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.view",
+        "label": "Browse All",
+        "url": "klaviyo://new-arrivals",
+        "icon": "eye.fill"
+      },
+      {
+        "id": "com.klaviyo.test.favorites",
+        "label": "Favorites",
+        "url": "klaviyo://favorites",
+        "icon": "heart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.dismiss",
+        "label": "Not Now"
+      }
+    ]
+  }
+}

--- a/test-payloads/4-single-button.json
+++ b/test-payloads/4-single-button.json
@@ -1,0 +1,22 @@
+{
+  "aps": {
+    "alert": {
+      "title": "Don't Miss Out!",
+      "body": "Your cart items are selling fast"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_single_button_004",
+    "url": "klaviyo://cart",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.checkout",
+        "label": "Complete Purchase",
+        "url": "klaviyo://checkout",
+        "icon": "creditcard.fill"
+      }
+    ]
+  }
+}

--- a/test-payloads/5-abandoned-cart.json
+++ b/test-payloads/5-abandoned-cart.json
@@ -1,0 +1,29 @@
+{
+  "aps": {
+    "alert": {
+      "title": "Your Cart is Waiting 🛒",
+      "body": "Complete your purchase now and get free shipping!"
+    },
+    "mutable-content": 1,
+    "sound": "default",
+    "badge": 1
+  },
+  "body": {
+    "_k": "test_abandoned_cart_005",
+    "url": "klaviyo://cart",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.checkout",
+        "label": "Checkout",
+        "url": "klaviyo://checkout?source=push",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.browse",
+        "label": "Keep Shopping",
+        "url": "klaviyo://shop",
+        "icon": "square.grid.2x2.fill"
+      }
+    ]
+  }
+}

--- a/test-payloads/6-back-in-stock.json
+++ b/test-payloads/6-back-in-stock.json
@@ -1,0 +1,28 @@
+{
+  "aps": {
+    "alert": {
+      "title": "Good News! 🎉",
+      "body": "The Nike Air Max you wanted is back in stock"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_back_in_stock_006",
+    "url": "klaviyo://product/nike-air-max-123",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.buy",
+        "label": "Buy Now",
+        "url": "klaviyo://product/nike-air-max-123/quick-buy",
+        "icon": "cart.fill.badge.plus"
+      },
+      {
+        "id": "com.klaviyo.test.view",
+        "label": "View Product",
+        "url": "klaviyo://product/nike-air-max-123",
+        "icon": "eye.fill"
+      }
+    ]
+  }
+}

--- a/test-payloads/7-predefined-fallback.json
+++ b/test-payloads/7-predefined-fallback.json
@@ -1,0 +1,20 @@
+{
+  "aps": {
+    "alert": {
+      "title": "Order Shipped",
+      "body": "Your order is on its way"
+    },
+    "category": "com.klaviyo.category.viewDismiss",
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_predefined_007",
+    "url": "klaviyo://orders/12345",
+    "actions": {
+      "com.klaviyo.action.view": {
+        "url": "klaviyo://orders/12345/track"
+      },
+      "com.klaviyo.action.dismiss": {}
+    }
+  }
+}

--- a/test-payloads/8-hybrid.json
+++ b/test-payloads/8-hybrid.json
@@ -1,0 +1,33 @@
+{
+  "aps": {
+    "alert": {
+      "title": "Special Offer Inside",
+      "body": "Exclusive deal just for you"
+    },
+    "category": "com.klaviyo.category.viewDismiss",
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_hybrid_008",
+    "url": "klaviyo://offers",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.claim",
+        "label": "Claim Offer",
+        "url": "klaviyo://offers/claim",
+        "icon": "gift.fill"
+      },
+      {
+        "id": "com.klaviyo.test.dismiss",
+        "label": "No Thanks"
+      }
+    ],
+    "actions": {
+      "com.klaviyo.action.view": {
+        "url": "klaviyo://offers"
+      },
+      "com.klaviyo.action.dismiss": {}
+    }
+  }
+}

--- a/test-payloads/9-localization-spanish.json
+++ b/test-payloads/9-localization-spanish.json
@@ -1,0 +1,27 @@
+{
+  "aps": {
+    "alert": {
+      "title": "¡Venta Relámpago!",
+      "body": "50% de descuento en todo"
+    },
+    "mutable-content": 1,
+    "sound": "default"
+  },
+  "body": {
+    "_k": "test_localization_009",
+    "url": "klaviyo://home",
+    "action_buttons": [
+      {
+        "id": "com.klaviyo.test.shop",
+        "label": "Comprar Ahora",
+        "url": "klaviyo://sale",
+        "icon": "cart.fill"
+      },
+      {
+        "id": "com.klaviyo.test.later",
+        "label": "Recordar Después",
+        "url": "klaviyo://reminders"
+      }
+    ]
+  }
+}

--- a/test-payloads/README.md
+++ b/test-payloads/README.md
@@ -1,0 +1,147 @@
+# Test Payloads for Push Action Buttons
+
+This directory contains ready-to-use JSON payload files for testing dynamic push action buttons with apns-cli.
+
+## Quick Start
+
+```bash
+cd /Users/ajay.subramanya/Klaviyo/Repos/apns-cli
+
+# Send a test notification
+apns-cli send \
+  --token YOUR_DEVICE_TOKEN \
+  --bundle-id YOUR_BUNDLE_ID \
+  --team-id YOUR_TEAM_ID \
+  --key-id YOUR_KEY_ID \
+  --key-path /path/to/AuthKey_XXXXX.p8 \
+  --payload /path/to/klaviyo-swift-sdk/test-payloads/1-basic-two-buttons.json
+```
+
+## Available Test Payloads
+
+| File | Description | Buttons | Features |
+|------|-------------|---------|----------|
+| `1-basic-two-buttons.json` | Flash sale notification | Shop Now, Remind Later | Basic 2-button layout |
+| `2-with-icons.json` | Order delivered | View Details, Contact Support | SF Symbols icons (iOS 15+) |
+| `3-three-buttons.json` | New arrivals | Browse All, Favorites, Not Now | 3-button layout |
+| `4-single-button.json` | Cart reminder | Complete Purchase | Single CTA |
+| `5-abandoned-cart.json` | Cart recovery | Checkout, Keep Shopping | E-commerce scenario |
+| `6-back-in-stock.json` | Product availability | Buy Now, View Product | Stock alert |
+| `7-predefined-fallback.json` | Order shipped | View, Dismiss | Predefined categories (no mutable-content) |
+| `8-hybrid.json` | Special offer | Claim Offer, No Thanks | Both dynamic + predefined |
+| `9-localization-spanish.json` | Spanish language | Comprar Ahora, Recordar Después | Localization example |
+| `10-error-case.json` | Invalid payload | Test Button | Missing mutable-content (should fallback) |
+
+## Test Script
+
+Save this as `send-test.sh`:
+
+```bash
+#!/bin/bash
+
+# Configuration - UPDATE THESE VALUES
+DEVICE_TOKEN="YOUR_DEVICE_TOKEN_HERE"
+BUNDLE_ID="YOUR_BUNDLE_ID_HERE"
+TEAM_ID="YOUR_TEAM_ID_HERE"
+KEY_ID="YOUR_KEY_ID_HERE"
+KEY_PATH="/path/to/AuthKey_XXXXX.p8"
+
+# Path to payload (defaults to test 1)
+PAYLOAD="${1:-test-payloads/1-basic-two-buttons.json}"
+
+# Navigate to apns-cli
+cd /Users/ajay.subramanya/Klaviyo/Repos/apns-cli
+
+# Send notification
+apns-cli send \
+  --token "$DEVICE_TOKEN" \
+  --bundle-id "$BUNDLE_ID" \
+  --team-id "$TEAM_ID" \
+  --key-id "$KEY_ID" \
+  --key-path "$KEY_PATH" \
+  --payload "../klaviyo-swift-sdk/$PAYLOAD"
+
+echo "✅ Sent: $PAYLOAD"
+```
+
+### Usage
+
+```bash
+chmod +x send-test.sh
+
+# Send specific test
+./send-test.sh test-payloads/1-basic-two-buttons.json
+./send-test.sh test-payloads/2-with-icons.json
+./send-test.sh test-payloads/5-abandoned-cart.json
+```
+
+## Verification Checklist
+
+After sending a payload:
+
+### Visual
+- [ ] Notification appears in notification center
+- [ ] Long-press or swipe shows action buttons
+- [ ] Button labels are correct
+- [ ] Icons appear (iOS 15+) or gracefully absent
+- [ ] 2-button order is reversed (confirmatory action on right)
+
+### Functional
+- [ ] Tapping notification body opens default URL
+- [ ] Tapping each button opens correct deep link
+- [ ] App launches correctly
+
+### Analytics
+- [ ] `$opened_push` event tracked (body tap)
+- [ ] `$opened_push_action` event tracked (button tap)
+- [ ] Event contains `action_id` property
+- [ ] Event contains `action_label` property (dynamic buttons only)
+
+## Customization
+
+To test with your own URLs, edit any JSON file and replace:
+- `klaviyo://` with your app's URL scheme
+- Button labels with your desired text
+- Icons with SF Symbol names from [SF Symbols](https://developer.apple.com/sf-symbols/)
+
+## Common SF Symbols for E-commerce
+
+| Icon Name | Symbol | Use Case |
+|-----------|--------|----------|
+| `cart.fill` | 🛒 | Shopping, cart |
+| `creditcard.fill` | 💳 | Checkout, payment |
+| `shippingbox.fill` | 📦 | Shipping, delivery |
+| `gift.fill` | 🎁 | Offers, promotions |
+| `heart.fill` | ❤️ | Favorites, wishlist |
+| `star.fill` | ⭐ | Featured items |
+| `eye.fill` | 👁 | View, browse |
+| `bell.fill` | 🔔 | Reminders, alerts |
+| `message.fill` | 💬 | Support, chat |
+| `tag.fill` | 🏷 | Deals, discounts |
+| `bag.fill` | 👜 | Products, shop |
+
+## Troubleshooting
+
+**Buttons don't appear:**
+1. Check `mutable-content: 1` is set in payload
+2. Verify NSE is configured correctly
+3. Check device iOS version (iOS 10+ required)
+4. Look for errors in Xcode console
+
+**Events not tracked:**
+1. Verify SDK is initialized in app
+2. Check notification delegate is implemented
+3. Wait a few minutes for events to appear in dashboard
+4. Check Xcode console for event creation logs
+
+**Deep links don't work:**
+1. Verify URL scheme in Info.plist
+2. Test URL in Safari first (should prompt to open app)
+3. Check deep link handler implementation
+4. Look for routing errors in console
+
+## Full Documentation
+
+See parent directory for complete documentation:
+- `PUSH_ACTION_BUTTONS_PAYLOAD_SPEC.md` - Full payload specification
+- `TEST_PAYLOADS.md` - Detailed testing guide

--- a/test-payloads/send-test.sh
+++ b/test-payloads/send-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Configuration - UPDATE THESE VALUES
+DEVICE_TOKEN="YOUR_DEVICE_TOKEN_HERE"
+BUNDLE_ID="YOUR_BUNDLE_ID_HERE"
+TEAM_ID="YOUR_TEAM_ID_HERE"
+KEY_ID="YOUR_KEY_ID_HERE"
+KEY_PATH="/path/to/AuthKey_XXXXX.p8"
+
+# Path to payload (defaults to test 1)
+PAYLOAD="${1:-test-payloads/1-basic-two-buttons.json}"
+
+# Navigate to apns-cli
+cd /Users/ajay.subramanya/Klaviyo/Repos/apns-cli
+
+# Send notification
+apns-cli send \
+  --token "$DEVICE_TOKEN" \
+  --bundle-id "$BUNDLE_ID" \
+  --team-id "$TEAM_ID" \
+  --key-id "$KEY_ID" \
+  --key-path "$KEY_PATH" \
+  --payload "../klaviyo-swift-sdk/$PAYLOAD"
+
+echo "✅ Sent: $PAYLOAD"


### PR DESCRIPTION
# Description
  This PR implements dynamic push action buttons that allow fully customizable button labels, icons, and actions to be defined per notification via APNs payloads, with automatic fallback to predefined categories for
  backwards compatibility.

  ## Due Diligence
  - [ ] I have tested this on a simulator or a physical device.
  - [ ] I have added sufficient unit/integration tests of my changes.
  - [ ] I have adjusted or added new test cases to team test docs, if applicable.
  - [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

  ## Release/Versioning Considerations
  - [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - [x] `Minor` Contains changes to the public API.
  - [ ] `Major` Contains **breaking** changes.
  - [x] Contains readme or migration guide changes.
    - If so, please merge to a feature branch so documentation updates only go live upon official release.
  - [ ] This is planned work for an upcoming release.
    - If no, author or reviewer should account for this in a release plan, or describe why not below.

  ## Changelog / Code Overview

  ### New Features
  - **Dynamic Action Buttons**: Support for 1-4 custom action buttons defined dynamically in push payloads
  - **SF Symbols Support**: Action buttons can include SF Symbol icons (iOS 15+)
  - **Automatic Category Management**: Categories are created on-the-fly from payload definitions
  - **Backwards Compatible Fallback**: Predefined categories still work using the legacy `category` field

  ### New Files
  - `KlaviyoActionButtonParser.swift` - Parses action button definitions from push payloads
  - `KlaviyoCategoryController.swift` - Manages dynamic notification category creation and registration
  - `UNNotificationResponse+Klaviyo.swift` - Extension for extracting button click metadata
  - `PUSH_ACTION_BUTTONS_PAYLOAD_SPEC.md` - Complete specification for payload format
  - `TEST_PAYLOADS.md` - Documentation of all test scenarios
  - 9 JSON test payload files covering various use cases
  - `send-test.sh` - Shell script for easy payload testing with apns-cli

  ### Updated Files
  - `Klaviyo.swift` - Added action button parsing and category registration hooks
  - `KlaviyoExtension.swift` - Integrated dynamic category creation in notification service extension
  - `Event.swift` - Added support for button-specific event metadata
  - `README.md` - Updated with dynamic action buttons documentation

  ## Test Plan

  1. **Basic Testing**:
     - Send test notifications using the provided JSON payloads in `test-payloads/`
     - Use `send-test.sh` script with apns-cli for quick testing
     - Verify buttons appear correctly on lock screen and notification center

  2. **Dynamic Button Scenarios**:
     - Test 1-4 buttons (test payloads 1-4)
     - Test with SF Symbol icons (payload 2)
     - Test abandoned cart and back-in-stock flows (payloads 5-6)

  3. **Fallback Testing**:
     - Test predefined category fallback (payload 7)
     - Test hybrid dynamic/predefined approach (payload 8)

  4. **Edge Cases**:
     - Test with invalid/missing data (payload 10)
     - Test localization (payload 9)
     - Verify analytics events fire correctly on button taps

  5. **Compatibility**:
     - Test on iOS 15+ (with icons)
     - Test on iOS 10-14 (without icons)
     - Verify NSE integration works properly

## Demo
https://github.com/user-attachments/assets/84131962-71e9-4223-8b69-828658a2c1c6
