### PR TITLE
refactor(core): move global environment behind KlaviyoEnv holder for Swift 6

### DIFF
--- a/Sources/KlaviyoCore/AppLifeCycleEvents.swift
+++ b/Sources/KlaviyoCore/AppLifeCycleEvents.swift
@@ -23,6 +23,7 @@ public enum LifeCycleEvents {
 public struct AppLifeCycleEvents {
     public var lifeCycleEvents: () -> AnyPublisher<LifeCycleEvents, Never>
 
+    @_spi(KlaviyoPrivate)
     public init(lifeCycleEvents: @escaping () -> AnyPublisher<LifeCycleEvents, Never> = {
         let terminated = environment
             .notificationCenterPublisher(UIApplication.willTerminateNotification)

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -10,7 +10,16 @@ import CoreLocation
 import Foundation
 import UIKit
 
-public var environment = KlaviyoEnvironment.production
+@_spi(KlaviyoPrivate) public enum KlaviyoEnv {
+    nonisolated(unsafe) public static var current = KlaviyoEnvironment.production
+}
+
+@_spi(KlaviyoPrivate)
+@available(*, deprecated, renamed: "KlaviyoEnv.current")
+public var environment: KlaviyoEnvironment {
+    get { KlaviyoEnv.current }
+    set { KlaviyoEnv.current = newValue }
+}
 
 public struct KlaviyoEnvironment {
     public init(

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -10,8 +10,13 @@ import CoreLocation
 import Foundation
 import UIKit
 
-@_spi(KlaviyoPrivate) public enum KlaviyoEnv {
-    nonisolated(unsafe) public static var current = KlaviyoEnvironment.production
+@_spi(KlaviyoPrivate)
+public enum KlaviyoEnv {
+    #if compiler(>=5.10)
+    public nonisolated(unsafe) static var current = KlaviyoEnvironment.production
+    #else
+    public static var current = KlaviyoEnvironment.production
+    #endif
 }
 
 @_spi(KlaviyoPrivate)

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct KlaviyoAPI {
     public var send: (KlaviyoRequest, RequestAttemptInfo) async -> Result<Data, KlaviyoAPIError>
 
+    @_spi(KlaviyoPrivate)
     public init(send: @escaping (KlaviyoRequest, RequestAttemptInfo) async -> Result<Data, KlaviyoAPIError> = { request, requestAttemptInfo in
         let start = environment.date()
 

--- a/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoRequest.swift
@@ -23,6 +23,7 @@ public struct KlaviyoRequest: Identifiable, Equatable, Codable {
     /// - Parameters:
     ///   - id: A unique identifier for this request. If not provided, a UUID will be generated.
     ///   - endpoint: The endpoint this request will target.
+    @_spi(KlaviyoPrivate)
     public init(
         id: String = environment.uuid().uuidString,
         endpoint: KlaviyoEndpoint

--- a/Sources/KlaviyoCore/Utils/LoggerClient.swift
+++ b/Sources/KlaviyoCore/Utils/LoggerClient.swift
@@ -19,7 +19,6 @@ public struct LoggerClient {
     public static let production = Self(error: { message in os_log("%{public}s", type: .error, message) })
 }
 
-@usableFromInline
 @inline(__always)
 func runtimeWarn(
     _ message: @autoclosure () -> String,

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 import UIKit

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 import WebKit

--- a/Sources/KlaviyoForms/InAppForms/Observers/CompanyObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/CompanyObserver.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoForms/InAppForms/Observers/LifecycleObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/LifecycleObserver.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -8,7 +8,7 @@
 #if DEBUG
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import WebKit
 
 // ViewModel for testing the KlaviyoWebViewController & KlaviyoWebViewModeling protocol in Xcode previews only.

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import OSLog
 import UIKit
 import WebKit

--- a/Sources/KlaviyoLocation/GeofenceService.swift
+++ b/Sources/KlaviyoLocation/GeofenceService.swift
@@ -6,7 +6,7 @@
 //
 
 import CoreLocation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoLocation/KlaviyoLocationManager+CLLocationManagerDelegate.swift
+++ b/Sources/KlaviyoLocation/KlaviyoLocationManager+CLLocationManagerDelegate.swift
@@ -7,7 +7,7 @@
 
 import CoreLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
+++ b/Sources/KlaviyoLocation/KlaviyoLocationManager.swift
@@ -8,7 +8,7 @@
 import Combine
 import CoreLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import OSLog
 

--- a/Sources/KlaviyoLocation/Models/Geofence.swift
+++ b/Sources/KlaviyoLocation/Models/Geofence.swift
@@ -7,7 +7,7 @@
 
 import CoreLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 
 /// Represents a Klaviyo geofence

--- a/Sources/KlaviyoLocation/Utilities/GeofenceCooldownTracker.swift
+++ b/Sources/KlaviyoLocation/Utilities/GeofenceCooldownTracker.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 
 /// Manages geofence transition cooldown periods to prevent duplicate

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -7,7 +7,7 @@
 
 import AnyCodable
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import OSLog
 import UIKit
 

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 /// The internal interface for the Klaviyo SDK.
 ///

--- a/Sources/KlaviyoSwift/Models/Event.swift
+++ b/Sources/KlaviyoSwift/Models/Event.swift
@@ -7,7 +7,7 @@
 
 import AnyCodable
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 public struct Event: Equatable {
     public enum EventName: Equatable, Hashable {

--- a/Sources/KlaviyoSwift/Models/LifecycleEventsExtension.swift
+++ b/Sources/KlaviyoSwift/Models/LifecycleEventsExtension.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 extension LifeCycleEvents {
     var transformToKlaviyoAction: KlaviyoAction {

--- a/Sources/KlaviyoSwift/Models/Profile.swift
+++ b/Sources/KlaviyoSwift/Models/Profile.swift
@@ -7,7 +7,7 @@
 
 import AnyCodable
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 public struct Profile: Equatable, Codable {
     public enum ProfileKey: Equatable, Hashable, Codable {

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 extension String {
     internal func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 enum ErrorHandlingConstants {
     static let maxBackoff = 60 * 3 // 3 minutes

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -7,7 +7,7 @@
 
 import AnyCodable
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import UIKit
 
 typealias DeviceMetadata = PushTokenPayload.PushToken.Attributes.MetaData

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -14,7 +14,7 @@
 import AnyCodable
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import OSLog
 import UIKit
 import UserNotifications

--- a/Sources/KlaviyoSwift/Utilities/EventBuffer.swift
+++ b/Sources/KlaviyoSwift/Utilities/EventBuffer.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import OSLog
 
 // MARK: - Logger

--- a/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 class ArchivalUtilsTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/DeepLinkHandlerTests.swift
+++ b/Tests/KlaviyoCoreTests/DeepLinkHandlerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Claude on 9/17/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 final class DeepLinkHandlerTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/Dictionary+MetadataTests.swift
+++ b/Tests/KlaviyoCoreTests/Dictionary+MetadataTests.swift
@@ -5,7 +5,7 @@
 //  Created by Ajay Subramanya on 10/10/25.
 //
 
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 final class DictionaryMetadataTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/EncodableTests.swift
+++ b/Tests/KlaviyoCoreTests/EncodableTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 11/14/22.
 //
 
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import SnapshotTesting
 import XCTest
 

--- a/Tests/KlaviyoCoreTests/FileUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/FileUtilsTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 9/29/22.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 class FileUtilsTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 11/16/22.
 //
 
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import SnapshotTesting
 import XCTest
 

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -1,4 +1,4 @@
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 final class KlaviyoEndpointTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/KlaviyoRequestTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoRequestTests.swift
@@ -1,4 +1,4 @@
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 final class KlaviyoRequestTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 11/18/22.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import SnapshotTesting
 import XCTest
 

--- a/Tests/KlaviyoCoreTests/RequestAttemptInfoTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestAttemptInfoTests.swift
@@ -1,4 +1,4 @@
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 final class RequestAttemptInfoTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -5,7 +5,7 @@
 //  Created by Ajay Subramanya on 8/15/24.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import Combine
 import CoreLocation
 import Foundation

--- a/Tests/KlaviyoCoreTests/WithTimeoutTests.swift
+++ b/Tests/KlaviyoCoreTests/WithTimeoutTests.swift
@@ -1,4 +1,4 @@
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import XCTest
 
 final class WithTimeoutTests: XCTestCase {

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoForms
 @testable import KlaviyoSwift
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import WebKit
 import XCTest
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoForms
 @testable import KlaviyoSwift
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import WebKit
 import XCTest
 

--- a/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
@@ -5,7 +5,7 @@
 //  Created by Isobelle Lim on 5/6/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import Combine
 import CoreLocation
 import Foundation

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -1,6 +1,6 @@
 @testable import KlaviyoForms
 @testable import KlaviyoSwift
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import OSLog
 import UIKit
 import WebKit

--- a/Tests/KlaviyoLocationTests/GeofenceCooldownTrackerTests.swift
+++ b/Tests/KlaviyoLocationTests/GeofenceCooldownTrackerTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import KlaviyoSwift
 import XCTest
 

--- a/Tests/KlaviyoLocationTests/GeofenceTests.swift
+++ b/Tests/KlaviyoLocationTests/GeofenceTests.swift
@@ -9,7 +9,7 @@
 @testable import KlaviyoSwift
 import CoreLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 final class GeofenceTests: XCTestCase {

--- a/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
+++ b/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
@@ -8,7 +8,7 @@
 @testable import KlaviyoLocation
 import CoreLocation
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 @_spi(KlaviyoPrivate) @testable import KlaviyoSwift
 import Combine
 import XCTest

--- a/Tests/KlaviyoLocationTests/KlaviyoLocationTestUtils.swift
+++ b/Tests/KlaviyoLocationTests/KlaviyoLocationTestUtils.swift
@@ -5,7 +5,7 @@
 //  Created by Isobelle Lim on 1/27/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import Combine
 import CoreLocation
 import Foundation

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 let TIMEOUT_NANOSECONDS: UInt64 = 10_000_000_000 // 10 seconds

--- a/Tests/KlaviyoSwiftTests/AppLifeCycleEventsTests.swift
+++ b/Tests/KlaviyoSwiftTests/AppLifeCycleEventsTests.swift
@@ -8,7 +8,7 @@
 @testable import KlaviyoSwift
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 class AppLifeCycleEventsTests: XCTestCase {

--- a/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
+++ b/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
@@ -1,4 +1,4 @@
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import XCTest
 

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -4,7 +4,7 @@
 //  Created by Cursor AI on 8/11/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import Combine
 import Foundation

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import SnapshotTesting
 import XCTest

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -8,7 +8,7 @@
 import Combine
 import XCTest
 @_spi(KlaviyoPrivate) @testable import KlaviyoSwift
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 final class KlaviyoInternalTests: XCTestCase {
     var cancellables = Set<AnyCancellable>()

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 // MARK: - KlaviyoSDKTests

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import SnapshotTesting
 import XCTest
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 9/30/22.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 import Combine
 import CombineSchedulers
 import CoreLocation

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -5,7 +5,7 @@
 //  Created by Claude on 8/4/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import Combine
 import XCTest

--- a/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
@@ -10,7 +10,7 @@ import CombineSchedulers
 import Foundation
 import XCTest
 @_spi(KlaviyoPrivate) @testable import KlaviyoSwift
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 
 final class StateChangePublisherTests: XCTestCase {
     @MainActor

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -7,7 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 import XCTest
 
 class StateManagementEdgeCaseTests: XCTestCase {

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noah Durell on 12/6/22.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import AnyCodable
 import Combine

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -7,7 +7,7 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
+@_spi(KlaviyoPrivate) import KlaviyoCore
 @_spi(KlaviyoPrivate) @testable import KlaviyoSwift
 
 let TEST_API_KEY = "fake-key"

--- a/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
+++ b/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
@@ -5,7 +5,7 @@
 //  Created by Claude on 8/4/25.
 //
 
-@testable import KlaviyoCore
+@_spi(KlaviyoPrivate) @testable import KlaviyoCore
 @testable import KlaviyoSwift
 import XCTest
 


### PR DESCRIPTION
# Description

Step 1.1 of the Swift 6 strict-concurrency migration. Replaces the public mutable global `environment` at `Sources/KlaviyoCore/KlaviyoEnvironment.swift:13` with a typed holder `KlaviyoEnv.current`, gated behind `@_spi(KlaviyoPrivate)`. The original `environment` symbol remains as a deprecated SPI shim for source compatibility while call sites migrate (chunk 1.2.*).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

(No new tests — this is a pure refactor with zero behavior change. Existing test suite passes.)

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

The new `KlaviyoEnv` symbol and the deprecated `environment` shim are both `@_spi(KlaviyoPrivate)` — they can only be reached via `@_spi(KlaviyoPrivate) import KlaviyoCore`. The pre-existing `environment` global was plain `public`; tightening it to SPI is a deliberate access narrowing. All call sites in this repo (and our sibling test apps, which already use the SPI import) are unaffected.

## Changelog / Code Overview

**New canonical entrypoint:**
```swift
@_spi(KlaviyoPrivate) public enum KlaviyoEnv {
    nonisolated(unsafe) public static var current = KlaviyoEnvironment.production
}
```
- `nonisolated(unsafe)` is the documented Apple stopgap for nonisolated global shared mutable state under `-strict-concurrency=complete`. Race surface is unchanged — labeled, not eliminated. Real isolation lands when the closures inside `KlaviyoEnvironment` get rehomed into per-feature containers in later chunks.

**Deprecated source-compat shim:**
```swift
@_spi(KlaviyoPrivate)
@available(*, deprecated, renamed: "KlaviyoEnv.current")
public var environment: KlaviyoEnvironment {
    get { KlaviyoEnv.current }
    set { KlaviyoEnv.current = newValue }
}
```

**Knock-on changes required by the SPI gating:**
- All cross-module imports of `KlaviyoCore` flipped to `@_spi(KlaviyoPrivate) import KlaviyoCore` (40 source + test files). Mechanical change; no call-site edits.
- Three public inits in KlaviyoCore reference `environment` in their **default-argument values**, which the compiler rejects for non-SPI public ABI (default args become part of the public interface):
  - `KlaviyoAPI.init(send:)`
  - `KlaviyoRequest.init(id:endpoint:)`
  - `AppLifeCycleEvents.init(lifeCycleEvents:)`

  These are gated `@_spi(KlaviyoPrivate)` to match. All current callers already have SPI access via the import flip; customer-facing surface (`KlaviyoSDK`, `Klaviyo.shared`, etc.) is unchanged.
- Dropped `@usableFromInline` on `runtimeWarn` in `LoggerClient.swift` — no `@inlinable` callers exist in KlaviyoCore, and the annotation was inadvertently exposing its default args to the cross-module surface.

**What chunk 1.2.* will do (out of scope here):**
- Migrate ~30 in-repo `environment.X` call sites to `KlaviyoEnv.current.X` (deprecation warnings flag them today).
- Delete the deprecated `environment` shim once call sites are migrated.

**Out of scope for the broader 1.x effort, separate chunks:**
- The `networkSession` global at `KlaviyoEnvironment.swift:300`.
- Sibling test apps in `klaviyo-{ios,swift}-test-app` (no changes needed — they already use `@_spi(KlaviyoPrivate) import KlaviyoCore`).

## Test Plan

- `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` — succeeds, with the expected deprecation warnings on existing `environment.X` call sites (to be cleared in chunk 1.2.*).
- `make test-library` — full test suite passes.
- Verified deprecation warnings flow through (`'environment' is deprecated: renamed to 'KlaviyoEnv.current'`) on all in-repo call sites.

## Related Issues/Tickets

Swift 6 strict concurrency initiative.