### PR TITLE
feat(KlaviyoCore): AuthTokenManager proactive refresh scheduling (MAGE-625)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew Balmer on 2026-05-14.
 //
 
+import Combine
 import Foundation
 import OSLog
 
@@ -62,7 +63,46 @@ package actor AuthTokenManager {
     /// task is present without its id, or vice versa.
     private var inFlight: (id: UUID, task: Task<String, Error>)?
 
-    package init() {}
+    /// Sleep-and-refresh task that fires at ``refreshAtWallClock``. Cancelled
+    /// and replaced when a new token is acquired (chaining), when
+    /// ``registerProvider(_:)`` runs, or when the foreground transition handler
+    /// detects that the wall-clock target has already passed.
+    private var refreshTask: Task<Void, Never>?
+
+    /// Absolute wall-clock target for the next proactive refresh, or `nil` when
+    /// no refresh is scheduled. Stored as an absolute `Date` rather than a
+    /// duration so the sleep loop can re-check against the *current* clock on
+    /// every wakeup — `Task.sleep` drifts during backgrounding, so trusting the
+    /// elapsed-sleep duration alone would fire late.
+    private var refreshAtWallClock: Date?
+
+    /// Long-lived task that consumes the lifecycle event stream and dispatches
+    /// foreground transitions to ``handleForegroundTransition()``. Bound to the
+    /// actor's lifetime (started in ``init`` and survives ``registerProvider(_:)``).
+    private var lifecycleObserverTask: Task<Void, Never>?
+
+    /// Lifecycle event source. Injected for testability; defaults to the
+    /// SDK-wide `environment.appLifeCycle`.
+    private let lifeCycle: AppLifeCycleEvents
+
+    /// Wall-clock source. Injected for testability; defaults to the SDK-wide
+    /// `environment.date` closure. Used by both cached-token validity checks
+    /// and the proactive-refresh scheduling formula so a single time source
+    /// drives every clock-sensitive decision the actor makes.
+    private let currentDate: () -> Date
+
+    /// - Parameters:
+    ///   - lifeCycle: Source of foreground/background events. Defaults to
+    ///     `environment.appLifeCycle`.
+    ///   - currentDate: Wall-clock source. Defaults to `environment.date`.
+    package init(
+        lifeCycle: AppLifeCycleEvents = environment.appLifeCycle,
+        currentDate: @escaping () -> Date = { environment.date() }
+    ) {
+        self.lifeCycle = lifeCycle
+        self.currentDate = currentDate
+        Task { await self.startLifecycleObserver() }
+    }
 
     /// Registers a new provider, discards any cached token from a previous
     /// provider, cancels any in-flight fetch, and triggers an eager fetch to
@@ -75,6 +115,9 @@ package actor AuthTokenManager {
     package func registerProvider(_ newProvider: @escaping AuthTokenProvider) async {
         inFlight?.task.cancel()
         inFlight = nil
+        refreshTask?.cancel()
+        refreshTask = nil
+        refreshAtWallClock = nil
         cachedToken = nil
         provider = newProvider
 
@@ -171,6 +214,7 @@ package actor AuthTokenManager {
             switch JWTParser.parseAndValidate(rawToken) {
             case let .success(validated):
                 cachedToken = validated
+                scheduleRefresh(for: validated)
                 if #available(iOS 14.0, *) {
                     Logger.auth.info(
                         """
@@ -202,6 +246,191 @@ package actor AuthTokenManager {
                 )
             }
             throw error
+        }
+    }
+
+    /// Computes the wall-clock target for the proactive refresh of `token`.
+    ///
+    /// The ideal target is `iat + 0.9 * (exp - iat)` — fire when 90% of the
+    /// token's lifetime has elapsed. That target is clamped to the window
+    /// `[now + 5s, exp - JWTParser.defaultLeeway]`:
+    ///
+    /// - The upper bound matches the same skew window ``JWTParser`` uses for
+    ///   the expiry check, so the refresh fires before the cache itself would
+    ///   be considered stale.
+    /// - The lower bound prevents tight refresh loops when a token is
+    ///   acquired very close to its own expiration (e.g., a server returned a
+    ///   short-lived token, or the system clock jumped forward).
+    ///
+    /// Pulled out as a static pure function so tests can verify the formula
+    /// and clamps directly, without driving the full schedule-and-sleep
+    /// lifecycle.
+    static func refreshTarget(for token: ValidatedToken, currentDate: Date) -> Date {
+        let total = token.expiresAt.timeIntervalSince(token.issuedAt)
+        let ideal = token.issuedAt.addingTimeInterval(0.9 * total)
+        let upperBound = token.expiresAt.addingTimeInterval(-JWTParser.defaultLeeway)
+        let lowerBound = currentDate.addingTimeInterval(5)
+        return max(lowerBound, min(ideal, upperBound))
+    }
+
+    /// Schedules a proactive refresh for `token`. Cancels any prior
+    /// ``refreshTask`` so chained refreshes (success → schedule next) and
+    /// provider swaps don't leak overlapping schedules.
+    private func scheduleRefresh(for token: ValidatedToken) {
+        let target = Self.refreshTarget(for: token, currentDate: currentDate())
+
+        refreshTask?.cancel()
+        refreshAtWallClock = target
+        refreshTask = Task { [weak self] in
+            await self?.sleepUntilAndRefresh(target: target)
+        }
+
+        if #available(iOS 14.0, *) {
+            Logger.auth.info(
+                "AuthTokenManager: refresh scheduled (target=\(target, privacy: .private))"
+            )
+        }
+    }
+
+    /// Sleeps until `target` wall-clock time, then fires
+    /// ``performScheduledRefresh()``. The loop re-reads ``now()`` on every
+    /// wakeup rather than trusting that `Task.sleep` slept the full requested
+    /// duration: when the app is backgrounded, wall time advances but
+    /// `Task.sleep` does not, so a single sleep would fire late by exactly the
+    /// backgrounded duration. Re-checking the clock self-corrects — the next
+    /// wakeup observes the post-jump time and exits.
+    ///
+    /// Not a polling loop. Each iteration sleeps the *full* remaining
+    /// duration, so in the happy path the body runs at most ~2–3 times across
+    /// the entire scheduled window (one long sleep, then a final short
+    /// iteration that observes `remaining <= 0` and breaks).
+    private func sleepUntilAndRefresh(target: Date) async {
+        while !Task.isCancelled {
+            let remaining = target.timeIntervalSince(currentDate())
+            if remaining <= 0 { break }
+            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+        }
+        guard !Task.isCancelled else { return }
+        refreshAtWallClock = nil
+        await performScheduledRefresh()
+    }
+
+    /// Fires a proactive refresh by routing through the same dedup slot that
+    /// user-driven ``currentToken(mode:)`` callers use. If a fetch is already
+    /// in flight (e.g., a form-display caller raced ahead of the scheduled
+    /// wakeup), this awaits that fetch instead of kicking off a second.
+    ///
+    /// On success: ``runFetch`` has already written the new token to the cache
+    /// *and* scheduled the next refresh (via the wiring inside that method).
+    /// On failure: leaves the cached token in place — the cache only goes
+    /// stale at `exp - leeway`, so a foreground transition or user fetch
+    /// before then will retry. Connectivity-driven retry is owned by MAGE-683.
+    private func performScheduledRefresh() async {
+        guard provider != nil else { return }
+        let task = inFlight?.task ?? startFetch()
+        do {
+            _ = try await task.value
+            if #available(iOS 14.0, *) {
+                Logger.auth.info("AuthTokenManager: refresh succeeded")
+            }
+            // Hook for MAGE-626: emit refresh-stream notification to live
+            // consumers here.
+        } catch {
+            if #available(iOS 14.0, *) {
+                let reason = String(describing: error)
+                Logger.auth.warning(
+                    "AuthTokenManager: refresh failed: \(reason, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    /// Starts the long-lived ``lifecycleObserverTask`` that drives
+    /// ``handleForegroundTransition()`` on each `.foregrounded` event. Idempotent:
+    /// no-op if the observer is already running, so retry-on-restart paths can
+    /// call this safely.
+    private func startLifecycleObserver() {
+        guard lifecycleObserverTask == nil else { return }
+        lifecycleObserverTask = Task { [weak self] in
+            guard let stream = await self?.makeLifecycleStream() else { return }
+            for await event in stream {
+                guard case .foregrounded = event else { continue }
+                await self?.handleForegroundTransition()
+            }
+        }
+    }
+
+    /// Bridges the Combine-backed ``AppLifeCycleEvents`` publisher into an
+    /// `AsyncStream`. iOS 15+ uses `Publisher.values`; iOS 13/14 falls back to
+    /// `sink`-into-continuation (the pattern already established by
+    /// `LifecycleObserver` in `KlaviyoForms`). The wrapping `AsyncStream` keeps
+    /// the consumer call site homogeneous, and when the SDK eventually bumps
+    /// its iOS minimum to 15 the `else` branch is a clean delete.
+    private func makeLifecycleStream() -> AsyncStream<LifeCycleEvents> {
+        let publisher = lifeCycle.lifeCycleEvents()
+        return AsyncStream { continuation in
+            if #available(iOS 15.0, *) {
+                let task = Task {
+                    for await event in publisher.values {
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            } else {
+                let cancellable = publisher.sink { event in
+                    continuation.yield(event)
+                }
+                continuation.onTermination = { _ in cancellable.cancel() }
+            }
+        }
+    }
+
+    /// Reconciles cache and scheduled-refresh state with wall-clock time when
+    /// the app returns to the foreground. `Task.sleep` does not advance during
+    /// backgrounding, so any scheduled refresh whose target fell inside the
+    /// background window will not have fired yet — and a sufficiently long
+    /// background window can outlive the cached token entirely.
+    ///
+    /// Three cases, in this order:
+    /// 1. Cached token expired during backgrounding — clear cache, cancel any
+    ///    pending refresh, kick off an eager fetch so a subsequent caller
+    ///    isn't the one paying the round-trip.
+    /// 2. Scheduled refresh time has passed but the cache is still valid —
+    ///    cancel the stuck refresh task and fire the refresh immediately.
+    /// 3. Cache valid and refresh still in the future — no-op.
+    private func handleForegroundTransition() async {
+        if let cached = cachedToken, !isCachedTokenValid(cached) {
+            cachedToken = nil
+            refreshTask?.cancel()
+            refreshTask = nil
+            refreshAtWallClock = nil
+            Task { [weak self] in
+                _ = try? await self?.currentToken(mode: .background)
+            }
+            if #available(iOS 14.0, *) {
+                Logger.auth.info(
+                    "AuthTokenManager: foreground transition (case=expired-cached-token)"
+                )
+            }
+            return
+        }
+        if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
+            refreshTask?.cancel()
+            refreshTask = nil
+            refreshAtWallClock = nil
+            if #available(iOS 14.0, *) {
+                Logger.auth.info(
+                    "AuthTokenManager: foreground transition (case=missed-refresh)"
+                )
+            }
+            await performScheduledRefresh()
+            return
+        }
+        if #available(iOS 14.0, *) {
+            Logger.auth.info(
+                "AuthTokenManager: foreground transition (case=still-valid)"
+            )
         }
     }
 
@@ -246,35 +475,8 @@ package actor AuthTokenManager {
 
     /// `true` when the cached token's `exp` is still in the future after applying
     /// the same clock-skew leeway ``JWTParser`` uses on acquisition.
-    private func isCachedTokenValid(_ token: ValidatedToken, currentTime: Date = Date()) -> Bool {
+    private func isCachedTokenValid(_ token: ValidatedToken) -> Bool {
         let expiresAtSeconds = token.expiresAt.timeIntervalSince1970
-        return currentTime.timeIntervalSince1970 < expiresAtSeconds - JWTParser.defaultLeeway
-    }
-}
-
-/// Serializes the first of two concurrent producers onto a `CheckedContinuation`
-/// so that the loser's resume becomes a no-op. Used by ``AuthTokenManager`` to
-/// race the in-flight fetch against a timeout without leaning on
-/// `withThrowingTaskGroup` (which would block on the loser even after the
-/// winner has resolved).
-private actor OnceResolver<T> {
-    private var resumed = false
-    private let continuation: CheckedContinuation<T, Error>
-
-    init(_ continuation: CheckedContinuation<T, Error>) {
-        self.continuation = continuation
-    }
-
-    /// - Returns: `true` if this call won the race and resumed the continuation;
-    ///   `false` if the continuation was already resumed by an earlier call.
-    @discardableResult
-    func resolve(_ result: Result<T, Error>) -> Bool {
-        guard !resumed else { return false }
-        resumed = true
-        switch result {
-        case let .success(value): continuation.resume(returning: value)
-        case let .failure(error): continuation.resume(throwing: error)
-        }
-        return true
+        return currentDate().timeIntervalSince1970 < expiresAtSeconds - JWTParser.defaultLeeway
     }
 }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,10 +76,10 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
-    /// Long-lived task that consumes the lifecycle event stream and dispatches
-    /// foreground transitions to ``handleForegroundTransition()``. Bound to the
-    /// actor's lifetime (started in ``init`` and survives ``registerProvider(_:)``).
-    private var lifecycleObserverTask: Task<Void, Never>?
+    /// Long-lived Combine subscription that dispatches foreground transitions to
+    /// ``handleForegroundTransition()``. Bound to the actor's lifetime (started in
+    /// ``init`` and survives ``registerProvider(_:)``).
+    private var lifecycleCancellable: AnyCancellable?
 
     /// Lifecycle event source. Injected for testability; defaults to the
     /// SDK-wide `environment.appLifeCycle`.
@@ -345,45 +345,23 @@ package actor AuthTokenManager {
         }
     }
 
-    /// Starts the long-lived ``lifecycleObserverTask`` that drives
+    /// Starts the long-lived Combine subscription that drives
     /// ``handleForegroundTransition()`` on each `.foregrounded` event. Idempotent:
     /// no-op if the observer is already running, so retry-on-restart paths can
     /// call this safely.
+    ///
+    /// The `sink` closure is non-isolated, so each event hops back onto the actor
+    /// via an unstructured `Task`. Foreground events are not bursty (a
+    /// `.foregrounded` is always preceded by a `.backgrounded`), and the actor
+    /// already serializes the state `handleForegroundTransition()` touches, so the
+    /// lack of cross-event ordering between those tasks is immaterial.
     private func startLifecycleObserver() {
-        guard lifecycleObserverTask == nil else { return }
-        lifecycleObserverTask = Task { [weak self] in
-            guard let stream = await self?.makeLifecycleStream() else { return }
-            for await event in stream {
-                guard case .foregrounded = event else { continue }
-                await self?.handleForegroundTransition()
+        guard lifecycleCancellable == nil else { return }
+        lifecycleCancellable = lifeCycle.lifeCycleEvents()
+            .sink { [weak self] event in
+                guard case .foregrounded = event else { return }
+                Task { await self?.handleForegroundTransition() }
             }
-        }
-    }
-
-    /// Bridges the Combine-backed ``AppLifeCycleEvents`` publisher into an
-    /// `AsyncStream`. iOS 15+ uses `Publisher.values`; iOS 13/14 falls back to
-    /// `sink`-into-continuation (the pattern already established by
-    /// `LifecycleObserver` in `KlaviyoForms`). The wrapping `AsyncStream` keeps
-    /// the consumer call site homogeneous, and when the SDK eventually bumps
-    /// its iOS minimum to 15 the `else` branch is a clean delete.
-    private func makeLifecycleStream() -> AsyncStream<LifeCycleEvents> {
-        let publisher = lifeCycle.lifeCycleEvents()
-        return AsyncStream { continuation in
-            if #available(iOS 15.0, *) {
-                let task = Task {
-                    for await event in publisher.values {
-                        continuation.yield(event)
-                    }
-                    continuation.finish()
-                }
-                continuation.onTermination = { _ in task.cancel() }
-            } else {
-                let cancellable = publisher.sink { event in
-                    continuation.yield(event)
-                }
-                continuation.onTermination = { _ in cancellable.cancel() }
-            }
-        }
     }
 
     /// Reconciles cache and scheduled-refresh state with wall-clock time when

--- a/Sources/KlaviyoCore/Auth/OnceResolver.swift
+++ b/Sources/KlaviyoCore/Auth/OnceResolver.swift
@@ -1,0 +1,36 @@
+//
+//  OnceResolver.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-14.
+//
+
+import Foundation
+
+/// Serializes the first of two concurrent producers onto a
+/// `CheckedContinuation` so that the loser's resume becomes a no-op. Used by
+/// ``AuthTokenManager`` to race the in-flight fetch against a timeout without
+/// leaning on `withThrowingTaskGroup` (which would block on the loser even
+/// after the winner has resolved).
+actor OnceResolver<T> {
+    private var resumed = false
+    private let continuation: CheckedContinuation<T, Error>
+
+    init(_ continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    /// - Returns: `true` if this call won the race and resumed the
+    ///   continuation; `false` if the continuation was already resumed by an
+    ///   earlier call.
+    @discardableResult
+    func resolve(_ result: Result<T, Error>) -> Bool {
+        guard !resumed else { return false }
+        resumed = true
+        switch result {
+        case let .success(value): continuation.resume(returning: value)
+        case let .failure(error): continuation.resume(throwing: error)
+        }
+        return true
+    }
+}

--- a/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
@@ -1,0 +1,109 @@
+//
+//  AuthTestHelpers.swift
+//  KlaviyoCore
+//
+//  Shared fixtures for ``AuthTokenManager`` test suites: JWT minting,
+//  deterministic clock injection, and async-coordination primitives.
+//
+
+@testable import KlaviyoCore
+import Foundation
+
+// MARK: - JWT minting
+
+/// Builds a JWT with default `iat` slightly in the past and `exp` an hour
+/// ahead so it passes ``JWTParser`` validation in the present.
+func makeJWT(
+    issuedAt: TimeInterval? = nil,
+    expiresAt: TimeInterval? = nil,
+    extraClaims: [String: Any] = [:]
+) throws -> String {
+    let nowSeconds = Date().timeIntervalSince1970
+    let issuedAtSeconds = issuedAt ?? (nowSeconds - 60)
+    let expiresAtSeconds = expiresAt ?? (nowSeconds + 3600)
+
+    var payload: [String: Any] = extraClaims
+    payload["iat"] = issuedAtSeconds
+    payload["exp"] = expiresAtSeconds
+
+    let header: [String: Any] = ["alg": "HS256", "typ": "JWT"]
+    let headerSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: header))
+    let payloadSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: payload))
+    return "\(headerSeg).\(payloadSeg).signature"
+}
+
+private func base64URLEncode(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+// MARK: - Concurrency primitives
+
+/// One-shot async gate. ``wait()`` suspends until ``open()`` is called; once
+/// open it stays open. Used to interleave a provider's resumption with other
+/// operations in deterministic order.
+actor Latch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        for waiter in waiters {
+            waiter.resume()
+        }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+/// Counts provider invocations and lets tests await a specific call count
+/// without sleeping. Every increment resumes any waiters whose threshold the
+/// new value has reached, so tests block only as long as necessary.
+actor CallCounter {
+    private(set) var value = 0
+    private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func increment() {
+        value += 1
+        waiters = waiters.compactMap { waiter in
+            if value >= waiter.threshold {
+                waiter.continuation.resume()
+                return nil
+            }
+            return waiter
+        }
+    }
+
+    func waitFor(atLeast threshold: Int) async throws {
+        if value >= threshold { return }
+        await withCheckedContinuation { continuation in
+            waiters.append((threshold, continuation))
+        }
+    }
+}
+
+/// Mutable token holder used to change a registered provider's return value
+/// over time without re-registering (re-registration would clear the cache
+/// and defeat tests that depend on a warm cache).
+actor TokenBox {
+    private(set) var value: String
+
+    init(_ initial: String) {
+        value = initial
+    }
+
+    func set(_ token: String) {
+        value = token
+    }
+}
+
+enum ProviderTestError: Error, Equatable {
+    case network
+}

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1,0 +1,276 @@
+//
+//  AuthTokenManagerRefreshTests.swift
+//  KlaviyoCore
+//
+//  Created by Andrew Balmer on 2026-05-29.
+//
+
+@testable import KlaviyoCore
+import Combine
+import Foundation
+
+#if canImport(Testing)
+import Testing
+
+@Suite
+struct AuthTokenManagerRefreshTests {
+    // MARK: - Scheduling formula (pure-function tests, no real time)
+
+    @Test
+    func refreshTargetLandsAt90PercentOfTokenLifetime() {
+        // issued=1000, expires=1200 → 200s lifetime → ideal target at 1180.
+        // Lifetime is large enough that the upper clamp (exp-30=1170) and the
+        // lower clamp (now+5=1005) are both satisfied by the ideal point.
+        // But wait: ideal=1180 > upper=1170, so the upper clamp wins → 1170.
+        let issued = Date(timeIntervalSince1970: 1000)
+        let expires = Date(timeIntervalSince1970: 1200)
+        let token = ValidatedToken(rawToken: "ignored", expiresAt: expires, issuedAt: issued)
+
+        let target = AuthTokenManager.refreshTarget(for: token, currentDate: issued)
+
+        // The 0.9-of-lifetime point lands past `exp - leeway`, so the upper
+        // clamp takes effect.
+        #expect(target == Date(timeIntervalSince1970: 1170))
+    }
+
+    @Test
+    func refreshTargetUsesIdealPointWhenInsideClamps() {
+        // Need ideal target inside `[now + 5, exp - 30]`. A 1-hour token gives
+        // plenty of room: issued=1000, expires=4600 (3600s lifetime) → ideal
+        // at 1000 + 0.9*3600 = 4240. Upper=4570, lower=1005. Ideal is
+        // comfortably between, so no clamp fires.
+        let issued = Date(timeIntervalSince1970: 1000)
+        let expires = Date(timeIntervalSince1970: 4600)
+        let token = ValidatedToken(rawToken: "ignored", expiresAt: expires, issuedAt: issued)
+
+        let target = AuthTokenManager.refreshTarget(for: token, currentDate: issued)
+
+        #expect(target == Date(timeIntervalSince1970: 4240))
+    }
+
+    @Test
+    func refreshTargetClampsToExpMinusLeewayWhenIdealExceedsUpperBound() {
+        // Short-lifetime token where 0.9 of lifetime overshoots `exp - 30s`.
+        // issued=0, expires=100, ideal=90, upper=70, lower=5 → target = 70.
+        let issued = Date(timeIntervalSince1970: 0)
+        let expires = Date(timeIntervalSince1970: 100)
+        let token = ValidatedToken(rawToken: "ignored", expiresAt: expires, issuedAt: issued)
+
+        let target = AuthTokenManager.refreshTarget(for: token, currentDate: issued)
+
+        #expect(target == Date(timeIntervalSince1970: 70))
+    }
+
+    @Test
+    func refreshTargetClampsToNowPlusFiveWhenIdealAlreadyPast() {
+        // Token issued in the deep past — ideal target is behind us. The
+        // lower clamp should bump it to `now + 5s` so the refresh task doesn't
+        // spin-loop. now=1000, issued=0, expires=10 → ideal=9, upper=-20,
+        // lower=1005. The min(ideal, upper) = -20 is way past, so
+        // max(lower, that) = 1005.
+        let issued = Date(timeIntervalSince1970: 0)
+        let expires = Date(timeIntervalSince1970: 10)
+        let currentDate = Date(timeIntervalSince1970: 1000)
+        let token = ValidatedToken(rawToken: "ignored", expiresAt: expires, issuedAt: issued)
+
+        let target = AuthTokenManager.refreshTarget(for: token, currentDate: currentDate)
+
+        #expect(target == Date(timeIntervalSince1970: 1005))
+    }
+
+    // MARK: - Refresh fires (real-time, end-to-end)
+
+    @Test
+    func refreshFiresAtScheduledTimeAndChainsNextSchedule() async throws {
+        // Token lifetime is chosen so the refresh target lands at the lower
+        // clamp (now + 5s). The token must still validate against JWTParser,
+        // which requires `now < exp - 30s`, so exp must be at least ~31s out.
+        // exp=now+40 gives a ~10s validation window for test startup latency.
+        // iat=now-60, exp=now+40 → 100s lifetime, ideal=now+30, upper=now+10,
+        // lower=now+5 → max(now+5, min(now+30, now+10)) = now+10.
+        let nowSeconds = Date().timeIntervalSince1970
+        let firstToken = try makeJWT(
+            issuedAt: nowSeconds - 60,
+            expiresAt: nowSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(extraClaims: ["sub": "second"])
+
+        let manager = AuthTokenManager(lifeCycle: noopLifecycle())
+        let counter = CallCounter()
+        let tokens = TokenBox(firstToken)
+
+        await manager.registerProvider {
+            await counter.increment()
+            return await tokens.value
+        }
+        try await counter.waitFor(atLeast: 1)
+
+        // Swap the provider's payload so we can observe the next fetch.
+        await tokens.set(secondToken)
+
+        // Scheduled refresh fires at ~now+10s. Wait for the second invocation.
+        try await counter.waitFor(atLeast: 2)
+
+        // The successful refresh wrote secondToken to the cache.
+        let cached = try await manager.currentToken(mode: .background)
+        #expect(cached == secondToken)
+    }
+
+    // MARK: - Foreground transitions
+
+    @Test
+    func foregroundWithStillValidTokenIsNoOp() async throws {
+        // Hour-long token; foreground transition should be a no-op (refresh
+        // is far in the future, cache is healthy). Assert by counting
+        // provider invocations: exactly one (initial fetch) is expected.
+        let validToken = try makeJWT()
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+
+        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return validToken
+        }
+        try await counter.waitFor(atLeast: 1)
+
+        lifecycleSubject.send(.foregrounded)
+
+        // No positive signal to await — yield generously and sample.
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(invocations == 1, "still-valid foreground should be a no-op, saw \(invocations) invocations")
+    }
+
+    @Test
+    func nonForegroundLifecycleEventsAreIgnored() async throws {
+        // Backgrounded/terminated/reachabilityChanged must not trigger the
+        // foreground handler.
+        let token = try makeJWT()
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+
+        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return token
+        }
+        try await counter.waitFor(atLeast: 1)
+
+        lifecycleSubject.send(.backgrounded)
+        lifecycleSubject.send(.terminated)
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(invocations == 1, "non-foreground events must be ignored, saw \(invocations)")
+    }
+
+    @Test
+    func foregroundWithExpiredCachedTokenClearsCacheAndRefetches() async throws {
+        // Token lifetime is just barely past JWTParser's 30s leeway, so it
+        // validates at acquisition but becomes "expired" (per
+        // `isCachedTokenValid`) within a couple of real seconds.
+        //
+        // iat=now-60, exp=now+31 → validates if real wall time < exp-30 = now+1.
+        // After sleeping ~2s, the cached token is stale. Sending .foregrounded
+        // then drives the "expired cached token" branch of
+        // handleForegroundTransition, which clears the cache and triggers an
+        // eager fetch via the swapped TokenBox.
+        let nowSeconds = Date().timeIntervalSince1970
+        let shortLivedToken = try makeJWT(
+            issuedAt: nowSeconds - 60,
+            expiresAt: nowSeconds + 31,
+            extraClaims: ["sub": "expiring"]
+        )
+        let freshToken = try makeJWT(extraClaims: ["sub": "fresh"])
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let counter = CallCounter()
+        let tokens = TokenBox(shortLivedToken)
+
+        await manager.registerProvider {
+            await counter.increment()
+            return await tokens.value
+        }
+        try await counter.waitFor(atLeast: 1)
+
+        // Swap to a long-lived token and wait until the cached token has
+        // crossed the staleness threshold.
+        await tokens.set(freshToken)
+        try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
+
+        lifecycleSubject.send(.foregrounded)
+        try await counter.waitFor(atLeast: 2)
+
+        let resolved = try await manager.currentToken(mode: .background)
+        #expect(resolved == freshToken)
+    }
+
+    // MARK: - registerProvider cancellation
+
+    @Test
+    func registerProviderCancelsPriorScheduledRefresh() async throws {
+        // Acquire a short-lived token whose refresh would fire at ~now+10s,
+        // then immediately re-register with a long-lived token. Wait past
+        // where the original refresh would have fired; the original provider
+        // must not be called a second time.
+        let nowSeconds = Date().timeIntervalSince1970
+        let firstToken = try makeJWT(
+            issuedAt: nowSeconds - 60,
+            expiresAt: nowSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(extraClaims: ["sub": "second"])
+
+        let manager = AuthTokenManager(lifeCycle: noopLifecycle())
+        let firstCounter = CallCounter()
+        let secondCounter = CallCounter()
+
+        await manager.registerProvider {
+            await firstCounter.increment()
+            return firstToken
+        }
+        try await firstCounter.waitFor(atLeast: 1)
+
+        await manager.registerProvider {
+            await secondCounter.increment()
+            return secondToken
+        }
+        try await secondCounter.waitFor(atLeast: 1)
+
+        // Wait past where the original refresh would have fired (~now+10s).
+        // The default proactive timeout (5s) and the original schedule's
+        // lower-clamp (now+5s) are both below 12s, so 12s is safely past.
+        try await Task.sleep(nanoseconds: UInt64(12 * 1_000_000_000))
+
+        let firstInvocations = await firstCounter.value
+        #expect(
+            firstInvocations == 1,
+            "original provider's scheduled refresh must have been cancelled, saw \(firstInvocations)"
+        )
+    }
+
+    // MARK: - Test helpers
+
+    /// Lifecycle source that emits nothing, for tests that don't exercise the
+    /// foreground transition path. Uses an `Empty` publisher so the observer
+    /// task simply parks on the await without ever firing.
+    private func noopLifecycle() -> AppLifeCycleEvents {
+        AppLifeCycleEvents(lifeCycleEvents: { Empty().eraseToAnyPublisher() })
+    }
+}
+#endif

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -96,7 +96,7 @@ struct AuthTokenManagerRefreshTests {
         )
         let secondToken = try makeJWT(extraClaims: ["sub": "second"])
 
-        let manager = AuthTokenManager(lifeCycle: noopLifecycle())
+        let manager = makeManager(lifeCycle: noopLifecycle())
         let counter = CallCounter()
         let tokens = TokenBox(firstToken)
 
@@ -128,7 +128,7 @@ struct AuthTokenManagerRefreshTests {
         let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
 
-        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let manager = makeManager(lifeCycle: lifecycle)
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -156,7 +156,7 @@ struct AuthTokenManagerRefreshTests {
         let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
 
-        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let manager = makeManager(lifeCycle: lifecycle)
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -198,7 +198,7 @@ struct AuthTokenManagerRefreshTests {
 
         let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
-        let manager = AuthTokenManager(lifeCycle: lifecycle)
+        let manager = makeManager(lifeCycle: lifecycle)
         let counter = CallCounter()
         let tokens = TokenBox(shortLivedToken)
 
@@ -236,7 +236,7 @@ struct AuthTokenManagerRefreshTests {
         )
         let secondToken = try makeJWT(extraClaims: ["sub": "second"])
 
-        let manager = AuthTokenManager(lifeCycle: noopLifecycle())
+        let manager = makeManager(lifeCycle: noopLifecycle())
         let firstCounter = CallCounter()
         let secondCounter = CallCounter()
 
@@ -271,6 +271,21 @@ struct AuthTokenManagerRefreshTests {
     /// task simply parks on the await without ever firing.
     private func noopLifecycle() -> AppLifeCycleEvents {
         AppLifeCycleEvents(lifeCycleEvents: { Empty().eraseToAnyPublisher() })
+    }
+
+    /// Builds a manager pinned to the real wall-clock.
+    ///
+    /// The manager's `currentDate` defaults to the *global* `environment.date()`.
+    /// Under Swift Testing's parallel execution, sibling XCTest suites set
+    /// `environment = .test()`, whose clock is frozen to 2009
+    /// (`Date(timeIntervalSince1970: 1_234_567_890)`). Tokens here are minted
+    /// with real `Date()`, so a contaminated global clock leaves the manager
+    /// ~17 years behind the tokens — making `sleepUntilAndRefresh`'s remaining
+    /// duration astronomically large and the scheduled refresh effectively
+    /// never fire. Injecting the real clock keeps the manager's time source
+    /// consistent with the tokens and immune to that cross-suite mutation.
+    private func makeManager(lifeCycle: AppLifeCycleEvents) -> AuthTokenManager {
+        AuthTokenManager(lifeCycle: lifeCycle, currentDate: { Date() })
     }
 }
 #endif

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -319,7 +319,8 @@ struct AuthTokenManagerTests {
 
         // The success required a *new* provider invocation, which only happens
         // if the post-failure `defer` cleared `inFlight`.
-        #expect(await counter.value > failingInvocations)
+        let recoveredInvocations = await counter.value
+        #expect(recoveredInvocations > failingInvocations)
     }
 
     // MARK: - currentToken: cache integrity across provider swap


### PR DESCRIPTION
# Description

Adds proactive refresh to `AuthTokenManager` so personalized in-app forms have a fresh JWT ready before the cached one expires, without forcing form-display callers to pay the provider round-trip. Stacks on **MAGE-624** (dedup + timeouts) — targeting that branch until 624 merges to `rel/*`.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No public API changes — `AuthTokenManager` is `package`. The new `init` parameters (`lifeCycle`, `currentDate`) default to the existing `environment` closures, so `AuthTokenManager.shared` and all current call sites are unaffected.

## Changelog / Code Overview

**Refresh scheduling**
- Target: `iat + 0.9 * (exp - iat)`, clamped to `[now + 5s, exp - JWTParser.defaultLeeway]`. The upper clamp matches the same skew window `JWTParser` uses for the expiry check, so refresh fires before the cache itself would be considered stale. The lower clamp prevents tight refresh loops when a token is acquired close to its own expiration.
- Extracted as a static pure function `AuthTokenManager.refreshTarget(for:currentDate:)` so tests can verify the formula and clamps directly without driving the full schedule-and-sleep lifecycle.

**Wall-clock-aware sleep loop**
- `refreshAtWallClock: Date?` stores the absolute target; the loop re-reads `currentDate()` on every wakeup rather than trusting `Task.sleep`'s elapsed duration. Self-corrects automatically after backgrounding.

**Foreground transition handler**
Triages three cases on each `.foregrounded` event:
1. **Expired cached token** — clear cache, cancel refresh, kick off eager fetch.
2. **Missed scheduled refresh** — cancel stuck refresh task, fire immediately.
3. **Still valid** — no-op.

**Lifecycle observer**
Bridges `AppLifeCycleEvents`'s Combine publisher into an `AsyncStream`:
- iOS 15+: `Publisher.values` (cleanest path).
- iOS 13/14: `AsyncStream + sink` fallback, mirroring the pattern established by `LifecycleObserver` in KlaviyoForms.
- The wrapping `AsyncStream` keeps the consumer call site homogeneous; when the SDK eventually bumps its iOS minimum to 15 the `else` branch is a clean delete.

**Dedup sharing**
`performScheduledRefresh()` routes through the same `inFlight` slot that user-driven `currentToken(mode:)` callers use, so concurrent demand + the scheduled refresh collapse onto a single provider invocation.

**Logging**
All new OSLog lines gated `@available(iOS 14.0, *)`. Refresh failures log at `warning`, not `error` — the cached token remains valid until `exp - leeway`, and a foreground transition or user fetch will retry naturally.

**Out of scope**
- `ConnectivityMonitoring` and network-failure retry → MAGE-683
- Public refresh-stream notification API → MAGE-626 (a placeholder comment marks where the hook will live)
- `clearTokenState()` and profile-reset interaction → MAGE-626

**Scaffolding note**
MAGE-623 intentionally deferred the refresh-related actor properties (`refreshTask`, `refreshAtWallClock`, `lifecycleObserverTask`, `lifeCycle` injection) to this ticket so the design decisions land alongside the implementation that uses them.

## Test Plan

**Automated** — 9 new tests in `AuthTokenManagerRefreshTests.swift`, all passing alongside the 38 existing auth/JWT tests.

Pure-function tests (no real time):
- [x] `refreshTargetLandsAt90PercentOfTokenLifetime` — happy-path 90%-of-lifetime calculation.
- [x] `refreshTargetUsesIdealPointWhenInsideClamps` — neither clamp fires.
- [x] `refreshTargetClampsToExpMinusLeewayWhenIdealExceedsUpperBound` — upper clamp.
- [x] `refreshTargetClampsToNowPlusFiveWhenIdealAlreadyPast` — lower clamp.

Integration tests (real time):
- [x] `refreshFiresAtScheduledTimeAndChainsNextSchedule` — scheduled refresh fires, replaces cache, chains next schedule.
- [x] `foregroundWithStillValidTokenIsNoOp` — no extra provider invocation when cache is healthy.
- [x] `nonForegroundLifecycleEventsAreIgnored` — backgrounded/terminated/reachabilityChanged don't trigger the handler.
- [x] `foregroundWithExpiredCachedTokenClearsCacheAndRefetches` — case A of the foreground handler.
- [x] `registerProviderCancelsPriorScheduledRefresh` — provider swap cancels the pending refresh task.

**Manual smoke (recommended for reviewer)**
- [ ] Integrate a test app with a short-lived JWT provider (60s lifetime). Filter `Console.app` on the `Klaviyo.auth` subsystem; verify `refresh scheduled` → `refresh succeeded` cadence at ~54s.
- [ ] Background the test app past the scheduled refresh time, then foreground. Expect `foreground transition (case=missed-refresh)` or `(case=expired-cached-token)` followed by a fresh fetch.

## Related Issues/Tickets
- Linear: [MAGE-625](https://linear.app/klaviyo/issue/MAGE-625/ios-authtokenmanager-proactive-refresh-scheduling)
- Parent: [MAGE-615](https://linear.app/klaviyo/issue/MAGE-615) (JWT support in SDK/onsite)
- Stacks on: MAGE-624 (`ab/MAGE-624/authtokenmanager-dedup-and-timeouts`)
- Follows up with: MAGE-626 (refresh stream + profile reset), MAGE-683 (connectivity retry)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable proactive token refreshes with robust handling across background/foreground transitions.
  * Prevents stale refreshes and avoids unnecessary provider calls when returning to foreground.
  * Improved token validity checks to reduce unexpected expirations.

* **Tests**
  * New deterministic tests covering refresh timing, lifecycle behavior, and re-registration scenarios.

* **Chores**
  * Consolidated and centralized authentication test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->