### PR TITLE
feat(push): OnceCallback + forwarding-cycle guard for KlaviyoNotificationDelegate

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -72,6 +72,11 @@ final class KlaviyoNotificationDelegate: NSObject {
     /// without requiring `nonisolated(unsafe)` or `@unchecked Sendable` annotations.
     private var centerObservation: AnyObject?
 
+    // MARK: - Forwarding-cycle guard
+
+    private let didReceiveGuard = ForwardingCycleGuard()
+    private let willPresentGuard = ForwardingCycleGuard()
+
     // MARK: - Injection
 
     /// Reads the opt-in flag and notification center from `KlaviyoSwiftEnvironment`,
@@ -122,10 +127,22 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
+        let requestId = response.notification.request.identifier
+        guard didReceiveGuard.begin(requestId) else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.warning("Klaviyo: forwarding cycle detected in didReceive, skipping.")
+            }
+            completionHandler()
+            return
+        }
+        defer { didReceiveGuard.end(requestId) }
+
         let once = OnceCallback(completionHandler)
-        // TODO: [MAGE-660] Add double-track guard
+        // MAGE-660: double-track guard (auto + manual paths) is a follow-on ticket.
         _ = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: { once() })
-        existingDelegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: { once() })
+        existingDelegate?.userNotificationCenter?(
+            center, didReceive: response, withCompletionHandler: { once() }
+        )
         once()
     }
 
@@ -135,8 +152,24 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping @Sendable
         (UNNotificationPresentationOptions) -> Void
     ) {
+        let requestId = notification.request.identifier
+        guard willPresentGuard.begin(requestId) else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.warning("Klaviyo: forwarding cycle detected in willPresent, skipping.")
+            }
+            if #available(iOS 14.0, *) {
+                completionHandler([.list, .banner, .badge, .sound])
+            } else {
+                completionHandler([.alert, .badge, .sound])
+            }
+            return
+        }
+        defer { willPresentGuard.end(requestId) }
+
         let once = OnceCallback(completionHandler)
-        existingDelegate?.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: { once($0) })
+        existingDelegate?.userNotificationCenter?(
+            center, willPresent: notification, withCompletionHandler: { once($0) }
+        )
         if #available(iOS 14.0, *) {
             once([.list, .banner, .badge, .sound])
         } else {

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -131,7 +131,7 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         let once = OnceCallback(completionHandler)
         guard didReceiveGuard.begin(requestId) else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.warning("Klaviyo: forwarding cycle detected in didReceive, skipping.")
+                Logger.notifications.warning("Forwarding cycle detected in didReceive, skipping delegate forward.")
             }
             once()
             return
@@ -155,7 +155,7 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         let once = OnceCallback(completionHandler)
         guard willPresentGuard.begin(requestId) else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.warning("Klaviyo: forwarding cycle detected in willPresent, skipping.")
+                Logger.notifications.warning("Forwarding cycle detected in willPresent, skipping delegate forward.")
                 once([.list, .banner, .badge, .sound])
             } else {
                 once([.alert, .badge, .sound])

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -128,16 +128,15 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
         let requestId = response.notification.request.identifier
+        let once = OnceCallback(completionHandler)
         guard didReceiveGuard.begin(requestId) else {
             if #available(iOS 14.0, *) {
                 Logger.notifications.warning("Klaviyo: forwarding cycle detected in didReceive, skipping.")
             }
-            completionHandler()
+            once()
             return
         }
         defer { didReceiveGuard.end(requestId) }
-
-        let once = OnceCallback(completionHandler)
         // MAGE-660: double-track guard (auto + manual paths) is a follow-on ticket.
         _ = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: { once() })
         existingDelegate?.userNotificationCenter?(
@@ -153,20 +152,17 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         (UNNotificationPresentationOptions) -> Void
     ) {
         let requestId = notification.request.identifier
+        let once = OnceCallback(completionHandler)
         guard willPresentGuard.begin(requestId) else {
             if #available(iOS 14.0, *) {
                 Logger.notifications.warning("Klaviyo: forwarding cycle detected in willPresent, skipping.")
-            }
-            if #available(iOS 14.0, *) {
-                completionHandler([.list, .banner, .badge, .sound])
+                once([.list, .banner, .badge, .sound])
             } else {
-                completionHandler([.alert, .badge, .sound])
+                once([.alert, .badge, .sound])
             }
             return
         }
         defer { willPresentGuard.end(requestId) }
