### PR TITLE
fix: skip redundant profile API call when setProfile has no changes

### DIFF
--- a/Sources/KlaviyoSwift/Models/Profile.swift
+++ b/Sources/KlaviyoSwift/Models/Profile.swift
@@ -84,6 +84,19 @@ public struct Profile: Equatable, Codable {
 
     let _properties: AnyCodable
 
+    /// Returns `true` if the profile contains any data beyond the three identifier fields
+    /// (email, phoneNumber, externalId). Used to decide whether to skip a redundant API
+    /// call when the caller's identifiers haven't changed.
+    var hasNonIdentifierData: Bool {
+        firstName != nil ||
+            lastName != nil ||
+            organization != nil ||
+            title != nil ||
+            image != nil ||
+            location != nil ||
+            !properties.isEmpty
+    }
+
     /// Create or update properties about a profile without tracking an associated event.
     /// - Parameters:
     ///   - email: Individual's email address

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -548,16 +548,26 @@ struct KlaviyoReducer: ReducerProtocol {
                 $0?.trimWhiteSpaceOrReturnNilIfEmpty()
             }
 
+            let identifiersChanged = currentIds != incomingIds
+
             // Only reset if the incoming profile has different identifiers.
             // Anonymous ID is the lowest-order identifier, so there's no reason
             // to regenerate it when higher-order identifiers haven't changed.
             // Resetting with the same identifiers causes unnecessary anonymous ID
             // churn, which triggers spurious push-token API requests.
             // resetProfile() remains available for explicitly clobbering all state.
-            if state.isIdentified, currentIds != incomingIds {
+            if state.isIdentified, identifiersChanged {
                 state.reset(preserveTokenData: false)
             }
             state.updateStateWithProfile(profile: profile)
+
+            // Skip the API call entirely when there is nothing new to sync:
+            // identifiers are unchanged, the profile carries no extra attributes,
+            // and no profile properties are queued up via setProfileProperty.
+            if !identifiersChanged, !profile.hasNonIdentifierData, state.pendingProfile == nil {
+                return .none
+            }
+
             guard let anonymousId = state.anonymousId,
                   let apiKey = state.apiKey
             else {

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -584,25 +584,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        // Same identifiers → no reset → pushTokenData preserved on state, anonymousId unchanged.
-        // The reducer still builds a registerPushToken request using the captured pushTokenData,
-        // but the state's pushTokenData is NOT cleared (only reset() clears it).
-        _ = await store.send(.enqueueProfile(Profile(email: "same@email.com", phoneNumber: "+15555555555", externalId: "ext-123"))) {
-            // anonymousId stays the same — no reset, pushTokenData stays on state
-            let request = KlaviyoRequest(
-                endpoint: .registerPushToken(
-                    TEST_API_KEY,
-                    PushTokenPayload(
-                        pushToken: initialState.pushTokenData!.pushToken,
-                        enablement: initialState.pushTokenData!.pushEnablement.rawValue,
-                        background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "same@email.com", phoneNumber: "+15555555555", externalId: "ext-123")
-                            .toAPIModel(anonymousId: initialState.anonymousId!)
-                    )
-                )
-            )
-            $0.queue = [request]
-        }
+        // Same identifiers + no non-identifier attributes → no reset, no API call, no state change.
+        // Nothing changed, so there's no reason to hit the network.
+        // The pushTokenData and anonymousId both remain untouched on state.
+        _ = await store.send(.enqueueProfile(Profile(email: "same@email.com", phoneNumber: "+15555555555", externalId: "ext-123")))
     }
 
     @MainActor


### PR DESCRIPTION
When `setProfile` is called with the same identifiers and no non-identifier attributes, the SDK was still enqueuing a profile API request. This PR eliminates that unnecessary network call, completing the de-duplication work started in #543 (which stopped anonymous ID churn but left the profile request itself unconditional).

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.

## Changelog / Code Overview

**`Profile.swift`** — adds `hasNonIdentifierData: Bool` computed property. Returns `true` if the profile carries any data beyond email/phoneNumber/externalId (i.e. firstName, lastName, org, title, image, location, or custom properties). Used as the de-dupe signal.

**`StateManagement.swift`** — in the `enqueueProfile` handler, after `updateStateWithProfile`, an early return now skips building and enqueuing any request when:
1. identifiers didn't change, AND
2. the profile has no non-identifier attributes, AND
3. no pending profile properties are queued via `setProfileProperty`

This mirrors the existing `shouldSendTokenUpdate` pattern used by `setPushToken`.

**`StateManagementEdgeCaseTests.swift`** — updates `testSetProfileSameIdentifiersDoesNotReset` to reflect the new (correct) behavior: same identifiers + no attributes = no state change, no API call.

**Behavioral matrix:**

| `setProfile` call | identifiers changed? | non-identifier data? | API call? |
|---|---|---|---|
| Same email/phone/externalId, no attributes | No | No | Skipped ✅ |
| Same identifiers, but new `firstName` | No | Yes | Sent |
| Different identifiers | Yes | — | Sent (reset + API call) |
| Fresh anonymous user with new identifiers | Yes (nil→value) | — | Sent |

## Test Plan
1. Call `setProfile` repeatedly with the same `email` — confirm no repeated network requests in Charles/proxyman.
2. Call `setProfile` with the same identifiers but a new `firstName` — confirm a single profile request is sent.
3. Call `setProfile` with a different `email` — confirm reset + profile request fires normally.
4. Run `make test-library` — all 220 tests pass.

## Related Issues/Tickets
- Follows up on #543 (fix: skip profile reset when setProfile called with same identifiers)
- Linear ticket: [MAGE-482](https://linear.app/klaviyo/issue/MAGE-482/skip-redundant-profile-api-call-when-identifiers-unchanged)