### PR TITLE
Audit and trim AGENTS.md for conciseness and accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,6 @@ swiftlint --fix --strict
 swiftformat .
 ```
 
-### Branching
-
-Branch format: `<initials>/<ticket-id>/<short-description>` (e.g. `ab/MAGE-123/fix-push-token`).
-
 ### Commits & Pull Requests
 If prompted to commit, push, or open pull requests:
 


### PR DESCRIPTION
# Description
Audit AGENTS.md to reduce verbosity and improve accuracy, removing redundant or overly prescriptive guidance while preserving essential context for AI agents.

## Due Diligence
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.

## Changelog / Code Overview
- Condensed the role description from a verbose paragraph to a single directive sentence
- Removed testing guidance that was overly prescriptive or duplicated XCTest defaults (e.g., "use XCTestExpectation for async testing", "mock external dependencies")
- Clarified snapshot testing references to use the correct library name (`pointfreeco/swift-snapshot-testing`)
- Removed code style rules that are either enforced by linters or are general Swift conventions (e.g., "avoid force unwrapping", "use trailing closures")

## Test Plan
- N/A — documentation-only change

## Related Issues/Tickets
- MAGE-339