### PR TITLE
fix(KlaviyoCore): reject JWT segments with non-base64url characters (MAGE-613 follow-up)

### DIFF
--- a/Sources/KlaviyoCore/Auth/JWTParser.swift
+++ b/Sources/KlaviyoCore/Auth/JWTParser.swift
@@ -34,10 +34,11 @@ enum JWTParser {
     /// for `decode(_:from:)` and this path is hit on every token acquisition / refresh.
     private static let decoder = JSONDecoder()
 
-    // Cyclomatic complexity is intrinsic here: every validation step inlines its own
-    // OSLog call behind an iOS 14 availability guard, which doubles the apparent branch
-    // count. Routing through a logging wrapper would lose the per-failure call site.
-    // swiftlint:disable cyclomatic_complexity
+    // Cyclomatic complexity and function-body length are intrinsic here: every
+    // validation step inlines its own OSLog call behind an iOS 14 availability
+    // guard, which doubles the apparent branch count. Routing through a logging
+    // wrapper would lose the per-failure call site.
+    // swiftlint:disable cyclomatic_complexity function_body_length
 
     /// Parses a JWT string and validates the `exp` and `iat` claims.
     ///
@@ -59,6 +60,13 @@ enum JWTParser {
                 Logger.auth.warning("JWT validation failed: malformed structure")
             }
             return .failure(.malformedStructure)
+        }
+
+        for segment in segments where !isBase64URLShape(segment) {
+            if #available(iOS 14.0, *) {
+                Logger.auth.warning("JWT validation failed: malformed base64URL segment")
+            }
+            return .failure(.malformedBase64)
         }
 
         guard let payloadData = base64URLDecode(String(segments[1])) else {
@@ -105,7 +113,22 @@ enum JWTParser {
         ))
     }
 
-    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable cyclomatic_complexity function_body_length
+
+    /// Base64URL alphabet (RFC 7515 §2): `A-Z`, `a-z`, `0-9`, `-`, `_`. Padding `=` is
+    /// stripped from JWT segments and is intentionally not part of this set — a `=` in
+    /// a JWT segment is malformed.
+    private static let base64URLCharacterSet = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    )
+
+    /// Returns `true` when every code unit in `segment` is in the Base64URL alphabet.
+    /// Empty segments are accepted — RFC 7515 §3 permits an empty signature segment
+    /// (`alg: none`); structural emptiness of payload/header is caught downstream by
+    /// the JSON decode step.
+    private static func isBase64URLShape(_ segment: Substring) -> Bool {
+        segment.unicodeScalars.allSatisfy { base64URLCharacterSet.contains($0) }
+    }
 
     /// Decodes a Base64URL string (RFC 7515 §2): `+` is replaced by `-`, `/` by `_`, and
     /// trailing `=` padding is omitted. We reverse those substitutions and re-pad before

