### PR TITLE
feat(forms): data-klaviyo-device attribute + layout contract updates

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -38,20 +38,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .initialize(with: "YOUR_PUBLIC_API_KEY")
             .registerForInAppForms() // STEP2A: register for in app forms
             .registerGeofencing() // STEP2B: register for in geofencing
-            .registerFormLifecycleHandler { event, context in
+            .registerFormLifecycleHandler { event in
                 // STEP2C: [OPTIONAL] Register for form lifecycle events to track form interactions
                 // This handler is called whenever a form is shown, dismissed, or a CTA is clicked
 
                 switch event {
                 case .formShown:
-                    print("🎨 [Form Lifecycle] Form Shown: \(context.formId ?? "unknown")")
-                    print("   Form Name: \(context.formName ?? "unknown")")
+                    print("🎨 [Form Lifecycle] Form Shown: \(event.formId)")
+                    print("   Form Name: \(event.formName)")
                 case .formDismissed:
-                    print("👋 [Form Lifecycle] Form Dismissed: \(context.formId ?? "unknown")")
-                    print("   Form Name: \(context.formName ?? "unknown")")
-                case .formCTAClicked:
-                    print("🖱️  [Form Lifecycle] Form CTA Clicked: \(context.formId ?? "unknown")")
-                    print("   Form Name: \(context.formName ?? "unknown")")
+                    print("👋 [Form Lifecycle] Form Dismissed: \(event.formId)")
+                    print("   Form Name: \(event.formName)")
+                case let .formCtaClicked(_, _, buttonLabel, deepLinkUrl):
+                    print("🖱️  [Form Lifecycle] Form CTA Clicked: \(event.formId)")
+                    print("   Form Name: \(event.formName)")
+                    print("   Button: \(buttonLabel) → \(deepLinkUrl)")
                 }
             }
 

--- a/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
+++ b/Sources/KlaviyoForms/InAppForms/Assets/InAppFormsTemplate.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head data-native-bridge-name="KlaviyoNativeBridge" data-klaviyo-local-tracking="1">
+<head data-native-bridge-name="KlaviyoNativeBridge" data-klaviyo-local-tracking="1" data-klaviyo-device="{}">
     <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover">
             <title>Klaviyo In-App Form Template</title>

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -104,8 +104,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     /// attribute injections in this file.
     @MainActor
     private var deviceInfoWKScript: WKUserScript {
-        let json = DeviceInfo.current().toJsonString().klaviyoJsSingleQuoteEscaped
-        let script = "document.head.setAttribute('data-klaviyo-device', '\(json)');"
+        let script = DeviceInfo.current().asAttributeAssignmentScript()
         return WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
     }
 
@@ -147,8 +146,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     /// so onsite stays in sync with the device state.
     @MainActor
     func pushDeviceInfo() {
-        let json = DeviceInfo.current().toJsonString().klaviyoJsSingleQuoteEscaped
-        let script = "document.head.setAttribute('data-klaviyo-device', '\(json)');"
+        let script = DeviceInfo.current().asAttributeAssignmentScript()
         Task { @MainActor in
             do {
                 _ = try await delegate?.evaluateJavaScript(script)

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -12,6 +12,7 @@ import KlaviyoSwift
 import OSLog
 import WebKit
 
+// swiftlint:disable:next type_body_length
 class IAFWebViewModel: KlaviyoWebViewModeling {
     private enum MessageHandler: String, CaseIterable {
         case klaviyoNativeBridge = "KlaviyoNativeBridge"
@@ -96,6 +97,18 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         return WKUserScript(source: profileAttributesScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    /// Publishes a snapshot of the current `DeviceInfo` onto `document.head` before any
+    /// inline `<script>` in the template runs. Injected at `.atDocumentStart` so that
+    /// onsite can consult `document.head.dataset.klaviyoDevice` during the synchronous
+    /// HTML parse phase — this is what distinguishes it from the other `.atDocumentEnd`
+    /// attribute injections in this file.
+    @MainActor
+    private var deviceInfoWKScript: WKUserScript {
+        let json = DeviceInfo.current().toJsonString().klaviyoJsSingleQuoteEscaped
+        let script = "document.head.setAttribute('data-klaviyo-device', '\(json)');"
+        return WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+    }
+
     // MARK: - Initializer
 
     @MainActor
@@ -120,11 +133,30 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         loadScripts?.insert(sdkNameWKScript)
         loadScripts?.insert(sdkVersionWKScript)
         loadScripts?.insert(handshakeWKScript)
+        loadScripts?.insert(deviceInfoWKScript)
         if let profileAttributesWKScript {
             loadScripts?.insert(profileAttributesWKScript)
         }
         if let dataEnvironmentWKScript {
             loadScripts?.insert(dataEnvironmentWKScript)
+        }
+    }
+
+    /// Push a fresh `DeviceInfo` snapshot to the webview's `data-klaviyo-device` head
+    /// attribute. Called from the view controller on orientation and safe-area changes
+    /// so onsite stays in sync with the device state.
+    @MainActor
+    func pushDeviceInfo() {
+        let json = DeviceInfo.current().toJsonString().klaviyoJsSingleQuoteEscaped
+        let script = "document.head.setAttribute('data-klaviyo-device', '\(json)');"
+        Task { @MainActor in
+            do {
+                _ = try await delegate?.evaluateJavaScript(script)
+            } catch {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("Error pushing updated device info to web view: \(error)")
+                }
+            }
         }
     }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -102,6 +102,14 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     /// onsite can consult `document.head.dataset.klaviyoDevice` during the synchronous
     /// HTML parse phase — this is what distinguishes it from the other `.atDocumentEnd`
     /// attribute injections in this file.
+    ///
+    /// Note on staleness: this is a computed property re-evaluated each time
+    /// `setupLoadScripts` assembles the script set, so each navigation captures a fresh
+    /// snapshot. Any device-state change between `loadScripts` assembly and the document
+    /// parse is corrected at runtime by `pushDeviceInfo()` via `evaluateJavaScript` on
+    /// `viewWillTransition` / `viewSafeAreaInsetsDidChange`, so onsite's first runtime
+    /// read sees the up-to-date value. IAF view models are 1:1 with a form presentation,
+    /// so the parse-time staleness window is small and acceptable.
     @MainActor
     private var deviceInfoWKScript: WKUserScript {
         let script = DeviceInfo.current().asAttributeAssignmentScript()

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -143,13 +143,13 @@ class InAppWindowManager {
         // into the provided offsets and the SDK should not add insets of its own.
         let effectiveSafeArea: UIEdgeInsets = layout.addSafeAreaInsetsToOffsets ? safeArea : .zero
 
-        let marginTop = effectiveSafeArea.top + offsets.top
-        let marginBottom = effectiveSafeArea.bottom + offsets.bottom
-        let marginLeft = effectiveSafeArea.left + offsets.left
-        let marginRight = effectiveSafeArea.right + offsets.right
+        let offsetTop = effectiveSafeArea.top + offsets.top
+        let offsetBottom = effectiveSafeArea.bottom + offsets.bottom
+        let offsetLeft = effectiveSafeArea.left + offsets.left
+        let offsetRight = effectiveSafeArea.right + offsets.right
 
-        let availableWidth = max(0, screenWidth - marginLeft - marginRight)
-        let availableHeight = max(0, screenHeight - marginTop - marginBottom)
+        let availableWidth = max(0, screenWidth - offsetLeft - offsetRight)
+        let availableHeight = max(0, screenHeight - offsetTop - offsetBottom)
         let clampedWidth = min(width, availableWidth)
         let clampedHeight = min(height, availableHeight)
 
@@ -158,26 +158,26 @@ class InAppWindowManager {
 
         switch layout.position {
         case .top:
-            x = marginLeft + (availableWidth - clampedWidth) / 2
-            y = marginTop
+            x = offsetLeft + (availableWidth - clampedWidth) / 2
+            y = offsetTop
         case .topLeft:
-            x = marginLeft
-            y = marginTop
+            x = offsetLeft
+            y = offsetTop
         case .topRight:
-            x = screenWidth - clampedWidth - marginRight
-            y = marginTop
+            x = screenWidth - clampedWidth - offsetRight
+            y = offsetTop
         case .bottom:
-            x = marginLeft + (availableWidth - clampedWidth) / 2
-            y = screenHeight - clampedHeight - marginBottom
+            x = offsetLeft + (availableWidth - clampedWidth) / 2
+            y = screenHeight - clampedHeight - offsetBottom
         case .bottomLeft:
-            x = marginLeft
-            y = screenHeight - clampedHeight - marginBottom
+            x = offsetLeft
+            y = screenHeight - clampedHeight - offsetBottom
         case .bottomRight:
-            x = screenWidth - clampedWidth - marginRight
-            y = screenHeight - clampedHeight - marginBottom
+            x = screenWidth - clampedWidth - offsetRight
+            y = screenHeight - clampedHeight - offsetBottom
         case .center:
-            x = marginLeft + (availableWidth - clampedWidth) / 2
-            y = marginTop + (availableHeight - clampedHeight) / 2
+            x = offsetLeft + (availableWidth - clampedWidth) / 2
+            y = offsetTop + (availableHeight - clampedHeight) / 2
         case .fullscreen:
             return screenBounds
         }

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -16,6 +16,11 @@ class InAppWindowManager {
     private var windowScene: UIWindowScene?
     private var currentLayout: FormLayout?
 
+    /// Exposes the form's overlay window so callers that enumerate scene windows can
+    /// filter it out — e.g. `DeviceInfo.current()` must not read bounds/insets from
+    /// our own overlay (which becomes key while the user interacts with the form).
+    var currentFormWindow: UIWindow? { window }
+
     /// Tracks the most-recently-reported keyboard end frame so that layout
     /// is keyboard-aware even when a form is presented while the keyboard is
     /// already visible (no new keyboardWillShow fires in that case).

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -116,25 +116,37 @@ class InAppWindowManager {
     }
 
     private func calculateFrame(for layout: FormLayout, in screenBounds: CGRect) -> CGRect {
+        // Read safe area insets from the key window to avoid placing the form
+        // behind notches, Dynamic Island, or the home indicator.
+        let safeArea = windowScene?.windows.first?.safeAreaInsets ?? .zero
+        return Self.calculateFrame(for: layout, in: screenBounds, safeArea: safeArea)
+    }
+
+    /// Pure layout computation, extracted for testability.
+    nonisolated static func calculateFrame(
+        for layout: FormLayout,
+        in screenBounds: CGRect,
+        safeArea: UIEdgeInsets
+    ) -> CGRect {
         guard layout.position != .fullscreen else {
             return screenBounds
         }
 
-        // Read safe area insets from the key window to avoid placing the form
-        // behind notches, Dynamic Island, or the home indicator.
-        let safeArea = windowScene?.windows.first?.safeAreaInsets ?? .zero
-
-        let margin = layout.margin
+        let offsets = layout.offsets
         let screenWidth = screenBounds.width
         let screenHeight = screenBounds.height
 
         let width = layout.width.toPoints(relativeTo: screenWidth)
         let height = layout.height.toPoints(relativeTo: screenHeight)
 
-        let marginTop = safeArea.top + margin.top
-        let marginBottom = safeArea.bottom + margin.bottom
-        let marginLeft = safeArea.left + margin.left
-        let marginRight = safeArea.right + margin.right
+        // When `addSafeAreaInsetsToOffsets` is false, onsite has already baked safe-area handling
+        // into the provided offsets and the SDK should not add insets of its own.
+        let effectiveSafeArea: UIEdgeInsets = layout.addSafeAreaInsetsToOffsets ? safeArea : .zero
+
+        let marginTop = effectiveSafeArea.top + offsets.top
+        let marginBottom = effectiveSafeArea.bottom + offsets.bottom
+        let marginLeft = effectiveSafeArea.left + offsets.left
+        let marginRight = effectiveSafeArea.right + offsets.right
 
         let availableWidth = max(0, screenWidth - marginLeft - marginRight)
         let availableHeight = max(0, screenHeight - marginTop - marginBottom)

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -107,31 +107,39 @@ struct DeviceInfo: Codable, Equatable {
 
     // MARK: - Live capture
 
-    /// Snapshot the current device state by consulting `UIScreen.main` and the foreground
-    /// window scene's safe-area insets.
+    /// Snapshot the current device state.
+    ///
+    /// Uses the customer app's key window bounds as the primary source so dimensions reflect
+    /// the actual drawable area under iPad split view / stage manager / external-display
+    /// scenarios. Falls back to `scene.screen` and `UIScreen.main` for pathological
+    /// pre-scene cold-launch scenarios.
     @MainActor
     static func current() -> DeviceInfo {
-        let screen = UIScreen.main
-        let windowScene = UIApplication.shared
-            .connectedScenes
+        let scene = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .first { $0.activationState == .foregroundActive }
-            ?? UIApplication.shared
-            .connectedScenes
+            ?? UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .first
 
-        let orientation: UIInterfaceOrientation = windowScene?.interfaceOrientation ?? .portrait
+        let window = scene?.windows.first(where: \.isKeyWindow)
+            ?? scene?.windows.first
 
-        let keyWindow = windowScene?.windows.first(where: \.isKeyWindow)
-            ?? windowScene?.windows.first
+        let bounds = window?.bounds.size
+            ?? scene?.screen.bounds.size
+            ?? UIScreen.main.bounds.size
 
-        let insets = keyWindow?.safeAreaInsets ?? .zero
+        let nativeScale = window?.screen.nativeScale
+            ?? scene?.screen.nativeScale
+            ?? UIScreen.main.nativeScale
+
+        let orientation = scene?.interfaceOrientation ?? .portrait
+        let insets = window?.safeAreaInsets ?? .zero
 
         return DeviceInfo.make(
-            screenBounds: screen.bounds.size,
+            screenBounds: bounds,
             orientation: orientation,
-            nativeScale: screen.nativeScale,
+            nativeScale: nativeScale,
             safeAreaInsets: insets
         )
     }

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -56,43 +56,19 @@ struct DeviceInfo: Codable, Equatable {
 
     // MARK: - Construction
 
-    /// Construct a `DeviceInfo` from raw inputs. Separating computation from UIKit lookups
-    /// keeps the logic pure and testable.
-    ///
-    /// - Parameters:
-    ///   - screenBounds: The raw, orientation-relative `UIScreen.bounds` value.
-    ///   - orientation: The current interface orientation — used both to pick the CSSOM
-    ///     label and to swap `screenBounds` when UIKit is reporting them in the natural
-    ///     (portrait) orientation.
-    ///   - nativeScale: The backing `UIScreen.nativeScale`.
-    ///   - safeAreaInsets: The window's current safe-area insets.
+    /// Construct a `DeviceInfo` from raw inputs. `screenBounds` should already reflect the
+    /// current window's drawable area (not the raw device screen) — live capture uses
+    /// `window.bounds` as the source.
     static func make(
         screenBounds: CGSize,
         orientation: UIInterfaceOrientation,
         nativeScale: CGFloat,
         safeAreaInsets: UIEdgeInsets
     ) -> DeviceInfo {
-        // `UIScreen.bounds` is *usually* orientation-relative on modern iOS, but older iPad
-        // multitasking paths (and a handful of simulator edge cases) still report dimensions
-        // in natural orientation. Swap defensively so our payload always reflects the
-        // logical orientation.
-        let reportedWidth = screenBounds.width
-        let reportedHeight = screenBounds.height
-        let (width, height): (CGFloat, CGFloat) = {
-            let isLandscape = orientation.isLandscape
-            if isLandscape, reportedWidth < reportedHeight {
-                return (reportedHeight, reportedWidth)
-            }
-            if !isLandscape, reportedWidth > reportedHeight {
-                return (reportedHeight, reportedWidth)
-            }
-            return (reportedWidth, reportedHeight)
-        }()
-
-        return DeviceInfo(
+        DeviceInfo(
             screen: Screen(
-                width: Int(width.rounded()),
-                height: Int(height.rounded())
+                width: Int(screenBounds.width.rounded()),
+                height: Int(screenBounds.height.rounded())
             ),
             safeAreaInsets: SafeAreaInsets(
                 top: Int(safeAreaInsets.top.rounded()),

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -43,12 +43,19 @@ struct DeviceInfo: Codable, Equatable {
 
     /// Map `UIInterfaceOrientation` to the CSSOM `ScreenOrientation.type` vocabulary.
     /// See https://drafts.csswg.org/screen-orientation/#enumdef-orientationtype
+    ///
+    /// Matches WebKit's own iOS Safari implementation of `screen.orientation.type`:
+    /// `UIInterfaceOrientation.landscapeRight` (home button on the LEFT, angle 90°) is
+    /// `landscape-primary`; `.landscapeLeft` (home button on the RIGHT, angle 270°) is
+    /// `landscape-secondary`. The confusion comes from `UIInterfaceOrientation` and
+    /// `UIDeviceOrientation` being opposites for the same physical position — we use
+    /// the interface flavor here, same as WebKit.
     static func cssOrientation(for orientation: UIInterfaceOrientation) -> String {
         switch orientation {
         case .portrait: return "portrait-primary"
         case .portraitUpsideDown: return "portrait-secondary"
-        case .landscapeLeft: return "landscape-primary"
-        case .landscapeRight: return "landscape-secondary"
+        case .landscapeRight: return "landscape-primary"
+        case .landscapeLeft: return "landscape-secondary"
         case .unknown: return "portrait-primary"
         @unknown default: return "portrait-primary"
         }

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import UIKit
 
 /// Describes the device's current physical display characteristics, exposed to onsite JS
@@ -23,6 +24,7 @@ struct DeviceInfo: Codable, Equatable {
 
     /// Safe-area insets in CSS points for the currently displayed window.
     struct SafeAreaInsets: Codable, Equatable {
+        // `top` name locked by wire contract (CSSOM / data-klaviyo-device spec).
         // swiftlint:disable:next identifier_name
         let top: Int
         let bottom: Int
@@ -33,6 +35,7 @@ struct DeviceInfo: Codable, Equatable {
     let screen: Screen
     let safeAreaInsets: SafeAreaInsets
     let orientation: String
+    // `dpr` name locked by wire contract (CSSOM / data-klaviyo-device spec).
     // swiftlint:disable:next identifier_name
     let dpr: Int
 
@@ -141,11 +144,23 @@ struct DeviceInfo: Codable, Equatable {
         let encoder = JSONEncoder()
         // Stable key ordering helps downstream diffing and snapshot tests.
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(self),
-              let json = String(data: data, encoding: .utf8) else {
+        do {
+            let data = try encoder.encode(self)
+            return String(data: data, encoding: .utf8) ?? "{}"
+        } catch {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.error("DeviceInfo encode failed: \(error)")
+            }
             return "{}"
         }
-        return json
+    }
+
+    /// JS statement that sets the `data-klaviyo-device` attribute on the document head
+    /// using this payload. Centralizes the attribute name and JS-escaping contract so
+    /// injection-time and runtime-push call sites stay in lockstep.
+    func asAttributeAssignmentScript() -> String {
+        let json = toJsonString().klaviyoJsSingleQuoteEscaped
+        return "document.head.setAttribute('data-klaviyo-device', '\(json)');"
     }
 }
 

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -140,23 +140,15 @@ struct DeviceInfo: Codable, Equatable {
     }
 
     /// JS statement that sets the `data-klaviyo-device` attribute on the document head
-    /// using this payload. Centralizes the attribute name and JS-escaping contract so
-    /// injection-time and runtime-push call sites stay in lockstep.
-    func asAttributeAssignmentScript() -> String {
-        let json = toJsonString().klaviyoJsSingleQuoteEscaped
-        return "document.head.setAttribute('data-klaviyo-device', '\(json)');"
-    }
-}
-
-// MARK: - JS escaping
-
-extension String {
-    /// Escapes a JSON payload for embedding inside a single-quoted JS string literal.
+    /// using this payload. Centralizes the attribute name so injection-time and
+    /// runtime-push call sites stay in lockstep.
     ///
-    /// JSON already escapes double quotes, control characters, and non-ASCII characters,
-    /// so only backslashes and single quotes need additional handling.
-    var klaviyoJsSingleQuoteEscaped: String {
-        replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
+    /// JSON is a subset of JavaScript — embedding the raw JSON as a JS object expression
+    /// and letting the engine `JSON.stringify` it sidesteps any JS string-literal escaping
+    /// concerns (no need to escape single quotes, backslashes, etc. that might appear
+    /// inside the payload).
+    func asAttributeAssignmentScript() -> String {
+        let json = toJsonString()
+        return "document.head.setAttribute('data-klaviyo-device', JSON.stringify(\(json)));"
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -1,0 +1,163 @@
+//
+//  DeviceInfo.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Evan Masseau on 4/22/26.
+//
+
+import Foundation
+import UIKit
+
+/// Describes the device's current physical display characteristics, exposed to onsite JS
+/// via the `data-klaviyo-device` attribute on the HTML `<head>` element.
+///
+/// The shape intentionally mirrors CSSOM conventions so onsite code can treat the payload
+/// as a reliable, orientation-aware substitute for `window.screen.*` during the synchronous
+/// HTML parse phase, before the web view attaches to the view hierarchy.
+struct DeviceInfo: Codable, Equatable {
+    /// Screen dimensions in CSS points, oriented to match the current interface orientation.
+    struct Screen: Codable, Equatable {
+        let width: Int
+        let height: Int
+    }
+
+    /// Safe-area insets in CSS points for the currently displayed window.
+    struct SafeAreaInsets: Codable, Equatable {
+        // swiftlint:disable:next identifier_name
+        let top: Int
+        let bottom: Int
+        let left: Int
+        let right: Int
+    }
+
+    let screen: Screen
+    let safeAreaInsets: SafeAreaInsets
+    let orientation: String
+    // swiftlint:disable:next identifier_name
+    let dpr: Int
+
+    // MARK: - CSSOM orientation mapping
+
+    /// Map `UIInterfaceOrientation` to the CSSOM `ScreenOrientation.type` vocabulary.
+    /// See https://drafts.csswg.org/screen-orientation/#enumdef-orientationtype
+    static func cssOrientation(for orientation: UIInterfaceOrientation) -> String {
+        switch orientation {
+        case .portrait: return "portrait-primary"
+        case .portraitUpsideDown: return "portrait-secondary"
+        case .landscapeLeft: return "landscape-primary"
+        case .landscapeRight: return "landscape-secondary"
+        case .unknown: return "portrait-primary"
+        @unknown default: return "portrait-primary"
+        }
+    }
+
+    // MARK: - Construction
+
+    /// Construct a `DeviceInfo` from raw inputs. Separating computation from UIKit lookups
+    /// keeps the logic pure and testable.
+    ///
+    /// - Parameters:
+    ///   - screenBounds: The raw, orientation-relative `UIScreen.bounds` value.
+    ///   - orientation: The current interface orientation — used both to pick the CSSOM
+    ///     label and to swap `screenBounds` when UIKit is reporting them in the natural
+    ///     (portrait) orientation.
+    ///   - nativeScale: The backing `UIScreen.nativeScale`.
+    ///   - safeAreaInsets: The window's current safe-area insets.
+    static func make(
+        screenBounds: CGSize,
+        orientation: UIInterfaceOrientation,
+        nativeScale: CGFloat,
+        safeAreaInsets: UIEdgeInsets
+    ) -> DeviceInfo {
+        // `UIScreen.bounds` is *usually* orientation-relative on modern iOS, but older iPad
+        // multitasking paths (and a handful of simulator edge cases) still report dimensions
+        // in natural orientation. Swap defensively so our payload always reflects the
+        // logical orientation.
+        let reportedWidth = screenBounds.width
+        let reportedHeight = screenBounds.height
+        let (width, height): (CGFloat, CGFloat) = {
+            let isLandscape = orientation.isLandscape
+            if isLandscape, reportedWidth < reportedHeight {
+                return (reportedHeight, reportedWidth)
+            }
+            if !isLandscape, reportedWidth > reportedHeight {
+                return (reportedHeight, reportedWidth)
+            }
+            return (reportedWidth, reportedHeight)
+        }()
+
+        return DeviceInfo(
+            screen: Screen(
+                width: Int(width.rounded()),
+                height: Int(height.rounded())
+            ),
+            safeAreaInsets: SafeAreaInsets(
+                top: Int(safeAreaInsets.top.rounded()),
+                bottom: Int(safeAreaInsets.bottom.rounded()),
+                left: Int(safeAreaInsets.left.rounded()),
+                right: Int(safeAreaInsets.right.rounded())
+            ),
+            orientation: cssOrientation(for: orientation),
+            dpr: max(1, Int(nativeScale.rounded()))
+        )
+    }
+
+    // MARK: - Live capture
+
+    /// Snapshot the current device state by consulting `UIScreen.main` and the foreground
+    /// window scene's safe-area insets.
+    @MainActor
+    static func current() -> DeviceInfo {
+        let screen = UIScreen.main
+        let windowScene = UIApplication.shared
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+            ?? UIApplication.shared
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+
+        let orientation: UIInterfaceOrientation = windowScene?.interfaceOrientation ?? .portrait
+
+        let keyWindow = windowScene?.windows.first(where: \.isKeyWindow)
+            ?? windowScene?.windows.first
+
+        let insets = keyWindow?.safeAreaInsets ?? .zero
+
+        return DeviceInfo.make(
+            screenBounds: screen.bounds.size,
+            orientation: orientation,
+            nativeScale: screen.nativeScale,
+            safeAreaInsets: insets
+        )
+    }
+
+    // MARK: - Serialization
+
+    /// Serializes the device info into its JSON representation as published on the
+    /// `data-klaviyo-device` head attribute.
+    func toJsonString() -> String {
+        let encoder = JSONEncoder()
+        // Stable key ordering helps downstream diffing and snapshot tests.
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(self),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}
+
+// MARK: - JS escaping
+
+extension String {
+    /// Escapes a JSON payload for embedding inside a single-quoted JS string literal.
+    ///
+    /// JSON already escapes double quotes, control characters, and non-ASCII characters,
+    /// so only backslashes and single quotes need additional handling.
+    var klaviyoJsSingleQuoteEscaped: String {
+        replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+    }
+}

--- a/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/DeviceInfo.swift
@@ -92,10 +92,14 @@ struct DeviceInfo: Codable, Equatable {
 
     /// Snapshot the current device state.
     ///
-    /// Uses the customer app's key window bounds as the primary source so dimensions reflect
-    /// the actual drawable area under iPad split view / stage manager / external-display
-    /// scenarios. Falls back to `scene.screen` and `UIScreen.main` for pathological
-    /// pre-scene cold-launch scenarios.
+    /// Dimensions come from the scene's coordinate space, not any specific window — this
+    /// gives the scene's actual drawable rect under iPad split view / stage manager /
+    /// external-display scenarios, AND avoids reading bounds from our own form overlay
+    /// window when it is currently key (e.g. while the user interacts with a form input).
+    ///
+    /// Safe-area insets come from the customer app's key window. Our own form overlay
+    /// window is explicitly excluded so we report host-level insets regardless of which
+    /// window is currently key.
     @MainActor
     static func current() -> DeviceInfo {
         let scene = UIApplication.shared.connectedScenes
@@ -105,19 +109,19 @@ struct DeviceInfo: Codable, Equatable {
             .compactMap { $0 as? UIWindowScene }
             .first
 
-        let window = scene?.windows.first(where: \.isKeyWindow)
-            ?? scene?.windows.first
+        let ourFormWindow = InAppWindowManager.shared.currentFormWindow
+        let hostWindows = scene?.windows.filter { $0 !== ourFormWindow && !$0.isHidden } ?? []
+        let hostWindow = hostWindows.first(where: \.isKeyWindow) ?? hostWindows.first
 
-        let bounds = window?.bounds.size
+        let bounds = scene?.coordinateSpace.bounds.size
             ?? scene?.screen.bounds.size
             ?? UIScreen.main.bounds.size
 
-        let nativeScale = window?.screen.nativeScale
-            ?? scene?.screen.nativeScale
+        let nativeScale = scene?.screen.nativeScale
             ?? UIScreen.main.nativeScale
 
         let orientation = scene?.interfaceOrientation ?? .portrait
-        let insets = window?.safeAreaInsets ?? .zero
+        let insets = hostWindow?.safeAreaInsets ?? .zero
 
         return DeviceInfo.make(
             screenBounds: bounds,

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import UIKit
 
 /// Position where the form should be anchored on screen.
@@ -42,7 +43,9 @@ struct Dimension: Codable, Equatable {
     }
 }
 
-/// Margins from the anchor position, in points.
+/// Offsets from the anchor position, in points.
+///
+/// Kept named `Margins` (type alias `Offsets`) to minimize call-site churn; the wire key is `offsets`.
 struct Margins: Codable, Equatable {
     let top: CGFloat
     let bottom: CGFloat
@@ -52,25 +55,81 @@ struct Margins: Codable, Equatable {
     static let zero = Margins(top: 0, bottom: 0, left: 0, right: 0)
 }
 
+typealias Offsets = Margins
+
+/// Tracks whether we've already logged the `margin` → `offsets` fallback deprecation for this session.
+private enum FormLayoutDeprecationLogger {
+    private static let hasLoggedMarginFallback = Atomic(false)
+
+    static func logMarginFallbackOnce() {
+        guard hasLoggedMarginFallback.compareAndSet(expected: false, newValue: true) else { return }
+        if #available(iOS 14.0, *) {
+            let message =
+                "formWillAppear payload used deprecated `margin` key; prefer `offsets`. " +
+                "This warning is logged once per session."
+            Logger.webViewLogger.info("\(message)")
+        }
+    }
+
+    static func resetForTesting() {
+        hasLoggedMarginFallback.set(false)
+    }
+}
+
+/// Minimal atomic Bool wrapper to gate the one-shot deprecation log.
+private final class Atomic {
+    private let lock = NSLock()
+    private var value: Bool
+
+    init(_ value: Bool) { self.value = value }
+
+    func set(_ newValue: Bool) {
+        lock.lock(); defer { lock.unlock() }
+        value = newValue
+    }
+
+    func compareAndSet(expected: Bool, newValue: Bool) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard value == expected else { return false }
+        value = newValue
+        return true
+    }
+}
+
 /// Layout configuration for flexible/banner forms.
 struct FormLayout: Codable, Equatable {
     let position: FormPosition
     let width: Dimension
     let height: Dimension
-    let margin: Margins
+    let offsets: Offsets
+    /// When `true` (default), the SDK adds the window's safe-area insets on top of `offsets`
+    /// when positioning the form. When `false`, `offsets` are used as-is — the onsite/web layer
+    /// is responsible for accounting for safe-area.
+    let addSafeAreaInsetsToOffsets: Bool
 
     static let fullDimension = Dimension(value: 100, unit: .percent)
+
+    enum CodingKeys: String, CodingKey {
+        case position
+        case width
+        case height
+        case offsets
+        case margin
+        case addSafeAreaInsetsToOffsets
+    }
 
     init(
         position: FormPosition,
         width: Dimension = fullDimension,
         height: Dimension = fullDimension,
-        margin: Margins = .zero
+        offsets: Offsets = .zero,
+        addSafeAreaInsetsToOffsets: Bool = true
     ) {
         self.position = position
         self.width = width
         self.height = height
-        self.margin = margin
+        self.offsets = offsets
+        self.addSafeAreaInsetsToOffsets = addSafeAreaInsetsToOffsets
     }
 
     init(from decoder: Decoder) throws {
@@ -78,6 +137,34 @@ struct FormLayout: Codable, Equatable {
         position = try container.decode(FormPosition.self, forKey: .position)
         width = try container.decodeIfPresent(Dimension.self, forKey: .width) ?? Self.fullDimension
         height = try container.decodeIfPresent(Dimension.self, forKey: .height) ?? Self.fullDimension
-        margin = try container.decodeIfPresent(Margins.self, forKey: .margin) ?? .zero
+
+        if let decodedOffsets = try container.decodeIfPresent(Offsets.self, forKey: .offsets) {
+            offsets = decodedOffsets
+        } else if let legacyMargin = try container.decodeIfPresent(Offsets.self, forKey: .margin) {
+            FormLayoutDeprecationLogger.logMarginFallbackOnce()
+            offsets = legacyMargin
+        } else {
+            offsets = .zero
+        }
+
+        addSafeAreaInsetsToOffsets = try container
+            .decodeIfPresent(Bool.self, forKey: .addSafeAreaInsetsToOffsets) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(position, forKey: .position)
+        try container.encode(width, forKey: .width)
+        try container.encode(height, forKey: .height)
+        try container.encode(offsets, forKey: .offsets)
+        try container.encode(addSafeAreaInsetsToOffsets, forKey: .addSafeAreaInsetsToOffsets)
     }
 }
+
+#if DEBUG
+enum FormLayoutTestHooks {
+    static func resetDeprecationLogger() {
+        FormLayoutDeprecationLogger.resetForTesting()
+    }
+}
+#endif

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
@@ -55,10 +55,13 @@ struct Offsets: Codable, Equatable {
 
 /// Tracks whether we've already logged the `margin` → `offsets` fallback deprecation for this session.
 private enum FormLayoutDeprecationLogger {
-    private static let hasLoggedMarginFallback = Atomic(false)
+    // nonisolated(unsafe) because the one call site (`FormLayout.init(from:)` invoked via
+    // `WKScriptMessageHandler`) is main-actor serialized — race would only double-log a debug message.
+    private nonisolated(unsafe) static var hasLoggedMarginFallback = false
 
     static func logMarginFallbackOnce() {
-        guard hasLoggedMarginFallback.compareAndSet(expected: false, newValue: true) else { return }
+        guard !hasLoggedMarginFallback else { return }
+        hasLoggedMarginFallback = true
         if #available(iOS 14.0, *) {
             let message =
                 "formWillAppear payload used deprecated `margin` key; prefer `offsets`. " +
@@ -68,27 +71,7 @@ private enum FormLayoutDeprecationLogger {
     }
 
     static func resetForTesting() {
-        hasLoggedMarginFallback.set(false)
-    }
-}
-
-/// Minimal atomic Bool wrapper to gate the one-shot deprecation log.
-private final class Atomic {
-    private let lock = NSLock()
-    private var value: Bool
-
-    init(_ value: Bool) { self.value = value }
-
-    func set(_ newValue: Bool) {
-        lock.lock(); defer { lock.unlock() }
-        value = newValue
-    }
-
-    func compareAndSet(expected: Bool, newValue: Bool) -> Bool {
-        lock.lock(); defer { lock.unlock() }
-        guard value == expected else { return false }
-        value = newValue
-        return true
+        hasLoggedMarginFallback = false
     }
 }
 

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import OSLog
 import UIKit
 
 /// Position where the form should be anchored on screen.
@@ -53,28 +52,6 @@ struct Offsets: Codable, Equatable {
     static let zero = Offsets(top: 0, bottom: 0, left: 0, right: 0)
 }
 
-/// Tracks whether we've already logged the `margin` → `offsets` fallback deprecation for this session.
-private enum FormLayoutDeprecationLogger {
-    // nonisolated(unsafe) because the one call site (`FormLayout.init(from:)` invoked via
-    // `WKScriptMessageHandler`) is main-actor serialized — race would only double-log a debug message.
-    private nonisolated(unsafe) static var hasLoggedMarginFallback = false
-
-    static func logMarginFallbackOnce() {
-        guard !hasLoggedMarginFallback else { return }
-        hasLoggedMarginFallback = true
-        if #available(iOS 14.0, *) {
-            let message =
-                "formWillAppear payload used deprecated `margin` key; prefer `offsets`. " +
-                "This warning is logged once per session."
-            Logger.webViewLogger.info("\(message)")
-        }
-    }
-
-    static func resetForTesting() {
-        hasLoggedMarginFallback = false
-    }
-}
-
 /// Layout configuration for flexible/banner forms.
 struct FormLayout: Codable, Equatable {
     let position: FormPosition
@@ -93,7 +70,6 @@ struct FormLayout: Codable, Equatable {
         case width
         case height
         case offsets
-        case margin
         case addSafeAreaInsetsToOffsets
     }
 
@@ -117,14 +93,7 @@ struct FormLayout: Codable, Equatable {
         width = try container.decodeIfPresent(Dimension.self, forKey: .width) ?? Self.fullDimension
         height = try container.decodeIfPresent(Dimension.self, forKey: .height) ?? Self.fullDimension
 
-        if let decodedOffsets = try container.decodeIfPresent(Offsets.self, forKey: .offsets) {
-            offsets = decodedOffsets
-        } else if let legacyMargin = try container.decodeIfPresent(Offsets.self, forKey: .margin) {
-            FormLayoutDeprecationLogger.logMarginFallbackOnce()
-            offsets = legacyMargin
-        } else {
-            offsets = .zero
-        }
+        offsets = try container.decodeIfPresent(Offsets.self, forKey: .offsets) ?? .zero
 
         addSafeAreaInsetsToOffsets = try container
             .decodeIfPresent(Bool.self, forKey: .addSafeAreaInsetsToOffsets) ?? true
@@ -139,11 +108,3 @@ struct FormLayout: Codable, Equatable {
         try container.encode(addSafeAreaInsetsToOffsets, forKey: .addSafeAreaInsetsToOffsets)
     }
 }
-
-#if DEBUG
-enum FormLayoutTestHooks {
-    static func resetDeprecationLogger() {
-        FormLayoutDeprecationLogger.resetForTesting()
-    }
-}
-#endif

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLayout.swift
@@ -44,18 +44,14 @@ struct Dimension: Codable, Equatable {
 }
 
 /// Offsets from the anchor position, in points.
-///
-/// Kept named `Margins` (type alias `Offsets`) to minimize call-site churn; the wire key is `offsets`.
-struct Margins: Codable, Equatable {
+struct Offsets: Codable, Equatable {
     let top: CGFloat
     let bottom: CGFloat
     let left: CGFloat
     let right: CGFloat
 
-    static let zero = Margins(top: 0, bottom: 0, left: 0, right: 0)
+    static let zero = Offsets(top: 0, bottom: 0, left: 0, right: 0)
 }
-
-typealias Offsets = Margins
 
 /// Tracks whether we've already logged the `margin` → `offsets` fallback deprecation for this session.
 private enum FormLayoutDeprecationLogger {

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -105,12 +105,18 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         // transition's animation block so `UIScreen.bounds` and the key window's
         // safe-area insets have settled before we read them.
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
-            (self?.viewModel as? IAFWebViewModel)?.pushDeviceInfo()
+            guard let self else { return }
+            guard self.view.window != nil, !self.webView.isLoading else { return }
+            (self.viewModel as? IAFWebViewModel)?.pushDeviceInfo()
         }
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
+        // Skip while we're not window-attached or mid-load — otherwise preload-phase
+        // safe-area changes fire `evaluateJavaScript` against a webview that can't
+        // service it, producing noisy "Error pushing updated device info" warnings.
+        guard view.window != nil, !webView.isLoading else { return }
         (viewModel as? IAFWebViewModel)?.pushDeviceInfo()
     }
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -100,6 +100,18 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         onSizeTransition?(size, coordinator)
+        // Re-publish `data-klaviyo-device` after the transition completes so the new
+        // orientation and safe-area values are available to onsite. We wait on the
+        // transition's animation block so `UIScreen.bounds` and the key window's
+        // safe-area insets have settled before we read them.
+        coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            (self?.viewModel as? IAFWebViewModel)?.pushDeviceInfo()
+        }
+    }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        (viewModel as? IAFWebViewModel)?.pushDeviceInfo()
     }
 
     @MainActor

--- a/Tests/KlaviyoFormsTests/InAppForms/InAppWindowManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/InAppWindowManagerTests.swift
@@ -59,14 +59,14 @@ final class InAppWindowManagerTests: XCTestCase {
             in: screenBounds,
             safeArea: safeArea
         )
-        let marginTop = safeArea.top + 10
-        let marginBottom = safeArea.bottom + 10
-        let marginLeft = safeArea.left + 10
-        let marginRight = safeArea.right + 10
-        let availableWidth = screenBounds.width - marginLeft - marginRight
-        let availableHeight = screenBounds.height - marginTop - marginBottom
-        XCTAssertEqual(center.origin.x, marginLeft + (availableWidth - 300) / 2)
-        XCTAssertEqual(center.origin.y, marginTop + (availableHeight - 200) / 2)
+        let offsetTop = safeArea.top + 10
+        let offsetBottom = safeArea.bottom + 10
+        let offsetLeft = safeArea.left + 10
+        let offsetRight = safeArea.right + 10
+        let availableWidth = screenBounds.width - offsetLeft - offsetRight
+        let availableHeight = screenBounds.height - offsetTop - offsetBottom
+        XCTAssertEqual(center.origin.x, offsetLeft + (availableWidth - 300) / 2)
+        XCTAssertEqual(center.origin.y, offsetTop + (availableHeight - 200) / 2)
     }
 
     // MARK: - addSafeAreaInsetsToOffsets=false uses offsets as-is

--- a/Tests/KlaviyoFormsTests/InAppForms/InAppWindowManagerTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/InAppWindowManagerTests.swift
@@ -1,0 +1,158 @@
+//
+//  InAppWindowManagerTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Evan Masseau on 4/22/26.
+//
+
+@testable import KlaviyoForms
+import UIKit
+import XCTest
+
+final class InAppWindowManagerTests: XCTestCase {
+    // A representative iPhone-ish layout for tests.
+    private let screenBounds = CGRect(x: 0, y: 0, width: 400, height: 800)
+    private let safeArea = UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+
+    private func layout(
+        position: FormPosition,
+        width: CGFloat = 300,
+        height: CGFloat = 200,
+        offsets: Offsets = .zero,
+        addSafeAreaInsetsToOffsets: Bool = true
+    ) -> FormLayout {
+        FormLayout(
+            position: position,
+            width: Dimension(value: Double(width), unit: .fixed),
+            height: Dimension(value: Double(height), unit: .fixed),
+            offsets: offsets,
+            addSafeAreaInsetsToOffsets: addSafeAreaInsetsToOffsets
+        )
+    }
+
+    // MARK: - addSafeAreaInsetsToOffsets=true (default) preserves existing behavior
+
+    func testAddSafeAreaInsetsTrueIncludesSafeAreaForCornerAndCenteredPositions() {
+        let offsets = Offsets(top: 10, bottom: 10, left: 10, right: 10)
+
+        // TOP_LEFT: x = safeArea.left + offsets.left, y = safeArea.top + offsets.top
+        let topLeft = InAppWindowManager.calculateFrame(
+            for: layout(position: .topLeft, offsets: offsets, addSafeAreaInsetsToOffsets: true),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        XCTAssertEqual(topLeft.origin.x, safeArea.left + 10)
+        XCTAssertEqual(topLeft.origin.y, safeArea.top + 10)
+
+        // BOTTOM_RIGHT: x = screenWidth - width - (safeArea.right + offsets.right)
+        let bottomRight = InAppWindowManager.calculateFrame(
+            for: layout(position: .bottomRight, offsets: offsets, addSafeAreaInsetsToOffsets: true),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        XCTAssertEqual(bottomRight.origin.x, screenBounds.width - 300 - (safeArea.right + 10))
+        XCTAssertEqual(bottomRight.origin.y, screenBounds.height - 200 - (safeArea.bottom + 10))
+
+        // CENTER: y = (safeArea.top + offsets.top) + (availableHeight - height) / 2
+        let center = InAppWindowManager.calculateFrame(
+            for: layout(position: .center, offsets: offsets, addSafeAreaInsetsToOffsets: true),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        let marginTop = safeArea.top + 10
+        let marginBottom = safeArea.bottom + 10
+        let marginLeft = safeArea.left + 10
+        let marginRight = safeArea.right + 10
+        let availableWidth = screenBounds.width - marginLeft - marginRight
+        let availableHeight = screenBounds.height - marginTop - marginBottom
+        XCTAssertEqual(center.origin.x, marginLeft + (availableWidth - 300) / 2)
+        XCTAssertEqual(center.origin.y, marginTop + (availableHeight - 200) / 2)
+    }
+
+    // MARK: - addSafeAreaInsetsToOffsets=false uses offsets as-is
+
+    func testAddSafeAreaInsetsFalseUsesOffsetsAsIs() {
+        let offsets = Offsets(top: 10, bottom: 10, left: 10, right: 10)
+
+        let topLeft = InAppWindowManager.calculateFrame(
+            for: layout(position: .topLeft, offsets: offsets, addSafeAreaInsetsToOffsets: false),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        XCTAssertEqual(topLeft.origin.x, 10, "safe area must not be added to left offset")
+        XCTAssertEqual(topLeft.origin.y, 10, "safe area must not be added to top offset")
+
+        let bottomRight = InAppWindowManager.calculateFrame(
+            for: layout(position: .bottomRight, offsets: offsets, addSafeAreaInsetsToOffsets: false),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        XCTAssertEqual(bottomRight.origin.x, screenBounds.width - 300 - 10)
+        XCTAssertEqual(bottomRight.origin.y, screenBounds.height - 200 - 10)
+
+        let center = InAppWindowManager.calculateFrame(
+            for: layout(position: .center, offsets: offsets, addSafeAreaInsetsToOffsets: false),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        // With safe area skipped, margins are just the offsets.
+        let availableWidth = screenBounds.width - 10 - 10
+        let availableHeight = screenBounds.height - 10 - 10
+        XCTAssertEqual(center.origin.x, 10 + (availableWidth - 300) / 2)
+        XCTAssertEqual(center.origin.y, 10 + (availableHeight - 200) / 2)
+    }
+
+    func testAddSafeAreaInsetsFalseProducesMoreAvailableSpaceThanTrueWhenSafeAreaIsNonZero() {
+        // Use a percent dimension so clamping shows the diff.
+        let fullWidth = Dimension(value: 100, unit: .percent)
+        let fullHeight = Dimension(value: 100, unit: .percent)
+        let offsets = Offsets(top: 5, bottom: 5, left: 5, right: 5)
+        // Use a safe area with non-zero insets on all four sides so both width and height diverge.
+        let fourSidedSafeArea = UIEdgeInsets(top: 47, left: 20, bottom: 34, right: 20)
+
+        let safeAreaTrue = FormLayout(
+            position: .center,
+            width: fullWidth,
+            height: fullHeight,
+            offsets: offsets,
+            addSafeAreaInsetsToOffsets: true
+        )
+        let safeAreaFalse = FormLayout(
+            position: .center,
+            width: fullWidth,
+            height: fullHeight,
+            offsets: offsets,
+            addSafeAreaInsetsToOffsets: false
+        )
+
+        let trueFrame = InAppWindowManager.calculateFrame(
+            for: safeAreaTrue, in: screenBounds, safeArea: fourSidedSafeArea
+        )
+        let falseFrame = InAppWindowManager.calculateFrame(
+            for: safeAreaFalse, in: screenBounds, safeArea: fourSidedSafeArea
+        )
+
+        XCTAssertGreaterThan(falseFrame.width, trueFrame.width)
+        XCTAssertGreaterThan(falseFrame.height, trueFrame.height)
+    }
+
+    // MARK: - FULLSCREEN ignores the flag
+
+    func testFullscreenFillsScreenBoundsRegardlessOfFlag() {
+        let offsets = Offsets(top: 10, bottom: 10, left: 10, right: 10)
+
+        let withSafeArea = InAppWindowManager.calculateFrame(
+            for: layout(position: .fullscreen, offsets: offsets, addSafeAreaInsetsToOffsets: true),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+        let withoutSafeArea = InAppWindowManager.calculateFrame(
+            for: layout(position: .fullscreen, offsets: offsets, addSafeAreaInsetsToOffsets: false),
+            in: screenBounds,
+            safeArea: safeArea
+        )
+
+        XCTAssertEqual(withSafeArea, screenBounds)
+        XCTAssertEqual(withoutSafeArea, screenBounds)
+    }
+}

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
@@ -1,0 +1,121 @@
+//
+//  DeviceInfoTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Evan Masseau on 4/22/26.
+//
+
+@testable import KlaviyoForms
+import UIKit
+import XCTest
+
+final class DeviceInfoTests: XCTestCase {
+    // MARK: - Serialization shape
+
+    func testSerializationMatchesDocumentedShape() throws {
+        let info = DeviceInfo(
+            screen: .init(width: 402, height: 874),
+            safeAreaInsets: .init(top: 47, bottom: 34, left: 0, right: 0),
+            orientation: "portrait-primary",
+            dpr: 3
+        )
+
+        let json = info.toJsonString()
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let parsed = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        let screen = try XCTUnwrap(parsed["screen"] as? [String: Any])
+        XCTAssertEqual(screen["width"] as? Int, 402)
+        XCTAssertEqual(screen["height"] as? Int, 874)
+
+        let insets = try XCTUnwrap(parsed["safeAreaInsets"] as? [String: Any])
+        XCTAssertEqual(insets["top"] as? Int, 47)
+        XCTAssertEqual(insets["bottom"] as? Int, 34)
+        XCTAssertEqual(insets["left"] as? Int, 0)
+        XCTAssertEqual(insets["right"] as? Int, 0)
+
+        XCTAssertEqual(parsed["orientation"] as? String, "portrait-primary")
+        XCTAssertEqual(parsed["dpr"] as? Int, 3)
+    }
+
+    // MARK: - Orientation mapping
+
+    func testOrientationMappingCoversAllCSSOMLabels() {
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .portrait), "portrait-primary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .portraitUpsideDown), "portrait-secondary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeLeft), "landscape-primary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeRight), "landscape-secondary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .unknown), "portrait-primary")
+    }
+
+    // MARK: - Screen + insets at various native scales
+
+    func testMakeAtNativeScale2() {
+        let info = DeviceInfo.make(
+            screenBounds: CGSize(width: 390, height: 844),
+            orientation: .portrait,
+            nativeScale: 2,
+            safeAreaInsets: UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+        )
+
+        XCTAssertEqual(info.screen.width, 390)
+        XCTAssertEqual(info.screen.height, 844)
+        XCTAssertEqual(info.safeAreaInsets.top, 47)
+        XCTAssertEqual(info.safeAreaInsets.bottom, 34)
+        XCTAssertEqual(info.dpr, 2)
+        XCTAssertEqual(info.orientation, "portrait-primary")
+    }
+
+    func testMakeAtNativeScale3() {
+        let info = DeviceInfo.make(
+            screenBounds: CGSize(width: 402, height: 874),
+            orientation: .portrait,
+            nativeScale: 3,
+            safeAreaInsets: UIEdgeInsets(top: 47, left: 0, bottom: 34, right: 0)
+        )
+
+        XCTAssertEqual(info.screen.width, 402)
+        XCTAssertEqual(info.screen.height, 874)
+        XCTAssertEqual(info.dpr, 3)
+    }
+
+    func testMakeSwapsDimensionsWhenBoundsDoNotMatchOrientation() {
+        // Simulate UIKit reporting natural (portrait) bounds while interface is landscape.
+        let info = DeviceInfo.make(
+            screenBounds: CGSize(width: 402, height: 874),
+            orientation: .landscapeLeft,
+            nativeScale: 3,
+            safeAreaInsets: .zero
+        )
+
+        XCTAssertEqual(info.screen.width, 874)
+        XCTAssertEqual(info.screen.height, 402)
+        XCTAssertEqual(info.orientation, "landscape-primary")
+    }
+
+    // MARK: - JS escaping
+
+    func testJsEscapingHandlesBackslashesAndSingleQuotes() {
+        let payload = "it's a back\\slash"
+        XCTAssertEqual(payload.klaviyoJsSingleQuoteEscaped, "it\\'s a back\\\\slash")
+    }
+
+    func testJsEscapingLeavesDoubleQuotesUntouched() {
+        // JSON's own double-quote syntax must survive embedding in a single-quoted
+        // JS string literal — otherwise onsite will see a broken payload.
+        let payload = "{\"screen\":{\"width\":402}}"
+        XCTAssertEqual(payload.klaviyoJsSingleQuoteEscaped, payload)
+    }
+
+    func testEndToEndJsEscapedPayloadIsSingleQuoteSafe() {
+        let info = DeviceInfo(
+            screen: .init(width: 402, height: 874),
+            safeAreaInsets: .init(top: 47, bottom: 34, left: 0, right: 0),
+            orientation: "portrait-primary",
+            dpr: 3
+        )
+        let escaped = info.toJsonString().klaviyoJsSingleQuoteEscaped
+        // The escaped payload must be safely embeddable inside `'...'` JS literal.
+        XCTAssertFalse(escaped.contains("'"), "unescaped single quote in payload")
+    }
+}

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
@@ -93,6 +93,51 @@ final class DeviceInfoTests: XCTestCase {
         XCTAssertEqual(info.orientation, "landscape-primary")
     }
 
+    func testMakeSwapsDimensionsWhenBoundsReportLandscapeButOrientationIsPortrait() {
+        // Opposite of the landscape case: UIKit reports landscape-shaped bounds while
+        // the interface is in portrait. We still swap so the payload matches the
+        // logical orientation.
+        let info = DeviceInfo.make(
+            screenBounds: CGSize(width: 874, height: 402),
+            orientation: .portrait,
+            nativeScale: 3,
+            safeAreaInsets: .zero
+        )
+
+        XCTAssertEqual(info.screen.width, 402)
+        XCTAssertEqual(info.screen.height, 874)
+        XCTAssertEqual(info.orientation, "portrait-primary")
+    }
+
+    func testMakeClampsDprToAtLeastOne() {
+        // `nativeScale` is never *supposed* to be zero, but we clamp defensively so
+        // onsite never divides by zero on the JS side.
+        let info = DeviceInfo.make(
+            screenBounds: CGSize(width: 10, height: 10),
+            orientation: .portrait,
+            nativeScale: 0,
+            safeAreaInsets: .zero
+        )
+
+        XCTAssertEqual(info.dpr, 1)
+    }
+
+    // MARK: - JSON determinism
+
+    func testJsonStringUsesSortedKeysForDeterministicOutput() {
+        let info = DeviceInfo(
+            screen: .init(width: 402, height: 874),
+            safeAreaInsets: .init(top: 47, bottom: 34, left: 0, right: 0),
+            orientation: "portrait-primary",
+            dpr: 3
+        )
+
+        XCTAssertEqual(
+            info.toJsonString(),
+            #"{"dpr":3,"orientation":"portrait-primary","safeAreaInsets":{"bottom":34,"left":0,"right":0,"top":47},"screen":{"height":874,"width":402}}"#
+        )
+    }
+
     // MARK: - JS escaping
 
     func testJsEscapingHandlesBackslashesAndSingleQuotes() {

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
@@ -43,8 +43,8 @@ final class DeviceInfoTests: XCTestCase {
     func testOrientationMappingCoversAllCSSOMLabels() {
         XCTAssertEqual(DeviceInfo.cssOrientation(for: .portrait), "portrait-primary")
         XCTAssertEqual(DeviceInfo.cssOrientation(for: .portraitUpsideDown), "portrait-secondary")
-        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeLeft), "landscape-primary")
-        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeRight), "landscape-secondary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeRight), "landscape-primary")
+        XCTAssertEqual(DeviceInfo.cssOrientation(for: .landscapeLeft), "landscape-secondary")
         XCTAssertEqual(DeviceInfo.cssOrientation(for: .unknown), "portrait-primary")
     }
 

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
@@ -79,36 +79,6 @@ final class DeviceInfoTests: XCTestCase {
         XCTAssertEqual(info.dpr, 3)
     }
 
-    func testMakeSwapsDimensionsWhenBoundsDoNotMatchOrientation() {
-        // Simulate UIKit reporting natural (portrait) bounds while interface is landscape.
-        let info = DeviceInfo.make(
-            screenBounds: CGSize(width: 402, height: 874),
-            orientation: .landscapeLeft,
-            nativeScale: 3,
-            safeAreaInsets: .zero
-        )
-
-        XCTAssertEqual(info.screen.width, 874)
-        XCTAssertEqual(info.screen.height, 402)
-        XCTAssertEqual(info.orientation, "landscape-primary")
-    }
-
-    func testMakeSwapsDimensionsWhenBoundsReportLandscapeButOrientationIsPortrait() {
-        // Opposite of the landscape case: UIKit reports landscape-shaped bounds while
-        // the interface is in portrait. We still swap so the payload matches the
-        // logical orientation.
-        let info = DeviceInfo.make(
-            screenBounds: CGSize(width: 874, height: 402),
-            orientation: .portrait,
-            nativeScale: 3,
-            safeAreaInsets: .zero
-        )
-
-        XCTAssertEqual(info.screen.width, 402)
-        XCTAssertEqual(info.screen.height, 874)
-        XCTAssertEqual(info.orientation, "portrait-primary")
-    }
-
     func testMakeClampsDprToAtLeastOne() {
         // `nativeScale` is never *supposed* to be zero, but we clamp defensively so
         // onsite never divides by zero on the JS side.

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/DeviceInfoTests.swift
@@ -108,29 +108,22 @@ final class DeviceInfoTests: XCTestCase {
         )
     }
 
-    // MARK: - JS escaping
+    // MARK: - JS injection script shape
 
-    func testJsEscapingHandlesBackslashesAndSingleQuotes() {
-        let payload = "it's a back\\slash"
-        XCTAssertEqual(payload.klaviyoJsSingleQuoteEscaped, "it\\'s a back\\\\slash")
-    }
-
-    func testJsEscapingLeavesDoubleQuotesUntouched() {
-        // JSON's own double-quote syntax must survive embedding in a single-quoted
-        // JS string literal — otherwise onsite will see a broken payload.
-        let payload = "{\"screen\":{\"width\":402}}"
-        XCTAssertEqual(payload.klaviyoJsSingleQuoteEscaped, payload)
-    }
-
-    func testEndToEndJsEscapedPayloadIsSingleQuoteSafe() {
+    func testAsAttributeAssignmentScriptWrapsJsonInStringify() {
         let info = DeviceInfo(
             screen: .init(width: 402, height: 874),
             safeAreaInsets: .init(top: 47, bottom: 34, left: 0, right: 0),
             orientation: "portrait-primary",
             dpr: 3
         )
-        let escaped = info.toJsonString().klaviyoJsSingleQuoteEscaped
-        // The escaped payload must be safely embeddable inside `'...'` JS literal.
-        XCTAssertFalse(escaped.contains("'"), "unescaped single quote in payload")
+        let script = info.asAttributeAssignmentScript()
+        // We rely on JSON being a valid JS expression: embed the object literal directly
+        // and let the engine JSON.stringify it — no JS-string escaping required.
+        XCTAssertTrue(
+            script.hasPrefix("document.head.setAttribute('data-klaviyo-device', JSON.stringify(")
+        )
+        XCTAssertTrue(script.hasSuffix("));"))
+        XCTAssertTrue(script.contains(info.toJsonString()))
     }
 }

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/FormLayoutTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/FormLayoutTests.swift
@@ -1,0 +1,118 @@
+//
+//  FormLayoutTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Evan Masseau on 4/22/26.
+//
+
+@testable import KlaviyoForms
+import UIKit
+import XCTest
+
+final class FormLayoutTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        #if DEBUG
+        FormLayoutTestHooks.resetDeprecationLogger()
+        #endif
+    }
+
+    // MARK: - Decoding: offsets / margin wire key
+
+    func testDecodesOffsetsKey() throws {
+        let jsonString = """
+        {
+            "position": "BOTTOM",
+            "width":  { "value": 100, "unit": "PERCENT" },
+            "height": { "value": 200, "unit": "FIXED" },
+            "offsets": { "top": 1, "bottom": 2, "left": 3, "right": 4 }
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertEqual(layout.offsets, Offsets(top: 1, bottom: 2, left: 3, right: 4))
+        XCTAssertTrue(
+            layout.addSafeAreaInsetsToOffsets,
+            "addSafeAreaInsetsToOffsets should default to true when absent"
+        )
+    }
+
+    func testFallsBackToMarginKeyWhenOffsetsMissing() throws {
+        let jsonString = """
+        {
+            "position": "TOP",
+            "width":  { "value": 100, "unit": "PERCENT" },
+            "height": { "value": 100, "unit": "PERCENT" },
+            "margin": { "top": 5, "bottom": 6, "left": 7, "right": 8 }
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertEqual(layout.offsets, Offsets(top: 5, bottom: 6, left: 7, right: 8))
+    }
+
+    func testOffsetsWinsWhenBothKeysPresent() throws {
+        let jsonString = """
+        {
+            "position": "CENTER",
+            "width":  { "value": 100, "unit": "PERCENT" },
+            "height": { "value": 100, "unit": "PERCENT" },
+            "offsets": { "top": 10, "bottom": 10, "left": 10, "right": 10 },
+            "margin":  { "top": 99, "bottom": 99, "left": 99, "right": 99 }
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertEqual(layout.offsets, Offsets(top: 10, bottom: 10, left: 10, right: 10))
+    }
+
+    func testDefaultsOffsetsToZeroWhenBothKeysAbsent() throws {
+        let jsonString = """
+        {
+            "position": "FULLSCREEN"
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertEqual(layout.offsets, .zero)
+    }
+
+    // MARK: - Decoding: addSafeAreaInsetsToOffsets
+
+    func testAddSafeAreaInsetsToOffsetsDefaultsToTrue() throws {
+        let jsonString = """
+        {
+            "position": "BOTTOM",
+            "offsets": { "top": 0, "bottom": 0, "left": 0, "right": 0 }
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertTrue(layout.addSafeAreaInsetsToOffsets)
+    }
+
+    func testAddSafeAreaInsetsToOffsetsParsesFalse() throws {
+        let jsonString = """
+        {
+            "position": "BOTTOM",
+            "offsets": { "top": 0, "bottom": 0, "left": 0, "right": 0 },
+            "addSafeAreaInsetsToOffsets": false
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertFalse(layout.addSafeAreaInsetsToOffsets)
+    }
+
+    func testAddSafeAreaInsetsToOffsetsParsesTrueExplicitly() throws {
+        let jsonString = """
+        {
+            "position": "BOTTOM",
+            "addSafeAreaInsetsToOffsets": true
+        }
+        """
+
+        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
+        XCTAssertTrue(layout.addSafeAreaInsetsToOffsets)
+    }
+}

--- a/Tests/KlaviyoFormsTests/InAppForms/Models/FormLayoutTests.swift
+++ b/Tests/KlaviyoFormsTests/InAppForms/Models/FormLayoutTests.swift
@@ -10,14 +10,7 @@ import UIKit
 import XCTest
 
 final class FormLayoutTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        #if DEBUG
-        FormLayoutTestHooks.resetDeprecationLogger()
-        #endif
-    }
-
-    // MARK: - Decoding: offsets / margin wire key
+    // MARK: - Decoding: offsets wire key
 
     func testDecodesOffsetsKey() throws {
         let jsonString = """
@@ -37,36 +30,7 @@ final class FormLayoutTests: XCTestCase {
         )
     }
 
-    func testFallsBackToMarginKeyWhenOffsetsMissing() throws {
-        let jsonString = """
-        {
-            "position": "TOP",
-            "width":  { "value": 100, "unit": "PERCENT" },
-            "height": { "value": 100, "unit": "PERCENT" },
-            "margin": { "top": 5, "bottom": 6, "left": 7, "right": 8 }
-        }
-        """
-
-        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
-        XCTAssertEqual(layout.offsets, Offsets(top: 5, bottom: 6, left: 7, right: 8))
-    }
-
-    func testOffsetsWinsWhenBothKeysPresent() throws {
-        let jsonString = """
-        {
-            "position": "CENTER",
-            "width":  { "value": 100, "unit": "PERCENT" },
-            "height": { "value": 100, "unit": "PERCENT" },
-            "offsets": { "top": 10, "bottom": 10, "left": 10, "right": 10 },
-            "margin":  { "top": 99, "bottom": 99, "left": 99, "right": 99 }
-        }
-        """
-
-        let layout = try JSONDecoder().decode(FormLayout.self, from: Data(jsonString.utf8))
-        XCTAssertEqual(layout.offsets, Offsets(top: 10, bottom: 10, left: 10, right: 10))
-    }
-
-    func testDefaultsOffsetsToZeroWhenBothKeysAbsent() throws {
+    func testDefaultsOffsetsToZeroWhenAbsent() throws {
         let jsonString = """
         {
             "position": "FULLSCREEN"


### PR DESCRIPTION
# Description

Adds a `data-klaviyo-device` attribute on the in-app forms webview `<head>` so onsite JS can read device dimensions / safe-area insets / orientation / DPR during synchronous HTML parse, before the webview attaches. Plus a wire-contract rename (`margin` → `offsets`) and a new `addSafeAreaInsetsToOffsets` flag that lets onsite opt out of SDK-managed safe-area math entirely. Cross-platform parity with the Android SDK (MAGE-541).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

### `data-klaviyo-device` onsite attribute
- New `DeviceInfo` model (`screen`, `safeAreaInsets`, `orientation`, `dpr`) shaped to CSSOM `screen.*` conventions.
- Baked into the HTML template at initial load (via `WKUserScript` at `.atDocumentStart`) and refreshed via `evaluateJavaScript` on orientation / safe-area changes.
- Injection sidesteps JS string-escape concerns by emitting the raw JSON as a JS object expression wrapped in `JSON.stringify(...)` — the engine parses it natively.

### Window-source correctness
- Dimensions come from `scene.coordinateSpace.bounds` instead of a specific window — handles iPad split view / stage manager / external-display scenarios, and avoids the "our overlay is key" race (see below).
- Our form's overlay `UIWindow` is explicitly excluded when sourcing safe-area insets. The overlay becomes `isKeyWindow` whenever the user taps a form input; prior logic would then read the overlay's own (shrunken) bounds and insets. `DeviceInfo.current()` now filters via `!==` against `InAppWindowManager.currentFormWindow`.
- Removed a dimension-swap heuristic that was only necessary when the source was `UIScreen.main.bounds`. With scene-based bounds it was actively incorrect (would corrupt legitimate tall/narrow iPad split-view windows in landscape).

### CSSOM orientation mapping
- `UIInterfaceOrientation.landscapeRight` → `landscape-primary`, `.landscapeLeft` → `landscape-secondary`, matching WebKit's own Safari implementation. Previous mapping had the two landscape labels inverted.

### Wire rename + safe-area opt-out
- **`margin` → `offsets`** in the `formWillAppear.layout` payload. The legacy `margin` fallback has been removed now that onsite is fully migrated in production.
- `Margins` struct renamed to `Offsets` to match the wire contract; no typealias tombstone.
- **`addSafeAreaInsetsToOffsets: Bool`** (optional, defaults to `true`). When `false`, the SDK uses `offsets` as absolute distances from the screen edge — no safe-area inflation in position math or available-space clamping. Onsite takes responsibility for safe-area policy.

### Misc hardening
- `pushDeviceInfo()` call sites (`viewWillTransition`, `viewSafeAreaInsetsDidChange`) guard against firing while off-window / mid-load — avoids noisy warnings during preload.
- `InAppWindowManager.calculateFrame` extracted to a `nonisolated static` pure function for direct testability.
- Local variable renames `marginX` → `offsetX` to match the new wire/struct naming.
- `InAppWindowManager.currentFormWindow` surfaced for filtering in `DeviceInfo.current()`.

## Wire-contract changes for Fender coordination
- **`margin` → `offsets`** on `formWillAppear.layout`. No backward-compat fallback.
- **New `addSafeAreaInsetsToOffsets: Bool`** on `formWillAppear.layout`, defaults to `true`.
- **`<head data-klaviyo-device='{…}'>`** attribute with CSSOM-shaped JSON; updated on rotation and inset changes.

## Test Plan

- [x] `xcodebuild test -scheme klaviyo-swift-sdk-Package` passes.
- [x] Present a flex/banner form on a notched iPhone with default layout; renders below the notch and above the home indicator.
- [x] Rotate the device mid-form; `data-klaviyo-device` refreshes to match the new orientation (inspect via Safari Web Inspector).
- [x] Trigger a form with `addSafeAreaInsetsToOffsets: false` and non-zero `offsets`; SDK renders using offsets as-is (no safe-area inflation).
- [ ] Verify CSSOM `orientation` label matches what `screen.orientation.type` reports natively in Safari at each of the four rotation states.
- [ ] Verify a fullscreen form still fills the screen regardless of the flag.
- [ ] iPad split-view regression: flex form in 1/3 split reports the split's actual width in `data-klaviyo-device.screen`, not the full physical screen.

## Related Issues/Tickets

Related to [MAGE-541](https://linear.app/klaviyo/issue/MAGE-541)
