### PR TITLE
feat(KlaviyoCore): AuthTokenManager skeleton + registerAuthTokenProvider API

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenError.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenError.swift
@@ -1,0 +1,29 @@
+//
+//  AuthTokenError.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+import Foundation
+
+/// Errors thrown by ``AuthTokenManager`` when an auth-token request cannot be
+/// satisfied.
+///
+/// In v1 the SDK does not surface these to host code via callback — failures are
+/// observable only via OSLog and form-display behavior. The cases exist so SDK
+/// modules that consume ``AuthTokenManager`` (e.g. `KlaviyoForms`) can distinguish
+/// between "no provider has been registered yet" and "the provider returned an
+/// invalid token" when shaping their fallback behavior.
+package enum AuthTokenError: Error, Equatable {
+    /// ``currentToken()`` was called before any ``AuthTokenProvider`` was
+    /// registered, or after the manager's internal `reset()` (handled in a
+    /// sibling sub-issue) cleared the provider. Callers should treat this as
+    /// "auth is not enabled" rather than "auth failed".
+    case noProviderRegistered
+
+    /// The provider returned a token that did not pass ``JWTParser`` validation.
+    /// The associated value carries the specific reason (malformed, expired,
+    /// missing claim, …).
+    case validationFailed(JWTValidationFailure)
+}

--- a/Sources/KlaviyoCore/Auth/AuthTokenError.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenError.swift
@@ -10,16 +10,15 @@ import Foundation
 /// Errors thrown by ``AuthTokenManager`` when an auth-token request cannot be
 /// satisfied.
 ///
-/// In v1 the SDK does not surface these to host code via callback — failures are
+/// The SDK does not surface these to host code via callback — failures are
 /// observable only via OSLog and form-display behavior. The cases exist so SDK
