### PR TITLE
CHNL-26495: Narrow 5XX retry codes to 500, 502-504 only

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -54,7 +54,7 @@ public struct KlaviyoAPI {
             return .failure(KlaviyoAPIError.rateLimitError(backOff: nextBackOffWithJitter))
         }
 
-        if (501...599).contains(httpResponse.statusCode) {
+        if [500, 502, 503, 504].contains(httpResponse.statusCode) {
             let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             let jitter = environment.randomInt()
             let nextBackOffWithJitter = exponentialBackOff + jitter


### PR DESCRIPTION
## Summary
- Narrow retry logic from `501...599` to only `[500, 502, 503, 504]`
- 500 (Internal Server Error) now retries (was previously excluded)
- 501 (Not Implemented) now does NOT retry (was previously included)
- 505+ codes no longer retry

## Changes
- Updated status code check in `KlaviyoAPI.swift`
- Changed `testNoRetryOn500InternalServerError` → `testRetryOn500InternalServerError`
- Changed `testRetryOn599EdgeCase5XX` → `testNoRetryOn501NotImplemented`

## Test plan
- [x] All 24 `APIRequestErrorHandlingTests` pass

#470 

🤖 Generated with [Claude Code](https://claude.com/claude-code)