### PR TITLE
Align form lifecycle events with Android SDK

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -33,14 +33,6 @@ class IAFPresentationManager {
 
     private var configuration: InAppFormsConfig?
     private var assetSource: String?
-    private var hasInvokedDismissed = false
-
-    /// Stores the formId from the most recent presentForm call, used as a fallback
-    /// in dismissForm/destroyWebView when the bridge doesn't send context.
-    private var lastPresentedFormId: String?
-    /// Stores the formName from the most recent presentForm call, used as a fallback
-    /// in dismissForm/destroyWebView when the bridge doesn't send context.
-    private var lastPresentedFormName: String?
 
     private var formEventTask: Task<Void, Never>?
     private var delayedPresentationTask: Task<Void, Never>?
@@ -191,10 +183,10 @@ class IAFPresentationManager {
                 Logger.webViewLogger.info("✅ Handshake confirmed from webview, starting profile observation")
             }
             startProfileObservation()
-        case let .present(formId, formName):
-            presentForm(formId: formId, formName: formName)
-        case let .dismiss(formId, formName):
-            dismissForm(formId: formId, formName: formName)
+        case .present:
+            presentForm()
+        case .dismiss:
+            dismissForm()
         case .abort:
             destroyWebviewAndListeners()
         }
@@ -380,7 +372,7 @@ class IAFPresentationManager {
 
     // MARK: - View Lifecycle
 
-    private func presentForm(formId: String? = nil, formName: String? = nil) {
+    private func presentForm() {
         guard let viewController else {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.warning("KlaviyoWebViewController is nil; ignoring `presentForm()` request")
@@ -407,7 +399,7 @@ class IAFPresentationManager {
             delayedPresentationTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 try? Task.checkCancellation()
-                self.presentForm(formId: formId, formName: formName)
+                self.presentForm()
             }
         } else {
             if topController.isKlaviyoVC || topController.hasKlaviyoVCInStack {
@@ -415,24 +407,13 @@ class IAFPresentationManager {
                     Logger.webViewLogger.warning("In-App Form is already being presented; ignoring request")
                 }
             } else {
-                hasInvokedDismissed = false
-                lastPresentedFormId = formId
-                lastPresentedFormName = formName
-                invokeLifecycleHandler(for: .formShown(formId: formId, formName: formName))
                 topController.present(viewController, animated: false, completion: nil)
             }
         }
     }
 
-    func dismissForm(formId: String? = nil, formName: String? = nil) {
+    func dismissForm() {
         guard let viewController else { return }
-        // Fall back to the context captured at present time if the bridge sends nil identifiers
-        let effectiveFormId = formId ?? lastPresentedFormId
-        let effectiveFormName = formName ?? lastPresentedFormName
-        if !hasInvokedDismissed {
-            invokeLifecycleHandler(for: .formDismissed(formId: effectiveFormId, formName: effectiveFormName))
-            hasInvokedDismissed = true
-        }
         viewController.dismiss(animated: false)
     }
 
@@ -441,17 +422,8 @@ class IAFPresentationManager {
     func destroyWebView() {
         guard let viewController else { return }
 
-        // Invoke lifecycle handler if form was visible
-        // This covers timeout-based and programmatic dismissals
-        if viewController.presentingViewController != nil && !hasInvokedDismissed {
-            invokeLifecycleHandler(for: .formDismissed(formId: lastPresentedFormId, formName: lastPresentedFormName))
-            hasInvokedDismissed = true
-        }
-
         viewController.dismiss(animated: false, completion: nil)
 
-        lastPresentedFormId = nil
-        lastPresentedFormName = nil
         self.viewController = nil
         viewModel = nil
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -280,21 +280,20 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 Logger.webViewLogger.info("Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
             }
 
-            // Notify lifecycle handler that CTA was clicked (always fire, even if URL is nil/invalid)
+            // Only emit CTA lifecycle event and attempt deep link when URL is present
+            guard let url = url, !url.absoluteString.isEmpty else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("CTA clicked but no deep link URL configured — skipping lifecycle event")
+                }
+                return
+            }
+
             IAFPresentationManager.shared.invokeLifecycleHandler(for: .formCtaClicked(
                 formId: formId,
                 formName: formName,
                 buttonLabel: buttonLabel,
                 deepLinkUrl: url
             ))
-
-            // Only attempt to open valid URLs (skip if nil or empty)
-            guard let url = url, !url.absoluteString.isEmpty else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.info("CTA clicked but no deep link URL configured in form")
-                }
-                return
-            }
 
             if UIApplication.shared.canOpenURL(url) {
                 if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -260,11 +260,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Received 'formWillAppear' event from KlaviyoJS")
             }
+            IAFPresentationManager.shared.invokeLifecycleHandler(for: .formShown(formId: formId, formName: formName))
             formLifecycleContinuation.yield(.present(formId: formId, formName: formName))
         case let .formDisappeared(formId, formName):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Received 'formDisappeared' event from KlaviyoJS")
             }
