### PR TITLE
refactor(forms): simplify keyboard handling in InAppWindowManager

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -103,6 +103,8 @@ class IAFPresentationManager {
         companyObserver?.startObserving()
         isInitializingOrInitialized = true
 
+        _ = InAppWindowManager.shared
+
         companyEventsTask = Task { [weak self] in
             guard let self, let eventsStream = companyObserver?.eventsStream else { return }
             for await event in eventsStream {

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -22,16 +22,16 @@ class InAppWindowManager {
     private var currentKeyboardFrame: CGRect = .zero
 
     private init() {
-        let names: [Notification.Name] = [
+        let keyboardEvents: [Notification.Name] = [
             UIResponder.keyboardWillShowNotification,
             UIResponder.keyboardWillChangeFrameNotification,
             UIResponder.keyboardWillHideNotification
         ]
-        for name in names {
+        for keyboardEvent in keyboardEvents {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(handleKeyboardChange(_:)),
-                name: name,
+                name: keyboardEvent,
                 object: nil
             )
         }

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -5,7 +5,6 @@
 //  Created by Isobelle Lim on 1/22/26.
 //
 
-import Foundation
 import UIKit
 
 /// Manages the UIWindow lifecycle for flexible/banner in-app forms.
@@ -17,7 +16,26 @@ class InAppWindowManager {
     private var windowScene: UIWindowScene?
     private var currentLayout: FormLayout?
 
-    private init() {}
+    /// Tracks the most-recently-reported keyboard end frame so that layout
+    /// is keyboard-aware even when a form is presented while the keyboard is
+    /// already visible (no new keyboardWillShow fires in that case).
+    private var currentKeyboardFrame: CGRect = .zero
+
+    private init() {
+        let names: [Notification.Name] = [
+            UIResponder.keyboardWillShowNotification,
+            UIResponder.keyboardWillChangeFrameNotification,
+            UIResponder.keyboardWillHideNotification
+        ]
+        for name in names {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleKeyboardChange(_:)),
+                name: name,
+                object: nil
+            )
+        }
+    }
 
     /// Presents the view controller in a window configured according to the layout.
     func present(viewController: KlaviyoWebViewController, layout: FormLayout) {
@@ -39,10 +57,13 @@ class InAppWindowManager {
         window.clipsToBounds = true
         window.windowLevel = .normal + 1
         window.isHidden = false
-        window.makeKeyAndVisible()
-
         updateWindowFrame()
-        setupObservers(on: viewController)
+
+        viewController.onSizeTransition = { [weak self] _, coordinator in
+            coordinator.animate(alongsideTransition: { _ in
+                self?.updateWindowFrame()
+            }, completion: nil)
+        }
     }
 
     /// Returns true if the window manager has an active window.
@@ -52,7 +73,6 @@ class InAppWindowManager {
 
     /// Dismisses and removes the window.
     func dismiss() {
-        NotificationCenter.default.removeObserver(self)
         window?.isHidden = true
         window?.rootViewController = nil
         window = nil
@@ -64,7 +84,27 @@ class InAppWindowManager {
 
     private func updateWindowFrame() {
         guard let window, let currentLayout else { return }
-        window.frame = calculateFrame(for: currentLayout, in: getScreenBounds())
+        let screenBounds = getScreenBounds()
+        var frame = calculateFrame(for: currentLayout, in: screenBounds)
+
+        // Shift the frame up to avoid keyboard overlap. Form dimensions are
+        // always calculated against full screen bounds so percentage-based sizes
+        // aren't affected; we only adjust origin (and height as a last resort).
+        if currentLayout.position != .fullscreen, currentKeyboardFrame != .zero {
+            let keyboardTop = max(0, currentKeyboardFrame.origin.y)
+            let overlap = max(0, frame.maxY - keyboardTop)
+            if overlap > 0 {
+                let safeAreaTop = windowScene?.windows.first?.safeAreaInsets.top ?? 0
+                frame.origin.y = max(safeAreaTop, frame.origin.y - overlap)
+                // Only clamp height if the form is taller than the space above the keyboard.
+                let remainingOverlap = max(0, frame.maxY - keyboardTop)
+                if remainingOverlap > 0 {
+                    frame.size.height -= remainingOverlap
+                }
+            }
+        }
+
+        window.frame = frame
     }
 
     private func getScreenBounds() -> CGRect {
@@ -133,52 +173,11 @@ class InAppWindowManager {
         return CGRect(x: x, y: y, width: clampedWidth, height: clampedHeight)
     }
 
-    private func setupObservers(on viewController: KlaviyoWebViewController) {
-        // Handle orientation changes via viewWillTransition
-        viewController.onSizeTransition = { [weak self] _, coordinator in
-            coordinator.animate(alongsideTransition: { _ in
-                self?.updateWindowFrame()
-            }, completion: nil)
-        }
-
-        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardChange(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardChange(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-
     @objc
     private func handleKeyboardChange(_ notification: Notification) {
-        guard let window,
-              let currentLayout,
-              let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
-            return
-        }
-
-        let screenBounds = getScreenBounds()
-
-        guard currentLayout.position != .fullscreen else { return }
-        if notification.name == UIResponder.keyboardWillShowNotification {
-            // Calculate the form's bottom edge position and gap from screen bottom
-            let baseFrame = calculateFrame(for: currentLayout, in: screenBounds)
-            let formBottomEdge = baseFrame.maxY
-            let screenBottom = screenBounds.maxY
-            let gap = screenBottom - formBottomEdge
-
-            // Calculate actual keyboard overlap
-            let keyboardHeight = keyboardFrame.height
-            let overlap = max(0, keyboardHeight - gap)
-
-            if overlap > 0 {
-                // Shift window up by the overlap amount, clamped to safe area top
-                let safeAreaTop = windowScene?.windows.first?.safeAreaInsets.top ?? 0
-                var adjustedFrame = baseFrame
-                adjustedFrame.origin.y = max(safeAreaTop, baseFrame.origin.y - overlap)
-                window.frame = adjustedFrame
-            } else {
-                window.frame = baseFrame
-            }
-        } else {
-            // Keyboard dismissed, restore original frame
-            window.frame = calculateFrame(for: currentLayout, in: screenBounds)
-        }
+        currentKeyboardFrame = notification.name == UIResponder.keyboardWillHideNotification
+            ? .zero
+            : (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect ?? .zero)
+        updateWindowFrame()
     }
 }


### PR DESCRIPTION
Refactors keyboard avoidance in `InAppWindowManager` to be more robust across form presentations.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**Problem:** Keyboard observers were registered per-presentation (in `setupObservers`) and torn down in `dismiss()`. This meant if a form was presented while the keyboard was already visible — with no new `keyboardWillShow` firing — the form had no knowledge of the keyboard and would render overlapping it.

**Changes:**
- Move keyboard `NotificationCenter` observers to singleton `init()` so they persist for the manager's lifetime, not per form presentation
- Track latest keyboard frame in `currentKeyboardFrame`
- Centralize keyboard avoidance math inside `updateWindowFrame()`, replacing the duplicated layout logic in the old `handleKeyboardChange`
- Add `keyboardWillChangeFrameNotification` observation (covers undocking/resizing the keyboard on iPad)
- Remove `setupObservers()` and per-presentation `removeObserver` call
- Remove `makeKeyAndVisible()` (forms do not contain text inputs that require key window status)

## Test Plan
1. Open an app with an in-app form configured
2. Open the keyboard (e.g. via a text field in the host app) before triggering the form
3. Trigger the form — verify it renders above the keyboard without overlap
4. Dismiss and re-present the form with the keyboard at different states (shown, hidden, transitioning)

## Related Issues/Tickets
https://linear.app/klaviyo/issue/MAGE-536/wonky-behavior-when-form-is-displayed-while-keyboard-is-visible