--- a/Sources/KlaviyoCore/Auth/JWTParser.swift
+++ b/Sources/KlaviyoCore/Auth/JWTParser.swift
@@ -115,19 +115,18 @@ enum JWTParser {
 
     // swiftlint:enable cyclomatic_complexity function_body_length
 
-    /// Base64URL alphabet (RFC 7515 §2): `A-Z`, `a-z`, `0-9`, `-`, `_`. Padding `=` is
-    /// stripped from JWT segments and is intentionally not part of this set — a `=` in
-    /// a JWT segment is malformed.
-    private static let base64URLCharacterSet = CharacterSet(
-        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-    )
-
-    /// Returns `true` when every code unit in `segment` is in the Base64URL alphabet.
+    /// Returns `true` when every character in `segment` is in the Base64URL alphabet
+    /// (RFC 7515 §2): ASCII letter, ASCII digit, `-`, or `_`. Padding `=` is stripped
+    /// from JWT segments and is intentionally not accepted — a `=` in a JWT segment
+    /// is malformed.
+    ///
     /// Empty segments are accepted — RFC 7515 §3 permits an empty signature segment
     /// (`alg: none`); structural emptiness of payload/header is caught downstream by
     /// the JSON decode step.
     private static func isBase64URLShape(_ segment: Substring) -> Bool {
-        segment.unicodeScalars.allSatisfy { base64URLCharacterSet.contains($0) }
+        segment.allSatisfy { char in
+            char.isASCII && (char.isLetter || char.isNumber || char == "-" || char == "_")
+        }
     }
 
     /// Decodes a Base64URL string (RFC 7515 §2): `+` is replaced by `-`, `/` by `_`, and

--- a/Sources/KlaviyoCore/Auth/JWTValidationFailure.swift
+++ b/Sources/KlaviyoCore/Auth/JWTValidationFailure.swift
@@ -17,7 +17,12 @@ enum JWTValidationFailure: Error, Equatable {
     /// The token did not contain three `.`-separated segments.
     case malformedStructure
 
-    /// The payload segment could not be Base64URL-decoded.
+    /// A segment contained characters outside the Base64URL alphabet (RFC 7515 §2:
+    /// `A-Z`, `a-z`, `0-9`, `-`, `_`; no `=` padding), or the payload segment failed
+    /// Base64URL decoding for some other reason. Applied to all three segments — not
+    /// just the payload — so that ``ValidatedToken/rawToken`` is safe to interpolate
+    /// into contexts that assume a base64url-shaped string (e.g. attribute injection
+    /// into a WebView's JavaScript context).
     case malformedBase64
 
     /// The payload segment did not decode to a JSON object with the expected claim types.

--- a/Tests/KlaviyoCoreTests/Auth/JWTParserTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/JWTParserTests.swift
@@ -97,6 +97,81 @@ struct JWTParserTests {
         )
     }
 
+    @Test
+    func singleQuoteInSignatureIsRejected() throws {
+        // Reproduces the WebView-injection vector: a token whose signature segment
+        // contains a `'` would break out of a single-quoted JS string literal if it
+        // ever reached the WebView interpolation site. The parser must reject it
+        // before that can happen.
+        let payload = try base64URLEncode(JSONSerialization.data(withJSONObject: [
+            "iat": Self.defaultIat,
+            "exp": Self.defaultExp
+        ]))
+        let header = try base64URLEncode(JSONSerialization.data(withJSONObject: ["alg": "HS256"]))
+        let token = "\(header).\(payload).'); evilJS(); //"
+
+        expectFailure(
+            JWTParser.parseAndValidate(token, currentTime: Self.referenceNow),
+            .malformedBase64
+        )
+    }
+
+    @Test
+    func backslashInHeaderIsRejected() throws {
+        let payload = try base64URLEncode(JSONSerialization.data(withJSONObject: [
+            "iat": Self.defaultIat,
+            "exp": Self.defaultExp
+        ]))
+        // Backslashes are the other half of the JS-literal escape concern.
+        let token = "head\\er.\(payload).signature"
+
+        expectFailure(
+            JWTParser.parseAndValidate(token, currentTime: Self.referenceNow),
+            .malformedBase64
+        )
+    }
+
+    @Test(arguments: [" ", "\n", "\t", "\"", "<", ">", "/", "+", "=", ","])
+    func nonBase64URLCharacterInSegmentIsRejected(badChar: String) throws {
+        // Sweeps the most common characters that aren't in the Base64URL alphabet
+        // (RFC 7515 §2). Each one, placed inside any segment, must fail validation.
+        // `+`, `/`, and `=` are notable because they ARE in standard Base64 — the
+        // JWT compact serialization substitutes/strips them, so their presence in a
+        // segment is itself a sign of malformed input.
+        //
+        // `.` is intentionally absent: inserting it would change the segment count
+        // and trigger `.malformedStructure` instead, which is already covered by
+        // ``malformedStructureIsRejected``.
+        let payload = try base64URLEncode(JSONSerialization.data(withJSONObject: [
+            "iat": Self.defaultIat,
+            "exp": Self.defaultExp
+        ]))
+        let header = "head\(badChar)er"
+        let token = "\(header).\(payload).signature"
+
+        expectFailure(
+            JWTParser.parseAndValidate(token, currentTime: Self.referenceNow),
+            .malformedBase64
+        )
+    }
+
+    @Test
+    func emptySignatureSegmentIsAccepted() throws {
+        // RFC 7515 §3 permits an empty signature segment for `alg: none`. The parser
+        // doesn't verify signatures, so this case must validate just like any other
+        // well-formed payload.
+        let header = try base64URLEncode(JSONSerialization.data(withJSONObject: ["alg": "none"]))
+        let payload = try base64URLEncode(JSONSerialization.data(withJSONObject: [
+            "iat": Self.defaultIat,
+            "exp": Self.defaultExp
+        ]))
+        let token = "\(header).\(payload)."
+
+        _ = try requireValidated(
+            JWTParser.parseAndValidate(token, currentTime: Self.referenceNow)
+        )
+    }
+
     // MARK: - Malformed JSON
 
     @Test


### PR DESCRIPTION
# Description

Follow-up to [MAGE-613](https://linear.app/klaviyo/issue/MAGE-613/ios-jwt-parsing-and-validation). Tightens `JWTParser.parseAndValidate` to reject tokens whose header or signature segments contain characters outside the RFC 7515 §2 base64url alphabet. Previously only the payload segment was charset-checked (implicitly, via `Data(base64Encoded:)`), so a token like `header.<valid-payload>.'); evilJS(); //` would pass validation and the raw string would flow into downstream consumers verbatim.

This was flagged on [#577](https://github.com/klaviyo/klaviyo-swift-sdk/pull/577) by Cursor Bugbot as a WebView script-injection vector. Fixing at the parser layer closes the concern at the source — `ValidatedToken.rawToken` is now guaranteed to consist of three `.`-separated runs of `[A-Za-z0-9_-]`, with no characters that need escaping when interpolated into a JS string literal.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] ` + "`Patch`" + ` Contains internal changes or backwards-compatible bug fixes.
- [ ] ` + "`Minor`" + ` Contains changes to the public API.
- [ ] ` + "`Major`" + ` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- ` + "`JWTParser`" + `: new ` + "`isBase64URLShape(_:)`" + ` helper and ` + "`base64URLCharacterSet`" + ` constant. After the segment-count check, every segment is verified to contain only ` + "`[A-Za-z0-9_-]`" + ` before the payload decode proceeds. Failure returns the existing ` + "`.malformedBase64`" + ` case (semantics widened to cover all segments — see below).
- Empty segments are intentionally still accepted at this layer. RFC 7515 §3 permits an empty signature for ` + "`alg: none`" + `, and the existing ` + "`emptyPayloadSegmentIsRejected`" + ` test pins the boundary that empty payload surfaces as ` + "`.malformedJSON`" + ` downstream, not ` + "`.malformedBase64`" + `.
- ` + "`JWTValidationFailure.malformedBase64`" + `: docstring updated to reflect that the case now covers any segment (not just the payload) containing non-base64url characters.
- Extended the existing ` + "`swiftlint:disable`" + ` directive on ` + "`parseAndValidate`" + ` to also suppress ` + "`function_body_length`" + ` — same reasoning as the existing ` + "`cyclomatic_complexity`" + ` suppression (each validation step inlines its own ` + "`OSLog`" + ` call behind an iOS 14 guard).

## Test Plan

- ` + "`singleQuoteInSignatureIsRejected`" + ` — direct reproduction of the bugbot's flagged injection vector.
- ` + "`backslashInHeaderIsRejected`" + ` — the other half of the JS-literal escape concern.
- ` + "`nonBase64URLCharacterInSegmentIsRejected`" + ` — parameterized sweep over the most common non-alphabet characters (space, tab, newline, `\"`, `<`, `>`, `/`, `+`, `=`, `,`). `+`, `/`, and `=` are the standard-Base64 characters that the JWT compact serialization substitutes/strips, so their presence is itself a sign of malformed input.
- ` + "`emptySignatureSegmentIsAccepted`" + ` — pins that ` + "`header.payload.`" + ` (empty signature, ` + "`alg: none`" + `) still validates.
- All existing ` + "`JWTParserTests`" + ` continue to pass without modification — including the pre-existing ` + "`malformedBase64PayloadIsRejected`" + ` (now caught by the new charset check rather than the downstream ` + "`Data(base64Encoded:)`" + ` failure) and ` + "`emptyPayloadSegmentIsRejected`" + ` (empty segments still pass the charset check; the failure surfaces as ` + "`.malformedJSON`" + ` downstream).

## Related Issues/Tickets

- [MAGE-613](https://linear.app/klaviyo/issue/MAGE-613) — reopened for this follow-up
- [#577](https://github.com/klaviyo/klaviyo-swift-sdk/pull/577) (MAGE-616) — where the gap was flagged; will resolve the bugbot thread once this lands and #577 rebases onto it