### PR TITLE
fix(forms): add missing channel_type field to TrackAggregateEventPayload

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -154,6 +154,7 @@ extension IAFNativeBridgeEvent {
             let formVersionId: Int?
             let formType: String?
             let deviceType: String?
+            let channelType: String?
             let hostname: String?
             let href: String?
             let pageURL: String?
@@ -172,6 +173,7 @@ extension IAFNativeBridgeEvent {
                 case formVersionId = "form_version_id"
                 case formType = "form_type"
                 case deviceType = "device_type"
+                case channelType = "channel_type"
                 case hostname
                 case href
                 case pageURL = "page_url"
@@ -303,6 +305,7 @@ extension IAFNativeBridgeEvent {
                                 formVersionId: 0,
                                 formType: "",
                                 deviceType: "",
+                                channelType: nil,
                                 hostname: "",
                                 href: "",
                                 pageURL: "",


### PR DESCRIPTION
# Description
Fixes a 400 error from the metrics service when aggregate events are submitted via in-app forms.

## Root Cause
The `TrackAggregateEventPayload.EventDetails` typed struct introduced in this branch was missing the `channel_type` field. Because we decode the bridge payload into this typed struct and then re-encode it before POSTing to the backend, any fields not represented in the struct are silently dropped. The backend requires `channel_type` and returns:

```
400: "required field missing @ $.events[0].event_details.channel_type"
```

This was **not** a merge conflict artifact — the struct was incomplete in `flyout-WIP-combined` itself, before any merges.

## Fix
Added `channelType: String?` with CodingKey `"channel_type"` to `EventDetails`, preserving the field through the decode→re-encode round-trip.

## Caveats
Other fields in `EventDetails` may also be missing from the struct. If additional 400s appear from aggregate events, cross-check the struct definition against the full payload fender sends. A longer-term alternative would be to pass the raw bridge JSON through as `Data` without re-encoding through a typed struct.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- `IAFNativeBridgeEvent.EventDetails`: added `channelType: String?` / `"channel_type"`
- Handshake placeholder updated to pass `channelType: nil`

## Test Plan
1. Load an in-app form that triggers a form submission (aggregate event)
2. Confirm no 400 error in the console
3. Confirm `channel_type` is present in the outgoing payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)