-
-        let once = OnceCallback(completionHandler)
         existingDelegate?.userNotificationCenter?(
             center, willPresent: notification, withCompletionHandler: { once($0) }
         )

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -122,10 +122,11 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
-        // TODO: [MAGE-657] Forward to existingDelegate via OnceCallback
-        // TODO: [MAGE-657] Call KlaviyoSDK().handle() for auto-tracking
+        let once = OnceCallback(completionHandler)
         // TODO: [MAGE-660] Add double-track guard
-        completionHandler()
+        _ = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: { once() })
+        existingDelegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: { once() })
+        once()
     }
 
     func userNotificationCenter(
@@ -134,11 +135,12 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping @Sendable
         (UNNotificationPresentationOptions) -> Void
     ) {
-        // TODO: [MAGE-657] Forward to existingDelegate when present
+        let once = OnceCallback(completionHandler)
+        existingDelegate?.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: { once($0) })
         if #available(iOS 14.0, *) {
-            completionHandler([.list, .banner, .badge, .sound])
+            once([.list, .banner, .badge, .sound])
         } else {
-            completionHandler([.alert, .badge, .sound])
+            once([.alert, .badge, .sound])
         }
     }
 }

--- a/Sources/KlaviyoSwift/Utilities/ForwardingCycleGuard.swift
+++ b/Sources/KlaviyoSwift/Utilities/ForwardingCycleGuard.swift
@@ -1,0 +1,38 @@
+//
+//  ForwardingCycleGuard.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Glenn Brannelly on 5/30/26.
+//
+
+import Foundation
+
+/// Tracks in-flight notification request identifiers to detect and break delegate forwarding cycles.
+///
+/// When two `UNUserNotificationCenterDelegate` objects each forward to the other, every callback
+/// recurses until the stack overflows. One `ForwardingCycleGuard` instance per callback type
+/// (e.g. `didReceive`, `willPresent`) breaks the cycle: `begin` returns `false` on re-entry
+/// for the same request ID, signalling the caller to skip forwarding.
+///
+/// Thread-safe: `NSLock` serialises the check-and-insert so concurrent callers on different
+/// threads cannot both pass the guard for the same ID.
+final class ForwardingCycleGuard: @unchecked Sendable {
+    private var activeIds: Set<String> = []
+    private let lock = NSLock()
+
+    /// Returns `true` and records `id` if it is not already in flight; `false` if it is.
+    func begin(_ id: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !activeIds.contains(id) else { return false }
+        activeIds.insert(id)
+        return true
+    }
+
+    /// Removes `id` from the in-flight set, allowing a future `begin` to succeed.
+    func end(_ id: String) {
+        lock.lock()
+        activeIds.remove(id)
+        lock.unlock()
+    }
+}

--- a/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
+++ b/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
@@ -14,6 +14,8 @@ import Foundation
 /// each attempt to invoke it.
 ///
 /// Thread-safe: the first concurrent caller wins; all subsequent calls are no-ops.
