### PR TITLE
test(KlaviyoSwift): de-flake action-button push tests (MAGE-723)

### DIFF
--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -47,7 +47,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test initialize
 
-    func testInitializeSDk() throws {
+    func testInitializeSDk() {
         let expectation = setupActionAssertion(expectedAction: .initialize(TEST_API_KEY))
 
         klaviyo.initialize(with: TEST_API_KEY)
@@ -57,7 +57,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test set proprety
 
-    func testSetFirstName() throws {
+    func testSetFirstName() {
         let expectation = setupActionAssertion(expectedAction: .setProfileProperty(.firstName, "test"))
 
         klaviyo.set(profileAttribute: .firstName, value: "test")
@@ -67,7 +67,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test set profile
 
-    func testSetProfile() throws {
+    func testSetProfile() {
         let profile = Profile(
             email: "john.smith@example.com",
             phoneNumber: "+15555551212",
@@ -83,7 +83,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test create event
 
-    func testCreateEvent() throws {
+    func testCreateEvent() {
         let event = Event(name: .openedAppMetric)
         let expectation = setupActionAssertion(expectedAction: .enqueueEvent(event))
 
@@ -92,7 +92,7 @@ class KlaviyoSDKTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testCreateEventFromDocumentation() throws {
+    func testCreateEventFromDocumentation() {
         let event = Event(name: .addedToCartMetric, properties: [
             "Total Price": 10.99,
             "Items Purchased": ["Hot Dog", "Fries", "Shake"]
@@ -106,7 +106,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test set push token
 
-    func testSetPushToken() throws {
+    func testSetPushToken() {
         let tokenData = "mytoken".data(using: .utf8)!
         let strToken = tokenData.reduce("") { $0 + String(format: "%02.2hhx", $1) }
         let expectation = setupActionAssertion(expectedAction: .setPushToken(strToken, .authorized))
@@ -118,7 +118,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test set external id
 
-    func testSetExternalId() throws {
+    func testSetExternalId() {
         let expectation = setupActionAssertion(expectedAction: .setExternalId("foo"))
 
         _ = klaviyo.set(externalId: "foo")
@@ -170,7 +170,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     // MARK: test property getters
 
-    func testPropertyGetters() throws {
+    func testPropertyGetters() {
         klaviyoSwiftEnvironment.state = { KlaviyoState(email: "foo@foo.com", phoneNumber: "555BLOB", externalId: "my_test_id", pushTokenData: .init(pushToken: "blobtoken", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.appContextInfo())), queue: []) }
         let klaviyo = KlaviyoSDK()
         XCTAssertEqual("foo@foo.com", klaviyo.email)
@@ -309,6 +309,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleActionButtonTap_DeepLinkWithAllProperties() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        let eventCaptured = XCTestExpectation(description: "opened_push event enqueued")
         let actionURL = try XCTUnwrap(URL(string: "myapp://products/123"))
         let actionId = "com.klaviyo.test.shop"
         let buttonLabel = "Shop Now"
@@ -332,6 +333,14 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            // `handle(notificationResponse:)` enqueues the event and invokes the
+            // completion handler on two *independent* unstructured Tasks, so the
+            // callback can fulfill before the event is captured. Fulfill on the
+            // captured event too and wait on both, rather than asserting on a
+            // side effect that may not have landed yet.
+            if case let .enqueueEvent(event) = action, event.metric.name == ._openedPush {
+                eventCaptured.fulfill()
+            }
             return nil
         }
 
@@ -344,7 +353,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, eventCaptured], timeout: 1.0)
         XCTAssertTrue(handled, "Should handle Klaviyo notification with action button")
 
         // Verify event was created
@@ -357,7 +366,7 @@ class KlaviyoSDKTests: XCTestCase {
         XCTAssertNotNil(eventAction, "Should create $opened_push event")
 
         // Verify event properties
-        if case let .enqueueEvent(event) = eventAction! {
+        if case let .enqueueEvent(event) = try XCTUnwrap(eventAction) {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
             XCTAssertEqual(event.properties["Button Label"] as? String, buttonLabel, "Should include Button Label")
             XCTAssertEqual(event.properties["Button ID"] as? String, actionId, "Should include Button ID")
@@ -373,6 +382,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleActionButtonTap_OpenAppWithoutURL() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        let eventCaptured = XCTestExpectation(description: "opened_push event enqueued")
         let actionId = "com.klaviyo.test.open"
         let buttonLabel = "Open App"
 
@@ -393,6 +403,14 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            // `handle(notificationResponse:)` enqueues the event and invokes the
+            // completion handler on two *independent* unstructured Tasks, so the
+            // callback can fulfill before the event is captured. Fulfill on the
+            // captured event too and wait on both, rather than asserting on a
+            // side effect that may not have landed yet.
+            if case let .enqueueEvent(event) = action, event.metric.name == ._openedPush {
+                eventCaptured.fulfill()
+            }
             return nil
         }
 
@@ -405,7 +423,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, eventCaptured], timeout: 1.0)
         XCTAssertTrue(handled)
 
         // Verify event was created
@@ -418,7 +436,7 @@ class KlaviyoSDKTests: XCTestCase {
         XCTAssertNotNil(eventAction, "Should create $opened_push event")
 
         // Verify event properties
-        if case let .enqueueEvent(event) = eventAction! {
+        if case let .enqueueEvent(event) = try XCTUnwrap(eventAction) {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
             XCTAssertEqual(event.properties["Button Label"] as? String, buttonLabel, "Should include Button Label")
             XCTAssertEqual(event.properties["Button ID"] as? String, actionId, "Should include Button ID")
@@ -429,6 +447,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleActionButtonTap_NotTriggeredOnBodyTap() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        let eventCaptured = XCTestExpectation(description: "opened_push event enqueued")
         let actionId = "com.klaviyo.test.button"
         let buttonLabel = "Tap Me"
 
@@ -448,6 +467,14 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            // `handle(notificationResponse:)` enqueues the event and invokes the
+            // completion handler on two *independent* unstructured Tasks, so the
+            // callback can fulfill before the event is captured. Fulfill on the
+            // captured event too and wait on both, rather than asserting on a
+            // side effect that may not have landed yet.
+            if case let .enqueueEvent(event) = action, event.metric.name == ._openedPush {
+                eventCaptured.fulfill()
+            }
             return nil
         }
 
@@ -461,7 +488,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, eventCaptured], timeout: 1.0)
         XCTAssertTrue(handled)
 
         // Verify event was created (for body tap)
@@ -474,7 +501,7 @@ class KlaviyoSDKTests: XCTestCase {
         XCTAssertNotNil(eventAction, "Should create $opened_push event for body tap")
 
         // Verify button properties are NOT included for body tap
-        if case let .enqueueEvent(event) = eventAction! {
+        if case let .enqueueEvent(event) = try XCTUnwrap(eventAction) {
             XCTAssertEqual(event.metric.name.value, "$opened_push", "Event name should be $opened_push")
             XCTAssertNil(event.properties["Button ID"], "Should NOT include Button ID for body tap")
             XCTAssertNil(event.properties["Button Label"], "Should NOT include Button Label for body tap")


### PR DESCRIPTION
# Description
De-flakes the three `testHandleActionButtonTap_*` push-notification tests in `KlaviyoSDKTests`, which fail intermittently on CI due to an async race. Test-only change.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.

This is a test-only change with no production or public-API impact.

## Changelog / Code Overview
`KlaviyoSDK.handle(notificationResponse:)` enqueues the `$opened_push` event and invokes the completion handler on two **independent** unstructured `Task`s, with no ordering between them. The affected tests waited only on the completion callback, then asserted on the enqueued event — so under CI load the callback could fulfill before the event was captured, and `XCTAssertNotNil(eventAction)` failed intermittently.

Fix (test-only): each test now declares an additional `XCTestExpectation` that is fulfilled from the `klaviyoSwiftEnvironment.send` hook when the `$opened_push` enqueue is observed, and waits on `[callback, eventCaptured]` instead of just the callback.

Affected tests:
- `testHandleActionButtonTap_OpenAppWithoutURL`
- `testHandleActionButtonTap_DeepLinkWithAllProperties`
- `testHandleActionButtonTap_NotTriggeredOnBodyTap`

No production code changed.

## Test Plan
- Ran the three tests in isolation, repeated 8×: all pass deterministically.
- Ran the full `KlaviyoSwiftTests` suite (228 tests): passes.
- Observed the original flake on PR #592 CI: `testHandleActionButtonTap_OpenAppWithoutURL` failed in the 16.4-debug job, then in the 16.4-release job on a later run — confirming a load-dependent race rather than a logic error.

## Related Issues/Tickets
- MAGE-723: https://linear.app/klaviyo/issue/MAGE-723/de-flake-action-button-push-notification-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of asynchronous push notification action tests with stronger ordering guarantees
  * Enhanced event verification with more robust error handling in test assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->