### PR TITLE
fix(ci): add explicit permissions to iOS SDK CI workflow jobs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,6 +17,9 @@ jobs:
   library-macos-14:
     name: Build and Run Unit Tests
     runs-on: macos-14
+    permissions:
+      contents: read
+      checks: write
     env:
       GITHUB_CI: true
     strategy:
@@ -40,6 +43,9 @@ jobs:
   library-macos-15:
     name: Build and Run Unit Tests
     runs-on: macos-15
+    permissions:
+      contents: read
+      checks: write
     env:
       GITHUB_CI: true
     strategy:


### PR DESCRIPTION
## Summary

Adds explicit `permissions` block to the library-macos-14 and library-macos-15 jobs in the iOS SDK CI workflow (swift.yml). This allows `slidoapp/xcresulttool` to post test result summaries on Dependabot PRs.

**Why:** Dependabot PRs run with restricted `GITHUB_TOKEN` that only has `read` scope. The xcresulttool action requires `checks:write` to create check run annotations. Without it, the step fails with "Resource not accessible by integration" error (though all tests still pass).

**Security:** This is also a security improvement — explicitly declaring permissions narrows the token's scope vs. relying on implicit defaults. Follows GitHub's documented best practice.

This is Claude's analysis of the security risks of this permissions change:
- Low. checks: write is a narrow scope — it only allows creating/updating check run annotations on PRs. It can't modify code, secrets, or any other repo resource.
- The only real risk is accidentally dropping a permission you forgot to list. In this workflow, contents: read and checks: write cover everything being used (checkout + xcresulttool), so that shouldn't be an issue.
- This is actually a security improvement over the current state — right now the jobs run with whatever the repo's default permissions are (likely broader than needed). Explicitly declaring permissions narrows the token's blast radius.

## Test plan

- [ ] Rebase #410 when merged and verify xcresulttool step succeeds
- [ ] Verify existing CI still passes for push-to-master and human-opened PRs

Fixes #410 (symptom only — the real fix is this workflow change)
Closes [MAGE-525](https://linear.app/klaviyo/issue/MAGE-525/fixci-add-explicit-permissions-to-ios-sdk-ci-workflow-jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)