-/// modules that consume ``AuthTokenManager`` (e.g. `KlaviyoForms`) can distinguish
-/// between "no provider has been registered yet" and "the provider returned an
-/// invalid token" when shaping their fallback behavior.
+/// modules that consume ``AuthTokenManager`` (e.g. `KlaviyoForms`) can
+/// distinguish between "no provider has been registered yet" and "the provider
+/// returned an invalid token" when shaping their fallback behavior.
 package enum AuthTokenError: Error, Equatable {
     /// ``currentToken()`` was called before any ``AuthTokenProvider`` was
-    /// registered, or after the manager's internal `reset()` (handled in a
-    /// sibling sub-issue) cleared the provider. Callers should treat this as
-    /// "auth is not enabled" rather than "auth failed".
+    /// registered. Callers should treat this as "auth is not enabled" rather
+    /// than "auth failed".
     case noProviderRegistered
 
     /// The provider returned a token that did not pass ``JWTParser`` validation.

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -31,14 +31,6 @@ package actor AuthTokenManager {
     /// Starts `nil`; set by ``registerProvider(_:)``.
     private var provider: AuthTokenProvider?
 
-    // MARK: - Reserved storage
-
-    // TODO: - [MAGE-624] dedup concurrent currentToken() callers
-    private var inFlightFetch: Task<String, Error>?
-
-    // TODO: - [MAGE-625] proactively refresh the cached token
-    private var refreshTask: Task<Void, Never>?
-
     init() {}
 
     /// Registers a new provider, discards any cached token from a previous

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -1,0 +1,135 @@
+//
+//  AuthTokenManager.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+import Foundation
+import OSLog
+
+/// Owns the host-supplied ``AuthTokenProvider`` and serves the current auth JWT to
+/// internal SDK consumers (in-app forms today, future feature modules tomorrow).
+///
+/// This skeleton ships only the happy-path acquisition flow: register a provider,
+/// fetch and validate a token, cache it, and hand the cached string to callers
+/// until the next provider change. Concurrent-caller deduplication, timeout
+/// enforcement, proactive refresh scheduling, the refresh notification stream, and
+/// the `reset()` lifecycle hook will land in sibling sub-issues. Their stored
+/// properties are declared here so adding those behaviors doesn't churn the
+/// actor's shape.
+///
+/// The token cache is in-memory only — never persisted to disk or Keychain.
+package actor AuthTokenManager {
+    /// Shared instance used by `KlaviyoSDK` and other SDK modules. Tests should
+    /// construct their own instances to keep test runs independent.
+    package static let shared = AuthTokenManager()
+
+    /// Most recently validated token, if any. Cleared whenever
+    /// ``registerProvider(_:)`` runs.
+    private var cachedToken: ValidatedToken?
+
+    /// Host-supplied closure that returns a fresh JWT on each invocation.
+    /// Starts `nil`; set by ``registerProvider(_:)``. There is no public API
+    /// for clearing — that happens internally via ``reset()`` (deferred to a
+    /// sibling sub-issue) when `KlaviyoSDK.resetProfile()` is called.
+    private var provider: AuthTokenProvider?
+
+    // MARK: - Deferred state
+
+    // The following properties are declared as part of this actor's shape so
+    // that sibling sub-issues can fill in their behaviors without churning the
+    // signature. They are unused in this skeleton.
+
+    /// Reserved for concurrent-caller deduplication. Sub-issue MAGE-624 will
+    /// populate this from ``currentToken()`` so that multiple callers share a
+    /// single provider invocation.
+    private var inFlightFetch: Task<String, Error>?
+
+    /// Reserved for proactive refresh scheduling. Sub-issue MAGE-625 will schedule
+    /// refreshes at `iat + 0.9 * (exp - iat)` bounded by `[now + 5s, exp - 30s]`.
+    private var refreshTask: Task<Void, Never>?
+
+    /// Reserved for the refresh-notification stream. Sub-issue MAGE-626 will fan
+    /// successful refresh tokens out to consumers via
+    /// `refreshes() -> AsyncStream<String>`.
+    private var refreshContinuations: [AsyncStream<String>.Continuation] = []
+
+    init() {}
+
+    /// Registers a new provider, discards any cached token from a previous
+    /// provider, and triggers an eager fetch to warm the cache.
+    ///
+    /// The eager fetch is fire-and-forget so registration call sites stay
+    /// responsive — failures during the warm-up surface only as logs (the same
+    /// logs ``currentToken()`` would emit). Calling this again later replaces
+    /// the previous provider; there is no public API for clearing a registered
+    /// provider, since clearing is part of the profile-reset lifecycle handled
+    /// in a sibling sub-issue.
+    package func registerProvider(_ newProvider: @escaping AuthTokenProvider) async {
+        cachedToken = nil
+        provider = newProvider
+
+        if #available(iOS 14.0, *) {
+            Logger.auth.info("AuthTokenManager: provider registered")
+        }
+        Task {
+            _ = try? await self.currentToken()
+        }
+    }
+
+    /// Returns the current auth token, fetching one via the registered provider
+    /// if the cache is empty or has gone stale.
+    ///
+    /// This is the happy-path skeleton: a single caller races directly against the
+    /// provider, with no in-flight deduplication and no timeout enforcement. Those
+    /// arrive in sub-issue MAGE-624; until then, two concurrent callers will both
+    /// invoke the provider — the wrong behavior is "extra fetches", not data
+    /// corruption.
+    ///
+    /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is
+    ///   registered; the provider's own error when the provider throws;
+    ///   ``AuthTokenError/validationFailed(_:)`` when the returned token fails
+    ///   ``JWTParser`` validation.
+    package func currentToken() async throws -> String {
+        if let cachedToken, isCachedTokenValid(cachedToken) {
+            return cachedToken.rawToken
+        }
+
+        guard let provider else {
+            throw AuthTokenError.noProviderRegistered
+        }
+
+        let rawToken = try await provider()
+
+        switch JWTParser.parseAndValidate(rawToken) {
+        case let .success(validated):
+            cachedToken = validated
+            if #available(iOS 14.0, *) {
+                Logger.auth.info(
+                    """
+                    AuthTokenManager: token acquired \
+                    (iat=\(validated.issuedAt, privacy: .private), \
+                    exp=\(validated.expiresAt, privacy: .private))
+                    """
+                )
+            }
+            return validated.rawToken
+        case let .failure(failure):
+            if #available(iOS 14.0, *) {
+                let reason = String(describing: failure)
+                Logger.auth.warning(
+                    "AuthTokenManager: validation failure on returned token: \(reason, privacy: .public)"
+                )
+            }
+            throw AuthTokenError.validationFailed(failure)
+        }
+    }
+
+    /// `true` when the cached token's `exp` is still in the future after applying
+    /// the same clock-skew leeway ``JWTParser`` uses on acquisition.
+    private func isCachedTokenValid(_ token: ValidatedToken, currentTime: Date = Date()) -> Bool {
+        let expiresAtSeconds = token.expiresAt.timeIntervalSince1970
+        return currentTime.timeIntervalSince1970 < expiresAtSeconds - JWTParser.defaultLeeway
+    }
+}

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -8,16 +8,14 @@
 import Foundation
 import OSLog
 
