### PR TITLE
feat(AutoPushTracking): Injection + KVO wiring for KlaviyoNotificationDelegate

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -64,6 +64,7 @@ public struct KlaviyoSDK {
     @discardableResult
     public func initialize(with apiKey: String) -> KlaviyoSDK {
         dispatchOnMainThread(action: .initialize(apiKey))
+        klaviyoSwiftEnvironment.injectNotificationDelegate()
         return self
     }
 

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -24,11 +24,16 @@ protocol UserNotificationCenterProtocol: AnyObject {
 
 extension UNUserNotificationCenter: UserNotificationCenterProtocol {
     func observeDelegate(using handler: @escaping @MainActor () -> Void) -> AnyObject {
-        // `MainActor.assumeIsolated` keeps `UNUserNotificationCenter` (non-Sendable) on
-        // the main actor without crossing isolation boundaries. A `Task { @MainActor in }`
-        // would send the center reference across actor domains, triggering Swift 6 diagnostics.
+        // KVO for UNUserNotificationCenter.delegate always fires on the main thread.
+        // `assumeIsolated` asserts that fact to the type system synchronously (iOS 17+).
+        // On earlier OS versions the Task hop is safe: handler is @MainActor-bound
+        // (implicitly Sendable) and we don't capture the non-Sendable center here.
         observe(\.delegate, options: [.new]) { _, _ in
-            MainActor.assumeIsolated { handler() }
+            if #available(iOS 17.0, *) {
+                MainActor.assumeIsolated { handler() }
+            } else {
+                Task { @MainActor in handler() }
+            }
         }
     }
 }

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -6,20 +6,107 @@
 //
 
 import Foundation
+import OSLog
 import UserNotifications
 
-/// A proxy `UNUserNotificationCenterDelegate` that the SDK installs as the active
-/// `UNUserNotificationCenter` delegate to intercept push notification responses automatically.
+// MARK: - UserNotificationCenterProtocol
+
+/// Abstracts the two `UNUserNotificationCenter` members the proxy needs — delegate
+/// assignment and delegate-change observation — so unit tests can supply a lightweight
+/// mock without the app-bundle context that `UNUserNotificationCenter.current()` requires.
+protocol UserNotificationCenterProtocol: AnyObject {
+    var delegate: (any UNUserNotificationCenterDelegate)? { get set }
+
+    /// Registers a handler invoked whenever the delegate property changes.
+    /// Returns a token whose lifetime controls the observation; release to stop observing.
+    func observeDelegate(using handler: @escaping @MainActor () -> Void) -> AnyObject
+}
+
+extension UNUserNotificationCenter: UserNotificationCenterProtocol {
+    func observeDelegate(using handler: @escaping @MainActor () -> Void) -> AnyObject {
+        // `MainActor.assumeIsolated` keeps `UNUserNotificationCenter` (non-Sendable) on
+        // the main actor without crossing isolation boundaries. A `Task { @MainActor in }`
+        // would send the center reference across actor domains, triggering Swift 6 diagnostics.
+        observe(\.delegate, options: [.new]) { _, _ in
+            MainActor.assumeIsolated { handler() }
+        }
+    }
+}
+
+// MARK: - KlaviyoNotificationDelegate
+
+/// A proxy `UNUserNotificationCenterDelegate` that Klaviyo installs as the active
+/// notification center delegate when automatic push tracking is enabled.
+///
+/// The proxy intercepts `didReceive` to fire the `Opened Push` event automatically,
+/// then forwards every callback to the delegate that was in place before injection,
+/// preserving full host behavior as though the proxy were never there.
+///
+/// ## Lifecycle
+/// `injectIfEnabled()` is called once from `KlaviyoSDK.initialize(with:)`. A change
+/// observer on `UNUserNotificationCenter.delegate` re-installs the proxy whenever the
+/// host app overwrites it (e.g. in `SceneDelegate.scene(_:willConnectTo:)`), capturing
+/// the new value as `existingDelegate`.
+///
+/// ## Thread safety
+/// All mutation is confined to `@MainActor`.
 final class KlaviyoNotificationDelegate: NSObject {
     static let shared = KlaviyoNotificationDelegate()
 
     override private init() {}
 
-    /// The host app's delegate that was in place before the SDK proxy was installed.
+    /// The host's delegate captured at injection time, or re-captured on re-installation.
     ///
-    /// `weak` mirrors `UNUserNotificationCenter.delegate`'s own weak contract — the SDK must
-    /// not silently extend the lifetime of the host's delegate object.
-    private weak var existingDelegate: (any UNUserNotificationCenterDelegate)?
+    /// Weak to mirror `UNUserNotificationCenter.delegate`'s own contract — the proxy
+    /// must not silently extend the lifetime of the host delegate object.
+    private(set) weak var existingDelegate: (any UNUserNotificationCenterDelegate)?
+
+    /// Retains the delegate-change observation token for the singleton's lifetime.
+    ///
+    /// Instance property (not `static var`) so it is naturally isolated to `@MainActor`
+    /// without requiring `nonisolated(unsafe)` or `@unchecked Sendable` annotations.
+    private var centerObservation: AnyObject?
+
+    // MARK: - Injection
+
+    /// Reads the opt-in flag and notification center from `KlaviyoSwiftEnvironment`,
+    /// then installs the proxy when automatic push tracking is enabled.
+    ///
+    /// Both dependencies are environment-injected so tests can control the plist gate
+    /// and substitute a mock center without requiring an app-bundle context.
+    ///
+    /// Called once from `KlaviyoSDK.initialize(with:)` via
+    /// `KlaviyoSwiftEnvironment.injectNotificationDelegate`.
+    @MainActor
+    static func injectIfEnabled() {
+        guard klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled() else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.info("Klaviyo automatic push tracking is off by default — set 'klaviyo_automatic_push_tracking' to YES in Info.plist to opt in.")
+            }
+            return
+        }
+        shared.inject(into: klaviyoSwiftEnvironment.notificationCenter())
+    }
+
+    /// Installs the proxy as the notification center's active delegate and registers
+    /// an observer to re-install it if the host later overwrites the delegate property.
+    ///
+    /// Idempotent: a second call while the proxy is already the active delegate returns
+    /// immediately, preventing duplicate observation tokens from accumulating.
+    @MainActor
+    private func inject(into center: any UserNotificationCenterProtocol) {
+        guard center.delegate !== self else { return }
+
+        existingDelegate = center.delegate
+        center.delegate = self
+
+        centerObservation = center.observeDelegate { [weak self] in
+            guard let self else { return }
+            guard center.delegate !== self else { return }
+            self.existingDelegate = center.delegate
+            center.delegate = self
+        }
+    }
 }
 
 // MARK: - UNUserNotificationCenterDelegate

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -81,7 +81,7 @@ final class KlaviyoNotificationDelegate: NSObject {
     static func injectIfEnabled() {
         guard klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled() else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.info("Klaviyo automatic push tracking is off by default — set 'klaviyo_automatic_push_tracking' to YES in Info.plist to opt in.")
+                Logger.notifications.info("Klaviyo automatic push tracking is off.")
             }
             return
         }

