### PR TITLE
feat(KlaviyoCore): AuthTokenManager dedup, timeouts, and cache integrity (MAGE-624)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenError.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenError.swift
@@ -25,4 +25,9 @@ package enum AuthTokenError: Error, Equatable {
     /// The associated value carries the specific reason (malformed, expired,
     /// missing claim, …).
     case validationFailed(JWTValidationFailure)
+
+    /// The provider did not produce a token within the caller's timeout budget.
+    /// The underlying fetch task may still be running and will write to the cache
+    /// if it eventually succeeds; the timeout only bounds the *caller's* wait.
+    case timedOut
 }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -17,8 +17,29 @@ import OSLog
 /// has elapsed (with the same clock-skew leeway ``JWTParser`` uses) or the
 /// provider is replaced via ``registerProvider(_:)``.
 ///
+/// Concurrent callers requesting a token while a fetch is in flight share the
+/// result of that fetch — they do not trigger additional provider invocations.
+/// Each caller bounds *its own* wait via ``FetchMode``; the underlying fetch
+/// task is unaffected by individual callers timing out and continues until it
+/// completes naturally (or until ``registerProvider(_:)`` cancels it).
+///
 /// The token cache is in-memory only — never persisted to disk or Keychain.
 package actor AuthTokenManager {
+    /// Latency budget for callers awaiting a token, expressed as a named policy
+    /// rather than a free `TimeInterval` so the two budgets stay
+    /// single-source-of-truth and can be tuned together based on production
+    /// telemetry.
+    package enum FetchMode: TimeInterval {
+        /// 500ms budget. Used at form-display time, where a user is waiting on
+        /// the form to appear — missing the personalization window is preferable
+        /// to delaying the form.
+        case bestEffort = 0.5
+
+        /// 5s budget. Used by background acquisition paths (eager fetch at
+        /// registration, scheduled refresh) where no user is actively waiting.
+        case proactive = 5.0
+    }
+
     /// Shared instance used by `KlaviyoSDK` and other SDK modules. Tests should
     /// construct their own instances to keep test runs independent.
     package static let shared = AuthTokenManager()
@@ -31,16 +52,29 @@ package actor AuthTokenManager {
     /// Starts `nil`; set by ``registerProvider(_:)``.
     private var provider: AuthTokenProvider?
 
-    init() {}
+    /// In-flight fetch slot: a token-fetch task paired with the generation `id`
+    /// that names it. Concurrent callers `await` the `task` rather than starting
+    /// their own fetch. The `id` lets the fetch task itself decide whether to
+    /// clear the slot on completion — a stale (cancelled) task waking up after
+    /// a newer fetch was installed must not clobber the newer slot.
+    ///
+    /// Always set and cleared as a unit: there is no valid state where the
+    /// task is present without its id, or vice versa.
+    private var inFlight: (id: UUID, task: Task<String, Error>)?
+
+    package init() {}
 
     /// Registers a new provider, discards any cached token from a previous
-    /// provider, and triggers an eager fetch to warm the cache.
+    /// provider, cancels any in-flight fetch, and triggers an eager fetch to
+    /// warm the cache.
     ///
     /// The eager fetch is fire-and-forget so registration call sites stay
     /// responsive — failures during the warm-up surface only as logs (the same
-    /// logs ``currentToken()`` would emit). Calling this again later replaces
-    /// the previous provider.
+    /// logs ``currentToken(mode:)`` would emit). Calling this again later
+    /// replaces the previous provider.
     package func registerProvider(_ newProvider: @escaping AuthTokenProvider) async {
+        inFlight?.task.cancel()
+        inFlight = nil
         cachedToken = nil
         provider = newProvider
 
@@ -48,56 +82,156 @@ package actor AuthTokenManager {
             Logger.auth.info("AuthTokenManager: provider registered")
         }
         Task {
-            _ = try? await self.currentToken()
+            // fetch a token to warm the cache
+            _ = try? await self.currentToken(mode: .proactive)
         }
     }
 
     /// Returns the current auth token, fetching one via the registered provider
     /// if the cache is empty or has gone stale.
     ///
-    /// A single caller invokes the provider directly. If two callers race, both
-    /// will invoke the provider — the result is extra network calls, not data
-    /// corruption.
+    /// Concurrent callers share the in-flight fetch — exactly one provider
+    /// invocation runs even under N simultaneous calls. Each caller's wait is
+    /// bounded by ``FetchMode``; on timeout the *caller* throws
+    /// ``AuthTokenError/timedOut`` while the underlying fetch task continues
+    /// (and may still warm the cache for later callers).
     ///
+    /// The SDK does not enforce an upper bound on the underlying fetch's
+    /// runtime. If the host's provider closure hangs indefinitely without
+    /// honoring cancellation, subsequent calls dedup with the stuck fetch and
+    /// uniformly throw ``AuthTokenError/timedOut``; the slot only recovers when
+    /// ``registerProvider(_:)`` runs again. Hosts must give their provider
+    /// closure a finite upper-bound (e.g., `URLSession`'s default
+    /// `timeoutIntervalForRequest` is sufficient).
+    ///
+    /// - Parameter mode: Latency budget for *this* call. Defaults to
+    ///   ``FetchMode/bestEffort`` — the form-display path.
     /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is
-    ///   registered; the provider's own error when the provider throws;
-    ///   ``AuthTokenError/validationFailed(_:)`` when the returned token fails
-    ///   ``JWTParser`` validation.
-    package func currentToken() async throws -> String {
+    ///   registered; ``AuthTokenError/timedOut`` when the caller's budget
+    ///   elapses before the fetch completes; the provider's own error when the
+    ///   provider throws; ``AuthTokenError/validationFailed(_:)`` when the
+    ///   returned token fails ``JWTParser`` validation.
+    package func currentToken(mode: FetchMode = .bestEffort) async throws -> String {
         if let cachedToken, isCachedTokenValid(cachedToken) {
             return cachedToken.rawToken
+        }
+
+        guard provider != nil else {
+            throw AuthTokenError.noProviderRegistered
+        }
+
+        let task = inFlight?.task ?? startFetch()
+        return try await race(fetch: task, timeoutSeconds: mode.rawValue)
+    }
+
+    /// Creates a new in-flight fetch task, stores it on the actor, and returns
+    /// it. Must be called from actor-isolated context.
+    private func startFetch() -> Task<String, Error> {
+        let fetchID = UUID()
+        let task = Task<String, Error> { [weak self] in
+            guard let self else { throw CancellationError() }
+            return try await self.runFetch(fetchID: fetchID)
+        }
+        inFlight = (id: fetchID, task: task)
+        return task
+    }
+
+    /// Body of the in-flight fetch task. Invokes the provider, validates the
+    /// returned token, writes the cache on success, and clears its slot from
+    /// the manager once it finishes — but only if it is still the *current*
+    /// fetch (a swap via ``registerProvider(_:)`` may have installed a newer
+    /// one in the meantime).
+    private func runFetch(fetchID: UUID) async throws -> String {
+        defer {
+            if inFlight?.id == fetchID {
+                inFlight = nil
+            }
         }
 
         guard let provider else {
             throw AuthTokenError.noProviderRegistered
         }
 
-        // TODO: [MAGE-624] cancel any in-flight fetch when `registerProvider(_:)`
-        // runs — the resumed continuation below can otherwise overwrite the cache
-        // with a token from a since-replaced provider.
-        let rawToken = try await provider()
+        do {
+            let rawToken = try await provider()
+            // Explicit cancellation checkpoint: if `registerProvider(_:)` cancelled
+            // us mid-fetch, the host's provider closure may not honor cancellation
+            // and could return its (now-stale) token regardless. Throwing here
+            // ensures we never write a stale token into the cache that has since
+            // been bound to a newer provider.
+            try Task.checkCancellation()
 
-        switch JWTParser.parseAndValidate(rawToken) {
-        case let .success(validated):
-            cachedToken = validated
+            switch JWTParser.parseAndValidate(rawToken) {
+            case let .success(validated):
+                cachedToken = validated
+                if #available(iOS 14.0, *) {
+                    Logger.auth.info(
+                        """
+                        AuthTokenManager: token acquired \
+                        (iat=\(validated.issuedAt, privacy: .private), \
+                        exp=\(validated.expiresAt, privacy: .private))
+                        """
+                    )
+                }
+                return validated.rawToken
+            case let .failure(failure):
+                if #available(iOS 14.0, *) {
+                    let reason = String(describing: failure)
+                    Logger.auth.error(
+                        "AuthTokenManager: validation failure on returned token: \(reason, privacy: .public)"
+                    )
+                }
+                throw AuthTokenError.validationFailed(failure)
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
             if #available(iOS 14.0, *) {
-                Logger.auth.info(
-                    """
-                    AuthTokenManager: token acquired \
-                    (iat=\(validated.issuedAt, privacy: .private), \
-                    exp=\(validated.expiresAt, privacy: .private))
-                    """
+                let reason = String(describing: error)
+                Logger.auth.error(
+                    "AuthTokenManager: provider error: \(reason, privacy: .public)"
                 )
             }
-            return validated.rawToken
-        case let .failure(failure):
-            if #available(iOS 14.0, *) {
-                let reason = String(describing: failure)
-                Logger.auth.warning(
-                    "AuthTokenManager: validation failure on returned token: \(reason, privacy: .public)"
-                )
+            throw error
+        }
+    }
+
+    /// Races the (shared) in-flight fetch against a `Task.sleep`-based timeout.
+    /// Whichever finishes first determines the result for *this caller*. The
+    /// underlying fetch task itself is not cancelled on timeout — other callers
+    /// (and the cache-warming path) may still benefit if it eventually succeeds.
+    ///
+    /// Implemented via two detached tasks racing into a one-shot resolver
+    /// rather than `withThrowingTaskGroup`. A task group implicitly awaits all
+    /// children before its closure returns, and `Task.value` does not honor the
+    /// awaiter's cancellation — so a group-based race would block the timeout
+    /// path until the underlying provider returned anyway, defeating the
+    /// purpose. The resolver lets the loser's resume become a no-op while the
+    /// winning task drives the continuation.
+    private nonisolated func race(
+        fetch: Task<String, Error>,
+        timeoutSeconds: TimeInterval
+    ) async throws -> String {
+        let timeoutNanos = UInt64(timeoutSeconds * 1_000_000_000)
+        return try await withCheckedThrowingContinuation { continuation in
+            let resolver = OnceResolver<String>(continuation)
+            Task {
+                do {
+                    let value = try await fetch.value
+                    await resolver.resolve(.success(value))
+                } catch {
+                    await resolver.resolve(.failure(error))
+                }
             }
-            throw AuthTokenError.validationFailed(failure)
+            Task {
+                try? await Task.sleep(nanoseconds: timeoutNanos)
+                if #available(iOS 14.0, *) {
+                    Logger.auth.error(
+                        "AuthTokenManager: fetch timed out after \(timeoutSeconds, privacy: .public)s"
+                    )
+                }
+                await resolver.resolve(.failure(AuthTokenError.timedOut))
+            }
         }
     }
 
@@ -106,5 +240,28 @@ package actor AuthTokenManager {
     private func isCachedTokenValid(_ token: ValidatedToken, currentTime: Date = Date()) -> Bool {
         let expiresAtSeconds = token.expiresAt.timeIntervalSince1970
         return currentTime.timeIntervalSince1970 < expiresAtSeconds - JWTParser.defaultLeeway
+    }
+}
+
+/// Serializes the first of two concurrent producers onto a `CheckedContinuation`
+/// so that the loser's resume becomes a no-op. Used by ``AuthTokenManager`` to
+/// race the in-flight fetch against a timeout without leaning on
+/// `withThrowingTaskGroup` (which would block on the loser even after the
+/// winner has resolved).
+private actor OnceResolver<T> {
+    private var resumed = false
+    private let continuation: CheckedContinuation<T, Error>
+
+    init(_ continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func resolve(_ result: Result<T, Error>) {
+        guard !resumed else { return }
+        resumed = true
+        switch result {
+        case let .success(value): continuation.resume(returning: value)
+        case let .failure(error): continuation.resume(throwing: error)
+        }
     }
 }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -148,6 +148,13 @@ package actor AuthTokenManager {
             }
         }
 
+        // Bail before reading `provider`: a task cancelled by `registerProvider(_:)`
+        // before its body began executing would otherwise read the *new* provider
+        // and invoke it, wasting an invocation and undermining dedup during rapid
+        // provider swaps. The checkpoint after `provider()` below covers
+        // cancellation that lands mid-fetch.
+        try Task.checkCancellation()
+
         guard let provider else {
             throw AuthTokenError.noProviderRegistered
         }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -225,12 +225,12 @@ package actor AuthTokenManager {
             }
             Task {
                 try? await Task.sleep(nanoseconds: timeoutNanos)
-                if #available(iOS 14.0, *) {
+                let didTimeout = await resolver.resolve(.failure(AuthTokenError.timedOut))
+                if didTimeout, #available(iOS 14.0, *) {
                     Logger.auth.error(
                         "AuthTokenManager: fetch timed out after \(timeoutSeconds, privacy: .public)s"
                     )
                 }
-                await resolver.resolve(.failure(AuthTokenError.timedOut))
             }
         }
     }