-/// Owns the host-supplied ``AuthTokenProvider`` and serves the current auth JWT to
-/// internal SDK consumers (in-app forms today, future feature modules tomorrow).
+/// Owns the host-supplied ``AuthTokenProvider`` and serves the current auth JWT
+/// to internal SDK consumers (in-app forms today, future feature modules
+/// tomorrow).
 ///
-/// This skeleton ships only the happy-path acquisition flow: register a provider,
-/// fetch and validate a token, cache it, and hand the cached string to callers
-/// until the next provider change. Concurrent-caller deduplication, timeout
-/// enforcement, proactive refresh scheduling, the refresh notification stream, and
-/// the `reset()` lifecycle hook will land in sibling sub-issues. Their stored
-/// properties are declared here so adding those behaviors doesn't churn the
-/// actor's shape.
+/// Validates each token via ``JWTParser`` on acquisition, caches the result in
+/// memory, and serves the cached string until either the cached token's `exp`
+/// has elapsed (with the same clock-skew leeway ``JWTParser`` uses) or the
+/// provider is replaced via ``registerProvider(_:)``.
 ///
 /// The token cache is in-memory only — never persisted to disk or Keychain.
 package actor AuthTokenManager {
@@ -30,29 +28,18 @@ package actor AuthTokenManager {
     private var cachedToken: ValidatedToken?
 
     /// Host-supplied closure that returns a fresh JWT on each invocation.
-    /// Starts `nil`; set by ``registerProvider(_:)``. There is no public API
-    /// for clearing — that happens internally via ``reset()`` (deferred to a
-    /// sibling sub-issue) when `KlaviyoSDK.resetProfile()` is called.
+    /// Starts `nil`; set by ``registerProvider(_:)``.
     private var provider: AuthTokenProvider?
 
-    // MARK: - Deferred state
+    // MARK: - Reserved storage
 
-    // The following properties are declared as part of this actor's shape so
-    // that sibling sub-issues can fill in their behaviors without churning the
-    // signature. They are unused in this skeleton.
-
-    /// Reserved for concurrent-caller deduplication. Sub-issue MAGE-624 will
-    /// populate this from ``currentToken()`` so that multiple callers share a
-    /// single provider invocation.
+    // TODO: - [MAGE-624] use to deduplicate concurrent currentToken() callers so they share a single provider invocation
     private var inFlightFetch: Task<String, Error>?
 
-    /// Reserved for proactive refresh scheduling. Sub-issue MAGE-625 will schedule
-    /// refreshes at `iat + 0.9 * (exp - iat)` bounded by `[now + 5s, exp - 30s]`.
+    // TODO: - [MAGE-625] schedule refreshes at iat + 0.9 * (exp - iat), bounded by [now + 5s, exp - 30s]
     private var refreshTask: Task<Void, Never>?
 
-    /// Reserved for the refresh-notification stream. Sub-issue MAGE-626 will fan
-    /// successful refresh tokens out to consumers via
-    /// `refreshes() -> AsyncStream<String>`.
+    // TODO: - [MAGE-626] fan successful refresh tokens out to consumers via refreshes() -> AsyncStream<String>
     private var refreshContinuations: [AsyncStream<String>.Continuation] = []
 
     init() {}
@@ -63,9 +50,7 @@ package actor AuthTokenManager {
     /// The eager fetch is fire-and-forget so registration call sites stay
     /// responsive — failures during the warm-up surface only as logs (the same
     /// logs ``currentToken()`` would emit). Calling this again later replaces
-    /// the previous provider; there is no public API for clearing a registered
-    /// provider, since clearing is part of the profile-reset lifecycle handled
-    /// in a sibling sub-issue.
+    /// the previous provider.
     package func registerProvider(_ newProvider: @escaping AuthTokenProvider) async {
         cachedToken = nil
         provider = newProvider
@@ -81,10 +66,8 @@ package actor AuthTokenManager {
     /// Returns the current auth token, fetching one via the registered provider
     /// if the cache is empty or has gone stale.
     ///
-    /// This is the happy-path skeleton: a single caller races directly against the
-    /// provider, with no in-flight deduplication and no timeout enforcement. Those
-    /// arrive in sub-issue MAGE-624; until then, two concurrent callers will both
-    /// invoke the provider — the wrong behavior is "extra fetches", not data
+    /// A single caller invokes the provider directly. If two callers race, both
+    /// will invoke the provider — the result is extra network calls, not data
     /// corruption.
     ///
     /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -39,9 +39,6 @@ package actor AuthTokenManager {
     // TODO: - [MAGE-625] proactively refresh the cached token
     private var refreshTask: Task<Void, Never>?
 
-    // TODO: - [MAGE-626] notify consumers when the cached token refreshes
-    private var refreshContinuations: [AsyncStream<String>.Continuation] = []
-
     init() {}
 
     /// Registers a new provider, discards any cached token from a previous

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -72,6 +72,9 @@ package actor AuthTokenManager {
             throw AuthTokenError.noProviderRegistered
         }
 
+        // TODO: [MAGE-624] cancel any in-flight fetch when `registerProvider(_:)`
+        // runs — the resumed continuation below can otherwise overwrite the cache
+        // with a token from a since-replaced provider.
         let rawToken = try await provider()
 
         switch JWTParser.parseAndValidate(rawToken) {

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -33,13 +33,13 @@ package actor AuthTokenManager {
 
     // MARK: - Reserved storage
 
-    // TODO: - [MAGE-624] use to deduplicate concurrent currentToken() callers so they share a single provider invocation
+    // TODO: - [MAGE-624] dedup concurrent currentToken() callers
     private var inFlightFetch: Task<String, Error>?
 
-    // TODO: - [MAGE-625] schedule refreshes at iat + 0.9 * (exp - iat), bounded by [now + 5s, exp - 30s]
+    // TODO: - [MAGE-625] proactively refresh the cached token
     private var refreshTask: Task<Void, Never>?
 
-    // TODO: - [MAGE-626] fan successful refresh tokens out to consumers via refreshes() -> AsyncStream<String>
+    // TODO: - [MAGE-626] notify consumers when the cached token refreshes
     private var refreshContinuations: [AsyncStream<String>.Continuation] = []
 
     init() {}

--- a/Sources/KlaviyoCore/Auth/AuthTokenProvider.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenProvider.swift
@@ -1,0 +1,18 @@
+//
+//  AuthTokenProvider.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+/// Host-supplied closure that produces a Klaviyo auth JWT on demand.
+///
+/// The SDK invokes the provider whenever it needs a fresh token: at registration
+/// time (eager fetch), when the cached token has expired, and during proactive
+/// refresh. Returning a token from a long-lived async source (e.g. a network call
+/// to the host's auth backend) is expected and supported — the SDK respects task
+/// cancellation, so timeouts propagate cleanly for well-behaved implementations.
+///
+/// Returning a malformed or already-expired token causes the SDK to discard it and
+/// log a validation failure; the SDK does not retry on its own.
+public typealias AuthTokenProvider = @Sendable () async throws -> String

--- a/Sources/KlaviyoCore/Auth/JWTValidationFailure.swift
+++ b/Sources/KlaviyoCore/Auth/JWTValidationFailure.swift
@@ -13,7 +13,7 @@ import Foundation
 /// security boundary for that. These cases capture only what the SDK can detect locally:
 /// structural problems, missing required claims, or tokens that are already expired at the time
 /// of acquisition (applying a clock-skew leeway).
-enum JWTValidationFailure: Error, Equatable {
+package enum JWTValidationFailure: Error, Equatable {
     /// The token did not contain three `.`-separated segments.
     case malformedStructure
 

--- a/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
+++ b/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
@@ -17,11 +17,10 @@ extension KlaviyoSDK {
     ///
     /// Each call invalidates any cached token and triggers an eager fetch to
     /// warm the cache. Calling again later replaces the previously registered
-    /// provider. There is no public API for clearing a registered provider —
-    /// that happens internally when `resetProfile()` is called.
+    /// provider.
     ///
-    /// The SDK does not surface acquisition errors to the host in v1 — failures
-    /// are observable only via OSLog (subsystem
+    /// The SDK does not surface acquisition errors to the host — failures are
+    /// observable only via OSLog (subsystem
     /// `com.klaviyo.klaviyo-swift-sdk.klaviyoCore`, category `Auth`) and via
     /// form-display behavior.
     ///

--- a/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
+++ b/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
@@ -1,0 +1,34 @@
+//
+//  Klaviyo+AuthToken.swift
+//  KlaviyoSwift
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+import KlaviyoCore
+
+/// Re-exports ``KlaviyoCore/AuthTokenProvider`` so host code that imports only
+/// `KlaviyoSwift` can reference the closure type without a second import.
+public typealias AuthTokenProvider = KlaviyoCore.AuthTokenProvider
+
+extension KlaviyoSDK {
+    /// Registers the host-supplied closure that produces the auth JWT used for
+    /// personalized in-app forms.
+    ///
+    /// Each call invalidates any cached token and triggers an eager fetch to
+    /// warm the cache. Calling again later replaces the previously registered
+    /// provider. There is no public API for clearing a registered provider —
+    /// that happens internally when `resetProfile()` is called.
+    ///
+    /// The SDK does not surface acquisition errors to the host in v1 — failures
+    /// are observable only via OSLog (subsystem
+    /// `com.klaviyo.klaviyo-swift-sdk.klaviyoCore`, category `Auth`) and via
+    /// form-display behavior.
+    ///
+    /// - Parameter provider: an `@Sendable` async closure that returns a JWT.
+    public func registerAuthTokenProvider(_ provider: @escaping AuthTokenProvider) {
+        Task {
+            await AuthTokenManager.shared.registerProvider(provider)
+        }
+    }
+}

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -1,0 +1,210 @@
+//
+//  AuthTokenManagerTests.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+@testable import KlaviyoCore
+import Foundation
+
+#if canImport(Testing)
+import Testing
+
+@Suite
+struct AuthTokenManagerTests {
+    // MARK: - currentToken: provider absence
+
+    @Test
+    func currentTokenWithoutProviderThrowsNoProviderRegistered() async {
+        let manager = AuthTokenManager()
+
+        await #expect(throws: AuthTokenError.noProviderRegistered) {
+            _ = try await manager.currentToken()
+        }
+    }
+
+    // MARK: - currentToken: happy path
+
+    @Test
+    func currentTokenInvokesProviderAndReturnsTokenString() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+
+        await manager.registerProvider { token }
+        let result = try await manager.currentToken()
+
+        #expect(result == token)
+    }
+
+    @Test
+    func currentTokenServesCachedTokenOnSubsequentCalls() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return token
+        }
+
+        // Drain the eager fetch so the cache is warm before the assertions below.
+        try await counter.waitFor(atLeast: 1)
+
+        let countBefore = await counter.value
+        let first = try await manager.currentToken()
+        let second = try await manager.currentToken()
+        let countAfter = await counter.value
+
+        #expect(first == token)
+        #expect(second == token)
+        #expect(countBefore == countAfter, "cached token should not re-invoke the provider")
+    }
+
+    // MARK: - currentToken: provider errors
+
+    @Test
+    func currentTokenRethrowsErrorFromProvider() async throws {
+        let manager = AuthTokenManager()
+
+        await manager.registerProvider {
+            throw ProviderTestError.network
+        }
+
+        await #expect(throws: ProviderTestError.network) {
+            _ = try await manager.currentToken()
+        }
+    }
+
+    @Test
+    func currentTokenThrowsValidationFailedForMalformedToken() async {
+        let manager = AuthTokenManager()
+
+        await manager.registerProvider { "not.a.valid.jwt" }
+
+        await #expect(throws: AuthTokenError.validationFailed(.malformedStructure)) {
+            _ = try await manager.currentToken()
+        }
+    }
+
+    @Test
+    func currentTokenThrowsValidationFailedForExpiredToken() async throws {
+        let manager = AuthTokenManager()
+        let past = Date().timeIntervalSince1970 - 3600
+        let expiredToken = try makeJWT(issuedAt: past - 60, expiresAt: past)
+
+        await manager.registerProvider { expiredToken }
+
+        await #expect(throws: AuthTokenError.validationFailed(.expiredOnReceipt)) {
+            _ = try await manager.currentToken()
+        }
+    }
+
+    // MARK: - registerProvider behaviors
+
+    @Test
+    func registerProviderEagerlyFetches() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return token
+        }
+
+        try await counter.waitFor(atLeast: 1)
+        let count = await counter.value
+        #expect(count >= 1)
+    }
+
+    @Test
+    func replacingProviderDiscardsCachedToken() async throws {
+        let manager = AuthTokenManager()
+        let firstToken = try makeJWT()
+        let secondToken = try makeJWT(extraClaims: ["sub": "user-2"])
+
+        let firstCounter = CallCounter()
+        await manager.registerProvider {
+            await firstCounter.increment()
+            return firstToken
+        }
+        try await firstCounter.waitFor(atLeast: 1)
+        let firstResult = try await manager.currentToken()
+        #expect(firstResult == firstToken)
+
+        // Swap the provider — the cached firstToken should be discarded, so the
+        // next currentToken() call must consult the new provider.
+        let secondCounter = CallCounter()
+        await manager.registerProvider {
+            await secondCounter.increment()
+            return secondToken
+        }
+        try await secondCounter.waitFor(atLeast: 1)
+        let secondResult = try await manager.currentToken()
+        #expect(secondResult == secondToken)
+    }
+}
+
+// MARK: - Test helpers
+
+extension AuthTokenManagerTests {
+    /// Counts provider invocations and lets tests await a specific call count
+    /// without sleeping. `signal` runs every increment so any waiters can wake up
+    /// promptly when their threshold is met.
+    actor CallCounter {
+        private(set) var value = 0
+        private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+        func increment() {
+            value += 1
+            waiters = waiters.compactMap { waiter in
+                if value >= waiter.threshold {
+                    waiter.continuation.resume()
+                    return nil
+                }
+                return waiter
+            }
+        }
+
+        func waitFor(atLeast threshold: Int) async throws {
+            if value >= threshold { return }
+            await withCheckedContinuation { continuation in
+                waiters.append((threshold, continuation))
+            }
+        }
+    }
+
+    enum ProviderTestError: Error, Equatable {
+        case network
+    }
+
+    /// Builds a JWT with default `iat` slightly in the past and `exp` an hour
+    /// ahead so it passes ``JWTParser`` validation in the present.
+    fileprivate func makeJWT(
+        issuedAt: TimeInterval? = nil,
+        expiresAt: TimeInterval? = nil,
+        extraClaims: [String: Any] = [:]
+    ) throws -> String {
+        let nowSeconds = Date().timeIntervalSince1970
+        let issuedAtSeconds = issuedAt ?? (nowSeconds - 60)
+        let expiresAtSeconds = expiresAt ?? (nowSeconds + 3600)
+
+        var payload: [String: Any] = extraClaims
+        payload["iat"] = issuedAtSeconds
+        payload["exp"] = expiresAtSeconds
+
+        let header: [String: Any] = ["alg": "HS256", "typ": "JWT"]
+        let headerSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: header))
+        let payloadSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: payload))
+        return "\(headerSeg).\(payloadSeg).signature"
+    }
+
+    fileprivate func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+#endif


