### PR TITLE
feat(AutoPushTrack): add KlaviyoNotificationDelegate proxy class shape

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -8,18 +8,11 @@
 import Foundation
 import UserNotifications
 
-/// A proxy `UNUserNotificationCenterDelegate` that the SDK will install as the active
+/// A proxy `UNUserNotificationCenterDelegate` that the SDK installs as the active
 /// `UNUserNotificationCenter` delegate to intercept push notification responses automatically.
-///
-/// This initial implementation provides only the class shape and barebones delegate stubs.
-/// Follow-on tickets will add:
-/// - Injection at `initialize()` and KVO re-injection (MAGE-657)
-/// - Forwarding callbacks to `existingDelegate` with once-style completion handler (MAGE-657)
-/// - Auto-open tracking via `KlaviyoSDK().handle(notificationResponse:)` (MAGE-657)
-/// - Double-track guard to prevent duplicate open events (MAGE-660)
 final class KlaviyoNotificationDelegate: NSObject, @unchecked Sendable {
     static let shared = KlaviyoNotificationDelegate()
-    
+
     /// The host app's delegate that was in place before the SDK proxy was installed.
     ///
     /// `weak` mirrors `UNUserNotificationCenter.delegate`'s own weak contract — the SDK must
@@ -35,17 +28,19 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
-        // Forwarding to existingDelegate and auto-tracking added in MAGE-657/MAGE-660.
+        // TODO: [MAGE-657] Forward to existingDelegate via OnceCallback
+        // TODO: [MAGE-657] Call KlaviyoSDK().handle() for auto-tracking
+        // TODO: [MAGE-660] Add double-track guard
         completionHandler()
     }