+            IAFPresentationManager.shared.invokeLifecycleHandler(for: .formDismissed(formId: formId, formName: formName))
             formLifecycleContinuation.yield(.dismiss(formId: formId, formName: formName))
         case let .trackProfileEvent(data):
             if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -56,7 +56,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     /// the event is captured even if URL routing fails. If no deep link
     /// URL is configured for the CTA, this event is not emitted.
     ///
-    /// - `buttonLabel`: The label text of the tapped button, if provided by the form.
+    /// - `buttonLabel`: The label text of the tapped button.
     /// - `deepLinkUrl`: The deep link URL associated with the CTA.
     case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
 

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -21,13 +21,13 @@ import Foundation
 /// KlaviyoSDK().registerFormLifecycleHandler { event in
 ///     switch event {
 ///     case .formShown(let formId, let formName):
-///         Analytics.track("Form Shown", properties: ["formId": formId ?? ""])
+///         Analytics.track("Form Shown", properties: ["formId": formId])
 ///     case .formDismissed(let formId, let formName):
-///         Analytics.track("Form Dismissed", properties: ["formId": formId ?? ""])
+///         Analytics.track("Form Dismissed", properties: ["formId": formId])
 ///     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
 ///         Analytics.track("Form CTA Clicked", properties: [
-///             "formId": formId ?? "",
-///             "buttonLabel": buttonLabel ?? ""
+///             "formId": formId,
+///             "buttonLabel": buttonLabel
 ///         ])
 ///     }
 /// }
@@ -37,7 +37,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     ///
     /// This event fires after all validation checks pass and immediately
     /// before the form view controller is presented.
-    case formShown(formId: String?, formName: String?)
+    case formShown(formId: String, formName: String)
 
     /// Triggered when a form is dismissed, regardless of the reason.
     ///
@@ -45,7 +45,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     /// - User-initiated dismissals (tapping outside, close button)
     /// - Timeout-based dismissals
     /// - Programmatic dismissals
-    case formDismissed(formId: String?, formName: String?)
+    case formDismissed(formId: String, formName: String)
 
     /// Triggered when a user taps a call-to-action button in a form.
     ///
@@ -54,10 +54,10 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     ///
     /// - `buttonLabel`: The label text of the tapped button, if provided by the form.
     /// - `deepLinkUrl`: The deep link URL associated with the CTA, if configured.
-    case formCtaClicked(formId: String?, formName: String?, buttonLabel: String?, deepLinkUrl: URL?)
+    case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL?)
 
     /// The unique identifier of the form that triggered this event.