### PR DESCRIPTION
# Description

Adds the foundational `AuthTokenManager` actor in `KlaviyoCore` and the public `registerAuthTokenProvider(_:)` API on `KlaviyoSDK`. Ships only the happy-path acquisition flow; concurrency hardening, proactive refresh, the refresh stream, and profile-reset interaction are deferred to sibling sub-issues so this can land as a small, focused PR.

## Due Diligence

- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations

- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**New public API (`KlaviyoSwift`)**
- `AuthTokenProvider` typealias — `@Sendable () async throws -> String`, re-aliased from `KlaviyoCore` so hosts only need `import KlaviyoSwift`.
- `KlaviyoSDK.registerAuthTokenProvider(_:)` — registers the host-supplied JWT-producing closure. Re-registering replaces the previous provider; there is no public clear path (deferred to `resetProfile()` in MAGE-626).

**New package API (`KlaviyoCore`)**
- `AuthTokenManager` actor — singleton accessed via `.shared`. Owns cached-token and provider state. `registerProvider(_:)` clears the cache, stores the provider, logs the event, and fires a fire-and-forget eager fetch. `currentToken()` returns a cached token when valid; otherwise invokes the provider, validates via `JWTParser`, caches, and returns.
- `AuthTokenError` — `.noProviderRegistered` and `.validationFailed(JWTValidationFailure)`.
- Stored properties for `inFlightFetch`, `refreshTask`, `refreshContinuations` are declared so sibling sub-issues can fill them in without churning the actor's shape.

**Visibility tweak**
- `JWTValidationFailure` widened from `internal` to `package` so it can be the associated value of the `package` `AuthTokenError`.

**Logging**
- OSLog at the `Auth` category for provider registration, token acquisition (exp/iat with `.private` privacy markers), and validation failure with reason. Token contents are never logged.

**Out of scope (sibling sub-issues)**
- Dedup + timeout enforcement: MAGE-624
- Proactive refresh scheduling: MAGE-625
- Refresh notification stream + profile-reset: MAGE-626

## Test Plan

- [ ] `xcodebuild build -scheme KlaviyoSwift -destination "platform=iOS Simulator,name=iPhone 17 Pro"` succeeds.
- [ ] `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:KlaviyoCoreTests` — `AuthTokenManagerTests` (8 tests) and `JWTParserTests` (20 tests) all pass.
- [ ] `swiftlint --strict` on changed files reports zero violations.

## Related Issues/Tickets

- Linear: [MAGE-623](https://linear.app/klaviyo/issue/MAGE-623)
- Parent: [MAGE-615](https://linear.app/klaviyo/issue/MAGE-615)
- Unblocks: [MAGE-616](https://linear.app/klaviyo/issue/MAGE-616) (iOS WebView injection)