### PR TITLE
Generalize wrapper SDK config plist loading

### DIFF
--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -58,7 +58,7 @@ public class DeepLinkHandler {
                 customDeepLinkHandler(url)
             }
         } else {
-            if !KlaviyoEnvironment.isReactNative {
+            if !KlaviyoEnvironment.isWrapperSDK {
                 if #available(iOS 14.0, *) {
                     Logger.navigation.info("A deep link handler has not been registered.\nHandling URL: '\(url.absoluteString, privacy: .public)' using fallback deep link handler")
                 }
@@ -74,7 +74,7 @@ public class DeepLinkHandler {
 
     @MainActor
     private static func openWithFallbackHandler(url: URL) async {
-        if !KlaviyoEnvironment.isReactNative {
+        if !KlaviyoEnvironment.isWrapperSDK {
             if #available(iOS 14.0, *) {
                 Logger.navigation.warning("""
                 Attempting to handle universal link via a fallback mechanism.

--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -80,14 +80,15 @@ package func loadPlist(named name: String) -> [String: AnyObject]? {
     return dict
 }
 
-/// Load plist from React Native SDK bundle (for dynamic linking scenarios)
+/// Load plist by searching all loaded bundles (for dynamic linking scenarios)
 /// - Parameter name: the name of the plist
 /// - Returns: the contents of the plist or nil if not found
-package func loadPlistFromReactNativeBundle(named name: String) -> [String: AnyObject]? {
-    guard let bundle = Bundle(identifier: "org.cocoapods.klaviyo-react-native-sdk"),
-          let path = bundle.path(forResource: name, ofType: "plist"),
-          let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {
-        return nil
+package func loadPlistFromAnyBundle(named name: String) -> [String: AnyObject]? {
+    for bundle in Bundle.allBundles + Bundle.allFrameworks {
+        if let path = bundle.path(forResource: name, ofType: "plist"),
+           let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
+            return dict
+        }
     }
-    return dict
+    return nil
 }

--- a/Tests/KlaviyoCoreTests/FileUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/FileUtilsTests.swift
@@ -81,12 +81,18 @@ class FileUtilsTests: XCTestCase {
         XCTAssertLessThan(elapsedTime, 0.1, "loadPlist should complete quickly (< 100ms), but took \(elapsedTime)s")
     }
 
-    func testLoadPlistFromReactNativeBundle_ReturnsNilWhenBundleNotFound() {
-        // This will be nil for non-RN test environments
-        let result = loadPlistFromReactNativeBundle(named: "klaviyo-sdk-configuration")
+    func testLoadPlistFromAnyBundle_ReturnsNilWhenPlistNotFound() {
+        let result = loadPlistFromAnyBundle(named: "non-existent-plist")
+        XCTAssertNil(result, "Should return nil when plist doesn't exist in any bundle")
+    }
 
-        // Should return nil without crashing
-        // In a real RN environment, this might return a value
-        XCTAssertTrue(result == nil || result is [String: AnyObject], "Should return nil or valid dictionary")
+    func testLoadPlistFromAnyBundle_ReturnsDictionaryIfPlistExists() {
+        let result = loadPlistFromAnyBundle(named: "klaviyo-sdk-configuration")
+
+        if result != nil {
+            XCTAssertTrue(result is [String: AnyObject], "Should return dictionary if plist exists")
+        } else {
+            XCTAssertNil(result, "Should return nil if plist doesn't exist in any bundle")
+        }
     }
 }


### PR DESCRIPTION
# Description
Remove the React Native-specific `RCTBridge` guard gate on SDK configuration plist loading so that any wrapper SDK (Flutter, React Native, or future wrappers) can provide a `klaviyo-sdk-configuration.plist` to override the SDK name and version in User-Agent headers, push token payloads, and event metadata.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

<img width="400" alt="Screenshot 2026-02-27 at 11 33 57" src="https://github.com/user-attachments/assets/cce6b097-e4be-45a8-acf1-1e04945d1782" />
<img width="400" alt="Screenshot 2026-02-27 at 14 21 57" src="https://github.com/user-attachments/assets/8b0d7860-d26d-4371-8f9c-d3666f12bdf1" />
<img width="400" alt="Screenshot 2026-02-27 at 14 22 27" src="https://github.com/user-attachments/assets/1ddec74a-e6bb-4457-872c-f4b97f82e53c" />
<img width="400" alt="Screenshot 2026-02-27 at 14 48 55" src="https://github.com/user-attachments/assets/478737fd-3977-4f1f-80dd-b89b608c2c15" />


## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview

**`KlaviyoEnvironment.swift`**
- Renamed `rnSDKConfig` → `wrapperSDKConfig`
- Removed the `NSClassFromString("RCTBridge")` guard that prevented plist loading in non-RN apps
- Replaced `loadPlistFromReactNativeBundle` fallback with generic `loadPlistFromAnyBundle`
- Renamed `isReactNative` → `isWrapperSDK` (now based on whether a wrapper config plist was found)

**`FileUtils.swift`**
- Replaced `loadPlistFromReactNativeBundle` (hardcoded to `org.cocoapods.klaviyo-react-native-sdk` bundle) with `loadPlistFromAnyBundle` (searches `Bundle.allBundles + Bundle.allFrameworks`)

**`DeepLinkHandler.swift`**
- Updated references from `isReactNative` → `isWrapperSDK`

**`FileUtilsTests.swift`**
- Replaced RN-specific test with tests for the new `loadPlistFromAnyBundle` function

### How it works across linking strategies:

| Scenario | Static Linking | Dynamic Linking |
|---|---|---|
| Native Swift | No plist → defaults to `swift`/version | Same |
| React Native | `loadPlist` finds in `Bundle.main` | `loadPlistFromAnyBundle` finds in framework bundle |
| Flutter | `loadPlist` finds in `Bundle.main` | `loadPlistFromAnyBundle` finds in framework bundle |


## Test Plan
1. Build the package: `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` — succeeds
2. Run `FileUtilsTests` and `DeepLinkHandlerTests` — all 13 tests pass, 0 failures
3. Verify that without a `klaviyo-sdk-configuration.plist`, the SDK still defaults to `swift`/`5.2.0`
4. Verify that with a plist containing `klaviyo_sdk_name`/`klaviyo_sdk_version`, those values are used in User-Agent, push token payloads, and event metadata


## Related Issues/Tickets
- Linear: MAGE-284
- Jira: CHNL-31878
- Prerequisite for the Flutter SDK to set its own SDK name/version in native iOS requests
- Reference: [klaviyo-react-native-sdk#175](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/175), [klaviyo-swift-sdk#204](https://github.com/klaviyo/klaviyo-swift-sdk/pull/204)