### PR TITLE
Handle keyboard and orientation changes smoother

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -16,12 +16,14 @@ class InAppWindowManager {
     private var window: UIWindow?
     private var windowScene: UIWindowScene?
     private var currentLayout: FormLayout?
+    private weak var viewController: KlaviyoWebViewController?
 
     private init() {}
 
     /// Presents the view controller in a window configured according to the layout.
     func present(viewController: KlaviyoWebViewController, layout: FormLayout) {
         dismiss()
+        self.viewController = viewController
         currentLayout = layout
 
         if #available(iOS 13.0, *) {
@@ -44,7 +46,7 @@ class InAppWindowManager {
         window.makeKeyAndVisible()
 
         updateWindowFrame()
-        setupObservers()
+        setupObservers(on: viewController)
     }
 
     /// Returns true if the window manager has an active window.
@@ -120,35 +122,50 @@ class InAppWindowManager {
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
-    private func setupObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleOrientationChange), name: UIDevice.orientationDidChangeNotification, object: nil)
+    private func setupObservers(on viewController: KlaviyoWebViewController) {
+        // Handle orientation changes via viewWillTransition
+        viewController.onSizeTransition = { [weak self] _, coordinator in
+            coordinator.animate(alongsideTransition: { _ in
+                self?.updateWindowFrame()
+            }, completion: nil)
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardChange(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardChange(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-
-    @objc
-    private func handleOrientationChange() {
-        updateWindowFrame()
     }
 
     @objc
     private func handleKeyboardChange(_ notification: Notification) {
         guard let window,
               let currentLayout,
-              let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              isBottomAnchored(currentLayout.position) else {
+              let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
             return
         }
 
-        var screenBounds = getScreenBounds()
+        let screenBounds = getScreenBounds()
+
         if notification.name == UIResponder.keyboardWillShowNotification {
-            screenBounds.size.height -= keyboardFrame.height
+            // Calculate the form's bottom edge position and gap from screen bottom
+            let baseFrame = calculateFrame(for: currentLayout, in: screenBounds)
+            let formBottomEdge = baseFrame.maxY
+            let screenBottom = screenBounds.maxY
+            let gap = screenBottom - formBottomEdge
+
+            // Calculate actual keyboard overlap
+            let keyboardHeight = keyboardFrame.height
+            let overlap = max(0, keyboardHeight - gap)
+
+            if overlap > 0 {
+                // Shift window up by the overlap amount
+                var adjustedFrame = baseFrame
+                adjustedFrame.origin.y -= overlap
+                window.frame = adjustedFrame
+            } else {
+                window.frame = baseFrame
+            }
+        } else {
+            // Keyboard dismissed, restore original frame
+            window.frame = calculateFrame(for: currentLayout, in: screenBounds)
         }
-
-        window.frame = calculateFrame(for: currentLayout, in: screenBounds)
-    }
-
-    private func isBottomAnchored(_ position: FormPosition) -> Bool {
-        position == .bottom || position == .bottomLeft || position == .bottomRight
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -75,7 +75,7 @@ class InAppWindowManager {
         }
     }
 
-    private func calculateFrame(for layout: FormLayout, in screenBounds: CGRect, keyboardVisible: Bool = false) -> CGRect {
+    private func calculateFrame(for layout: FormLayout, in screenBounds: CGRect) -> CGRect {
         guard layout.position != .fullscreen else {
             return screenBounds
         }
@@ -92,7 +92,7 @@ class InAppWindowManager {
         let height = layout.height.toPoints(relativeTo: screenHeight)
 
         let marginTop = safeArea.top + margin.top
-        let marginBottom = (keyboardVisible ? 0 : safeArea.bottom) + margin.bottom
+        let marginBottom = safeArea.bottom + margin.bottom
         let marginLeft = safeArea.left + margin.left
         let marginRight = safeArea.right + margin.right
 
@@ -168,9 +168,10 @@ class InAppWindowManager {
             let overlap = max(0, keyboardHeight - gap)
 
             if overlap > 0 {
-                // Shift window up by the overlap amount
+                // Shift window up by the overlap amount, clamped to safe area top
+                let safeAreaTop = windowScene?.windows.first?.safeAreaInsets.top ?? 0
                 var adjustedFrame = baseFrame
-                adjustedFrame.origin.y -= overlap
+                adjustedFrame.origin.y = max(safeAreaTop, baseFrame.origin.y - overlap)
                 window.frame = adjustedFrame
             } else {
                 window.frame = baseFrame

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -16,14 +16,12 @@ class InAppWindowManager {
     private var window: UIWindow?
     private var windowScene: UIWindowScene?
     private var currentLayout: FormLayout?
-    private weak var viewController: KlaviyoWebViewController?
 
     private init() {}
 
     /// Presents the view controller in a window configured according to the layout.
     func present(viewController: KlaviyoWebViewController, layout: FormLayout) {
         dismiss()
-        self.viewController = viewController
         currentLayout = layout
 
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
@@ -147,6 +145,8 @@ class InAppWindowManager {
         }
 
         let screenBounds = getScreenBounds()
+
+        guard currentLayout.position != .fullscreen else { return }
 
         if notification.name == UIResponder.keyboardWillShowNotification {
             // Calculate the form's bottom edge position and gap from screen bottom

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -44,6 +44,7 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     private var addedMessageHandlers: Set<String> = []
 
     private var viewModel: KlaviyoWebViewModeling
+    var onSizeTransition: (@MainActor (CGSize, UIViewControllerTransitionCoordinator) -> Void)?
 
     // MARK: - Initializers
 
@@ -94,6 +95,11 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
               webView.estimatedProgress != 1.0 else { return }
 
         loadUrl()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        onSizeTransition?(size, coordinator)
     }
 
     @MainActor


### PR DESCRIPTION
# Description
  Fixes two issues with in-app form window positioning: orientation changes were not animating smoothly, and keyboard avoidance was incorrectly applied to all bottom-anchored forms regardless of actual overlap.

  ## Due Diligence
  - [x] I have tested this on a simulator or a physical device.
  - [ ] I have added sufficient unit/integration tests of my changes.
  - [ ] I have adjusted or added new test cases to team test docs, if applicable.
  - [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

  ## Release/Versioning Considerations
  - [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - [ ] `Minor` Contains changes to the public API.
  - [ ] `Major` Contains **breaking** changes.
  - [ ] Contains readme or migration guide changes.
  - [x] This is planned work for an upcoming release.

  ## Changelog / Code Overview

  **Orientation handling**
  - Replaced `UIDevice.orientationDidChangeNotification` with `viewWillTransition(to:with:)` via a new `onSizeTransition` callback on `KlaviyoWebViewController`
  - Frame updates now run inside the transition coordinator's animation block so resizes animate in sync with the device rotation

  **Keyboard avoidance**
  - Instead of blindly subtracting keyboard height from screen bounds, the window manager now calculates the actual overlap between the keyboard and the form's bottom edge
  - The window only shifts up when there is real overlap, and only by the overlap amount — no unnecessary movement for forms that already clear the keyboard
  - Removed `isBottomAnchored` gate so all form positions participate in the overlap check

  ## Test Plan
  1. Present a bottom-anchored form and rotate the device — confirm the form reframes smoothly alongside the rotation animation
  2. Present a form that doesn't reach the bottom of the screen, then show the keyboard — confirm the form does not move
  3. Present a form near the bottom of the screen, then show the keyboard — confirm the form shifts up exactly enough to clear the keyboard
  4. Dismiss the keyboard — confirm the form returns to its original position


https://github.com/user-attachments/assets/bebc8119-9504-497c-917b-8e1150536a1f




  ## Related Issues/Tickets

  ---