### PR TITLE
docs: Add form lifecycle event hooks section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,38 @@ KlaviyoSDK().unregisterFromInAppForms()
 
 Note that after unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
 
+### Monitoring Form Lifecycle Events
+
+> ℹ️ Form lifecycle events are available in SDK version 5.x.0 and higher
+
+You can register a handler to track when forms are shown, dismissed, or when users tap call-to-action buttons. This is useful for sending form engagement data to third-party analytics platforms like Amplitude, Segment, or Mixpanel.
+
+```swift
+import KlaviyoForms
+
+KlaviyoSDK().registerFormLifecycleHandler { event in
+    switch event {
+    case .formShown:
+        // Track when a form is displayed
+        Analytics.track("Klaviyo Form Shown")
+    case .formDismissed:
+        // Track when a form is dismissed (user, timeout, or programmatic)
+        Analytics.track("Klaviyo Form Dismissed")
+    case .formCTAClicked:
+        // Track when a user taps a call-to-action button
+        Analytics.track("Klaviyo Form CTA Clicked")
+    }
+}
+```
+
+The handler is called on the main thread and will receive events for all form interactions. To unregister the handler:
+
+```swift
+KlaviyoSDK().unregisterFormLifecycleHandler()
+```
+
+**Note:** The handler is optional and does not affect normal form functionality. Forms will continue to display and track analytics in Klaviyo regardless of whether a handler is registered.
+
 ## Geofencing
 
 >  Geofencing support is available in SDK version 5.2.0 and higher.

--- a/README.md
+++ b/README.md
@@ -755,17 +755,26 @@ You can register a handler to track when forms are shown, dismissed, or when use
 ```swift
 import KlaviyoForms
 
-KlaviyoSDK().registerFormLifecycleHandler { event in
+KlaviyoSDK().registerFormLifecycleHandler { event, context in
     switch event {
     case .formShown:
         // Track when a form is displayed
-        Analytics.track("Klaviyo Form Shown")
+        Analytics.track("Klaviyo Form Shown", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     case .formDismissed:
         // Track when a form is dismissed (user, timeout, or programmatic)
-        Analytics.track("Klaviyo Form Dismissed")
+        Analytics.track("Klaviyo Form Dismissed", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     case .formCTAClicked:
         // Track when a user taps a call-to-action button
-        Analytics.track("Klaviyo Form CTA Clicked")
+        Analytics.track("Klaviyo Form CTA Clicked", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -808,21 +808,21 @@ KlaviyoSDK().registerFormLifecycleHandler { event in
     case .formShown(let formId, let formName):
         // Track when a form is displayed
         Analytics.track("Klaviyo Form Shown", properties: [
-            "formId": formId ?? "",
-            "formName": formName ?? ""
+            "formId": formId,
+            "formName": formName
         ])
     case .formDismissed(let formId, let formName):
-        // Track when a form is dismissed (user, timeout, or programmatic)
+        // Track when a form is dismissed
         Analytics.track("Klaviyo Form Dismissed", properties: [
-            "formId": formId ?? "",
-            "formName": formName ?? ""
+            "formId": formId,
+            "formName": formName
         ])
     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
         // Track when a user taps a call-to-action button
         Analytics.track("Klaviyo Form CTA Clicked", properties: [
-            "formId": formId ?? "",
-            "formName": formName ?? "",
-            "buttonLabel": buttonLabel ?? ""
+            "formId": formId,
+            "formName": formName,
+            "buttonLabel": buttonLabel
         ])
     }
 }

--- a/README.md
+++ b/README.md
@@ -802,17 +802,26 @@ You can register a handler to track when forms are shown, dismissed, or when use
 ```swift
 import KlaviyoForms
 
