### PR TITLE
spike(core): @available(iOSApplicationExtension, unavailable) annotation approach

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -227,6 +227,12 @@ public struct KlaviyoEnvironment {
         return __klaviyoSwiftVersion
     }
 
+    @available(iOSApplicationExtension, unavailable)
+    private static func backgroundSetting() -> PushBackground {
+        .create(from: UIApplication.shared.backgroundRefreshStatus)
+    }
+
+    @available(iOSApplicationExtension, unavailable)
     public static var production = KlaviyoEnvironment(
         archiverClient: ArchiverClient.production,
         fileClient: FileClient.production,
@@ -241,9 +247,7 @@ public struct KlaviyoEnvironment {
             let notificationSettings = await UNUserNotificationCenter.current().notificationSettings()
             return PushEnablement.create(from: notificationSettings.authorizationStatus)
         },
-        getBackgroundSetting: {
-            .create(from: UIApplication.shared.backgroundRefreshStatus)
-        },
+        getBackgroundSetting: { Self.backgroundSetting() },
         getBadgeAutoClearingSetting: {
             Bundle.main.object(forInfoDictionaryKey: "klaviyo_badge_autoclearing") as? Bool ?? true
         },

--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -49,6 +49,7 @@ public class DeepLinkHandler {
     // MARK: - Handle Link
 
     /// Attempts to route a Universal Link using the host application's Scene Delegate or App Delegate link handlers
+    @available(iOSApplicationExtension, unavailable)
     package func openURL(_ url: URL) async {
         if let customDeepLinkHandler {
             if #available(iOS 14.0, *) {
@@ -72,6 +73,7 @@ public class DeepLinkHandler {
         }
     }
 
+    @available(iOSApplicationExtension, unavailable)
     @MainActor
     private static func openWithFallbackHandler(url: URL) async {
         if !KlaviyoEnvironment.isWrapperSDK {
@@ -101,6 +103,7 @@ public class DeepLinkHandler {
     ///
     /// - Parameter url: The universal link URL to be handled.
     /// - Returns: `true` if the link was successfully submitted or handled, and `false` otherwise.
+    @available(iOSApplicationExtension, unavailable)
     @MainActor
     private static func routeWithSceneSessionActivation(url: URL) async -> Bool {
         if #available(iOS 14.0, *) {
@@ -166,6 +169,7 @@ public class DeepLinkHandler {
     }
 
     /// Routes the URL using the AppDelegate API.
+    @available(iOSApplicationExtension, unavailable)
     @MainActor
     @discardableResult
     private static func routeWithAppDelegate(url: URL) async -> Bool {
@@ -185,6 +189,7 @@ public class DeepLinkHandler {
     }
 
     /// Fallback that attempts to open the URL using ``UIApplication.shared.open(_:)``.
+    @available(iOSApplicationExtension, unavailable)
     @MainActor
     @discardableResult
     private static func openWithUIApplicationAPI(_ url: URL) async -> Bool {


### PR DESCRIPTION
## Summary

This spike demonstrates what annotating all `UIApplication`-touching methods looks like in practice, as one approach to making `KlaviyoCore` safe to import from `KlaviyoSwiftExtension` (a Notification Service Extension target).

**Problem:** `KlaviyoSwiftExtension` imports `KlaviyoCore`, but `KlaviyoCore` contains `UIApplication.shared` calls which are unavailable in extension contexts. This can cause issues for customers whose NSE targets enforce `APPLICATION_EXTENSION_API_ONLY`.

**Approach:** Annotate each `UIApplication`-touching method with `@available(iOSApplicationExtension, unavailable)`. The compiler suppresses extension-API errors within the body of such functions, since they're declared unreachable from extension contexts. Non-extension consumers (`KlaviyoSwift`) can still call them freely.

**Changes:**
- `DeepLinkHandler` — 5 methods annotated (`openURL`, `openWithFallbackHandler`, `routeWithSceneSessionActivation`, `routeWithAppDelegate`, `openWithUIApplicationAPI`)
- `KlaviyoEnvironment` — `getBackgroundSetting` extracted to an annotated static method; `production` static var annotated

**Trade-offs vs. the copy approach (see sibling PR):**
- `KlaviyoSwiftExtension` still imports all of `KlaviyoCore` (just can't call the annotated methods)
- More architecturally expressive — documents intent at the API level
- `environment` global and `KlaviyoEnvironment.production` are now annotated, which propagates to any extension consumer that tries to access them

> 🔍 Spike only — not intended to merge. For comparison against the copy approach.