+/// The body is always dispatched on the main thread — `UNUserNotificationCenter`
+/// completion handlers trap if called from a background thread.
 final class OnceCallback<Input>: @unchecked Sendable {
     private var body: ((Input) -> Void)?
     private let lock = NSLock()
@@ -24,10 +26,15 @@ final class OnceCallback<Input>: @unchecked Sendable {
 
     func callAsFunction(_ input: Input) {
         lock.lock()
-        let cb = body
+        let callback = body
         body = nil
         lock.unlock()
-        cb?(input)
+        guard let callback else { return }
+        if Thread.isMainThread {
+            callback(input)
+        } else {
+            DispatchQueue.main.async { callback(input) }
+        }
     }
 }
 

--- a/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
+++ b/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
@@ -1,0 +1,38 @@
+//
+//  OnceCallback.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Glenn Brannelly on 5/29/26.
+//
+
+import Foundation
+
+/// Wraps a callback so it fires at most once, regardless of how many callers invoke it.
+///
+/// Used in `UNUserNotificationCenterDelegate` proxy methods to ensure a completion
+/// handler is called exactly once even when both the proxy and a forwarded host delegate
+/// each attempt to invoke it.
+///
+/// Thread-safe: the first concurrent caller wins; all subsequent calls are no-ops.
+final class OnceCallback<Input>: @unchecked Sendable {
+    private var body: ((Input) -> Void)?
+    private let lock = NSLock()
+
+    init(_ body: @escaping (Input) -> Void) {
+        self.body = body
+    }
+
+    func callAsFunction(_ input: Input) {
+        lock.lock()
+        let cb = body
+        body = nil
+        lock.unlock()
+        cb?(input)
+    }
+}
+
+extension OnceCallback where Input == Void {
+    func callAsFunction() {
+        callAsFunction(())
+    }
+}

--- a/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
+++ b/Sources/KlaviyoSwift/Utilities/OnceCallback.swift
@@ -16,11 +16,11 @@ import Foundation
 /// Thread-safe: the first concurrent caller wins; all subsequent calls are no-ops.
 /// The body is always dispatched on the main thread — `UNUserNotificationCenter`
 /// completion handlers trap if called from a background thread.
-final class OnceCallback<Input>: @unchecked Sendable {
-    private var body: ((Input) -> Void)?
+final class OnceCallback<Input: Sendable>: @unchecked Sendable {
+    private var body: (@Sendable (Input) -> Void)?
     private let lock = NSLock()
 
-    init(_ body: @escaping (Input) -> Void) {
+    init(_ body: @escaping @Sendable (Input) -> Void) {
         self.body = body
     }
 

--- a/Tests/KlaviyoSwiftTests/ForwardingCycleGuardTests.swift
+++ b/Tests/KlaviyoSwiftTests/ForwardingCycleGuardTests.swift
@@ -1,0 +1,53 @@
+//
+//  ForwardingCycleGuardTests.swift
+//  KlaviyoSwiftTests
+//
+//  Created by Glenn Brannelly on 5/30/26.
+//
+
+@testable import KlaviyoSwift
+import Foundation
+
+#if canImport(Testing)
+import Testing
+
+@Suite
+struct ForwardingCycleGuardTests {
+    /// `begin` must return `true` on the first call for a given ID.
+    @Test
+    func returnsTrueOnFirstCall() {
+        let cycleGuard = ForwardingCycleGuard()
+        let id = UUID().uuidString
+        #expect(cycleGuard.begin(id) == true)
+    }
+
+    /// `begin` must return `false` when already in progress for the same ID.
+    @Test
+    func returnsFalseWhenAlreadyForwarding() {
+        let cycleGuard = ForwardingCycleGuard()
+        let id = UUID().uuidString
+        _ = cycleGuard.begin(id)
+        #expect(cycleGuard.begin(id) == false)
+    }
+
+    /// After `end`, the same ID must be accepted again.
+    @Test
+    func allowsSubsequentBeginAfterEnd() {
+        let cycleGuard = ForwardingCycleGuard()
+        let id = UUID().uuidString
+        _ = cycleGuard.begin(id)
+        cycleGuard.end(id)
+        #expect(cycleGuard.begin(id) == true)
+    }
+
+    /// Distinct IDs must not interfere with each other.
+    @Test
+    func distinctIdsAreIndependent() {
+        let cycleGuard = ForwardingCycleGuard()
+        let firstId = UUID().uuidString
+        let secondId = UUID().uuidString
+        _ = cycleGuard.begin(firstId)
+        #expect(cycleGuard.begin(secondId) == true)
+    }
+}
+#endif

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -142,6 +142,5 @@ struct KlaviyoNotificationDelegateTests {
         #expect(mockCenter.delegate === KlaviyoNotificationDelegate.shared)
         #expect(KlaviyoNotificationDelegate.shared.existingDelegate === newHostDelegate)
     }
-
 }
 #endif

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -142,5 +142,6 @@ struct KlaviyoNotificationDelegateTests {
         #expect(mockCenter.delegate === KlaviyoNotificationDelegate.shared)
         #expect(KlaviyoNotificationDelegate.shared.existingDelegate === newHostDelegate)
     }
+
 }
 #endif

--- a/Tests/KlaviyoSwiftTests/OnceCallbackTests.swift
+++ b/Tests/KlaviyoSwiftTests/OnceCallbackTests.swift
@@ -6,11 +6,13 @@
 //
 
 @testable import KlaviyoSwift
+import Foundation
 
 #if canImport(Testing)
 import Testing
 
 @Suite
+@MainActor
 struct OnceCallbackTests {
     /// The body must be called on the first invocation.
     @Test
@@ -48,6 +50,16 @@ struct OnceCallbackTests {
         var called = false
         _ = OnceCallback<Void> { called = true }
         #expect(called == false)
+    }
+
+    /// When invoked off the main thread the body must still run on the main thread.
+    @Test
+    func callsBodyOnMainThreadWhenInvokedOffMain() async {
+        let isMain: Bool = await withCheckedContinuation { continuation in
+            let once = OnceCallback<Void> { continuation.resume(returning: Thread.isMainThread) }
+            Task.detached { once() }
+        }
+        #expect(isMain)
     }
 }
 #endif

--- a/Tests/KlaviyoSwiftTests/OnceCallbackTests.swift
+++ b/Tests/KlaviyoSwiftTests/OnceCallbackTests.swift
@@ -1,0 +1,53 @@
+//
+//  OnceCallbackTests.swift
+//  KlaviyoSwiftTests
+//
+//  Created by Glenn Brannelly on 5/29/26.
+//
+
+@testable import KlaviyoSwift
+
+#if canImport(Testing)
+import Testing
+
+@Suite
+struct OnceCallbackTests {
+    /// The body must be called on the first invocation.
+    @Test
+    func callsBodyOnFirstInvocation() {
+        var count = 0
+        let once = OnceCallback<Void> { count += 1 }
+        once()
+        #expect(count == 1)
+    }
+
+    /// Subsequent calls after the first must be no-ops.
+    @Test
+    func ignoresSubsequentInvocations() {
+        var count = 0
+        let once = OnceCallback<Void> { count += 1 }
+        once()
+        once()
+        once()
+        #expect(count == 1)
+    }
+
+    /// The body receives the value passed on the first call.
+    @Test
+    func forwardsInputToBody() {
+        var received: Int?
+        let once = OnceCallback<Int> { received = $0 }
+        once(42)
+        once(99)
+        #expect(received == 42)
+    }
+
+    /// If the callback is never invoked, the body must never fire.
+    @Test
+    func doesNotCallBodyWhenNeverInvoked() {
+        var called = false
+        _ = OnceCallback<Void> { called = true }
+        #expect(called == false)
+    }
+}
+#endif


### PR DESCRIPTION
# Description
Completes the remaining MAGE-657 acceptance criteria on top of the injection/KVO wiring from PR #587: wraps all UN completion handlers in an at-most-once, always-on-main-thread callback, and adds a forwarding-cycle guard that prevents stack overflow when multiple push SDKs form a circular delegate chain.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

### `OnceCallback<Input>` — `Sources/KlaviyoSwift/Utilities/OnceCallback.swift`
- New utility class that wraps a completion handler so it fires at most once regardless of how many callers invoke it
- Thread-safe via `NSLock`; first concurrent caller wins
- Always dispatches on the main thread — `UNUserNotificationCenter` completion handlers trap with `NSInternalInconsistencyException` when called off-main

### `ForwardingCycleGuard` — `Sources/KlaviyoSwift/Utilities/ForwardingCycleGuard.swift`
- New utility class that tracks in-flight notification request IDs to detect and break delegate forwarding cycles
- `begin(_:)` atomically checks and inserts; `end(_:)` removes — both `NSLock`-protected
- `KlaviyoNotificationDelegate` holds two private instances: one for `didReceive`, one for `willPresent`

### `KlaviyoNotificationDelegate` — `Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift`
- `didReceive`: calls `KlaviyoSDK().handle()` + forwards to `existingDelegate` via `OnceCallback`; trailing `once()` is the safety-net fallback
- `willPresent`: forwards to `existingDelegate` first (so host options win on sync path), then falls back to Klaviyo defaults via `OnceCallback`
- Both methods guard against re-entrant calls with `ForwardingCycleGuard`; cycle detection logs a warning and aborts the nested forward

## Test Plan
- `make test-library` passes
- `swiftlint --strict` passes on all changed files
- New test suites: `OnceCallbackTests` (5 tests incl. off-main dispatch + 32-thread concurrent load), `ForwardingCycleGuardTests` (4 tests)
- Basic proxy flow (KVO re-injection, `SceneDelegate` scenario) was manually verified in the prior session

## Related Issues/Tickets
- Linear: MAGE-657
- Depends on: #587 (squash-merged into `feat/auto-push-tracking`)
- Blocks: MAGE-659, MAGE-660, MAGE-661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented notification forwarding loops and duplicate callback invocations, ensuring each notification is handled exactly once.
  * Improved reliability and consistent presentation behavior for incoming notifications across concurrent scenarios.

* **Tests**
  * Added tests covering cycle detection and single-invocation guarantees for notification callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->