-    public var formId: String? {
+    public var formId: String {
         switch self {
         case let .formShown(formId, _),
              let .formDismissed(formId, _),
@@ -67,7 +67,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     }
 
     /// The display name of the form that triggered this event.
-    public var formName: String? {
+    public var formName: String {
         switch self {
         case let .formShown(_, formName),
              let .formDismissed(_, formName),

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -49,14 +49,16 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     /// before a form is ever shown, such as session timeouts or aborts.
     case formDismissed(formId: String, formName: String)
 
-    /// Triggered when a user taps a call-to-action button in a form.
+    /// Triggered when a user taps a call-to-action button in a form
+    /// that has a deep link URL configured.
     ///
     /// This event fires before the deep link URL is processed, ensuring
-    /// the event is captured even if URL routing fails.
+    /// the event is captured even if URL routing fails. If no deep link
+    /// URL is configured for the CTA, this event is not emitted.
     ///
     /// - `buttonLabel`: The label text of the tapped button, if provided by the form.
-    /// - `deepLinkUrl`: The deep link URL associated with the CTA, if configured.
-    case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL?)
+    /// - `deepLinkUrl`: The deep link URL associated with the CTA.
+    case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
 
     /// The unique identifier of the form that triggered this event.
     public var formId: String {

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -33,18 +33,20 @@ import Foundation
 /// }
 /// ```
 public enum FormLifecycleEvent: Equatable, Sendable {
-    /// Triggered when a form is about to be presented to the user.
+    /// Triggered when the JavaScript bridge reports a form will appear.
     ///
-    /// This event fires after all validation checks pass and immediately
-    /// before the form view controller is presented.
+    /// This event reflects the JS-side `formWillAppear` signal and fires
+    /// before native presentation validation (e.g. checking for a visible
+    /// view controller). In practice, it reliably indicates the form was
+    /// shown and matches the analytics data tracked by the webview.
     case formShown(formId: String, formName: String)
 
-    /// Triggered when a form is dismissed, regardless of the reason.
+    /// Triggered when the JavaScript bridge reports a form has disappeared.
     ///
-    /// This event fires for all dismissal types including:
-    /// - User-initiated dismissals (tapping outside, close button)
-    /// - Timeout-based dismissals
-    /// - Programmatic dismissals
+    /// This event reflects the JS-side `formDisappeared` signal and fires
+    /// for user-initiated dismissals (e.g. tapping outside, close button).
+    /// It does **not** fire for scenarios where the webview is destroyed
+    /// before a form is ever shown, such as session timeouts or aborts.
     case formDismissed(formId: String, formName: String)
 
     /// Triggered when a user taps a call-to-action button in a form.

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFLifecycleEvent.swift
@@ -6,8 +6,8 @@
 //
 
 enum IAFLifecycleEvent {
-    case present(formId: String?, formName: String?)
-    case dismiss(formId: String?, formName: String?)
+    case present(formId: String, formName: String)
+    case dismiss(formId: String, formName: String)
     case abort
     case handShook
 

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -11,11 +11,11 @@ import OSLog
 
 enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formsDataLoaded
-    case formWillAppear(formId: String?, formName: String?)
-    case formDisappeared(formId: String?, formName: String?)
+    case formWillAppear(formId: String, formName: String)
+    case formDisappeared(formId: String, formName: String)
     case trackProfileEvent(Data)
     case trackAggregateEvent(Data)
-    case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
+    case openDeepLink(url: URL?, formId: String, formName: String, buttonLabel: String)
     case abort(String)
     case handShook
     case analyticsEvent
@@ -52,10 +52,10 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .formsDataLoaded
         case .formWillAppear:
             let payload = try? container.decode(FormContextPayload.self, forKey: .data)
-            self = .formWillAppear(formId: payload?.formId, formName: payload?.formName)
+            self = .formWillAppear(formId: payload?.formId ?? "", formName: payload?.formName ?? "")
         case .formDisappeared:
             let payload = try? container.decode(FormContextPayload.self, forKey: .data)
-            self = .formDisappeared(formId: payload?.formId, formName: payload?.formName)
+            self = .formDisappeared(formId: payload?.formId ?? "", formName: payload?.formName ?? "")
         case .trackProfileEvent:
             let decodedData = try container.decode(AnyCodable.self, forKey: .data)
             let data = try JSONEncoder().encode(decodedData)
@@ -92,9 +92,9 @@ extension IAFNativeBridgeEvent {
 
     struct DeepLinkEventPayload: Decodable {
         let ios: URL?
-        let formId: String?
-        let formName: String?
-        let buttonLabel: String?
+        let formId: String
+        let formName: String
+        let buttonLabel: String
 
         enum CodingKeys: String, CodingKey {
             case ios
@@ -105,9 +105,9 @@ extension IAFNativeBridgeEvent {
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            formId = try container.decodeIfPresent(String.self, forKey: .formId)
-            formName = try container.decodeIfPresent(String.self, forKey: .formName)
-            buttonLabel = try container.decodeIfPresent(String.self, forKey: .buttonLabel)
+            formId = try container.decodeIfPresent(String.self, forKey: .formId) ?? ""
+            formName = try container.decodeIfPresent(String.self, forKey: .formName) ?? ""
+            buttonLabel = try container.decodeIfPresent(String.self, forKey: .buttonLabel) ?? ""
             // Handle missing, null, or empty string gracefully
             guard let urlString = try container.decodeIfPresent(String.self, forKey: .ios),
                   !urlString.isEmpty else {
@@ -151,11 +151,11 @@ extension IAFNativeBridgeEvent {
     private static var handshakeEvents: [IAFNativeBridgeEvent] {
         // events that JS is permitted to sending
         [
-            .formWillAppear(formId: nil, formName: nil),
-            .formDisappeared(formId: nil, formName: nil),
+            .formWillAppear(formId: "", formName: ""),
+            .formDisappeared(formId: "", formName: ""),
             .trackProfileEvent(Data()),
             .trackAggregateEvent(Data()),
-            .openDeepLink(url: URL(string: "https://example.com")!, formId: nil, formName: nil, buttonLabel: nil),
+            .openDeepLink(url: URL(string: "https://example.com")!, formId: "", formName: "", buttonLabel: ""),
             .abort(""),
             .lifecycleEvent,
             .profileEvent,

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -60,13 +60,13 @@ extension KlaviyoSDK {
     /// KlaviyoSDK().registerFormLifecycleHandler { event in
     ///     switch event {
     ///     case .formShown(let formId, let formName):
-    ///         Analytics.track("Form Shown", properties: ["formId": formId ?? ""])
+    ///         Analytics.track("Form Shown", properties: ["formId": formId])
     ///     case .formDismissed(let formId, let formName):
-    ///         Analytics.track("Form Dismissed", properties: ["formId": formId ?? ""])
+    ///         Analytics.track("Form Dismissed", properties: ["formId": formId])
     ///     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
     ///         Analytics.track("Form CTA Clicked", properties: [
-    ///             "formId": formId ?? "",
-    ///             "buttonLabel": buttonLabel ?? ""
+    ///             "formId": formId,
+    ///             "buttonLabel": buttonLabel
     ///         ])
     ///     }
     /// }
@@ -90,7 +90,6 @@ extension KlaviyoSDK {
         IAFPresentationManager.shared.unregisterFormLifecycleHandler()
         return self
     }
-
 
     /// Registers app to receive and display In-App Forms from Klaviyo with a custom asset source.
     ///

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -180,7 +180,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
             formId: "",
             formName: "",
             buttonLabel: "",
-            deepLinkUrl: nil
+            deepLinkUrl: URL(string: "myapp://test")!
         ))
 
         // Then
@@ -239,7 +239,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         // When
         presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil)
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!)
         )
         presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
 
@@ -267,7 +267,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil)
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!)
         )
 
         // Test passes if no crash occurs
@@ -356,7 +356,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "abc", formName: "").formId, "abc")
         XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "def", formName: "").formId, "def")
         let ctaEvent = FormLifecycleEvent.formCtaClicked(
-            formId: "ghi", formName: "", buttonLabel: "", deepLinkUrl: nil
+            formId: "ghi", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
         )
         XCTAssertEqual(ctaEvent.formId, "ghi")
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formId, "")
@@ -366,7 +366,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "Form A").formName, "Form A")
         XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "", formName: "Form B").formName, "Form B")
         let ctaEventC = FormLifecycleEvent.formCtaClicked(
-            formId: "", formName: "Form C", buttonLabel: "", deepLinkUrl: nil
+            formId: "", formName: "Form C", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
         )
         XCTAssertEqual(ctaEventC.formName, "Form C")
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formName, "")
@@ -382,7 +382,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
             FormLifecycleEvent.formDismissed(formId: "", formName: "")
         )
         let ctaBuy = FormLifecycleEvent.formCtaClicked(
-            formId: "x", formName: "y", buttonLabel: "Buy", deepLinkUrl: nil
+            formId: "x", formName: "y", buttonLabel: "Buy", deepLinkUrl: URL(string: "myapp://test")!
         )
         XCTAssertEqual(ctaBuy, ctaBuy)
         XCTAssertNotEqual(
@@ -401,7 +401,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
             FormLifecycleEvent.formDismissed(formId: "", formName: "").eventName, "form_dismissed"
         )
         let ctaForEventName = FormLifecycleEvent.formCtaClicked(
-            formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil
+            formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
         )
         XCTAssertEqual(ctaForEventName.eventName, "form_cta_clicked")
     }

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -44,7 +44,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         presentationManager.registerFormLifecycleHandler(handler)
 
         // Then - verify handler works
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         if case .formShown = capturedEvent {
             // pass
         } else {
@@ -65,7 +65,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         presentationManager.unregisterFormLifecycleHandler()
 
         // Then - verify handler is not invoked after unregistration
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         XCTAssertFalse(handlerInvoked, "Handler should not be invoked after unregistration")
     }
 
