### PR TITLE
fix(ci): re-trigger pr-target-check when PR base branch changes

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -3,8 +3,6 @@ name: PR Target Branch Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
-    branches:
-      - master
 
 jobs:
   check-pr-target:
@@ -17,11 +15,19 @@ jobs:
       - name: Validate source branch
         env:
           HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           LABEL: "needs: release branch"
         run: |
+          # If PR doesn't target master, this check doesn't apply — clean up any stale label and pass
+          if [[ "$BASE_REF" != "master" ]]; then
+            echo "PR targets '$BASE_REF' (not master) — check not required."
+            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
             gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true


### PR DESCRIPTION
Removes the `branches: [master]` trigger filter and adds an early exit when the PR targets a non-master branch. This ensures the workflow re-runs when a PR is retargeted away from master (e.g. to a feat/* branch), removes any stale `needs: release branch` label, and passes — rather than never running and leaving the label stuck.

# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
