### PR TITLE
feat(KlaviyoForms): push refreshed auth tokens into live IAF WebView (MAGE-616)

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -176,11 +176,20 @@ class IAFPresentationManager {
     /// via ``IAFWebViewModel/pushAuthToken(_:)`` so onsite always has a fresh
     /// token — whether or not a form is currently on screen.
     ///
-    /// Bound to the WebView's lifetime, not a single form display: started here
-    /// (the single WebView-creation site) and cancelled in ``destroyWebView()``
-    /// (the single destruction site). `self` (the shared manager) is captured
-    /// weakly and re-acquired inside the loop, matching the other observer tasks.
+    /// Bound to the WebView's lifetime, not a single form display: started on
+    /// WebView creation and cancelled in ``destroyWebView()``. `self` (the shared
+    /// manager) is captured weakly and re-acquired inside the loop, matching the
+    /// other observer tasks.
+    ///
+    /// Cancels any existing task before replacing it: `viewController` can be
+    /// cleared without going through ``destroyWebView()`` (e.g. a failed
+    /// presentation in ``presentFormAsModal(viewController:)``), after which a
+    /// reinit can call this again — without this cancel the prior task's handle
+    /// would be overwritten and its `refreshes()` loop would leak (the shared
+    /// manager never deallocates, so the `[weak self]` guard never trips),
+    /// double-pushing every future token.
     private func startTokenRefreshObservation() {
+        tokenRefreshTask?.cancel()
         tokenRefreshTask = Task { [weak self] in
             let stream = await AuthTokenManager.shared.refreshes()
             for await token in stream {
@@ -484,12 +493,16 @@ class IAFPresentationManager {
     // MARK: - Cleanup & Destruction
 
     func destroyWebView() {
+        // Cancel before the guard: `viewController` may already have been cleared
+        // elsewhere (e.g. a failed presentation) while the token-refresh task is
+        // still running, so gating the cancel on `viewController` would leak it.
+        tokenRefreshTask?.cancel()
+        tokenRefreshTask = nil
+
         guard let viewController else { return }
 
         performDismiss(viewController: viewController)
 
-        tokenRefreshTask?.cancel()
-        tokenRefreshTask = nil
         self.viewController = nil
         viewModel = nil
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -36,6 +36,7 @@ class IAFPresentationManager {
 
     private var formEventTask: Task<Void, Never>?
     private var delayedPresentationTask: Task<Void, Never>?
+    private var tokenRefreshTask: Task<Void, Never>?
 
     lazy var indexHtmlFileUrl: URL? = {
         do {
@@ -166,6 +167,27 @@ class IAFPresentationManager {
         self.viewModel = viewModel
         viewController = KlaviyoWebViewController(viewModel: viewModel)
         viewController?.modalPresentationStyle = .overCurrentContext
+
+        startTokenRefreshObservation()
+    }
+
+    /// Subscribes to ``AuthTokenManager``'s proactive-refresh stream for the
+    /// lifetime of the WebView, pushing each refreshed token into the live page
+    /// via ``IAFWebViewModel/pushAuthToken(_:)`` so onsite always has a fresh
+    /// token — whether or not a form is currently on screen.
+    ///
+    /// Bound to the WebView's lifetime, not a single form display: started here
+    /// (the single WebView-creation site) and cancelled in ``destroyWebView()``
+    /// (the single destruction site). `self` (the shared manager) is captured
+    /// weakly and re-acquired inside the loop, matching the other observer tasks.
+    private func startTokenRefreshObservation() {
+        tokenRefreshTask = Task { [weak self] in
+            let stream = await AuthTokenManager.shared.refreshes()
+            for await token in stream {
+                guard let self else { return }
+                await self.viewModel?.pushAuthToken(token)
+            }
+        }
     }
 
     // MARK: - Form Lifecycle Listener Setup
@@ -466,6 +488,8 @@ class IAFPresentationManager {
 
         performDismiss(viewController: viewController)
 
+        tokenRefreshTask?.cancel()
+        tokenRefreshTask = nil
         self.viewController = nil
         viewModel = nil
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -101,7 +101,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     @MainActor
     private var authTokenWKScript: WKUserScript? {
         guard let authToken else { return nil }
-        let authTokenScript = "document.head.setAttribute('data-klaviyo-jwt', '\(authToken)');"
+        let authTokenScript = createAuthTokenScript(from: authToken)
         return WKUserScript(source: authTokenScript, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
@@ -241,6 +241,11 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     }
 
     @MainActor
+    private func createAuthTokenScript(from token: String) -> String {
+        "document.head.setAttribute('data-klaviyo-jwt', '\(token)');"
+    }
+
+    @MainActor
     private func handleProfileDataChange(_ newProfileData: ProfileData) {
         if #available(iOS 14.0, *) {
             Logger.webViewLogger.info("Attempting to update In-App Forms HTML with updated profile data")
@@ -257,6 +262,34 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Error updating In-App Forms HTML; error: \(error)")
                 }
+            }
+        }
+    }
+
+    // MARK: - Handle token refreshes
+
+    /// Pushes a refreshed auth token into the live page, updating the
+    /// `data-klaviyo-jwt` head attribute so onsite re-reads the new token without
+    /// a reload. Driven by ``IAFPresentationManager``'s refresh subscription,
+    /// which owns the `AuthTokenManager.refreshes()` stream for the WebView's
+    /// lifetime; this method is the per-token push, mirroring ``pushDeviceInfo()``.
+    ///
+    /// `async` so the caller can await it and apply refreshes in arrival order.
+    /// The token value is never logged — only the success/failure of the update.
+    @MainActor
+    func pushAuthToken(_ token: String) async {
+        if #available(iOS 14.0, *) {
+            Logger.webViewLogger.info("Auth token refreshed; updating In-App Forms HTML")
+        }
+        let authTokenScript = createAuthTokenScript(from: token)
+        do {
+            _ = try await delegate?.evaluateJavaScript(authTokenScript)
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Successfully updated In-App Forms HTML with refreshed auth token")
+            }
+        } catch {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("Error updating In-App Forms HTML with refreshed auth token; error: \(error)")
             }
         }
     }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -11,8 +11,8 @@ import KlaviyoCore
 import WebKit
 import XCTest
 
-// Test-specific subclass that overrides navigation policy to allow all navigation
-// This is required to get these unit tests to pass
+/// Test-specific subclass that overrides navigation policy to allow all navigation
+/// This is required to get these unit tests to pass
 private class TestKlaviyoWebViewController: KlaviyoWebViewController {
     override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         .allow
@@ -73,7 +73,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - SDK Attribute Tests
 
     @MainActor
-    func testInjectSdkNameAttribute() async throws {
+    func testInjectSdkNameAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let sdkNameScript = viewModel.findScript(containing: ["data-sdk-name", "swift"])
@@ -83,7 +83,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testInjectSdkVersionAttribute() async throws {
+    func testInjectSdkVersionAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let sdkVersionScript = viewModel.findScript(containing: ["data-sdk-version", "0.0.1"])
@@ -95,7 +95,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Environment Tests
 
     @MainActor
-    func testInjectFormsDataEnvironmentAttribute() async throws {
+    func testInjectFormsDataEnvironmentAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let environmentScript = viewModel.findScript(containing: "data-forms-data-environment")
@@ -125,7 +125,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Handshake Tests
 
     @MainActor
-    func testInjectHandshakeAttribute() async throws {
+    func testInjectHandshakeAttribute() throws {
         // When
         viewModel.initializeLoadScripts()
         let handshakeScript = viewModel.findScript(containing: "data-native-bridge-handshake")
@@ -179,7 +179,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testAuthTokenScriptNotInjectedWhenTokenIsNil() async throws {
+    func testAuthTokenScriptNotInjectedWhenTokenIsNil() {
         // When (default viewModel from setUp has authToken: nil)
         viewModel.initializeLoadScripts()
         let authTokenScript = viewModel.findScript(containing: "data-klaviyo-jwt")
@@ -191,7 +191,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Klaviyo JS Tests
 
     @MainActor
-    func testInjectKlaviyoJsScript() async throws {
+    func testInjectKlaviyoJsScript() {
         // When
         viewModel.initializeLoadScripts()
         let klaviyoJsScript = viewModel.findScript(containing: ["klaviyoJS", "static.klaviyo.com/onsite/js/klaviyo.js"])
@@ -205,7 +205,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Event Handling Tests
 
     @MainActor
-    func testFormWillAppearYieldsPresentLifecycleEvent() async throws {
+    func testFormWillAppearYieldsPresentLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Form will appear should yield present lifecycle event")
 
@@ -241,7 +241,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormDisappearedYieldsDismissLifecycleEvent() async throws {
+    func testFormDisappearedYieldsDismissLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Form disappeared should yield dismiss lifecycle event")
 
@@ -277,10 +277,11 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormWillAppearYieldsPresentEvenWithMissingMetadata() async throws {
+    func testFormWillAppearYieldsPresentEvenWithMissingMetadata() async {
         // Given
         let expectation = XCTestExpectation(
-            description: "formWillAppear with missing metadata should still yield .present")
+            description: "formWillAppear with missing metadata should still yield .present"
+        )
 
         let lifecycleTask = Task {
             for await event in viewModel.formLifecycleStream {
@@ -310,10 +311,11 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormDisappearedYieldsDismissEvenWithMissingMetadata() async throws {
+    func testFormDisappearedYieldsDismissEvenWithMissingMetadata() async {
         // Given
         let expectation = XCTestExpectation(
-            description: "formDisappeared with missing metadata should still yield .dismiss")
+            description: "formDisappeared with missing metadata should still yield .dismiss"
+        )
 
         let lifecycleTask = Task {
             for await event in viewModel.formLifecycleStream {
@@ -343,7 +345,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testAbortEventYieldsAbortLifecycleEvent() async throws {
+    func testAbortEventYieldsAbortLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Abort event should yield abort lifecycle event")
         let abortReason = "test abort reason"
@@ -377,6 +379,41 @@ final class IAFWebViewModelTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 5.0)
         lifecycleTask.cancel()
     }
+
+    // MARK: - Token Refresh Tests
+
+    @MainActor
+    func testPushAuthTokenUpdatesWebView() async throws {
+        // Given — a view model with a wired-up delegate
+        let (viewModel, delegate) = try makeTokenViewModel()
+
+        // When — a refreshed token is pushed (driven by the presentation
+        // manager's refresh subscription in production)
+        let refreshedToken = "header.refreshed.signature"
+        await viewModel.pushAuthToken(refreshedToken)
+
+        // Then — it is applied as a data-klaviyo-jwt update carrying the token
+        let script = try XCTUnwrap(tokenScripts(delegate).first)
+        XCTAssertTrue(script.contains(refreshedToken), "Pushed token should update data-klaviyo-jwt with the new value")
+    }
+
+    @MainActor
+    func testPushAuthTokenAppliesUpdatesInOrder() async throws {
+        // Given
+        let (viewModel, delegate) = try makeTokenViewModel()
+
+        // When — two tokens are pushed sequentially
+        let firstToken = "header.first.signature"
+        let secondToken = "header.second.signature"
+        await viewModel.pushAuthToken(firstToken)
+        await viewModel.pushAuthToken(secondToken)
+
+        // Then — both are applied, in order
+        let scripts = tokenScripts(delegate)
+        XCTAssertEqual(scripts.count, 2)
+        XCTAssertTrue(scripts[0].contains(firstToken))
+        XCTAssertTrue(scripts[1].contains(secondToken))
+    }
 }
 
 extension IAFWebViewModel {
@@ -394,5 +431,29 @@ extension IAFWebViewModel {
                 script.source.contains(text)
             }
         }
+    }
+}
+
+// MARK: - Token refresh test helpers
+
+extension IAFWebViewModelTests {
+    /// Builds a view model with a wired-up mock delegate, so `pushAuthToken`
+    /// tests can observe the resulting `evaluateJavaScript` calls.
+    @MainActor
+    private func makeTokenViewModel() throws -> (IAFWebViewModel, MockIAFWebViewDelegate) {
+        let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
+        let viewModel = IAFWebViewModel(url: fileUrl, apiKey: "abc123", profileData: nil)
+        let delegate = MockIAFWebViewDelegate(viewModel: viewModel)
+        viewModel.delegate = delegate
+        return (viewModel, delegate)
+    }
+
+    /// The auth-token update scripts among everything the delegate has evaluated.
+    /// Filters out the incidental `data-klaviyo-profile` updates that the view
+    /// model's profile subscription emits during setup, isolating the
+    /// token-update behavior under test.
+    @MainActor
+    private func tokenScripts(_ delegate: MockIAFWebViewDelegate) -> [String] {
+        delegate.evaluatedScripts.filter { $0.contains("data-klaviyo-jwt") }
     }
 }

--- a/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
+++ b/Tests/KlaviyoFormsTests/Mocks/MockIAFWebViewDelegate.swift
@@ -19,7 +19,13 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     let viewModel: IAFWebViewModel
 
     var handshakeResult: HandshakeResult?
-    var evaluateJavaScriptCalled = false
+
+    /// Records every script passed to ``evaluateJavaScript(_:)``, in call order,
+    /// so tests can assert both that an update fired and what it contained.
+    var evaluatedScripts: [String] = []
+    var evaluateJavaScriptCalled: Bool {
+        !evaluatedScripts.isEmpty
+    }
 
     init(viewModel: IAFWebViewModel) {
         self.viewModel = viewModel
@@ -58,7 +64,7 @@ class MockIAFWebViewDelegate: UIViewController, KlaviyoWebViewDelegate {
     }
 
     func evaluateJavaScript(_ script: String) async throws -> Any? {
-        evaluateJavaScriptCalled = true
+        evaluatedScripts.append(script)
         return true
     }
 


### PR DESCRIPTION
# Description
Subscribes In-App Forms to `AuthTokenManager.refreshes()` so proactively-refreshed JWTs are pushed into the live WebView, keeping `data-klaviyo-jwt` fresh whether or not a form is currently on screen. Completes the live-update portion (Phase 3) of MAGE-616.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
  - Unit tests run on the iOS simulator; end-to-end manual verification of the JWT flow is pending the full feature stack landing.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.
  - Uses `AsyncStream` / `for await` / `Task` only; `make CONFIG=release test-library` (Swift 5.9) not yet run locally — relying on CI to confirm.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - This PR is internal wiring only (no public API change); it's part of the larger public JWT feature (`registerAuthTokenProvider`) tracked across the MAGE-61x/62x stack.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
Phase 3 of MAGE-616 — live token updates. The subscription is bound to the **WebView's lifetime** (the WebView sits alive between form displays), not to a single form display.

- **`IAFPresentationManager`** owns the subscription (`tokenRefreshTask`):
  - `startTokenRefreshObservation()` subscribes to `AuthTokenManager.shared.refreshes()` and pushes each token to the view model. Started in `createFormWebView` (the single creation chokepoint, after the webview is built) and cancelled in `destroyWebView` (the single destruction chokepoint — covers the API-key-change and session-expiry recreate paths too).
  - Consolidates all `AuthTokenManager` interaction in one layer (it already does the initial `currentToken()` injection) and matches its existing observer-task pattern (`companyEventsTask`, `lifecycleEventsTask`, `profileEventsTask`, `formEventTask`).
- **`IAFWebViewModel`** gains `pushAuthToken(_:)`, a direct analogue of the existing `pushDeviceInfo()` — builds the `data-klaviyo-jwt` script via the existing `createAuthTokenScript` (so initial-load injection and live updates share one builder) and pushes it via `delegate.evaluateJavaScript`. The token value is never logged.
- **Tests**: `MockIAFWebViewDelegate` records evaluated scripts; two focused unit tests cover `pushAuthToken` (single update carries the token; sequential updates apply in order).

## Test Plan
1. `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing KlaviyoFormsTests` → all 60 pass, including `testPushAuthTokenUpdatesWebView` and `testPushAuthTokenAppliesUpdatesInOrder`.
2. Manual (pending full stack): with a registered auth-token provider and a form displayed, force a proactive refresh and confirm `document.head`'s `data-klaviyo-jwt` updates without a reload.

## Related Issues/Tickets
- [MAGE-616](https://linear.app/klaviyo/issue/MAGE-616) — iOS: inject auth token into In-App Forms WebView
- Stacked on `ab/MAGE-626/refresh-stream-and-profile-reset` (MAGE-626, in review); retarget to the appropriate base once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication token refresh mechanism for in-app forms, ensuring tokens remain valid and properly updated during active form sessions.

* **Tests**
  * Added comprehensive test coverage for token refresh functionality, including validation that updates are applied correctly and in proper order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klaviyo/klaviyo-swift-sdk/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->