@@ -86,7 +86,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         // When
         presentationManager.registerFormLifecycleHandler(firstHandler)
         presentationManager.registerFormLifecycleHandler(secondHandler)
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
 
         // Then
         XCTAssertFalse(firstHandlerInvoked, "First handler should be replaced")
@@ -107,13 +107,13 @@ final class FormLifecycleHandlerTests: XCTestCase {
         }
 
         // When
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
 
         // Then
         wait(for: [expectation], timeout: 1.0)
         if case let .formShown(formId, formName) = receivedEvent {
-            XCTAssertNil(formId, "formId should be nil when no form is active")
-            XCTAssertNil(formName, "formName should be nil when no form is active")
+            XCTAssertEqual(formId, "", "formId should be empty string when no form context available")
+            XCTAssertEqual(formName, "", "formName should be empty string when no form context available")
         } else {
             XCTFail("Handler should receive formShown event, got \(String(describing: receivedEvent))")
         }
@@ -153,7 +153,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         }
 
         // When
-        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
 
         // Then
         wait(for: [expectation], timeout: 1.0)
@@ -177,9 +177,9 @@ final class FormLifecycleHandlerTests: XCTestCase {
 
         // When
         presentationManager.invokeLifecycleHandler(for: .formCtaClicked(
-            formId: nil,
-            formName: nil,
-            buttonLabel: nil,
+            formId: "",
+            formName: "",
+            buttonLabel: "",
             deepLinkUrl: nil
         ))
 
@@ -237,11 +237,11 @@ final class FormLifecycleHandlerTests: XCTestCase {
         }
 
         // When
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: nil, formName: nil, buttonLabel: nil, deepLinkUrl: nil)
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil)
         )