-KlaviyoSDK().registerFormLifecycleHandler { event in
+KlaviyoSDK().registerFormLifecycleHandler { event, context in
     switch event {
     case .formShown:
         // Track when a form is displayed
-        Analytics.track("Klaviyo Form Shown")
+        Analytics.track("Klaviyo Form Shown", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     case .formDismissed:
         // Track when a form is dismissed (user, timeout, or programmatic)
-        Analytics.track("Klaviyo Form Dismissed")
+        Analytics.track("Klaviyo Form Dismissed", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     case .formCTAClicked:
         // Track when a user taps a call-to-action button
-        Analytics.track("Klaviyo Form CTA Clicked")
+        Analytics.track("Klaviyo Form CTA Clicked", properties: [
+            "formId": context.formId ?? "",
+            "formName": context.formName ?? ""
+        ])
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   - [Setup](#setup-1)
     - [In-App Forms Session Configuration](#in-app-forms-session-configuration)
   - [Unregistering from In-App Forms](#unregistering-from-in-app-forms)
+  - [Monitoring Form Lifecycle Events](#monitoring-form-lifecycle-events)
 - [Geofencing](#geofencing)
   - [Prerequisites](#prerequisites-2)
   - [Setup](#setup-2)
@@ -795,32 +796,33 @@ Note that after unregistering, the next call to `registerForInAppForms()` will b
 
 ### Monitoring Form Lifecycle Events
 
-> ℹ️ Form lifecycle events are available in SDK version 5.x.0 and higher
+> ℹ️ Form lifecycle events are available in SDK version 5.3.0 and higher
 
 You can register a handler to track when forms are shown, dismissed, or when users tap call-to-action buttons. This is useful for sending form engagement data to third-party analytics platforms like Amplitude, Segment, or Mixpanel.
 
 ```swift
 import KlaviyoForms
 
-KlaviyoSDK().registerFormLifecycleHandler { event, context in
+KlaviyoSDK().registerFormLifecycleHandler { event in
     switch event {
-    case .formShown:
+    case .formShown(let formId, let formName):
         // Track when a form is displayed
         Analytics.track("Klaviyo Form Shown", properties: [
-            "formId": context.formId ?? "",
-            "formName": context.formName ?? ""
+            "formId": formId ?? "",
+            "formName": formName ?? ""
         ])
-    case .formDismissed:
+    case .formDismissed(let formId, let formName):
         // Track when a form is dismissed (user, timeout, or programmatic)
         Analytics.track("Klaviyo Form Dismissed", properties: [
-            "formId": context.formId ?? "",
-            "formName": context.formName ?? ""
+            "formId": formId ?? "",
+            "formName": formName ?? ""
         ])
-    case .formCTAClicked:
+    case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
         // Track when a user taps a call-to-action button
         Analytics.track("Klaviyo Form CTA Clicked", properties: [
-            "formId": context.formId ?? "",
-            "formName": context.formName ?? ""
+            "formId": formId ?? "",
+            "formName": formName ?? "",
+            "buttonLabel": buttonLabel ?? ""
         ])
     }
 }

--- a/README.md
+++ b/README.md
@@ -793,6 +793,38 @@ KlaviyoSDK().unregisterFromInAppForms()
 
 Note that after unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
 
+### Monitoring Form Lifecycle Events
+
+> ℹ️ Form lifecycle events are available in SDK version 5.x.0 and higher
+
+You can register a handler to track when forms are shown, dismissed, or when users tap call-to-action buttons. This is useful for sending form engagement data to third-party analytics platforms like Amplitude, Segment, or Mixpanel.
+
+```swift
+import KlaviyoForms
+
+KlaviyoSDK().registerFormLifecycleHandler { event in
+    switch event {
+    case .formShown:
+        // Track when a form is displayed
+        Analytics.track("Klaviyo Form Shown")
+    case .formDismissed:
+        // Track when a form is dismissed (user, timeout, or programmatic)
+        Analytics.track("Klaviyo Form Dismissed")
+    case .formCTAClicked:
+        // Track when a user taps a call-to-action button
+        Analytics.track("Klaviyo Form CTA Clicked")
+    }
+}
+```
+
+The handler is called on the main thread and will receive events for all form interactions. To unregister the handler:
+
+```swift
+KlaviyoSDK().unregisterFormLifecycleHandler()
+```
+
+**Note:** The handler is optional and does not affect normal form functionality. Forms will continue to display and track analytics in Klaviyo regardless of whether a handler is registered.
+
 ## Geofencing
 
 >  Geofencing support is available in SDK version 5.2.0 and higher.

--- a/README.md
+++ b/README.md
@@ -822,7 +822,8 @@ KlaviyoSDK().registerFormLifecycleHandler { event in
         Analytics.track("Klaviyo Form CTA Clicked", properties: [
             "formId": formId,
             "formName": formName,
-            "buttonLabel": buttonLabel
+            "buttonLabel": buttonLabel,
+            "deepLinkUrl": deepLinkUrl.absoluteString
         ])
     }
 }


### PR DESCRIPTION
## Summary

- Adds documentation for the new `registerFormLifecycleHandler` / `unregisterFormLifecycleHandler` public API introduced in the form lifecycle hooks feature

## Notes

This PR is intentionally kept separate from the feature PR (#515) so it can be merged after the feature is released and the version number is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)