### PR TITLE
ci: run iOS SDK CI on pull requests to any base branch

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - '*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description

The `iOS SDK CI` workflow (`swift.yml`) only ran its build + test jobs for PRs whose **base branch** matched the glob `branches: ['*']`. In GitHub Actions branch filters, `*` matches `master` but **does not match any branch containing `/`** (`**` is required for that). So every PR stacked onto a feature or personal base — `feat/*`, `{initials}/*` — silently skipped the entire build/test matrix:

- `library-macos-14` (Xcode 15.2, 15.4)
- `library-macos-15` (Xcode 16.4)

Those stacked PRs only ran `pre-commit` and the bot scanners, giving an all-green status with **no compile or test coverage**.

### How this surfaced

Reviewing #587 (base `feat/auto-push-tracking`), the test target would fail to compile on Xcode 15.x, yet PR checks were green — because `swift.yml` never ran. `gh run list --workflow swift.yml` for that branch returns zero runs, and the status rollup contains only `pre-commit` + scanners.

## Change

Drop the `branches` filter under `pull_request:` so the workflow runs on **every** PR regardless of base branch — mirroring `pre-commit.yml`, which already does this and consequently runs everywhere. `push` remains scoped to `master`. Removing the glob also eliminates the `*`-vs-`**` foot-gun entirely.

```diff
   pull_request:
-    branches:
-      - '*'
   workflow_dispatch:
```

## Test Plan

- [ ] On this PR (base `master`), confirm `library-macos-14` / `library-macos-15` run as before — no regression on master-targeting PRs.
- [ ] Open or re-run a PR with a slashed base (e.g. a `feat/*` base) and confirm the build/test jobs now trigger.

## Notes

- `codeql.yml` has a related but **intentional** scoping (`branches: ['master', 'rel/*']`) and is left unchanged — expanding a heavy security scan to all PRs is a separate, cost-conscious decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to run on a specific branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klaviyo/klaviyo-swift-sdk/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->