-        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
 
         // Then
         wait(for: [expectation], timeout: 1.0)
@@ -264,10 +264,10 @@ final class FormLifecycleHandlerTests: XCTestCase {
         // Given - No handler registered
 
         // When/Then - Should not crash
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
-        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
+        presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: nil, formName: nil, buttonLabel: nil, deepLinkUrl: nil)
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil)
         )
 
         // Test passes if no crash occurs
@@ -286,7 +286,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         }
 
         // When
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
 
         // Then
         wait(for: [expectation], timeout: 1.0)
@@ -307,7 +307,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
 
         // Then
         wait(for: [expectation], timeout: 1.0)
@@ -330,7 +330,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
         KlaviyoSDK().unregisterFormLifecycleHandler()
 
         // Then
-        presentationManager.invokeLifecycleHandler(for: .formShown(formId: nil, formName: nil))
+        presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         XCTAssertFalse(handlerInvoked, "Handler should not be invoked after unregistration")
     }
 
@@ -353,23 +353,23 @@ final class FormLifecycleHandlerTests: XCTestCase {
     // MARK: - FormLifecycleEvent Computed Property Tests
 
     func testFormIdComputedProperty() {
-        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "abc", formName: nil).formId, "abc")
-        XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "def", formName: nil).formId, "def")
+        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "abc", formName: "").formId, "abc")
+        XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "def", formName: "").formId, "def")
         let ctaEvent = FormLifecycleEvent.formCtaClicked(
-            formId: "ghi", formName: nil, buttonLabel: nil, deepLinkUrl: nil
+            formId: "ghi", formName: "", buttonLabel: "", deepLinkUrl: nil
         )
         XCTAssertEqual(ctaEvent.formId, "ghi")
