### PR TITLE
Example of `registerDeepLinkHandler` implementation

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -54,6 +54,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     print("   Form Name: \(context.formName ?? "unknown")")
                 }
             }
+            .registerDeepLinkHandler { [weak self] url in
+                guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+                    return
+                }
+
+                switch (components.host, components.path) {
+                case ("www.google.com", "/"), ("www.google.com", ""):
+                    // Open in system browser
+                    UIApplication.shared.open(url)
+                case ("www.google.com", "/maps"):
+                    // Show an alert
+                    let alert = UIAlertController(title: "Maps", message: "Opening Google Maps", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "OK", style: .default))
+                    let keyWindow = UIApplication.shared.connectedScenes
+                        .compactMap { $0 as? UIWindowScene }
+                        .flatMap(\.windows)
+                        .first(where: \.isKeyWindow)
+                    keyWindow?.rootViewController?.present(alert, animated: true)
+                default:
+                    guard let host = components.host,
+                          let deeplink = DeepLinking(rawValue: host) else { return }
+                    self?.handle(deeplink, with: url.absoluteString)
+                }
+            }
 
         // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))


### PR DESCRIPTION
# Description
This PR shows an example how to implement `registerDeepLinkHandler` for custom handling of URLs and deep links.

Example of an In-App Form link to `https://www.google.com` opening an external browser:

https://github.com/user-attachments/assets/dc9a6475-f5f4-4b72-a95f-8b4354a29dfb

Example of an In-App Form link to `https://www.google.com/maps` showing an alert:

https://github.com/user-attachments/assets/61e1f7c5-9cc4-43f5-a9be-16f03e400df6

Example of a push notification with a link that opens in the default browser:

https://github.com/user-attachments/assets/8752dd0c-8f28-4ee1-b6c0-2e460849208f



