### PR TITLE
Remove separate opened push action event

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -280,7 +280,7 @@ public struct KlaviyoSDK {
         }
 
         // Track action button event
-        create(event: Event(name: ._openedPushAction, properties: actionProperties))
+        create(event: Event(name: ._openedPush, properties: actionProperties))
 
         // Handle action-specific deep link (if provided)
         if let actionURL = notificationResponse.actionButtonURL {

--- a/Sources/KlaviyoSwift/Models/Event.swift
+++ b/Sources/KlaviyoSwift/Models/Event.swift
@@ -22,10 +22,6 @@ public struct Event: Equatable {
             EventName.customEvent("_openedPush")
         }
 
-        internal static var _openedPushAction: EventName {
-            EventName.customEvent("_openedPushAction")
-        }
-
         public enum LocationEvent: Equatable {
             case geofenceEnter
             case geofenceExit
@@ -107,7 +103,6 @@ extension Event.EventName {
     public var value: String {
         switch self {
         case ._openedPush: return "$opened_push"
-        case ._openedPushAction: return "$opened_push_action"
         case .openedAppMetric: return "Opened App"
         case .viewedProductMetric: return "Viewed Product"
         case .addedToCartMetric: return "Added to Cart"


### PR DESCRIPTION
# Description
PoC originally implemented a separate action. We have since decided to just use the `$opened_push` action.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