-        XCTAssertNil(FormLifecycleEvent.formShown(formId: nil, formName: nil).formId)
+        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formId, "")
     }
 
     func testFormNameComputedProperty() {
-        XCTAssertEqual(FormLifecycleEvent.formShown(formId: nil, formName: "Form A").formName, "Form A")
-        XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: nil, formName: "Form B").formName, "Form B")
+        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "Form A").formName, "Form A")
+        XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "", formName: "Form B").formName, "Form B")
         let ctaEventC = FormLifecycleEvent.formCtaClicked(
-            formId: nil, formName: "Form C", buttonLabel: nil, deepLinkUrl: nil
+            formId: "", formName: "Form C", buttonLabel: "", deepLinkUrl: nil
         )
         XCTAssertEqual(ctaEventC.formName, "Form C")
-        XCTAssertNil(FormLifecycleEvent.formShown(formId: nil, formName: nil).formName)
+        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formName, "")
     }
 
     func testFormLifecycleEventEquality() {
@@ -378,30 +378,30 @@ final class FormLifecycleHandlerTests: XCTestCase {
             FormLifecycleEvent.formShown(formId: "abc", formName: "Test")
         )
         XCTAssertEqual(
-            FormLifecycleEvent.formDismissed(formId: nil, formName: nil),
-            FormLifecycleEvent.formDismissed(formId: nil, formName: nil)
+            FormLifecycleEvent.formDismissed(formId: "", formName: ""),
+            FormLifecycleEvent.formDismissed(formId: "", formName: "")
         )
         let ctaBuy = FormLifecycleEvent.formCtaClicked(
             formId: "x", formName: "y", buttonLabel: "Buy", deepLinkUrl: nil
         )
         XCTAssertEqual(ctaBuy, ctaBuy)
         XCTAssertNotEqual(
-            FormLifecycleEvent.formShown(formId: "abc", formName: nil),
-            FormLifecycleEvent.formShown(formId: "xyz", formName: nil)
+            FormLifecycleEvent.formShown(formId: "abc", formName: ""),
+            FormLifecycleEvent.formShown(formId: "xyz", formName: "")
         )
         XCTAssertNotEqual(
-            FormLifecycleEvent.formShown(formId: nil, formName: nil),
-            FormLifecycleEvent.formDismissed(formId: nil, formName: nil)
+            FormLifecycleEvent.formShown(formId: "", formName: ""),
+            FormLifecycleEvent.formDismissed(formId: "", formName: "")
         )
     }
 
     func testEventNameProperty() {
-        XCTAssertEqual(FormLifecycleEvent.formShown(formId: nil, formName: nil).eventName, "form_shown")
+        XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").eventName, "form_shown")
         XCTAssertEqual(
-            FormLifecycleEvent.formDismissed(formId: nil, formName: nil).eventName, "form_dismissed"
+            FormLifecycleEvent.formDismissed(formId: "", formName: "").eventName, "form_dismissed"
         )
         let ctaForEventName = FormLifecycleEvent.formCtaClicked(
-            formId: nil, formName: nil, buttonLabel: nil, deepLinkUrl: nil
+            formId: "", formName: "", buttonLabel: "", deepLinkUrl: nil
         )
         XCTAssertEqual(ctaForEventName.eventName, "form_cta_clicked")
     }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -91,7 +91,7 @@ struct IAFNativeBridgeEventTests {
         #expect(url == expectedUrl)
         #expect(formId == "form456")
         #expect(formName == "CTA Form")
-        #expect(buttonLabel == nil)
+        #expect(buttonLabel == "")
     }
 
     @Test