--- a/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
@@ -20,6 +20,19 @@ struct KlaviyoSwiftEnvironment {
     var stateChangePublisher: () -> AnyPublisher<KlaviyoAction, Never>
     var setBadgeCount: (Int) -> Task<Void, Never>?
     var pruneCategory: (String) -> Void
+    /// Called once from `KlaviyoSDK.initialize(with:)` to conditionally install
+    /// `KlaviyoNotificationDelegate` as the active `UNUserNotificationCenter` delegate.
+    /// Injected as a closure so tests can stub or assert the call without touching the
+    /// real notification center.
+    var injectNotificationDelegate: () -> Void
+    /// Returns whether the host has opted in to automatic push open tracking via the
+    /// `klaviyo_automatic_push_tracking` Info.plist key.
+    /// Injected so tests can enable or disable the feature without modifying `Bundle.main`.
+    var isAutomaticPushTrackingEnabled: () -> Bool
+    /// Provides the notification center for automatic push tracking injection.
+    /// Injected so tests can substitute a mock without the app-bundle context that
+    /// `UNUserNotificationCenter.current()` requires.
+    var notificationCenter: @MainActor () -> any UserNotificationCenterProtocol
 
     static let production: KlaviyoSwiftEnvironment = {
         let store = Store.production
@@ -49,6 +62,19 @@ struct KlaviyoSwiftEnvironment {
             },
             pruneCategory: { categoryIdentifier in
                 KlaviyoCategoryManager.shared.pruneCategory(categoryIdentifier: categoryIdentifier)
+            },
+            injectNotificationDelegate: {
+                // Dispatched onto the main actor because `UNUserNotificationCenter.delegate`
+                // is main-thread-only; `initialize(with:)` may be called from any thread.
+                Task { @MainActor in
+                    KlaviyoNotificationDelegate.injectIfEnabled()
+                }
+            },
+            isAutomaticPushTrackingEnabled: {
+                Bundle.main.object(forInfoDictionaryKey: "klaviyo_automatic_push_tracking") as? Bool == true
+            },
+            notificationCenter: {
+                UNUserNotificationCenter.current()
             }
         )
     }()

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -6,13 +6,141 @@
 //
 
 @testable import KlaviyoSwift
+import UserNotifications
 
 #if canImport(Testing)
 import Testing
 
