### PR TITLE
refactor: consolidate isKlaviyoNotification onto notification types

### DIFF
--- a/Sources/KlaviyoCore/Utils/Dictionary+Metadata.swift
+++ b/Sources/KlaviyoCore/Utils/Dictionary+Metadata.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 extension Dictionary where Key == String, Value == Any {
     /// Appends device, SDK, and app metadata to event properties
@@ -39,12 +40,19 @@ extension Dictionary where Key == AnyHashable {
     /// a "body" dictionary with a "_k" key in its userInfo.
     ///
     /// - Returns: `true` if the notification is from Klaviyo, `false` otherwise
-    public func isKlaviyoNotification() -> Bool {
+    func isKlaviyoNotification() -> Bool {
         guard let properties = self as? [String: Any],
               let body = properties["body"] as? [String: Any],
               body["_k"] != nil else {
             return false
         }
         return true
+    }
+}
+
+extension UNNotificationContent {
+    /// Determines if this notification content originated from Klaviyo.
+    public var isKlaviyoNotification: Bool {
+        userInfo.isKlaviyoNotification()
     }
 }

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -14,13 +14,23 @@ import KlaviyoCore
 import OSLog
 import UserNotifications
 
+extension UNNotification {
+    /// Determines if this notification originated from Klaviyo.
+    ///
+    /// A notification is considered a Klaviyo notification if it contains
+    /// a "body" dictionary with a "_k" key in its userInfo.
+    public var isKlaviyoNotification: Bool {
+        request.content.isKlaviyoNotification
+    }
+}
+
 extension UNNotificationResponse {
     /// Determines if a notification originated from Klaviyo.
     ///
     /// A notification is considered a Klaviyo notification if it contains
     /// a "body" dictionary with a "_k" key in its userInfo.
     public var isKlaviyoNotification: Bool {
-        notification.request.content.userInfo.isKlaviyoNotification()
+        notification.isKlaviyoNotification
     }
 
     /// Returns the custom Klaviyo properties from a Klaviyo notification payload, if present.

--- a/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoExtension.swift
@@ -217,7 +217,7 @@ public enum KlaviyoExtensionSDK {
         // Respect developer-set categories for non-Klaviyo notifications
         // Only process and set up action buttons for Klaviyo notifications
         let existingCategory = request.content.categoryIdentifier
-        guard bestAttemptContent.userInfo.isKlaviyoNotification() && existingCategory.isEmpty else {
+        guard bestAttemptContent.isKlaviyoNotification && existingCategory.isEmpty else {
             return
         }
 


### PR DESCRIPTION
# Description

Addresses PR feedback to move `isKlaviyoNotification` off the raw `userInfo` dictionary and onto the notification types themselves, so callers don't need to reach deep into the object graph.

## Changes

- `Dictionary.isKlaviyoNotification()` — narrowed to `internal`; remains the single source of truth for the check logic
- `UNNotificationContent.isKlaviyoNotification` — new `public` property in `KlaviyoCore`, used by `KlaviyoSwiftExtension`
- `UNNotification.isKlaviyoNotification` — new `public` property in `KlaviyoSwift`, delegates to `request.content.isKlaviyoNotification`
- `UNNotificationResponse.isKlaviyoNotification` — now delegates to `notification.isKlaviyoNotification`
- `KlaviyoExtension` — updated to `bestAttemptContent.isKlaviyoNotification`

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Related Issues/Tickets
Addresses review feedback on #502