@@ -144,9 +144,9 @@ struct IAFNativeBridgeEventTests {
 
         let expectedUrl = try #require(URL(string: "klaviyotest://settings"))
         #expect(url == expectedUrl)
-        #expect(formId == nil)
-        #expect(formName == nil)
-        #expect(buttonLabel == nil)
+        #expect(formId == "")
+        #expect(formName == "")
+        #expect(buttonLabel == "")
     }
 
     @Test
@@ -189,7 +189,7 @@ struct IAFNativeBridgeEventTests {
             return
         }
         #expect(formId == "abc123")
-        #expect(formName == nil)
+        #expect(formName == "")
     }
 
     @Test
@@ -229,8 +229,8 @@ struct IAFNativeBridgeEventTests {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
             return
         }
-        #expect(formId == nil)
-        #expect(formName == nil)
+        #expect(formId == "")
+        #expect(formName == "")
     }
 
     @Test

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -180,8 +180,8 @@ final class IAFWebViewModelTests: XCTestCase {
     func testFormWillAppearYieldsPresentLifecycleEvent() async throws {
         // Given
         let expectation = XCTestExpectation(description: "Form will appear should yield present lifecycle event")
-        var receivedFormId: String?
-        var receivedFormName: String?
+        var receivedFormId = ""
+        var receivedFormName = ""
 
         // Create a task to listen for lifecycle events
         let lifecycleTask = Task {
@@ -222,8 +222,8 @@ final class IAFWebViewModelTests: XCTestCase {
     func testFormDisappearedYieldsDismissLifecycleEvent() async throws {
         // Given
         let expectation = XCTestExpectation(description: "Form disappeared should yield dismiss lifecycle event")
-        var receivedFormId: String?
-        var receivedFormName: String?
+        var receivedFormId = ""
+        var receivedFormName = ""
 
         // Create a task to listen for lifecycle events
         let lifecycleTask = Task {


### PR DESCRIPTION
## Summary

Aligns the iOS form lifecycle event API with the Android SDK (PR klaviyo/klaviyo-android-sdk#414) to provide a consistent cross-platform developer experience:

- **Non-optional fields**: `formId`, `formName`, and `buttonLabel` are now `String` instead of `String?` across `FormLifecycleEvent`, `IAFNativeBridgeEvent`, and `IAFLifecycleEvent`. Missing bridge data falls back to empty string.
- **Non-optional `deepLinkUrl`**: `FormCtaClicked.deepLinkUrl` is now `URL` (non-optional). CTA events are only emitted when a valid deep link URL is configured.
- **Bridge-driven callbacks**: `formShown` and `formDismissed` lifecycle callbacks now fire from `IAFWebViewModel` (bridge layer), matching the existing `formCtaClicked` pattern. Previously they fired from `IAFPresentationManager`.
- **Removed safety net**: The `hasInvokedDismissed` guard and `destroyWebView` fallback dismiss callback are removed since dismiss events are now purely bridge-driven.
- **Removed in-memory form state**: `lastPresentedFormId` and `lastPresentedFormName` are removed from `IAFPresentationManager` along with associated fallback logic.

Companion PRs:
- Android: klaviyo/klaviyo-android-sdk#433
- RN: klaviyo/klaviyo-react-native-sdk#334
- Flutter: klaviyo/klaviyo-flutter-sdk#73

Part of MAGE-287

## Test plan

- [x] All existing `FormLifecycleHandlerTests` pass with updated non-optional types
- [x] All `IAFNativeBridgeEventTests` pass (empty string fallbacks for missing fields)
- [x] All `IAFWebViewModelTests` pass (lifecycle events still flow correctly)
- [ ] Manual: Verify formShown/formDismissed callbacks fire correctly when forms are presented/dismissed
- [ ] Manual: Verify formCtaClicked only fires when a deep link URL is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)