### PR TITLE
Add button id to opened push event

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -276,6 +276,10 @@ public struct KlaviyoSDK {
             actionProperties["Button Label"] = label
         }
 
+        if let buttonId = notificationResponse.actionButtonId {
+            actionProperties["Button ID"] = buttonId
+        }
+
         if let actionType = notificationResponse.actionButtonType {
             actionProperties["Button Action"] = actionType.displayName()
         }

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -359,6 +359,7 @@ class KlaviyoSDKTests: XCTestCase {
         if case let .enqueueEvent(event) = eventAction! {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
             XCTAssertEqual(event.properties["Button Label"] as? String, buttonLabel, "Should include Button Label")
+            XCTAssertEqual(event.properties["Button ID"] as? String, actionId, "Should include Button ID")
             XCTAssertEqual(event.properties["Button Action"] as? String, "Deep Link", "Should include Button Action with correct value")
             XCTAssertEqual(event.properties["Button Link"] as? String, actionURL.absoluteString, "Should include Button Link")
 
@@ -419,6 +420,7 @@ class KlaviyoSDKTests: XCTestCase {
         if case let .enqueueEvent(event) = eventAction! {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
             XCTAssertEqual(event.properties["Button Label"] as? String, buttonLabel, "Should include Button Label")
+            XCTAssertEqual(event.properties["Button ID"] as? String, actionId, "Should include Button ID")
             XCTAssertEqual(event.properties["Button Action"] as? String, "Open App", "Should include Button Action with correct value")
             XCTAssertNil(event.properties["Button Link"], "Should NOT include Button Link for openApp action")
         }
@@ -473,6 +475,7 @@ class KlaviyoSDKTests: XCTestCase {
         // Verify button properties are NOT included for body tap
         if case let .enqueueEvent(event) = eventAction! {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
+            XCTAssertNil(event.properties["Button ID"], "Should NOT include Button ID for body tap")
             XCTAssertNil(event.properties["Button Label"], "Should NOT include Button Label for body tap")
             XCTAssertNil(event.properties["Button Action"], "Should NOT include Button Action for body tap")
             XCTAssertNil(event.properties["Button Link"], "Should NOT include Button Link for body tap")


### PR DESCRIPTION
# Description
After much Slack [chatter](https://klaviyo.slack.com/archives/C09SWF0TBJ5/p1769715848774349), we will be adding Button ID to the event properties, whatever format (presumably String) it ends up taking that we get from Push -- synced with Android for parity!

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