+// MARK: - Test Doubles
+
+/// Minimal `UNUserNotificationCenterDelegate` conformer used for object-identity assertions.
+final class MockUNDelegate: NSObject, UNUserNotificationCenterDelegate {}
+
+/// Stands in for `UNUserNotificationCenter` in unit tests.
+///
+/// The real center requires an app-bundle context (`current()` crashes in the SPM test
+/// runner). This mock captures the observation handler so tests can fire it directly,
+/// simulating the host app reassigning `UNUserNotificationCenter.delegate` after injection.
+@MainActor
+final class MockNotificationCenter: UserNotificationCenterProtocol {
+    var delegate: (any UNUserNotificationCenterDelegate)?
+    private var observationHandler: (@MainActor () -> Void)?
+
+    func observeDelegate(using handler: @escaping @MainActor () -> Void) -> AnyObject {
+        observationHandler = handler
+        return NSObject()
+    }
+
+    /// Simulates the host app overwriting `UNUserNotificationCenter.delegate` after
+    /// the proxy has been installed (e.g. in `SceneDelegate.scene(_:willConnectTo:)`).
+    func simulateDelegateReassignment(to newDelegate: (any UNUserNotificationCenterDelegate)?) {
+        delegate = newDelegate
+        observationHandler?()
+    }
+}
+
+// MARK: - Tests
+
+// Note: the `klaviyo_automatic_push_tracking` plist key itself is verified manually
+// in the example app — `Bundle.main` in the test runner never carries it, and making
+// `Bundle` injectable would add abstraction beyond the current ticket's scope.
+
 @Suite
+@MainActor
 struct KlaviyoNotificationDelegateTests {
-    // TODO: [MAGE-657] Add tests for delegate forwarding and OnceCallback behavior
-    // TODO: [MAGE-660] Add tests for double-track guard
+    init() {
+        klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+    }
+
+    // MARK: - Injection Wiring
+
+    /// Verifies that `initialize(with:)` calls `injectNotificationDelegate` exactly once,
+    /// ensuring proxy installation is always attempted at SDK initialization time.
+    @Test
+    func initializeTriggersNotificationDelegateInjection() {
+        var callCount = 0
+        klaviyoSwiftEnvironment.injectNotificationDelegate = { callCount += 1 }
+
+        KlaviyoSDK().initialize(with: "test-key")
+
+        #expect(callCount == 1)
+    }
+
+    // MARK: - Plist Gating
+
+    /// When automatic push tracking is disabled (the default), `injectIfEnabled()` must
+    /// not install the proxy — the notification center's delegate must remain unchanged.
+    @Test
+    func injectIfEnabledIsNoOpWhenTrackingDisabled() {
+        let mockCenter = MockNotificationCenter()
+        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { false }
+        klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
+
+        KlaviyoNotificationDelegate.injectIfEnabled()
+
+        #expect(mockCenter.delegate == nil)
+    }
+
+    // MARK: - inject(into:) Behavior
+
+    /// After injection, the proxy must be the center's active delegate.
+    @Test
+    func injectSetsDelegateOnCenter() {
+        let mockCenter = MockNotificationCenter()
+        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
+
+        KlaviyoNotificationDelegate.injectIfEnabled()
+
+        #expect(mockCenter.delegate === KlaviyoNotificationDelegate.shared)
+    }
+
+    /// The delegate active at injection time must be captured as `existingDelegate`
+    /// so callbacks can be forwarded to it after the proxy handles them.
+    @Test
+    func injectCapturesPriorDelegate() {
+        let mockCenter = MockNotificationCenter()
+        let priorDelegate = MockUNDelegate()
+        mockCenter.delegate = priorDelegate
+        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
+
+        KlaviyoNotificationDelegate.injectIfEnabled()
+
+        #expect(KlaviyoNotificationDelegate.shared.existingDelegate === priorDelegate)
+    }
+
+    /// A second `injectIfEnabled()` call while the proxy is already the active delegate
+    /// must be a no-op — no duplicate observation tokens, no delegate reassignment.
+    @Test
+    func injectIsIdempotent() {
+        let mockCenter = MockNotificationCenter()
+        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
+
+        KlaviyoNotificationDelegate.injectIfEnabled()
+        KlaviyoNotificationDelegate.injectIfEnabled()
+
+        #expect(mockCenter.delegate === KlaviyoNotificationDelegate.shared)
+    }
+
+    // MARK: - KVO Re-injection
+
+    /// When the host app overwrites `UNUserNotificationCenter.delegate` after injection
+    /// (e.g. SceneDelegate scenario), the proxy must re-install itself and capture the
+    /// new host delegate as `existingDelegate`.
+    @Test
+    func observerReinstallsProxyAfterHostReassignment() {
+        let mockCenter = MockNotificationCenter()
+        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
+        KlaviyoNotificationDelegate.injectIfEnabled()
+
+        let newHostDelegate = MockUNDelegate()
+        mockCenter.simulateDelegateReassignment(to: newHostDelegate)
+
+        #expect(mockCenter.delegate === KlaviyoNotificationDelegate.shared)
+        #expect(KlaviyoNotificationDelegate.shared.existingDelegate === newHostDelegate)
+    }
 }
 #endif

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -8,9 +8,6 @@
 @testable import KlaviyoSwift
 import UserNotifications
 
