### PR TITLE
[MAGE-613] revise default leeway to 30s

### DIFF
--- a/Sources/KlaviyoCore/Auth/JWTParser.swift
+++ b/Sources/KlaviyoCore/Auth/JWTParser.swift
@@ -25,10 +25,10 @@ import OSLog
 enum JWTParser {
     /// Clock-skew leeway subtracted from `exp` before comparing to the current time.
     ///
-    /// A token is treated as expired when `now >= exp - leeway`. The 15-second window keeps
+    /// A token is treated as expired when `now >= exp - leeway`. The 30-second window keeps
     /// the SDK from injecting a token that the Klaviyo backend would reject due to clock
     /// drift between the device and the backend.
-    static let defaultLeeway: TimeInterval = 15
+    static let defaultLeeway: TimeInterval = 30
 
     /// Shared decoder for JWT payloads. Held statically because `JSONDecoder` is reentrant
     /// for `decode(_:from:)` and this path is hit on every token acquisition / refresh.

--- a/Tests/KlaviyoCoreTests/Auth/JWTParserTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/JWTParserTests.swift
@@ -290,7 +290,7 @@ struct JWTParserTests {
     func nowAtLeewayBoundaryIsRejected() throws {
         // `now == exp - leeway` is treated as expired (>= rule).
         let token = try makeJWT()
-        let leeway: TimeInterval = 15
+        let leeway: TimeInterval = 30
         let currentTime = Date(timeIntervalSince1970: Self.defaultExp - leeway)
 
         expectFailure(
@@ -303,7 +303,7 @@ struct JWTParserTests {
     func nowJustInsideLeewayIsAccepted() throws {
         // `now == exp - leeway - epsilon` is still valid.
         let token = try makeJWT()
-        let leeway: TimeInterval = 15
+        let leeway: TimeInterval = 30
         let currentTime = Date(timeIntervalSince1970: Self.defaultExp - leeway - 0.001)
 
         let validated = try requireValidated(
@@ -334,8 +334,8 @@ struct JWTParserTests {
     }
 
     @Test
-    func defaultLeewayIs15Seconds() {
-        #expect(JWTParser.defaultLeeway == 15)
+    func defaultLeewayIs30Seconds() {
+        #expect(JWTParser.defaultLeeway == 30)
     }
 
     // MARK: - Base64URL handling


### PR DESCRIPTION
# Description

Revises the default JWT clock-skew leeway from **15 seconds to 30 seconds** in `JWTParser`, per the resolution on the [Clock skew tolerance discussion](https://linear.app/klaviyo/document/personalized-in-app-forms-auth-token-integration-03d3495f6093#comment-68a21c6f) in the auth token integration spec.

ChatGPT, Gemini, and Claude all independently recommended a 30–60s leeway as standard practice for client SDKs (vs. server-to-server, where 15s is more typical). We're taking the low end of the unanimous range. With a typical 30-minute token TTL, 30s is still only ~1.7% of the token's lifetime, so the impact on effective freshness is negligible.

This is a constant-only change inside an internal `enum JWTParser` namespace — no public API surface is affected.

## Due Diligence

- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  * If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  * If no, author or reviewer should account for this in a release plan, or describe why not below.

This PR targets the `feat/jwts-for-personalized-forms` feature branch and ships as part of the broader JWT/auth-token integration work; it is not independently releasable.

## Changelog / Code Overview

- `Sources/KlaviyoCore/Auth/JWTParser.swift`: bumped `JWTParser.defaultLeeway` from `15` to `30` and updated the accompanying doc comment.
- `Tests/KlaviyoCoreTests/Auth/JWTParserTests.swift`: updated the three tests that pin the leeway value (`nowAtLeewayBoundaryIsRejected`, `nowJustInsideLeewayIsAccepted`, `defaultLeewayIs30Seconds` — renamed from `defaultLeewayIs15Seconds`).

## Test Plan

<!-- TODO: fill in -->

## Related Issues/Tickets

- Linear: [MAGE-613](https://linear.app/klaviyo/issue/MAGE-613/ios-jwt-parsing-and-validation)
- Spec discussion: [Clock skew tolerance comment thread](https://linear.app/klaviyo/document/personalized-in-app-forms-auth-token-integration-03d3495f6093#comment-68a21c6f)
- Original parser PR: #575
- Base branch: `feat/jwts-for-personalized-forms`