### PR TITLE
fix(ci): revert --include-podspecs for KlaviyoSwiftExtension lint (#561)

### DIFF
--- a/.github/workflows/cocoapods-publish.yml
+++ b/.github/workflows/cocoapods-publish.yml
@@ -2,7 +2,7 @@
 #
 # This workflow publishes all five podspecs in dependency order:
 # 1. KlaviyoCore (foundation, no dependencies)
-# 2. KlaviyoSwiftExtension (depends on KlaviyoCore)
+# 2. KlaviyoSwiftExtension (standalone, no dependencies)
 # 3. KlaviyoSwift (depends on KlaviyoCore)
 # 4. KlaviyoForms (depends on KlaviyoSwift)
 # 5. KlaviyoLocation (depends on KlaviyoSwift)
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "Validating all podspecs in dependency order..."
           pod lib lint KlaviyoCore.podspec --allow-warnings
-          pod lib lint KlaviyoSwiftExtension.podspec --allow-warnings --include-podspecs='*.podspec'
+          pod lib lint KlaviyoSwiftExtension.podspec --allow-warnings
           pod lib lint KlaviyoSwift.podspec --allow-warnings --include-podspecs='*.podspec'
           pod lib lint KlaviyoForms.podspec --allow-warnings --include-podspecs='*.podspec'
           pod lib lint KlaviyoLocation.podspec --allow-warnings --include-podspecs='*.podspec'


### PR DESCRIPTION
## Summary

Reverts the CI change from #561 now that it's no longer needed.

- #564 dropped `KlaviyoCore` as a dependency of `KlaviyoSwiftExtension` by copying shared types directly, so the `--include-podspecs='*.podspec'` flag added in #561 is now a no-op
- Restores the standalone lint command for `KlaviyoSwiftExtension`
- Updates the workflow comment to reflect the current state (`standalone, no dependencies`)

## Test plan

- [ ] Verify the CocoaPods publish workflow lint step passes in CI