-#if canImport(Testing)
-import Testing
-
 // MARK: - Test Doubles
 
 /// Minimal `UNUserNotificationCenterDelegate` conformer used for object-identity assertions.
@@ -40,6 +37,9 @@ final class MockNotificationCenter: UserNotificationCenterProtocol {
 }
 
 // MARK: - Tests
+
+#if canImport(Testing)
+import Testing
 
 // Note: the `klaviyo_automatic_push_tracking` plist key itself is verified manually
 // in the example app — `Bundle.main` in the test runner never carries it, and making

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -226,6 +226,12 @@ extension KlaviyoSwiftEnvironment {
             nil
         }, pruneCategory: { _ in
             // no-op: UNUserNotificationCenter.current() is unavailable in test runner
+        }, injectNotificationDelegate: {
+            // no-op: UNUserNotificationCenter.current() is unavailable in test runner
+        }, isAutomaticPushTrackingEnabled: {
+            false
+        }, notificationCenter: {
+            MockNotificationCenter()
         })
     }
 }


### PR DESCRIPTION
## Description

Phase 1 ticket #2 of the Automatic Push Open Tracking plan (MAGE-657), scoped to the injection and KVO wiring layer. Delegates the forwarding-cycle guard, `OnceCallback`, and full `didReceive`/`willPresent` implementations to follow-on PRs.

## Due Diligence

- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations

- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**`KlaviyoNotificationDelegate.swift`**
- New `UserNotificationCenterProtocol` — surfaces `delegate` and `observeDelegate(using:)` so tests can substitute a mock without the app-bundle context `UNUserNotificationCenter.current()` requires. `UNUserNotificationCenter` gets a retroactive conformance; `MainActor.assumeIsolated` rationale is documented where the KVO closure lives.
- `injectIfEnabled()` — reads opt-in flag and center from `KlaviyoSwiftEnvironment`, installs proxy when enabled. No plist or center references in the method body itself — both flow through the environment.
- `inject(into:)` — private; captures `existingDelegate`, sets proxy as delegate, installs change observer that re-injects if host later overwrites the delegate (SceneDelegate scenario).

**`KlaviyoSwiftEnvironment.swift`**
- `injectNotificationDelegate` — calls `injectIfEnabled()` on the main actor; wired into `initialize(with:)`.
- `isAutomaticPushTrackingEnabled` — reads `klaviyo_automatic_push_tracking` plist key in production; stubbable in tests.
- `notificationCenter` — returns `UNUserNotificationCenter.current()` in production; stubbable in tests.

**`Klaviyo.swift`** — one-liner: calls `klaviyoSwiftEnvironment.injectNotificationDelegate()` from `initialize(with:)`.

**`KlaviyoNotificationDelegateTests.swift`** — 6 automated tests via `MockNotificationCenter`:
- `initialize(with:)` calls `injectNotificationDelegate` exactly once
- No-op when tracking is disabled (plist gate)
- Proxy set as delegate after injection
- Prior delegate captured as `existingDelegate`
- Idempotent on repeated calls
- KVO observer re-installs proxy after host reassignment

> **Note:** The `klaviyo_automatic_push_tracking` plist key itself (key present + `true` → injection runs) is verified manually in the example app — `Bundle.main` in the SPM test runner never carries it.

## Test Plan

1. Build: `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"`
2. Tests: `make test-library`
3. Manual — in `SPMExample` with `klaviyo_automatic_push_tracking = YES` in Info.plist:
   - Cold launch → breakpoint in `inject(into:)` should hit at `initialize(with:)` time
   - Add a second `UNUserNotificationCenter.delegate` assignment in `SceneDelegate` → proxy should be re-installed (verify via breakpoint in KVO closure)
   - Remove plist key → breakpoint should not hit

## Related Issues/Tickets

Partially addresses MAGE-657
Blocked by MAGE-649 ✅
Blocks MAGE-659, MAGE-660, MAGE-661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification delegate injection now occurs during SDK initialization.
  * Automatic push tracking is controllable via Info.plist.
  * Delegate handling preserves the app's existing delegate and automatically re-injects the proxy if the app overwrites it.

* **Tests**
  * Added comprehensive tests for injection wiring, disabled-tracking behavior, idempotence, prior-delegate forwarding, and re-injection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klaviyo/klaviyo-swift-sdk/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->