@@ -256,12 +256,16 @@ private actor OnceResolver<T> {
         self.continuation = continuation
     }
 
-    func resolve(_ result: Result<T, Error>) {
-        guard !resumed else { return }
+    /// - Returns: `true` if this call won the race and resumed the continuation;
+    ///   `false` if the continuation was already resumed by an earlier call.
+    @discardableResult
+    func resolve(_ result: Result<T, Error>) -> Bool {
+        guard !resumed else { return false }
         resumed = true
         switch result {
         case let .success(value): continuation.resume(returning: value)
         case let .failure(error): continuation.resume(throwing: error)
         }
+        return true
     }
 }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -185,7 +185,7 @@ package actor AuthTokenManager {
             }
         } catch is CancellationError {
             throw CancellationError()
-        } catch is AuthTokenError {
+        } catch let error as AuthTokenError {
             throw error
         } catch {
             if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -185,6 +185,8 @@ package actor AuthTokenManager {
             }
         } catch is CancellationError {
             throw CancellationError()
+        } catch is AuthTokenError {
+            throw error
         } catch {
             if #available(iOS 14.0, *) {
                 let reason = String(describing: error)

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -33,11 +33,11 @@ package actor AuthTokenManager {
         /// 500ms budget. Used at form-display time, where a user is waiting on
         /// the form to appear — missing the personalization window is preferable
         /// to delaying the form.
-        case bestEffort = 0.5
+        case interactive = 0.5
 
         /// 5s budget. Used by background acquisition paths (eager fetch at
         /// registration, scheduled refresh) where no user is actively waiting.
-        case proactive = 5.0
+        case background = 5.0
     }
 
     /// Shared instance used by `KlaviyoSDK` and other SDK modules. Tests should
@@ -83,7 +83,7 @@ package actor AuthTokenManager {
         }
         Task {
             // fetch a token to warm the cache
-            _ = try? await self.currentToken(mode: .proactive)
+            _ = try? await self.currentToken(mode: .background)
         }
     }
 
