### PR TITLE
feat(KlaviyoForms): inject auth token into IAF WebView at load (MAGE-616 Phase 1)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -31,6 +31,17 @@ package actor AuthTokenManager {
     /// Starts `nil`; set by ``registerProvider(_:)``.
     private var provider: AuthTokenProvider?
 
+    // MARK: - Reserved storage
+
+    // TODO: - [MAGE-624] use to deduplicate concurrent currentToken() callers so they share a single provider invocation
+    private var inFlightFetch: Task<String, Error>?
+
+    // TODO: - [MAGE-625] schedule refreshes at iat + 0.9 * (exp - iat), bounded by [now + 5s, exp - 30s]
+    private var refreshTask: Task<Void, Never>?
+
+    // TODO: - [MAGE-626] fan successful refresh tokens out to consumers via refreshes() -> AsyncStream<String>
+    private var refreshContinuations: [AsyncStream<String>.Continuation] = []
+
     init() {}
 
     /// Registers a new provider, discards any cached token from a previous
@@ -55,10 +66,8 @@ package actor AuthTokenManager {
     /// Returns the current auth token, fetching one via the registered provider
     /// if the cache is empty or has gone stale.
     ///
-    /// This is the happy-path skeleton: a single caller races directly against the
-    /// provider, with no in-flight deduplication and no timeout enforcement. Those
-    /// arrive in sub-issue MAGE-624; until then, two concurrent callers will both
-    /// invoke the provider — the wrong behavior is "extra fetches", not data
+    /// A single caller invokes the provider directly. If two callers race, both
+    /// will invoke the provider — the result is extra network calls, not data
     /// corruption.
     ///
     /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -31,14 +31,6 @@ package actor AuthTokenManager {
     /// Starts `nil`; set by ``registerProvider(_:)``.
     private var provider: AuthTokenProvider?
 
-    // MARK: - Reserved storage
-
-    // TODO: - [MAGE-624] dedup concurrent currentToken() callers
-    private var inFlightFetch: Task<String, Error>?
-
-    // TODO: - [MAGE-625] proactively refresh the cached token
-    private var refreshTask: Task<Void, Never>?
-
     init() {}
 
     /// Registers a new provider, discards any cached token from a previous

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -55,8 +55,10 @@ package actor AuthTokenManager {
     /// Returns the current auth token, fetching one via the registered provider
     /// if the cache is empty or has gone stale.
     ///
-    /// A single caller invokes the provider directly. If two callers race, both
-    /// will invoke the provider — the result is extra network calls, not data
+    /// This is the happy-path skeleton: a single caller races directly against the
+    /// provider, with no in-flight deduplication and no timeout enforcement. Those
+    /// arrive in sub-issue MAGE-624; until then, two concurrent callers will both
+    /// invoke the provider — the wrong behavior is "extra fetches", not data
     /// corruption.
     ///
     /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -39,9 +39,6 @@ package actor AuthTokenManager {
     // TODO: - [MAGE-625] proactively refresh the cached token
     private var refreshTask: Task<Void, Never>?
 
-    // TODO: - [MAGE-626] notify consumers when the cached token refreshes
-    private var refreshContinuations: [AsyncStream<String>.Continuation] = []
-
     init() {}
 
     /// Registers a new provider, discards any cached token from a previous

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -33,13 +33,13 @@ package actor AuthTokenManager {
 
     // MARK: - Reserved storage
 
-    // TODO: - [MAGE-624] use to deduplicate concurrent currentToken() callers so they share a single provider invocation
+    // TODO: - [MAGE-624] dedup concurrent currentToken() callers
     private var inFlightFetch: Task<String, Error>?
 
-    // TODO: - [MAGE-625] schedule refreshes at iat + 0.9 * (exp - iat), bounded by [now + 5s, exp - 30s]
+    // TODO: - [MAGE-625] proactively refresh the cached token
     private var refreshTask: Task<Void, Never>?
 
-    // TODO: - [MAGE-626] fan successful refresh tokens out to consumers via refreshes() -> AsyncStream<String>
+    // TODO: - [MAGE-626] notify consumers when the cached token refreshes
     private var refreshContinuations: [AsyncStream<String>.Continuation] = []
 
     init() {}

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -126,15 +126,43 @@ class IAFPresentationManager {
 
     func createFormWebViewAndListen(apiKey: String) async throws {
         let profileData = try await KlaviyoInternal.fetchProfileData()
-        createFormWebView(apiKey: apiKey, profileData: profileData)
+        let authToken = await fetchAuthTokenBestEffort()
+        createFormWebView(apiKey: apiKey, profileData: profileData, authToken: authToken)
         setupFormLifecycleListener()
     }
 
+    /// Reads the current auth token from ``AuthTokenManager`` for initial WebView
+    /// injection. Returns `nil` on any failure — the form proceeds without a token
+    /// and the backend serves non-personalized content.
+    private func fetchAuthTokenBestEffort() async -> String? {
+        // TODO: [MAGE-624] AuthTokenManager will enforce its own 500ms best-effort
+        // deadline internally. No external timeout is needed here; once MAGE-624
+        // lands, this call site is correct as-is.
+        do {
+            let token = try await AuthTokenManager.shared.currentToken()
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Auth token injected at load")
+            }
+            return token
+        } catch {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Auth token unavailable at load — proceeding without token")
+            }
+            return nil
+        }
+    }
+
     /// Creates the webview, view model, and view controller for displaying in-app forms
-    private func createFormWebView(apiKey: String, profileData: ProfileData?) {
+    private func createFormWebView(apiKey: String, profileData: ProfileData?, authToken: String?) {
         guard let fileUrl = indexHtmlFileUrl else { return }
 
-        let viewModel = IAFWebViewModel(url: fileUrl, apiKey: apiKey, profileData: profileData, assetSource: assetSource)
+        let viewModel = IAFWebViewModel(
+            url: fileUrl,
+            apiKey: apiKey,
+            profileData: profileData,
+            authToken: authToken,
+            assetSource: assetSource
+        )
         self.viewModel = viewModel
         viewController = KlaviyoWebViewController(viewModel: viewModel)
         viewController?.modalPresentationStyle = .overCurrentContext

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -28,6 +28,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     let apiKey: String
     let profileData: ProfileData?
+    let authToken: String?
     private let assetSource: String?
 
     private var profileUpdatesCancellable: AnyCancellable?
@@ -97,6 +98,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         return WKUserScript(source: profileAttributesScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
+    @MainActor
+    private var authTokenWKScript: WKUserScript? {
+        guard let authToken else { return nil }
+        let authTokenScript = "document.head.setAttribute('data-klaviyo-jwt', '\(authToken)');"
+        return WKUserScript(source: authTokenScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+    }
+
     /// Publishes a snapshot of the current `DeviceInfo` onto `document.head` before any
     /// inline `<script>` in the template runs. Injected at `.atDocumentStart` so that
     /// onsite can consult `document.head.dataset.klaviyoDevice` during the synchronous
@@ -119,10 +127,17 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     // MARK: - Initializer
 
     @MainActor
-    init(url: URL, apiKey: String, profileData: ProfileData?, assetSource: String? = nil) {
+    init(
+        url: URL,
+        apiKey: String,
+        profileData: ProfileData?,
+        authToken: String? = nil,
+        assetSource: String? = nil
+    ) {
         self.url = url
         self.apiKey = apiKey
         self.profileData = profileData
+        self.authToken = authToken
         self.assetSource = assetSource
 
         let (stream, continuation) = AsyncStream.makeStream(of: IAFLifecycleEvent.self)
@@ -143,6 +158,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         loadScripts?.insert(deviceInfoWKScript)
         if let profileAttributesWKScript {
             loadScripts?.insert(profileAttributesWKScript)
+        }
+        if let authTokenWKScript {
+            loadScripts?.insert(authTokenWKScript)
         }
         if let dataEnvironmentWKScript {
             loadScripts?.insert(dataEnvironmentWKScript)
@@ -219,8 +237,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     @MainActor
     private func createProfileAttributesScript(from profileData: ProfileData) -> String? {
         guard let profileDataString = try? profileData.toHtmlString() else { return nil }
-        let profileAttributesScript = "document.head.setAttribute('data-klaviyo-profile', '\(profileDataString)');"
-        return profileAttributesScript
+        return "document.head.setAttribute('data-klaviyo-profile', '\(profileDataString)');"
     }
 
     @MainActor
@@ -302,11 +319,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if let formId, !formId.isEmpty,
                let formName, !formName.isEmpty {
                 IAFPresentationManager.shared.invokeLifecycleHandler(
-                    for: .formShown(formId: formId, formName: formName))
+                    for: .formShown(formId: formId, formName: formName)
+                )
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "formWillAppear missing metadata — skipping lifecycle callback")
+                        "formWillAppear missing metadata — skipping lifecycle callback"
+                    )
                 }
             }
         case let .formDisappeared(formId, formName):
@@ -317,11 +336,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if let formId, !formId.isEmpty,
                let formName, !formName.isEmpty {
                 IAFPresentationManager.shared.invokeLifecycleHandler(
-                    for: .formDismissed(formId: formId, formName: formName))
+                    for: .formDismissed(formId: formId, formName: formName)
+                )
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "formDisappeared missing metadata — skipping lifecycle callback")
+                        "formDisappeared missing metadata — skipping lifecycle callback"
+                    )
                 }
             }
         case let .trackProfileEvent(data):

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -40,25 +40,31 @@ struct AuthTokenManagerTests {
     @Test
     func currentTokenServesCachedTokenOnSubsequentCalls() async throws {
         let manager = AuthTokenManager()
-        let token = try makeJWT()
-        let counter = CallCounter()
+        let initialToken = try makeJWT()
+        let swappedToken = try makeJWT(extraClaims: ["sub": "user-after-swap"])
+        let providerToken = TokenBox(initialToken)
 
         await manager.registerProvider {
-            await counter.increment()
-            return token
+            await providerToken.value
         }
 
-        // Drain the eager fetch so the cache is warm before the assertions below.
-        try await counter.waitFor(atLeast: 1)
+        // Warm the cache deterministically: awaiting an explicit fetch
+        // guarantees the actor has parsed and cached `initialToken` before we
+        // mutate the provider's return value below.
+        let warmup = try await manager.currentToken()
+        #expect(warmup == initialToken)
 
-        let countBefore = await counter.value
+        // Swap the provider's output without re-registering (which would
+        // clear the cache). If the cache is honored, subsequent calls keep
+        // returning `initialToken`; if they re-invoke the provider, they
+        // observe `swappedToken`.
+        await providerToken.set(swappedToken)
+
         let first = try await manager.currentToken()
         let second = try await manager.currentToken()
-        let countAfter = await counter.value
 
-        #expect(first == token)
-        #expect(second == token)
-        #expect(countBefore == countAfter, "cached token should not re-invoke the provider")
+        #expect(first == initialToken, "cached token should be served, not the swapped provider output")
+        #expect(second == initialToken, "cached token should be served, not the swapped provider output")
     }
 
     // MARK: - currentToken: provider errors
@@ -172,6 +178,21 @@ extension AuthTokenManagerTests {
             await withCheckedContinuation { continuation in
                 waiters.append((threshold, continuation))
             }
+        }
+    }
+
+    /// Mutable token holder used to change a registered provider's return
+    /// value over time without re-registering (re-registration would clear
+    /// the cache and defeat tests that depend on a warm cache).
+    actor TokenBox {
+        private(set) var value: String
+
+        init(_ initial: String) {
+            value = initial
+        }
+
+        func set(_ new: String) {
+            value = new
         }
     }
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -160,6 +160,34 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertEqual(actualHandshakeData, expectedHandshakeData)
     }
 
+    // MARK: - Auth Token Tests
+
+    @MainActor
+    func testInjectAuthTokenAttribute() async throws {
+        // Given
+        let dummyToken = "header.payload.signature"
+        let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
+        let apiKey = try await KlaviyoInternal.fetchAPIKey()
+        viewModel = IAFWebViewModel(url: fileUrl, apiKey: apiKey, profileData: nil, authToken: dummyToken)
+
+        // When
+        viewModel.initializeLoadScripts()
+        let authTokenScript = viewModel.findScript(containing: ["data-klaviyo-jwt", dummyToken])
+
+        // Then
+        XCTAssertNotNil(authTokenScript, "Auth token script should be injected when authToken is provided")
+    }
+
+    @MainActor
+    func testAuthTokenScriptNotInjectedWhenTokenIsNil() async throws {
+        // When (default viewModel from setUp has authToken: nil)
+        viewModel.initializeLoadScripts()
+        let authTokenScript = viewModel.findScript(containing: "data-klaviyo-jwt")
+
+        // Then
+        XCTAssertNil(authTokenScript, "Auth token script should not be injected when authToken is nil")
+    }
+
     // MARK: - Klaviyo JS Tests
 
     @MainActor


### PR DESCRIPTION
# Description

Phase 1 of [MAGE-616](https://linear.app/klaviyo/issue/MAGE-616/ios-inject-auth-token-into-in-app-forms-webview): initial-injection-only path. Adds the `data-klaviyo-jwt` attribute to the IAF `WKUserScript` set so personalized form content can be served on first load. Best-effort recovery and live updates land in Phases 2/3 (future PRs under the same ticket).

> Stacked on [#576](https://github.com/klaviyo/klaviyo-swift-sdk/pull/576) (MAGE-623). Rebase once that lands.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] ` + "`Patch`" + ` Contains internal changes or backwards-compatible bug fixes.
- [ ] ` + "`Minor`" + ` Contains changes to the public API.
- [ ] ` + "`Major`" + ` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- ` + "`IAFWebViewModel`" + `: new ` + "`authToken: String?`" + ` init parameter and ` + "`authTokenWKScript`" + ` computed property. When the token is non-nil, a ` + "`WKUserScript`" + ` is inserted at ` + "`.atDocumentEnd`" + ` that sets ` + "`document.head.setAttribute('data-klaviyo-jwt', '<token>')`" + ` — mirroring the existing ` + "`profileAttributesWKScript`" + ` pattern. Attribute name matches fender's already-merged ` + "`JWT_ATTRIBUTE`" + ` ([MAGE-553](https://linear.app/klaviyo/issue/MAGE-553)).
- ` + "`IAFPresentationManager`" + `: ` + "`createFormWebViewAndListen(apiKey:)`" + ` now awaits ` + "`fetchAuthTokenBestEffort()`" + ` and passes the result through to ` + "`IAFWebViewModel.init`" + `. ` + "`fetchAuthTokenBestEffort()`" + ` calls ` + "`AuthTokenManager.shared.currentToken()`" + ` with ` + "`try?`" + `; any failure returns ` + "`nil`" + ` and the form proceeds without a token (backend serves non-personalized content). Success/miss is logged via ` + "`Logger.webViewLogger`" + ` at ` + "`.info`" + ` — token contents are never logged.
- ` + "`KlaviyoCore`" + ` does not import ` + "`WebKit`" + `; ` + "`KlaviyoForms`" + ` reads ` + "`AuthTokenManager`" + ` directly from ` + "`KlaviyoCore`" + ` (no ` + "`KlaviyoSwift`" + ` routing).
- TODO comment at the fetch site flags MAGE-624 (manager will own the 500ms best-effort deadline internally — no external ` + "`withTimeout`" + ` needed once that lands).

## Test Plan

Automated:
- ` + "`testInjectAuthTokenAttribute`" + ` — non-nil token produces a ` + "`data-klaviyo-jwt`" + ` ` + "`WKUserScript`" + ` with the token value embedded.
- ` + "`testAuthTokenScriptNotInjectedWhenTokenIsNil`" + ` — nil token produces no ` + "`data-klaviyo-jwt`" + ` script. Other scripts (SDK name, version, handshake, profile) are unaffected.

Manual (deferred until at least Phase 2 lands so there is an end-to-end personalized form to verify against): present an IAF after registering an auth-token provider, confirm via Web Inspector that ` + "`document.head.getAttribute('data-klaviyo-jwt')`" + ` returns the expected JWT.

## Related Issues/Tickets

- [MAGE-616](https://linear.app/klaviyo/issue/MAGE-616) — this ticket (iOS: inject auth token into In-App Forms WebView)
- [MAGE-623](https://linear.app/klaviyo/issue/MAGE-623) — blocking dep, stacked PR base ([#576](https://github.com/klaviyo/klaviyo-swift-sdk/pull/576))
- [MAGE-624](https://linear.app/klaviyo/issue/MAGE-624) — follows: dedup + 500ms timeout
- [MAGE-626](https://linear.app/klaviyo/issue/MAGE-626) — follows: ` + "`refreshes()`" + ` stream + profile reset
- [MAGE-553](https://linear.app/klaviyo/issue/MAGE-553) — fender ` + "`data-klaviyo-jwt`" + ` MutationObserver (merged 2026-05-19)