### PR TITLE
fix(ci): add --include-podspecs for KlaviyoSwiftExtension CocoaPods lint

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -2,7 +2,7 @@
 #
 # This workflow publishes all five podspecs in dependency order:
 # 1. KlaviyoCore (foundation, no dependencies)
-# 2. KlaviyoSwiftExtension (standalone, no dependencies)
+# 2. KlaviyoSwiftExtension (depends on KlaviyoCore)
 # 3. KlaviyoSwift (depends on KlaviyoCore)
 # 4. KlaviyoForms (depends on KlaviyoSwift)
 # 5. KlaviyoLocation (depends on KlaviyoSwift)
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "Validating all podspecs in dependency order..."
           pod lib lint KlaviyoCore.podspec --allow-warnings
-          pod lib lint KlaviyoSwiftExtension.podspec --allow-warnings
+          pod lib lint KlaviyoSwiftExtension.podspec --allow-warnings --include-podspecs='*.podspec'
           pod lib lint KlaviyoSwift.podspec --allow-warnings --include-podspecs='*.podspec'
           pod lib lint KlaviyoForms.podspec --allow-warnings --include-podspecs='*.podspec'
           pod lib lint KlaviyoLocation.podspec --allow-warnings --include-podspecs='*.podspec'


### PR DESCRIPTION
# Description
Fix CocoaPods publish workflow failing to validate `KlaviyoSwiftExtension` because it can't resolve its `KlaviyoCore` dependency from the CDN during pre-publish validation.

## Due Diligence
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.

## Changelog / Code Overview
`KlaviyoSwiftExtension` now depends on `KlaviyoCore`, but the `cocoapods-publish.yml` workflow was still linting it without `--include-podspecs='*.podspec'`. This caused validation to fail because `KlaviyoCore` hasn't been published to the CDN yet at validation time.

**Changes:**
- Added `--include-podspecs='*.podspec'` to the `KlaviyoSwiftExtension` lint command so it resolves `KlaviyoCore` from local podspec files
- Updated the comment from "standalone, no dependencies" to "depends on KlaviyoCore"

## Test Plan
- Re-run the `cocoapods-publish` workflow via `workflow_dispatch` with version `5.3.0` after merging
- The `publish_pod` function will skip already-published pods (KlaviyoCore) and proceed with the rest

## Related Issues/Tickets
5.3.0 CocoaPods publish failure: `KlaviyoSwiftExtension` validation failed with "CocoaPods could not find compatible versions for pod KlaviyoCore"