### PR TITLE
Add bump-version.sh script for version management

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -66,24 +66,12 @@ sed -i '' "s/s.version          = \"$currentVersion\"/s.version          = \"$ne
 sed -i '' "s/s.version          = \"$currentVersion\"/s.version          = \"$newVersion\"/" "KlaviyoLocation.podspec"
 sed -i '' "s/'KlaviyoSwift', '~> $currentVersion'/'KlaviyoSwift', '~> $newVersion'/" "KlaviyoLocation.podspec"
 
-# 3. Update example app Podfile
-EXAMPLE_PODFILE="Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile"
-if [[ -f "$EXAMPLE_PODFILE" ]]; then
-  echo "Updating $EXAMPLE_PODFILE..."
-  # Update version-pinned pod references
-  sed -i '' "s/'KlaviyoSwift', '$currentVersion'/'KlaviyoSwift', '$newVersion'/g" "$EXAMPLE_PODFILE"
-  sed -i '' "s/'KlaviyoForms', '$currentVersion'/'KlaviyoForms', '$newVersion'/g" "$EXAMPLE_PODFILE"
-  sed -i '' "s/'KlaviyoSwiftExtension', '$currentVersion'/'KlaviyoSwiftExtension', '$newVersion'/g" "$EXAMPLE_PODFILE"
-  sed -i '' "s/'KlaviyoLocation', '$currentVersion'/'KlaviyoLocation', '$newVersion'/g" "$EXAMPLE_PODFILE"
-fi
-
-# 4. Update test files with hardcoded versions
+# 3. Update test files/snapshots with hardcoded versions
 echo "Updating test files..."
 
 # NetworkSessionTests.swift
 sed -i '' "s/klaviyo-swift\/$currentVersion/klaviyo-swift\/$newVersion/g" "Tests/KlaviyoCoreTests/NetworkSessionTests.swift"
 
-# 5. Update test snapshots
 echo "Updating test snapshots..."
 
 for snapshot in \
@@ -100,14 +88,18 @@ do
   fi
 done
 
-# 6. Update README.md version references
-echo "Updating README.md..."
-if [[ -f "README.md" ]]; then
-  # Update specific version references (e.g., "SDK version X.Y.Z")
-  sed -i '' "s/SDK version $currentVersion/SDK version $newVersion/g" "README.md"
+# 4. Update example app Podfile
+EXAMPLE_PODFILE="Examples/KlaviyoSwiftExamples/CocoapodsExample/Podfile"
+if [[ -f "$EXAMPLE_PODFILE" ]]; then
+  echo "Updating $EXAMPLE_PODFILE..."
+  # Update version-pinned pod references
+  sed -i '' "s/'KlaviyoSwift', '$currentVersion'/'KlaviyoSwift', '$newVersion'/g" "$EXAMPLE_PODFILE"
+  sed -i '' "s/'KlaviyoForms', '$currentVersion'/'KlaviyoForms', '$newVersion'/g" "$EXAMPLE_PODFILE"
+  sed -i '' "s/'KlaviyoSwiftExtension', '$currentVersion'/'KlaviyoSwiftExtension', '$newVersion'/g" "$EXAMPLE_PODFILE"
+  sed -i '' "s/'KlaviyoLocation', '$currentVersion'/'KlaviyoLocation', '$newVersion'/g" "$EXAMPLE_PODFILE"
 fi
 
-# 7. Update example app project marketing versions
+# 5. Update example app project marketing versions
 echo "Updating example app project versions..."
 
 COCOAPODS_PROJECT="Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample.xcodeproj/project.pbxproj"


### PR DESCRIPTION
## Summary
- Adds a `bump-version.sh` script that updates the SDK version across all files in the repository

## Files Updated by Script
- `Sources/KlaviyoCore/Utils/Version.swift` (canonical source)
- All 5 podspecs (versions and dependencies)
- `Tests/KlaviyoCoreTests/NetworkSessionTests.swift`
- 7 test snapshot files
- `README.md` version references

## Usage
```bash
# With argument
./bump-version.sh 5.2.0

# Interactive (prompts for version)
./bump-version.sh
```

Example Run
```bash
evan.masseau@EvanMasseauMBP klaviyo-swift-sdk-bump-version-sh % ./bump-version.sh 
Current version: 5.1.1
Enter new version: 5.2.0
Bumping version: 5.1.1 -> 5.2.0

Updating Sources/KlaviyoCore/Utils/Version.swift...
Updating podspecs...
Updating test files...
Updating test snapshots...
Updating README.md...

✅ Version bumped from 5.1.1 to 5.2.0

Files updated:
  - Sources/KlaviyoCore/Utils/Version.swift
  - KlaviyoCore.podspec
  - KlaviyoSwift.podspec
  - KlaviyoForms.podspec
  - KlaviyoSwiftExtension.podspec
  - Tests/KlaviyoCoreTests/NetworkSessionTests.swift
  - Test snapshots (7 files)
  - README.md
```

## Test plan
- [x] Tested bump from 5.1.1 → 5.3.0
- [x] Verified all files updated correctly
- [x] Tested bump from 5.3.0 → 5.1.1
- [x] Verified version restored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)