-    
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping @Sendable
-        (UNNotificationPresentationOptions) -> Void
+            (UNNotificationPresentationOptions) -> Void
     ) {
-        // Forwarding to existingDelegate added in MAGE-657.
+        // TODO: [MAGE-657] Forward to existingDelegate when present
         if #available(iOS 14.0, *) {
             completionHandler([.list, .banner, .sound])
         } else {

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -19,7 +19,7 @@ final class KlaviyoNotificationDelegate: NSObject {
     ///
     /// `weak` mirrors `UNUserNotificationCenter.delegate`'s own weak contract — the SDK must
     /// not silently extend the lifetime of the host's delegate object.
-    weak var existingDelegate: (any UNUserNotificationCenterDelegate)?
+    private weak var existingDelegate: (any UNUserNotificationCenterDelegate)?
 }
 
 // MARK: - UNUserNotificationCenterDelegate

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -10,8 +10,10 @@ import UserNotifications
 
 /// A proxy `UNUserNotificationCenterDelegate` that the SDK installs as the active
 /// `UNUserNotificationCenter` delegate to intercept push notification responses automatically.
-final class KlaviyoNotificationDelegate: NSObject, @unchecked Sendable {
+final class KlaviyoNotificationDelegate: NSObject {
     static let shared = KlaviyoNotificationDelegate()
+
+    private override init() {}
 
     /// The host app's delegate that was in place before the SDK proxy was installed.
     ///

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -44,9 +44,9 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
     ) {
         // TODO: [MAGE-657] Forward to existingDelegate when present
         if #available(iOS 14.0, *) {
-            completionHandler([.list, .banner, .sound])
+            completionHandler([.list, .banner, .badge, .sound])
         } else {
-            completionHandler([.alert, .sound])
+            completionHandler([.alert, .badge, .sound])
         }
     }
 }

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -13,7 +13,7 @@ import UserNotifications
 final class KlaviyoNotificationDelegate: NSObject {
     static let shared = KlaviyoNotificationDelegate()
 
-    private override init() {}
+    override private init() {}
 
     /// The host app's delegate that was in place before the SDK proxy was installed.
     ///

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -38,7 +38,7 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping @Sendable
-            (UNNotificationPresentationOptions) -> Void
+        (UNNotificationPresentationOptions) -> Void
     ) {
         // TODO: [MAGE-657] Forward to existingDelegate when present
         if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -1,0 +1,55 @@
+//
+//  KlaviyoNotificationDelegate.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Glenn Brannelly on 5/13/26.
+//
+
+import Foundation
+import UserNotifications
+
+/// A proxy `UNUserNotificationCenterDelegate` that the SDK will install as the active
+/// `UNUserNotificationCenter` delegate to intercept push notification responses automatically.
+///
+/// This initial implementation provides only the class shape and barebones delegate stubs.
+/// Follow-on tickets will add:
+/// - Injection at `initialize()` and KVO re-injection (MAGE-657)
+/// - Forwarding callbacks to `existingDelegate` with once-style completion handler (MAGE-657)
+/// - Auto-open tracking via `KlaviyoSDK().handle(notificationResponse:)` (MAGE-657)
+/// - Double-track guard to prevent duplicate open events (MAGE-660)
+final class KlaviyoNotificationDelegate: NSObject, @unchecked Sendable {
+    static let shared = KlaviyoNotificationDelegate()
+    
+    /// The host app's delegate that was in place before the SDK proxy was installed.
+    ///
+    /// `weak` mirrors `UNUserNotificationCenter.delegate`'s own weak contract — the SDK must
+    /// not silently extend the lifetime of the host's delegate object.
+    weak var existingDelegate: (any UNUserNotificationCenterDelegate)?
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+    ) {
+        // Forwarding to existingDelegate and auto-tracking added in MAGE-657/MAGE-660.
+        completionHandler()
+    }
+    
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping @Sendable
+        (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Forwarding to existingDelegate added in MAGE-657.
+        if #available(iOS 14.0, *) {
+            completionHandler([.list, .banner, .sound])
+        } else {
+            completionHandler([.alert, .sound])
+        }
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @Suite
 struct KlaviyoNotificationDelegateTests {
-    // Add tests as delegate forwarding behavior is implemented in MAGE-657/MAGE-660.
+    // TODO: [MAGE-657] Add tests for delegate forwarding and OnceCallback behavior
+    // TODO: [MAGE-660] Add tests for double-track guard
 }
 #endif

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -1,0 +1,17 @@
+//
+//  KlaviyoNotificationDelegateTests.swift
+//  KlaviyoSwiftTests
+//
+//  Created by Glenn Brannelly on 5/21/26.
+//
+
+@testable import KlaviyoSwift
+
+#if canImport(Testing)
+import Testing
+
+@Suite
+struct KlaviyoNotificationDelegateTests {
+    // Add tests as delegate forwarding behavior is implemented in MAGE-657/MAGE-660.
+}
+#endif


### PR DESCRIPTION
## Description

Adds `KlaviyoNotificationDelegate`, a `UNUserNotificationCenterDelegate` proxy singleton that the SDK will install to intercept push notification responses automatically. This is a small PR that establishes the class shape only — injection, forwarding, and auto-tracking follow in subsequent PRs.

## Due Diligence

- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**Added**
- `Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift` — `final class KlaviyoNotificationDelegate: NSObject` singleton with a `weak var existingDelegate` and barebones `UNUserNotificationCenterDelegate` stubs
  - `didReceive` calls `completionHandler()` directly; forwarding and auto-tracking added in MAGE-657/MAGE-660
  - `willPresent` falls back to `[.list, .banner, .badge, .sound]` on iOS 14+ / `[.alert, .badge, .sound]` on earlier versions; forwarding added in MAGE-657
- `Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift` — empty Swift Testing suite shell with TODO markers for MAGE-657/MAGE-660

**Out of scope (follow-on tickets)**
- Injection at `initialize()` and KVO re-injection — MAGE-657
- Forwarding callbacks to `existingDelegate` with once-style completion handler — MAGE-657
- Auto-open tracking via `KlaviyoSDK().handle(notificationResponse:)` — MAGE-657
- Double-track guard — MAGE-660
- Swizzling `didRegisterForRemoteNotificationsWithDeviceToken` — MAGE-659

## Test Plan

1. `make test-library` — full test suite passes
2. `swiftlint --fix --strict` — zero violations
3. Build: `xcodebuild build -scheme KlaviyoSwift -destination "platform=iOS Simulator,name=iPhone 17 Pro"`

## Related Issues/Tickets

- [MAGE-649](https://linear.app/klaviyo/issue/MAGE-649/ios-implement-klaviyonotificationdelegate-proxy-class)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notification handling that selects appropriate foreground display options depending on iOS version (modern list/banner/badge/sound vs. legacy alert/badge/sound).

* **Tests**
  * Added a new test suite scaffold for notification handling with TODOs for future coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klaviyo/klaviyo-swift-sdk/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->