@@ -105,13 +105,13 @@ package actor AuthTokenManager {
     /// `timeoutIntervalForRequest` is sufficient).
     ///
     /// - Parameter mode: Latency budget for *this* call. Defaults to
-    ///   ``FetchMode/bestEffort`` — the form-display path.
+    ///   ``FetchMode/interactive`` — the form-display path.
     /// - Throws: ``AuthTokenError/noProviderRegistered`` when no provider is
     ///   registered; ``AuthTokenError/timedOut`` when the caller's budget
     ///   elapses before the fetch completes; the provider's own error when the
     ///   provider throws; ``AuthTokenError/validationFailed(_:)`` when the
     ///   returned token fails ``JWTParser`` validation.
-    package func currentToken(mode: FetchMode = .bestEffort) async throws -> String {
+    package func currentToken(mode: FetchMode = .interactive) async throws -> String {
         if let cachedToken, isCachedTokenValid(cachedToken) {
             return cachedToken.rawToken
         }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -135,9 +135,9 @@ class IAFPresentationManager {
     /// injection. Returns `nil` on any failure — the form proceeds without a token
     /// and the backend serves non-personalized content.
     private func fetchAuthTokenBestEffort() async -> String? {
-        // TODO: [MAGE-624] AuthTokenManager will enforce its own 500ms best-effort
-        // deadline internally. No external timeout is needed here; once MAGE-624
-        // lands, this call site is correct as-is.
+        // `currentToken()` defaults to `.bestEffort` mode, which applies the
+        // 500ms latency budget appropriate for form display. No external timeout
+        // is needed here.
         do {
             let token = try await AuthTokenManager.shared.currentToken()
             if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -135,7 +135,7 @@ class IAFPresentationManager {
     /// injection. Returns `nil` on any failure — the form proceeds without a token
     /// and the backend serves non-personalized content.
     private func fetchAuthTokenBestEffort() async -> String? {
-        // `currentToken()` defaults to `.bestEffort` mode, which applies the
+        // `currentToken()` defaults to `.interactive` mode, which applies the
         // 500ms latency budget appropriate for form display. No external timeout
         // is needed here.
         do {

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -150,11 +150,249 @@ struct AuthTokenManagerTests {
         let secondResult = try await manager.currentToken()
         #expect(secondResult == secondToken)
     }
+
+    // MARK: - currentToken: concurrent-caller deduplication
+
+    @Test
+    func concurrentCallersShareSingleProviderInvocation() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+        let counter = CallCounter()
+        let providerEntered = Latch()
+        let providerRelease = Latch()
+
+        await manager.registerProvider {
+            await counter.increment()
+            await providerEntered.open()
+            await providerRelease.wait()
+            return token
+        }
+        // Wait for the eager fetch to enter the provider so that subsequent
+        // currentToken() calls find an in-flight fetch and dedup with it.
+        await providerEntered.wait()
+
+        // Spawn 8 concurrent callers. They should all observe the in-flight
+        // fetch and `await` it rather than starting their own.
+        let callerCount = 8
+        async let results: [String] = withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0..<callerCount {
+                group.addTask {
+                    try await manager.currentToken(mode: .proactive)
+                }
+            }
+            var collected: [String] = []
+            for try await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        // Release the provider so the in-flight fetch can complete and all
+        // dedup'd awaiters can resume.
+        await providerRelease.open()
+
+        let allResults = try await results
+        #expect(allResults.count == callerCount)
+        #expect(allResults.allSatisfy { $0 == token })
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 1,
+            "exactly one provider invocation expected across \(callerCount) concurrent callers + eager fetch"
+        )
+    }
+
+    // MARK: - currentToken: timeout enforcement
+
+    @Test
+    func bestEffortTimeoutThrowsWithinBudget() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+
+        await manager.registerProvider {
+            // Sleep well past the best-effort budget so the timeout always wins.
+            try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
+            return token
+        }
+
+        let start = Date()
+        await #expect(throws: AuthTokenError.timedOut) {
+            _ = try await manager.currentToken(mode: .bestEffort)
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        // Allow generous headroom for CI scheduler jitter; the assertion that
+        // matters is "did not wait the full provider duration (2s)".
+        #expect(elapsed < 1.5, "best-effort caller should time out near 500ms, took \(elapsed)s")
+    }
+
+    @Test
+    func proactiveTimeoutThrowsWithinBudget() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+
+        await manager.registerProvider {
+            // Sleep well past the proactive budget so the timeout always wins.
+            try await Task.sleep(nanoseconds: UInt64(10 * 1_000_000_000))
+            return token
+        }
+
+        let start = Date()
+        await #expect(throws: AuthTokenError.timedOut) {
+            _ = try await manager.currentToken(mode: .proactive)
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(elapsed < 8.0, "proactive caller should time out near 5s, took \(elapsed)s")
+    }
+
+    @Test
+    func bestEffortTimeoutLeavesFetchTaskRunningForLaterCallers() async throws {
+        let manager = AuthTokenManager()
+        let token = try makeJWT()
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            // Sleep longer than best-effort but well under proactive.
+            try await Task.sleep(nanoseconds: UInt64(800 * 1_000_000))
+            return token
+        }
+
+        // First caller bails out via best-effort timeout.
+        await #expect(throws: AuthTokenError.timedOut) {
+            _ = try await manager.currentToken(mode: .bestEffort)
+        }
+
+        // The in-flight fetch should still be running — a proactive caller
+        // should dedup with it rather than triggering a second provider call.
+        let result = try await manager.currentToken(mode: .proactive)
+        #expect(result == token)
+
+        let invocations = await counter.value
+        // Eager fetch + the dedup'd call should sum to a single invocation.
+        // (If the bestEffort timeout had killed the underlying fetch, we'd
+        // see a second invocation here.)
+        #expect(
+            invocations == 1,
+            "best-effort timeout must not cancel the shared in-flight fetch; saw \(invocations) invocations"
+        )
+    }
+
+    // MARK: - currentToken: failure recovery
+
+    @Test
+    func failureClearsInFlightSoNextCallReinvokesProvider() async throws {
+        let manager = AuthTokenManager()
+        let counter = CallCounter()
+        let successToken = try makeJWT()
+
+        // First registration uses a provider that always throws. The eager
+        // fetch will fail; the cached token stays nil and inFlightFetch is
+        // cleared by the fetch task's defer.
+        await manager.registerProvider {
+            await counter.increment()
+            throw ProviderTestError.network
+        }
+
+        await #expect(throws: ProviderTestError.network) {
+            _ = try await manager.currentToken(mode: .proactive)
+        }
+
+        // Without re-registering, swap the provider's behavior by registering
+        // a fresh manager so the failure history doesn't carry across — this
+        // mirrors the spec: "the next call invokes the provider again (not the
+        // cached failure)".
+        let recoveryCounter = CallCounter()
+        let manager2 = AuthTokenManager()
+        await manager2.registerProvider {
+            await recoveryCounter.increment()
+            return successToken
+        }
+        let result = try await manager2.currentToken(mode: .proactive)
+        #expect(result == successToken)
+
+        let recoveryInvocations = await recoveryCounter.value
+        #expect(recoveryInvocations >= 1)
+
+        _ = await counter.value // silences unused warning if optimizer drops the await
+    }
+
+    // MARK: - currentToken: cache integrity across provider swap
+
+    @Test
+    func providerReplacedWhileFetchInFlightDoesNotPoisonCache() async throws {
+        // Regression test: actor reentrancy at the `await provider()` call in
+        // the in-flight fetch previously allowed a stale fetch from a replaced
+        // provider to write its (now-stale) token back into the cache after the
+        // new provider had already cached its own token. The fix relies on
+        // cancellation: `registerProvider(_:)` cancels the in-flight task, and
+        // the fetch body's explicit `Task.checkCancellation()` checkpoint drops
+        // the stale write on the floor even when the host's provider closure
+        // does not honor cancellation.
+        let manager = AuthTokenManager()
+        let firstToken = try makeJWT(extraClaims: ["sub": "user-a"])
+        let secondToken = try makeJWT(extraClaims: ["sub": "user-b"])
+
+        let firstProviderEntered = Latch()
+        let firstProviderRelease = Latch()
+
+        await manager.registerProvider {
+            await firstProviderEntered.open()
+            await firstProviderRelease.wait()
+            return firstToken
+        }
+        // Wait until the eager fetch has captured the first provider and is
+        // suspended inside `provider()` — precondition for the reentrancy race.
+        await firstProviderEntered.wait()
+
+        // Swap in a new provider. The new eager fetch caches `secondToken`.
+        let secondProviderCounter = CallCounter()
+        await manager.registerProvider {
+            await secondProviderCounter.increment()
+            return secondToken
+        }
+        try await secondProviderCounter.waitFor(atLeast: 1)
+
+        // Release the first provider. Its in-flight fetch returns
+        // `firstToken`; without cancellation safety it would overwrite the
+        // cache.
+        await firstProviderRelease.open()
+
+        // Yield so the resumed continuation has time to run before we sample
+        // the cache.
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        let result = try await manager.currentToken(mode: .proactive)
+        #expect(result == secondToken)
+    }
 }
 
 // MARK: - Test helpers
 
 extension AuthTokenManagerTests {
+    /// One-shot async gate. `wait()` suspends until `open()` is called; once
+    /// open it stays open. Used to interleave a provider's resumption with
+    /// other operations in deterministic order.
+    actor Latch {
+        private var isOpen = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func open() {
+            guard !isOpen else { return }
+            isOpen = true
+            for waiter in waiters {
+                waiter.resume()
+            }
+            waiters.removeAll()
+        }
+
+        func wait() async {
+            if isOpen { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+    }
+
     /// Counts provider invocations and lets tests await a specific call count
     /// without sleeping. `signal` runs every increment so any waiters can wake up
     /// promptly when their threshold is met.

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -177,7 +177,7 @@ struct AuthTokenManagerTests {
         async let results: [String] = withThrowingTaskGroup(of: String.self) { group in
             for _ in 0..<callerCount {
                 group.addTask {
-                    try await manager.currentToken(mode: .proactive)
+                    try await manager.currentToken(mode: .background)
                 }
             }
             var collected: [String] = []
@@ -205,75 +205,75 @@ struct AuthTokenManagerTests {
     // MARK: - currentToken: timeout enforcement
 
     @Test
-    func bestEffortTimeoutThrowsWithinBudget() async throws {
+    func interactiveTimeoutThrowsWithinBudget() async throws {
         let manager = AuthTokenManager()
         let token = try makeJWT()
 
         await manager.registerProvider {
-            // Sleep well past the best-effort budget so the timeout always wins.
+            // Sleep well past the interactive budget so the timeout always wins.
             try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
             return token
         }
 
         let start = Date()
         await #expect(throws: AuthTokenError.timedOut) {
-            _ = try await manager.currentToken(mode: .bestEffort)
+            _ = try await manager.currentToken(mode: .interactive)
         }
         let elapsed = Date().timeIntervalSince(start)
         // Allow generous headroom for CI scheduler jitter; the assertion that
         // matters is "did not wait the full provider duration (2s)".
-        #expect(elapsed < 1.5, "best-effort caller should time out near 500ms, took \(elapsed)s")
+        #expect(elapsed < 1.5, "interactive caller should time out near 500ms, took \(elapsed)s")
     }
 
     @Test
-    func proactiveTimeoutThrowsWithinBudget() async throws {
+    func backgroundTimeoutThrowsWithinBudget() async throws {
         let manager = AuthTokenManager()
         let token = try makeJWT()
 
         await manager.registerProvider {
-            // Sleep well past the proactive budget so the timeout always wins.
+            // Sleep well past the background budget so the timeout always wins.
             try await Task.sleep(nanoseconds: UInt64(10 * 1_000_000_000))
             return token
         }
 
         let start = Date()
         await #expect(throws: AuthTokenError.timedOut) {
-            _ = try await manager.currentToken(mode: .proactive)
+            _ = try await manager.currentToken(mode: .background)
         }
         let elapsed = Date().timeIntervalSince(start)
-        #expect(elapsed < 8.0, "proactive caller should time out near 5s, took \(elapsed)s")
+        #expect(elapsed < 8.0, "background caller should time out near 5s, took \(elapsed)s")
     }
 
     @Test
-    func bestEffortTimeoutLeavesFetchTaskRunningForLaterCallers() async throws {
+    func interactiveTimeoutLeavesFetchTaskRunningForLaterCallers() async throws {
         let manager = AuthTokenManager()
         let token = try makeJWT()
         let counter = CallCounter()
 
         await manager.registerProvider {
             await counter.increment()
-            // Sleep longer than best-effort but well under proactive.
+            // Sleep longer than the interactive budget but well under the background budget.
             try await Task.sleep(nanoseconds: UInt64(800 * 1_000_000))
             return token
         }
 
-        // First caller bails out via best-effort timeout.
+        // First caller bails out via the interactive timeout.
         await #expect(throws: AuthTokenError.timedOut) {
-            _ = try await manager.currentToken(mode: .bestEffort)
+            _ = try await manager.currentToken(mode: .interactive)
         }
 
-        // The in-flight fetch should still be running — a proactive caller
+        // The in-flight fetch should still be running — a background caller
         // should dedup with it rather than triggering a second provider call.
-        let result = try await manager.currentToken(mode: .proactive)
+        let result = try await manager.currentToken(mode: .background)
         #expect(result == token)
 
         let invocations = await counter.value
         // Eager fetch + the dedup'd call should sum to a single invocation.
-        // (If the bestEffort timeout had killed the underlying fetch, we'd
+        // (If the interactive timeout had killed the underlying fetch, we'd
         // see a second invocation here.)
         #expect(
             invocations == 1,
-            "best-effort timeout must not cancel the shared in-flight fetch; saw \(invocations) invocations"
+            "interactive timeout must not cancel the shared in-flight fetch; saw \(invocations) invocations"
         )
     }
 
@@ -294,7 +294,7 @@ struct AuthTokenManagerTests {
         }
 
         await #expect(throws: ProviderTestError.network) {
-            _ = try await manager.currentToken(mode: .proactive)
+            _ = try await manager.currentToken(mode: .background)
         }
 
         // Without re-registering, swap the provider's behavior by registering
@@ -307,7 +307,7 @@ struct AuthTokenManagerTests {
             await recoveryCounter.increment()
             return successToken
         }
-        let result = try await manager2.currentToken(mode: .proactive)
+        let result = try await manager2.currentToken(mode: .background)
         #expect(result == successToken)
 
         let recoveryInvocations = await recoveryCounter.value
@@ -363,7 +363,7 @@ struct AuthTokenManagerTests {
             await Task.yield()
         }
 
-        let result = try await manager.currentToken(mode: .proactive)
+        let result = try await manager.currentToken(mode: .background)
         #expect(result == secondToken)
     }
 }

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -284,36 +284,42 @@ struct AuthTokenManagerTests {
         let manager = AuthTokenManager()
         let counter = CallCounter()
         let successToken = try makeJWT()
+        // Single stateful provider on a single manager: it fails until we flip
+        // `behavior`, then succeeds. Crucially we never re-register (that would
+        // reset `inFlight` itself and make the test prove nothing).
+        let behavior = ProviderBehavior(failing: true)
 
-        // First registration uses a provider that always throws. The eager
-        // fetch will fail; the cached token stays nil and inFlightFetch is
-        // cleared by the fetch task's defer.
         await manager.registerProvider {
             await counter.increment()
-            throw ProviderTestError.network
+            if await behavior.isFailing {
+                throw ProviderTestError.network
+            }
+            return successToken
         }
 
+        // Phase 1 — drive a failure through the public API. Awaiting the fetch
+        // task to completion guarantees `runFetch`'s `defer` has cleared
+        // `inFlight` by the time this returns: `Task.value` resolves only after
+        // the task body (defers included) fully unwinds. This call either
+        // dedups with the eager warm fetch or starts its own — either way it
+        // throws and the slot it awaited is cleared.
         await #expect(throws: ProviderTestError.network) {
             _ = try await manager.currentToken(mode: .background)
         }
+        let failingInvocations = await counter.value
+        #expect(failingInvocations >= 1)
 
-        // Without re-registering, swap the provider's behavior by registering
-        // a fresh manager so the failure history doesn't carry across — this
-        // mirrors the spec: "the next call invokes the provider again (not the
-        // cached failure)".
-        let recoveryCounter = CallCounter()
-        let manager2 = AuthTokenManager()
-        await manager2.registerProvider {
-            await recoveryCounter.increment()
-            return successToken
-        }
-        let result = try await manager2.currentToken(mode: .background)
+        // Phase 2 — flip the provider to succeed (no re-registration). If the
+        // failed fetch had left a stale `inFlight`, this call would re-await the
+        // dead task and throw `.network` instead of starting a fresh fetch.
+        await behavior.stopFailing()
+
+        let result = try await manager.currentToken(mode: .background)
         #expect(result == successToken)
 
-        let recoveryInvocations = await recoveryCounter.value
-        #expect(recoveryInvocations >= 1)
-
-        _ = await counter.value // silences unused warning if optimizer drops the await
+        // The success required a *new* provider invocation, which only happens
+        // if the post-failure `defer` cleared `inFlight`.
+        #expect(await counter.value > failingInvocations)
     }
 
     // MARK: - currentToken: cache integrity across provider swap
@@ -431,6 +437,22 @@ extension AuthTokenManagerTests {
 
         func set(_ new: String) {
             value = new
+        }
+    }
+
+    /// One-way switch read by a stateful provider so its behavior can flip from
+    /// failing to succeeding across invocations *without* re-registering — which
+    /// would reset the in-flight slot and cache and defeat tests that exercise
+    /// post-failure recovery on a single manager.
+    actor ProviderBehavior {
+        private(set) var isFailing: Bool
+
+        init(failing: Bool) {
+            isFailing = failing
+        }
+
+        func stopFailing() {
+            isFailing = false
         }
     }
 


### PR DESCRIPTION
# Description
Adds concurrent-caller deduplication, per-caller timeout enforcement, and cache integrity across provider swaps to `AuthTokenManager`. Builds on the skeleton from MAGE-623; addresses the race condition explicitly called out in PR #576 review (and the stashed regression test from that thread is adapted here).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

All new surface is `package` — host code sees no API change. The IAF call site's bare `currentToken()` is unchanged; only its internal TODO comment moved.

## Changelog / Code Overview

**`AuthTokenManager` (`KlaviyoCore`)**
- New `FetchMode` raw-value enum: `.bestEffort = 0.5` (form-display default, matches the spec's "500ms enforced by the manager" at the IAF call site) and `.proactive = 5.0` (background acquisition: registration-time eager fetch, scheduled refresh in MAGE-625).
- Concurrent callers dedup via a single in-flight slot, `private var inFlight: (id: UUID, task: Task<String, Error>)?`. Always set/cleared as a unit so the invariant "ID and task travel together" is structural.
- Per-caller timeout race via a `OnceResolver` actor over `withCheckedThrowingContinuation` + two detached tasks. `withThrowingTaskGroup` is not suitable here — a group implicitly awaits all children before its closure returns, and `Task.value` does not honor the awaiter's cancellation, so a group-based race would block on the unfinished fetch child until the underlying provider returned regardless of which child won. Documented inline.
- `registerProvider(_:)` cancels any in-flight task and clears the slot before installing the new provider. The fetch body adds an explicit `Task.checkCancellation()` checkpoint immediately after `await provider()` and before any cache write, so a non-cancellation-aware host provider closure cannot poison the cache by writing its stale token after the provider has been swapped.
- The generation-UUID guard in the fetch task's `defer` ensures a cancelled task waking up after a newer in-flight slot has been installed by `registerProvider(_:)` cannot clobber the newer slot.

**`AuthTokenError` (`KlaviyoCore`)**
- New `timedOut` case for the per-caller budget elapsing.

**`IAFPresentationManager` (`KlaviyoForms`)**
- TODO comment refreshed to reflect the now-landed behavior. Method call (`AuthTokenManager.shared.currentToken()`) is unchanged: the new default `.bestEffort` is the 500ms form-display budget the spec requires.

**Design decisions worth flagging in review**
- API shape: `currentToken(mode: FetchMode = .bestEffort)` rather than a `timeout: TimeInterval` parameter or a `bestEffort: Bool` overload. The spec treats the two budgets as named *policies* (configurable from telemetry), not as a continuum. Enum cases keep call sites free of magic numbers and let the policies be tuned in one place.
- Hang-forever contract: the SDK does not enforce an upper bound on the underlying fetch's runtime — if a host's provider hangs without honoring cancellation, the slot is stuck until the next `registerProvider(_:)`. The doc comment makes this explicit. Adding a watchdog was considered and rejected: in practice URLSession-based providers cap out at 60s, and the user-visible degradation is already correct (forms display non-personalized content).

## Test Plan

All 14 tests in `AuthTokenManagerTests` pass. Six new tests added:

- [x] `concurrentCallersShareSingleProviderInvocation` — 8 concurrent callers + eager fetch → exactly 1 provider invocation
- [x] `bestEffortTimeoutThrowsWithinBudget` — 500ms budget caller throws `timedOut` against a 2s-sleeping provider
- [x] `proactiveTimeoutThrowsWithinBudget` — 5s budget caller throws `timedOut` against a 10s-sleeping provider
- [x] `bestEffortTimeoutLeavesFetchTaskRunningForLaterCallers` — first caller bails at ~500ms, second caller (proactive) gets the cached result at ~800ms; single provider invocation across both
- [x] `failureClearsInFlightSoNextCallReinvokesProvider` — failure path clears the slot for the next caller
- [x] `providerReplacedWhileFetchInFlightDoesNotPoisonCache` — adapted from the stashed regression test in #576 review; uses a `Latch` helper to drive deterministic interleaving; asserts the second-provider token survives the stale write attempt

Run: `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:KlaviyoCoreTests/AuthTokenManagerTests`

## Related Issues/Tickets

- [MAGE-624](https://linear.app/klaviyo/issue/MAGE-624) — this PR
- MAGE-615 — parent
- MAGE-623 — skeleton (#576) this builds on
- MAGE-625, MAGE-626, MAGE-683 — sibling sub-issues that consume the failure surface and dedup machinery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token acquisition now supports per-call timeout modes and deduplicated concurrent requests for faster, more efficient auth.
  * Eager background cache warm-up after registering a provider.

* **Bug Fixes**
  * Prevented stale in-flight fetches from overwriting newer cached tokens when providers change.
  * Caller timeouts no longer cancel the shared underlying fetch.

* **Documentation**
  * Clarified timeout behavior and default latency budget for interactive requests.

* **Tests**
  * Added tests for deduplication, timeout semantics, cache safety, and provider-swap cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->