### PR TITLE
feat(KlaviyoCore): connectivity-driven auth token refresh retry (MAGE-683)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,6 +76,20 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
+    /// `true` while a proactive refresh has failed for a network reason and the
+    /// manager is waiting for connectivity to be restored before retrying.
+    ///
+    /// This is a single boolean rather than a dedicated task because connectivity
+    /// is observed through the already-running ``lifecycleCancellable`` sink (the
+    /// SDK's existing reachability signal), not a separate per-wait subscription.
+    /// The flag is the "at most one pending wait" guarantee: a network-classified
+    /// refresh failure arms it (see ``performScheduledRefresh()``), the next
+    /// reachable ``Reachability/NetworkStatus`` consumes it (see
+    /// ``handleReachabilityChange(_:)``), and rapid network flapping cannot queue
+    /// multiple retries. Cleared by ``cancelInFlightWorkAndClearCache()`` so a
+    /// provider swap or profile reset drops any pending retry.
+    private var isAwaitingConnectivityRetry = false
+
     /// Long-lived Combine subscription that dispatches foreground transitions to
     /// ``handleForegroundTransition()``. Bound to the actor's lifetime (started in
     /// ``init`` and survives ``registerProvider(_:)``).
@@ -279,6 +293,7 @@ package actor AuthTokenManager {
         refreshTask?.cancel()
         refreshTask = nil
         refreshAtWallClock = nil
+        isAwaitingConnectivityRetry = false
         cachedToken = nil
     }
 
@@ -439,7 +454,10 @@ package actor AuthTokenManager {
     /// *and* scheduled the next refresh (via the wiring inside that method).
     /// On failure: leaves the cached token in place — the cache only goes
     /// stale at `exp - leeway`, so a foreground transition or user fetch
-    /// before then will retry. Connectivity-driven retry is owned by MAGE-683.
+    /// before then will retry. A *network-classified* failure additionally arms
+    /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
+    /// re-fires this method (see ``handleReachabilityChange(_:)``); other
+    /// failures do not, since waiting for connectivity would not address them.
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
         let task = inFlight?.task ?? startFetch()
@@ -463,26 +481,73 @@ package actor AuthTokenManager {
                     "AuthTokenManager: refresh failed: \(reason, privacy: .public)"
                 )
             }
+            // Network-classified failures are the only ones worth waiting on:
+            // connectivity restoration directly addresses them, whereas HTTP
+            // errors, validation rejections, or host-side bugs would just fail
+            // again. Arming the flag lets the next reachable transition retry.
+            if let urlError = error as? URLError, urlError.isConnectivityError {
+                isAwaitingConnectivityRetry = true
+                if #available(iOS 14.0, *) {
+                    Logger.auth.info(
+                        "AuthTokenManager: network-classified refresh failure, awaiting connectivity"
+                    )
+                }
+            }
         }
     }
 
-    /// Starts the long-lived Combine subscription that drives
-    /// ``handleForegroundTransition()`` on each `.foregrounded` event. Idempotent:
-    /// no-op if the observer is already running, so retry-on-restart paths can
-    /// call this safely.
+    /// Starts the long-lived Combine subscription that drives the actor's
+    /// reactions to app-lifecycle and reachability events. Idempotent: no-op if
+    /// the observer is already running, so retry-on-restart paths can call this
+    /// safely.
+    ///
+    /// Two events are handled:
+    /// - `.foregrounded` → ``handleForegroundTransition()`` (reconciles cache and
+    ///   scheduled-refresh state with wall-clock time after backgrounding).
+    /// - `.reachabilityChanged(status:)` → ``handleReachabilityChange(_:)`` (fires
+    ///   the connectivity-driven retry when a prior proactive refresh failed
+    ///   while offline).
+    ///
+    /// The SDK's existing reachability signal is reused here rather than standing
+    /// up a separate `NWPathMonitor`: the lifecycle publisher already multiplexes
+    /// reachability transitions, and consuming them through this single sink keeps
+    /// the actor's observation surface to one subscription.
     ///
     /// The `sink` closure is non-isolated, so each event hops back onto the actor
-    /// via an unstructured `Task`. Foreground events are not bursty (a
-    /// `.foregrounded` is always preceded by a `.backgrounded`), and the actor
-    /// already serializes the state `handleForegroundTransition()` touches, so the
-    /// lack of cross-event ordering between those tasks is immaterial.
+    /// via an unstructured `Task`. Neither event is bursty, and the actor already
+    /// serializes the state both handlers touch, so the lack of cross-event
+    /// ordering between those tasks is immaterial.
     private func startLifecycleObserver() {
         guard lifecycleCancellable == nil else { return }
         lifecycleCancellable = lifeCycle.lifeCycleEvents()
             .sink { [weak self] event in
-                guard case .foregrounded = event else { return }
-                Task { [weak self] in await self?.handleForegroundTransition() }
+                switch event {
+                case .foregrounded:
+                    Task { [weak self] in await self?.handleForegroundTransition() }
+                case let .reachabilityChanged(status):
+                    Task { [weak self] in await self?.handleReachabilityChange(status) }
+                case .backgrounded, .terminated:
+                    break
+                }
             }
+    }
+
+    /// Fires the connectivity-driven retry when reachability is restored after a
+    /// network-classified proactive-refresh failure.
+    ///
+    /// No-op unless a wait is actually armed (``isAwaitingConnectivityRetry``)
+    /// *and* the new status reports a path. A `.notReachable` transition — or any
+    /// reachability churn while no wait is pending — is ignored. The flag is
+    /// cleared *before* re-firing so a flurry of reachable transitions yields a
+    /// single retry; if that retry fails for a network reason,
+    /// ``performScheduledRefresh()`` re-arms the flag, re-enabling this path.
+    private func handleReachabilityChange(_ status: Reachability.NetworkStatus) async {
+        guard isAwaitingConnectivityRetry, status != .notReachable else { return }
+        isAwaitingConnectivityRetry = false
+        if #available(iOS 14.0, *) {
+            Logger.auth.info("AuthTokenManager: connectivity restored, retrying refresh")
+        }
+        await performScheduledRefresh()
     }
 
     /// Reconciles cache and scheduled-refresh state with wall-clock time when

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -77,24 +77,17 @@ package actor AuthTokenManager {
     private var refreshAtWallClock: Date?
 
     /// `true` while a proactive refresh has failed for a network reason and the
-    /// manager is waiting for connectivity to be restored before retrying.
-    ///
-    /// This is a single boolean rather than a dedicated task because connectivity
-    /// is observed through the already-running ``lifecycleCancellable`` sink (the
-    /// SDK's existing reachability signal), not a separate per-wait subscription.
-    /// The flag is the "at most one pending wait" guarantee: a network-classified
-    /// refresh failure arms it (see ``performScheduledRefresh()``), the next
-    /// reachable ``Reachability/NetworkStatus`` consumes it (see
-    /// ``handleReachabilityChange()``), and rapid network flapping cannot queue
-    /// multiple retries. Cleared by ``cancelInFlightWorkAndClearCache()`` so a
-    /// provider swap or profile reset drops any pending retry.
+    /// manager is awaiting connectivity before retrying. A single boolean (not a
+    /// task) because connectivity comes through the existing ``lifecycleCancellable``
+    /// reachability sink: a network-classified failure arms it
+    /// (``performScheduledRefresh()``), the next reachable status consumes it
+    /// (``handleReachabilityChange()``), so flapping can't queue multiple retries.
+    /// Cleared by ``cancelInFlightWorkAndClearCache()``.
     private var isAwaitingConnectivityRetry = false
 
     /// Test-only window onto ``isAwaitingConnectivityRetry`` so suites can
-    /// deterministically await the *arming* of the connectivity wait — which
-    /// lands asynchronously inside the refresh-failure path — instead of racing
-    /// it with a fixed number of yields. Reachable from the test target via
-    /// `@testable import`; not part of the package API.
+    /// deterministically await the wait being *armed* (which lands asynchronously
+    /// in the failure path) instead of racing it with fixed yields. Not package API.
     var isAwaitingConnectivityRetryForTesting: Bool {
         isAwaitingConnectivityRetry
     }
@@ -139,12 +132,10 @@ package actor AuthTokenManager {
     /// swallows the `CancellationError` `Task.sleep` throws.
     private let sleeper: @Sendable (UInt64) async -> Void
 
-    /// Current network reachability, consulted when arming a connectivity wait so
-    /// a retry armed *after* the offline→online transition already passed is not
-    /// stranded waiting for a future transition (see ``armConnectivityRetry()``).
-    /// Injected for testability; defaults to the SDK-wide
-    /// `environment.reachabilityStatus`. `nil` means "unknown" and is treated
-    /// conservatively as "no path".
+    /// Current network reachability, consulted when arming a connectivity wait so a
+    /// retry armed *after* the offline→online transition already passed isn't
+    /// stranded (see ``armConnectivityRetry()``). Injected for testability; defaults
+    /// to `environment.reachabilityStatus`. `nil`/unknown is treated as "no path".
     private let currentReachability: () -> Reachability.NetworkStatus?
 
     /// Production initializer. Wires the actor to the real SDK-wide clock
@@ -364,12 +355,9 @@ package actor AuthTokenManager {
             switch JWTParser.parseAndValidate(rawToken, currentTime: currentDate()) {
             case let .success(validated):
                 cachedToken = validated
-                // A fresh token from any acquisition path (interactive fetch,
-                // eager warm-up, foreground recovery, or a proactive/connectivity
-                // retry) obsoletes a pending connectivity wait: there is nothing
-                // left to retry, and the next refresh is scheduled just below.
-                // Leaving it armed would fire a redundant retry — an extra
-                // provider round-trip and `refreshes()` broadcast — on the next
+                // A fresh token from any path obsoletes a pending connectivity
+                // wait: nothing left to retry, and the next refresh is scheduled
+                // below. Leaving it armed would fire a redundant retry on the next
                 // reachability transition.
                 isAwaitingConnectivityRetry = false
                 scheduleRefresh(for: validated)
@@ -482,10 +470,9 @@ package actor AuthTokenManager {
     /// *and* scheduled the next refresh (via the wiring inside that method).
     /// On failure: leaves the cached token in place — the cache only goes
     /// stale at `exp - leeway`, so a foreground transition or user fetch
-    /// before then will retry. A *network-classified* failure additionally arms
+    /// before then will retry. A *network-classified* failure also arms
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
-    /// re-fires this method (see ``handleReachabilityChange()``); other
-    /// failures do not, since waiting for connectivity would not address them.
+    /// re-fires this method (``handleReachabilityChange()``); other failures don't.
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
         let task = inFlight?.task ?? startFetch()
@@ -509,37 +496,27 @@ package actor AuthTokenManager {
                     "AuthTokenManager: refresh failed: \(reason, privacy: .public)"
                 )
             }
-            // Network-classified failures are the only ones worth waiting on:
-            // connectivity restoration directly addresses them, whereas HTTP
-            // errors, validation rejections, or host-side bugs would just fail
-            // again.
+            // Only network failures are worth waiting on — connectivity
+            // restoration addresses them; HTTP/validation/host errors would
+            // just fail again.
             if let urlError = error as? URLError, urlError.isConnectivityError {
                 armConnectivityRetry()
             }
         }
     }
 
-    /// Starts the long-lived Combine subscription that drives the actor's
-    /// reactions to app-lifecycle and reachability events. Idempotent: no-op if
-    /// the observer is already running, so retry-on-restart paths can call this
-    /// safely.
+    /// Starts the long-lived Combine subscription driving the actor's reactions to
+    /// app-lifecycle and reachability events. Idempotent (no-op if already running).
     ///
-    /// Two events are handled:
-    /// - `.foregrounded` → ``handleForegroundTransition()`` (reconciles cache and
-    ///   scheduled-refresh state with wall-clock time after backgrounding).
-    /// - `.reachabilityChanged(status:)` → ``handleReachabilityChange()`` (fires
-    ///   the connectivity-driven retry when a prior proactive refresh failed
-    ///   while offline).
+    /// - `.foregrounded` → ``handleForegroundTransition()`` (reconcile cache/refresh
+    ///   state with wall-clock time after backgrounding).
+    /// - `.reachabilityChanged` → ``handleReachabilityChange()`` (fire the
+    ///   connectivity-driven retry when a prior refresh failed offline).
     ///
-    /// The SDK's existing reachability signal is reused here rather than standing
-    /// up a separate `NWPathMonitor`: the lifecycle publisher already multiplexes
-    /// reachability transitions, and consuming them through this single sink keeps
-    /// the actor's observation surface to one subscription.
-    ///
-    /// The `sink` closure is non-isolated, so each event hops back onto the actor
-    /// via an unstructured `Task`. Neither event is bursty, and the actor already
-    /// serializes the state both handlers touch, so the lack of cross-event
-    /// ordering between those tasks is immaterial.
+    /// Reuses the SDK's existing reachability signal rather than a separate
+    /// `NWPathMonitor`. The `sink` is non-isolated, so each event hops back onto the
+    /// actor via a `Task`; neither event is bursty and the actor serializes the
+    /// shared state, so cross-event ordering is immaterial.
     private func startLifecycleObserver() {
         guard lifecycleCancellable == nil else { return }
         lifecycleCancellable = lifeCycle.lifeCycleEvents()
@@ -555,24 +532,15 @@ package actor AuthTokenManager {
             }
     }
 
-    /// Arms the connectivity-retry wait after a network-classified
-    /// proactive-refresh failure, and kicks the retry immediately when the system
-    /// *already* reports a usable path.
+    /// Arms the connectivity-retry wait after a network-classified refresh failure,
+    /// kicking the retry immediately if the system *already* reports a usable path.
     ///
-    /// Reachability is observed as a transition stream
-    /// (``LifeCycleEvents/reachabilityChanged(status:)``) with no "current value":
-    /// if connectivity was restored while the failing fetch was still in flight,
-    /// that transition has already passed by the time this arms, and no future
-    /// event would wake the wait until the next flap or cache expiry. Consulting
+    /// Reachability is a transition stream with no "current value": if connectivity
+    /// returned while the failing fetch was in flight, that transition has already
+    /// passed and no future event would wake the wait. Consulting
     /// ``currentReachability`` here mirrors `NWPathMonitor` delivering the current
-    /// path on subscribe, closing that gap. `nil`/unknown is treated as "no path",
-    /// so the wait simply waits for a transition.
-    ///
-    /// Loop safety: a kicked retry that fails for a network reason re-arms and may
-    /// re-check a still-satisfied path. That recurs only in the contradictory
-    /// state where the system reports a path yet the request returns a genuine
-    /// *offline* `URLError` — which does not realistically persist, and each
-    /// iteration is gated by a full fetch.
+    /// path on subscribe; `nil`/unknown is treated as "no path". A kicked retry that
+    /// fails for a network reason re-arms, gated by a full fetch each iteration.
     private func armConnectivityRetry() {
         isAwaitingConnectivityRetry = true
         if #available(iOS 14.0, *) {
@@ -590,23 +558,18 @@ package actor AuthTokenManager {
     }
 
     /// Routes a reachability change into the connectivity-retry path. The event is
-    /// treated only as a *trigger* — its payload status is deliberately ignored,
-    /// because ``AppLifeCycleEvents`` coerces an unknown (`nil`) reachability read
-    /// to `.reachableViaWWAN`, so the payload can't distinguish "really online"
-    /// from "unknown". Instead re-read the live status and fire only when it
-    /// genuinely reports a path, matching the conservative `nil` handling in
-    /// ``armConnectivityRetry()``. A retry is a no-op when no wait is armed.
+    /// only a *trigger* — its payload status is ignored because ``AppLifeCycleEvents``
+    /// coerces an unknown read to `.reachableViaWWAN`. Re-reads the live status and
+    /// fires only on a genuine path; a no-op when no wait is armed.
     private func handleReachabilityChange() async {
         guard let status = currentReachability(), status != .notReachable else { return }
         await fireConnectivityRetryIfArmed()
     }
 
-    /// Consumes an armed connectivity wait and re-fires the proactive refresh
-    /// through the normal dedup/validate/reschedule/broadcast path. No-op when no
-    /// wait is armed. Clearing the flag *before* re-firing collapses concurrent
-    /// triggers (a reachability transition plus the arm-time current-path check)
-    /// into a single retry; a retry that fails for a network reason re-arms via
-    /// ``performScheduledRefresh()``.
+    /// Consumes an armed connectivity wait and re-fires the refresh through the
+    /// normal dedup/validate/reschedule/broadcast path. Clearing the flag *before*
+    /// re-firing collapses concurrent triggers (transition + arm-time check) into a
+    /// single retry; a network-failed retry re-arms via ``performScheduledRefresh()``.
     private func fireConnectivityRetryIfArmed() async {
         guard isAwaitingConnectivityRetry else { return }
         isAwaitingConnectivityRetry = false

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -85,7 +85,7 @@ package actor AuthTokenManager {
     /// The flag is the "at most one pending wait" guarantee: a network-classified
     /// refresh failure arms it (see ``performScheduledRefresh()``), the next
     /// reachable ``Reachability/NetworkStatus`` consumes it (see
-    /// ``handleReachabilityChange(_:)``), and rapid network flapping cannot queue
+    /// ``handleReachabilityChange()``), and rapid network flapping cannot queue
     /// multiple retries. Cleared by ``cancelInFlightWorkAndClearCache()`` so a
     /// provider swap or profile reset drops any pending retry.
     private var isAwaitingConnectivityRetry = false
@@ -484,7 +484,7 @@ package actor AuthTokenManager {
     /// stale at `exp - leeway`, so a foreground transition or user fetch
     /// before then will retry. A *network-classified* failure additionally arms
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
-    /// re-fires this method (see ``handleReachabilityChange(_:)``); other
+    /// re-fires this method (see ``handleReachabilityChange()``); other
     /// failures do not, since waiting for connectivity would not address them.
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
@@ -527,7 +527,7 @@ package actor AuthTokenManager {
     /// Two events are handled:
     /// - `.foregrounded` → ``handleForegroundTransition()`` (reconciles cache and
     ///   scheduled-refresh state with wall-clock time after backgrounding).
-    /// - `.reachabilityChanged(status:)` → ``handleReachabilityChange(_:)`` (fires
+    /// - `.reachabilityChanged(status:)` → ``handleReachabilityChange()`` (fires
     ///   the connectivity-driven retry when a prior proactive refresh failed
     ///   while offline).
     ///
@@ -547,8 +547,8 @@ package actor AuthTokenManager {
                 switch event {
                 case .foregrounded:
                     Task { [weak self] in await self?.handleForegroundTransition() }
-                case let .reachabilityChanged(status):
-                    Task { [weak self] in await self?.handleReachabilityChange(status) }
+                case .reachabilityChanged:
+                    Task { [weak self] in await self?.handleReachabilityChange() }
                 case .backgrounded, .terminated:
                     break
                 }
@@ -589,11 +589,15 @@ package actor AuthTokenManager {
         Task { [weak self] in await self?.fireConnectivityRetryIfArmed() }
     }
 
-    /// Routes a reachability transition into the connectivity-retry path. Only a
-    /// transition reporting a usable path can fire the retry; `.notReachable`
-    /// (and any churn while no wait is armed) is ignored.
-    private func handleReachabilityChange(_ status: Reachability.NetworkStatus) async {
-        guard status != .notReachable else { return }
+    /// Routes a reachability change into the connectivity-retry path. The event is
+    /// treated only as a *trigger* — its payload status is deliberately ignored,
+    /// because ``AppLifeCycleEvents`` coerces an unknown (`nil`) reachability read
+    /// to `.reachableViaWWAN`, so the payload can't distinguish "really online"
+    /// from "unknown". Instead re-read the live status and fire only when it
+    /// genuinely reports a path, matching the conservative `nil` handling in
+    /// ``armConnectivityRetry()``. A retry is a no-op when no wait is armed.
+    private func handleReachabilityChange() async {
+        guard let status = currentReachability(), status != .notReachable else { return }
         await fireConnectivityRetryIfArmed()
     }
 

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -139,6 +139,14 @@ package actor AuthTokenManager {
     /// swallows the `CancellationError` `Task.sleep` throws.
     private let sleeper: @Sendable (UInt64) async -> Void
 
+    /// Current network reachability, consulted when arming a connectivity wait so
+    /// a retry armed *after* the offline→online transition already passed is not
+    /// stranded waiting for a future transition (see ``armConnectivityRetry()``).
+    /// Injected for testability; defaults to the SDK-wide
+    /// `environment.reachabilityStatus`. `nil` means "unknown" and is treated
+    /// conservatively as "no path".
+    private let currentReachability: () -> Reachability.NetworkStatus?
+
     /// Production initializer. Wires the actor to the real SDK-wide clock
     /// (`environment.date`) and `Task.sleep`. This is the only initializer
     /// visible to sibling product modules, and is what ``shared`` uses.
@@ -149,6 +157,7 @@ package actor AuthTokenManager {
         self.lifeCycle = lifeCycle
         currentDate = { environment.date() }
         sleeper = { nanoseconds in try? await Task.sleep(nanoseconds: nanoseconds) }
+        currentReachability = { environment.reachabilityStatus() }
         Task { await self.startLifecycleObserver() }
     }
 
@@ -174,11 +183,13 @@ package actor AuthTokenManager {
         currentDate: @escaping () -> Date,
         sleep: @escaping @Sendable (UInt64) async -> Void = { nanoseconds in
             try? await Task.sleep(nanoseconds: nanoseconds)
-        }
+        },
+        reachabilityStatus: @escaping () -> Reachability.NetworkStatus? = { nil }
     ) {
         self.lifeCycle = lifeCycle
         self.currentDate = currentDate
         sleeper = sleep
+        currentReachability = reachabilityStatus
         Task { await self.startLifecycleObserver() }
     }
 
@@ -493,14 +504,9 @@ package actor AuthTokenManager {
             // Network-classified failures are the only ones worth waiting on:
             // connectivity restoration directly addresses them, whereas HTTP
             // errors, validation rejections, or host-side bugs would just fail
-            // again. Arming the flag lets the next reachable transition retry.
+            // again.
             if let urlError = error as? URLError, urlError.isConnectivityError {
-                isAwaitingConnectivityRetry = true
-                if #available(iOS 14.0, *) {
-                    Logger.auth.info(
-                        "AuthTokenManager: network-classified refresh failure, awaiting connectivity"
-                    )
-                }
+                armConnectivityRetry()
             }
         }
     }
@@ -541,20 +547,59 @@ package actor AuthTokenManager {
             }
     }
 
-    /// Fires the connectivity-driven retry when reachability is restored after a
-    /// network-classified proactive-refresh failure.
+    /// Arms the connectivity-retry wait after a network-classified
+    /// proactive-refresh failure, and kicks the retry immediately when the system
+    /// *already* reports a usable path.
     ///
-    /// No-op unless a wait is actually armed (``isAwaitingConnectivityRetry``)
-    /// *and* the new status reports a path. A `.notReachable` transition — or any
-    /// reachability churn while no wait is pending — is ignored. The flag is
-    /// cleared *before* re-firing so a flurry of reachable transitions yields a
-    /// single retry; if that retry fails for a network reason,
-    /// ``performScheduledRefresh()`` re-arms the flag, re-enabling this path.
+    /// Reachability is observed as a transition stream
+    /// (``LifeCycleEvents/reachabilityChanged(status:)``) with no "current value":
+    /// if connectivity was restored while the failing fetch was still in flight,
+    /// that transition has already passed by the time this arms, and no future
+    /// event would wake the wait until the next flap or cache expiry. Consulting
+    /// ``currentReachability`` here mirrors `NWPathMonitor` delivering the current
+    /// path on subscribe, closing that gap. `nil`/unknown is treated as "no path",
+    /// so the wait simply waits for a transition.
+    ///
+    /// Loop safety: a kicked retry that fails for a network reason re-arms and may
+    /// re-check a still-satisfied path. That recurs only in the contradictory
+    /// state where the system reports a path yet the request returns a genuine
+    /// *offline* `URLError` — which does not realistically persist, and each
+    /// iteration is gated by a full fetch.
+    private func armConnectivityRetry() {
+        isAwaitingConnectivityRetry = true
+        if #available(iOS 14.0, *) {
+            Logger.auth.info(
+                "AuthTokenManager: network-classified refresh failure, awaiting connectivity"
+            )
+        }
+        guard let status = currentReachability(), status != .notReachable else { return }
+        if #available(iOS 14.0, *) {
+            Logger.auth.info(
+                "AuthTokenManager: connectivity already available, retrying without waiting"
+            )
+        }
+        Task { [weak self] in await self?.fireConnectivityRetryIfArmed() }
+    }
+
+    /// Routes a reachability transition into the connectivity-retry path. Only a
+    /// transition reporting a usable path can fire the retry; `.notReachable`
+    /// (and any churn while no wait is armed) is ignored.
     private func handleReachabilityChange(_ status: Reachability.NetworkStatus) async {
-        guard isAwaitingConnectivityRetry, status != .notReachable else { return }
+        guard status != .notReachable else { return }
+        await fireConnectivityRetryIfArmed()
+    }
+
+    /// Consumes an armed connectivity wait and re-fires the proactive refresh
+    /// through the normal dedup/validate/reschedule/broadcast path. No-op when no
+    /// wait is armed. Clearing the flag *before* re-firing collapses concurrent
+    /// triggers (a reachability transition plus the arm-time current-path check)
+    /// into a single retry; a retry that fails for a network reason re-arms via
+    /// ``performScheduledRefresh()``.
+    private func fireConnectivityRetryIfArmed() async {
+        guard isAwaitingConnectivityRetry else { return }
         isAwaitingConnectivityRetry = false
         if #available(iOS 14.0, *) {
-            Logger.auth.info("AuthTokenManager: connectivity restored, retrying refresh")
+            Logger.auth.info("AuthTokenManager: connectivity available, retrying refresh")
         }
         await performScheduledRefresh()
     }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -364,6 +364,14 @@ package actor AuthTokenManager {
             switch JWTParser.parseAndValidate(rawToken, currentTime: currentDate()) {
             case let .success(validated):
                 cachedToken = validated
+                // A fresh token from any acquisition path (interactive fetch,
+                // eager warm-up, foreground recovery, or a proactive/connectivity
+                // retry) obsoletes a pending connectivity wait: there is nothing
+                // left to retry, and the next refresh is scheduled just below.
+                // Leaving it armed would fire a redundant retry — an extra
+                // provider round-trip and `refreshes()` broadcast — on the next
+                // reachability transition.
+                isAwaitingConnectivityRetry = false
                 scheduleRefresh(for: validated)
                 if #available(iOS 14.0, *) {
                     Logger.auth.info(

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -90,6 +90,15 @@ package actor AuthTokenManager {
     /// provider swap or profile reset drops any pending retry.
     private var isAwaitingConnectivityRetry = false
 
+    /// Test-only window onto ``isAwaitingConnectivityRetry`` so suites can
+    /// deterministically await the *arming* of the connectivity wait — which
+    /// lands asynchronously inside the refresh-failure path — instead of racing
+    /// it with a fixed number of yields. Reachable from the test target via
+    /// `@testable import`; not part of the package API.
+    var isAwaitingConnectivityRetryForTesting: Bool {
+        isAwaitingConnectivityRetry
+    }
+
     /// Long-lived Combine subscription that dispatches foreground transitions to
     /// ``handleForegroundTransition()``. Bound to the actor's lifetime (started in
     /// ``init`` and survives ``registerProvider(_:)``).

--- a/Sources/KlaviyoCore/Utils/URLError+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/URLError+Ext.swift
@@ -1,0 +1,29 @@
+//
+//  URLError+Ext.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2026-06-03.
+//
+
+import Foundation
+
+extension URLError {
+    /// `URLError` codes that indicate a genuine offline condition — the only
+    /// failures for which waiting on connectivity restoration is the right
+    /// remedy. HTTP error responses, validation rejections, and generic
+    /// timeouts are deliberately excluded: re-running the same request once a
+    /// path exists would not change their outcome.
+    private static let connectivityCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .dataNotAllowed,
+        .internationalRoamingOff
+    ]
+
+    /// `true` when this error represents a genuine offline condition for which
+    /// retrying once connectivity is restored is worthwhile (see
+    /// ``AuthTokenManager``'s connectivity-driven refresh retry).
+    var isConnectivityError: Bool {
+        Self.connectivityCodes.contains(code)
+    }
+}

--- a/Sources/KlaviyoCore/Utils/URLError+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/URLError+Ext.swift
@@ -9,10 +9,9 @@ import Foundation
 
 extension URLError {
     /// `URLError` codes that indicate a genuine offline condition — the only
-    /// failures for which waiting on connectivity restoration is the right
-    /// remedy. HTTP error responses, validation rejections, and generic
-    /// timeouts are deliberately excluded: re-running the same request once a
-    /// path exists would not change their outcome.
+    /// failures for which waiting on connectivity restoration helps. HTTP errors,
+    /// validation rejections, and timeouts are excluded: re-running them once a
+    /// path exists wouldn't change the outcome.
     private static let connectivityCodes: Set<URLError.Code> = [
         .notConnectedToInternet,
         .networkConnectionLost,

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -503,6 +503,8 @@ class IAFPresentationManager {
 
         performDismiss(viewController: viewController)
 
+        tokenRefreshTask?.cancel()
+        tokenRefreshTask = nil
         self.viewController = nil
         viewModel = nil
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -503,8 +503,6 @@ class IAFPresentationManager {
 
         performDismiss(viewController: viewController)
 
-        tokenRefreshTask?.cancel()
-        tokenRefreshTask = nil
         self.viewController = nil
         viewModel = nil
     }

--- a/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
@@ -161,6 +161,34 @@ final class TestClock: @unchecked Sendable {
     }
 }
 
+/// Manually-set network reachability, injected as the manager's live
+/// `reachabilityStatus` source. Lets a test model the real offline→online flow
+/// the connectivity retry depends on — start `.notReachable` so arming doesn't
+/// immediately kick, then ``set(_:)`` `.reachableViaWiFi` just before sending the
+/// `.reachabilityChanged` transition so the handler's live re-read sees a path.
+/// `NSLock`-guarded because the manager reads it from its actor while the test
+/// mutates it. `nil` models an "unknown" reading.
+final class TestReachability: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Reachability.NetworkStatus?
+
+    init(_ start: Reachability.NetworkStatus? = nil) {
+        value = start
+    }
+
+    func status() -> Reachability.NetworkStatus? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func set(_ status: Reachability.NetworkStatus?) {
+        lock.lock()
+        defer { lock.unlock() }
+        value = status
+    }
+}
+
 /// Gated stand-in for the manager's `sleeper`. Every `sleep(_:)` records its
 /// entry and parks until the test ``release()``s it — so a scheduled refresh
 /// fires exactly when the test advances the clock past its target and releases

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -971,15 +971,25 @@ struct AuthTokenManagerRefreshTests {
     /// Suspends until `manager` has armed its connectivity-retry wait. The arming
     /// lands asynchronously inside the refresh-failure path, so driving a
     /// reachability transition before it would drop the event against an unarmed
-    /// flag. Unlike a fixed yield count, this adapts to scheduling: under a
-    /// saturated cooperative pool (sibling suites running in parallel) it simply
-    /// iterates more, so it can never under-wait. It only fails to return if the
-    /// wait genuinely never arms — which is itself the bug a caller would want to
-    /// surface.
-    private func awaitConnectivityWaitArmed(_ manager: AuthTokenManager) async {
-        while await manager.isAwaitingConnectivityRetryForTesting == false {
+    /// flag. Unlike a fixed *small* yield count, this adapts to scheduling: under
+    /// a saturated cooperative pool (sibling suites running in parallel) it simply
+    /// iterates more, so it can't under-wait in the happy path.
+    ///
+    /// The yield budget is a deliberately large safety cap, not a timing knob:
+    /// arming lands within a handful of yields in practice, so the cap is never
+    /// reached unless the wait genuinely never arms (a production regression). In
+    /// that case it records a labeled failure rather than spinning until CI's
+    /// global timeout.
+    private func awaitConnectivityWaitArmed(
+        _ manager: AuthTokenManager,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async {
+        let maxYields = 10_000
+        for _ in 0..<maxYields {
+            if await manager.isAwaitingConnectivityRetryForTesting { return }
             await Task.yield()
         }
+        Issue.record("connectivity retry wait never armed", sourceLocation: sourceLocation)
     }
 
     /// Builds a manager driven by a deterministic clock and sleep gate.

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -569,6 +569,60 @@ struct AuthTokenManagerRefreshTests {
     }
 
     @Test
+    func armingWhileAlreadyOnlineRetriesWithoutWaitingForTransition() async throws {
+        // If connectivity is already restored by the time the offline failure is
+        // classified (e.g. the network returned while the failing fetch was still
+        // in flight), the `.reachabilityChanged` transition has already passed —
+        // no future event will wake the wait. The arm-time current-path check
+        // must kick the retry anyway. No reachability event is ever sent here, so
+        // recovery can only come from that check.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        // System reports a usable path throughout, and the lifecycle source emits
+        // nothing — so only the arm-time check can drive the retry.
+        let manager = makeManager(
+            lifeCycle: noopLifecycle(),
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { .reachableViaWiFi }
+        )
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // scheduled refresh fails offline...
+            default: return secondToken // ...but the arm-time path check retries at once
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        let stream = await manager.refreshes()
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+
+        let delivered = await firstElement(of: stream)
+        #expect(
+            delivered == secondToken,
+            "an already-online arm must retry without waiting for a reachability transition"
+        )
+    }
+
+    @Test
     func nonNetworkRefreshFailureDoesNotAwaitConnectivity() async throws {
         // A refresh failure that is *not* a network `URLError` must not arm the
         // connectivity wait — restoring connectivity wouldn't fix it. Note the
@@ -830,12 +884,14 @@ struct AuthTokenManagerRefreshTests {
     private func makeManager(
         lifeCycle: AppLifeCycleEvents,
         clock: TestClock,
-        gate: SleepGate
+        gate: SleepGate,
+        reachabilityStatus: @escaping () -> Reachability.NetworkStatus? = { nil }
     ) -> AuthTokenManager {
         AuthTokenManager(
             lifeCycle: lifeCycle,
             currentDate: { clock.now() },
-            sleep: { await gate.sleep($0) }
+            sleep: { await gate.sleep($0) },
+            reachabilityStatus: reachabilityStatus
         )
     }
 }

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -525,7 +525,15 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Offline at arm time so arming doesn't immediately kick; flipped online
+        // just before the satisfied transition below.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -550,15 +558,17 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 2)
         await awaitConnectivityWaitArmed(manager)
 
-        // A non-satisfied transition must not consume the armed wait.
+        // A change while still offline must not consume the armed wait — the
+        // handler re-reads live status (`.notReachable`) and ignores it.
         lifecycleSubject.send(.reachabilityChanged(status: .notReachable))
         for _ in 0..<100 {
             await Task.yield()
         }
         let invocationsAfterUnreachable = await counter.value
-        #expect(invocationsAfterUnreachable == 2, "`.notReachable` must not trigger the retry")
+        #expect(invocationsAfterUnreachable == 2, "a change while still offline must not trigger the retry")
 
         // Connectivity restored → retry fires (invocation 3), broadcasts and caches.
+        reachability.set(.reachableViaWiFi)
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
 
         let delivered = await firstElement(of: stream)
@@ -638,7 +648,14 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Online throughout, so a satisfied transition *would* fire a retry if one
+        // were armed — proving the absence is due to the failure not arming a wait.
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { .reachableViaWiFi }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -686,7 +703,15 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Offline at arm so arming doesn't immediately kick; flipped online before
+        // the transition so the only thing suppressing the retry is the cleared wait.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -711,8 +736,10 @@ struct AuthTokenManagerRefreshTests {
         let refreshed = try await manager.currentToken(mode: .background)
         #expect(refreshed == secondToken)
 
-        // Connectivity later transitions to satisfied. The cache is already fresh
-        // and the wait was cleared, so no redundant retry should fire.
+        // Connectivity later transitions to satisfied (and live status agrees). The
+        // cache is already fresh and the wait was cleared, so no redundant retry
+        // should fire.
+        reachability.set(.reachableViaWiFi)
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
         for _ in 0..<100 {
             await Task.yield()
@@ -745,7 +772,15 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Offline at arm so arming doesn't immediately kick; flipped online before
+        // the transition so the only thing suppressing the retry is the cancelled wait.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -768,6 +803,7 @@ struct AuthTokenManagerRefreshTests {
 
         await manager.clearTokenState()
 
+        reachability.set(.reachableViaWiFi)
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
         for _ in 0..<100 {
             await Task.yield()
@@ -800,7 +836,15 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Offline at arm so arming doesn't immediately kick; flipped online before
+        // the flurry so the transitions (not the arm-time check) drive the retry.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -821,6 +865,7 @@ struct AuthTokenManagerRefreshTests {
 
         // Three satisfied transitions in quick succession. Only the first should
         // consume the armed wait; the rest find it already cleared.
+        reachability.set(.reachableViaWiFi)
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWWAN))
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
@@ -855,7 +900,15 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        // Offline at arm so arming doesn't immediately kick; flipped online before
+        // the restoration below.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
         let counter = CallCounter()
 
         await manager.registerProvider {
@@ -874,24 +927,21 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 2)
         await awaitConnectivityWaitArmed(manager)
 
-        // First restoration drives a retry (invocation 3) that also fails with a
-        // network error, which re-arms the wait. The wait is cleared before the
-        // retry runs, so awaiting "armed" after invocation 3 enters the provider
-        // observes the *re-arm*, not the prior arming.
-        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
-        try await counter.waitFor(atLeast: 3)
-        await awaitConnectivityWaitArmed(manager)
-
-        // Subscribe before the second restoration so the successful retry's
-        // broadcast is observable, then restore connectivity again. Invocation 4
-        // succeeds, proving the wait re-armed and recovered.
+        // Subscribe before restoring connectivity so the eventual success broadcast
+        // is observable.
         let stream = await manager.refreshes()
+
+        // Restore connectivity. The transition fires the retry (invocation 3),
+        // which also fails — re-arming the wait. Because the path is still
+        // satisfied, the re-armed wait retries again at once (invocation 4), which
+        // succeeds and broadcasts. This exercises the re-arm-after-failure path.
+        reachability.set(.reachableViaWiFi)
         lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
 
         let delivered = await firstElement(of: stream)
         #expect(
             delivered == secondToken,
-            "a network-failed retry must re-arm and recover on the next restoration"
+            "a network-failed retry must re-arm and recover"
         )
     }
 

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -525,8 +525,8 @@ struct AuthTokenManagerRefreshTests {
         let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
         let clock = TestClock(referenceDate)
         let gate = SleepGate()
-        // Offline at arm time so arming doesn't immediately kick; flipped online
-        // just before the satisfied transition below.
+        // Offline at arm so arming doesn't kick immediately; flipped online just
+        // before the satisfied transition below.
         let reachability = TestReachability(.notReachable)
         let manager = makeManager(
             lifeCycle: lifecycle,
@@ -580,12 +580,10 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func armingWhileAlreadyOnlineRetriesWithoutWaitingForTransition() async throws {
-        // If connectivity is already restored by the time the offline failure is
-        // classified (e.g. the network returned while the failing fetch was still
-        // in flight), the `.reachabilityChanged` transition has already passed —
-        // no future event will wake the wait. The arm-time current-path check
-        // must kick the retry anyway. No reachability event is ever sent here, so
-        // recovery can only come from that check.
+        // If connectivity returned while the failing fetch was still in flight, the
+        // `.reachabilityChanged` transition has already passed — only the arm-time
+        // current-path check can kick the retry. No reachability event is sent here,
+        // so recovery can only come from that check.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 40,
@@ -968,18 +966,12 @@ struct AuthTokenManagerRefreshTests {
         AppLifeCycleEvents(lifeCycleEvents: { Empty().eraseToAnyPublisher() })
     }
 
-    /// Suspends until `manager` has armed its connectivity-retry wait. The arming
-    /// lands asynchronously inside the refresh-failure path, so driving a
-    /// reachability transition before it would drop the event against an unarmed
-    /// flag. Unlike a fixed *small* yield count, this adapts to scheduling: under
-    /// a saturated cooperative pool (sibling suites running in parallel) it simply
-    /// iterates more, so it can't under-wait in the happy path.
-    ///
-    /// The yield budget is a deliberately large safety cap, not a timing knob:
-    /// arming lands within a handful of yields in practice, so the cap is never
-    /// reached unless the wait genuinely never arms (a production regression). In
-    /// that case it records a labeled failure rather than spinning until CI's
-    /// global timeout.
+    /// Suspends until `manager` has armed its connectivity-retry wait, which lands
+    /// asynchronously in the refresh-failure path — driving a transition before it
+    /// would drop the event against an unarmed flag. Adapts to scheduling rather
+    /// than guessing a yield count. The large cap is a safety net: if it's ever hit
+    /// the wait never armed (a regression), and it records a labeled failure rather
+    /// than spinning to CI's global timeout.
     private func awaitConnectivityWaitArmed(
         _ manager: AuthTokenManager,
         sourceLocation: SourceLocation = #_sourceLocation

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -666,6 +666,66 @@ struct AuthTokenManagerRefreshTests {
     }
 
     @Test
+    func successfulFetchClearsPendingConnectivityWait() async throws {
+        // A connectivity wait armed by a failed proactive refresh must be dropped
+        // once a fresh token is acquired through *any other* path (here, a
+        // `currentToken` fetch). Otherwise a later reachability transition would
+        // fire a redundant retry against an already-fresh cache.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // proactive refresh fails offline → arms wait
+            default: return secondToken // fresh token via another path (currentToken)
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Fire the scheduled refresh; it fails offline and arms the wait.
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // A different path acquires a fresh token (firstToken is stale at ref+10),
+        // which must clear the pending wait.
+        let refreshed = try await manager.currentToken(mode: .background)
+        #expect(refreshed == secondToken)
+
+        // Connectivity later transitions to satisfied. The cache is already fresh
+        // and the wait was cleared, so no redundant retry should fire.
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 3,
+            "a successful fetch must clear the pending connectivity wait, saw \(invocations)"
+        )
+    }
+
+    @Test
     func clearTokenStateCancelsPendingConnectivityRetry() async throws {
         // Arm a connectivity wait via a network-failed refresh, then reset. The
         // pending wait must be dropped so a later reachability restoration does

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -502,6 +502,285 @@ struct AuthTokenManagerRefreshTests {
         )
     }
 
+    // MARK: - Connectivity-driven retry
+
+    @Test
+    func networkFailedRefreshRetriesWhenConnectivityRestored() async throws {
+        // Same timing as the refresh-fires test: the refresh target lands at
+        // ref+10. The scheduled refresh fails offline; the retry only fires once
+        // reachability reports a path again — a `.notReachable` transition in the
+        // meantime must be ignored.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // scheduled refresh, offline
+            default: return secondToken // connectivity-driven retry
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Subscribe before the retry so the broadcast can be observed.
+        let stream = await manager.refreshes()
+
+        // Fire the scheduled refresh: invocation 2 throws a network error, arming
+        // the connectivity wait. Await the arming deterministically before driving
+        // reachability so the transition can't race ahead of it.
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // A non-satisfied transition must not consume the armed wait.
+        lifecycleSubject.send(.reachabilityChanged(status: .notReachable))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+        let invocationsAfterUnreachable = await counter.value
+        #expect(invocationsAfterUnreachable == 2, "`.notReachable` must not trigger the retry")
+
+        // Connectivity restored → retry fires (invocation 3), broadcasts and caches.
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+
+        let delivered = await firstElement(of: stream)
+        #expect(delivered == secondToken)
+
+        let cached = try await manager.currentToken(mode: .background)
+        #expect(cached == secondToken)
+    }
+
+    @Test
+    func nonNetworkRefreshFailureDoesNotAwaitConnectivity() async throws {
+        // A refresh failure that is *not* a network `URLError` must not arm the
+        // connectivity wait — restoring connectivity wouldn't fix it. Note the
+        // failure here is `ProviderTestError.network`: despite the name, it is not
+        // a `URLError`, so it is correctly classified as non-connectivity.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            if invocation == 1 { return firstToken }
+            throw ProviderTestError.network
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2) // scheduled refresh failed (non-network)
+
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 2,
+            "a non-network failure must not arm a connectivity retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func clearTokenStateCancelsPendingConnectivityRetry() async throws {
+        // Arm a connectivity wait via a network-failed refresh, then reset. The
+        // pending wait must be dropped so a later reachability restoration does
+        // not retry against the outgoing profile.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet)
+            default: return secondToken
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        // Ensure the wait is genuinely armed before clearing, so the test proves
+        // clearTokenState *cancels* an armed wait rather than racing its arming.
+        await awaitConnectivityWaitArmed(manager)
+
+        await manager.clearTokenState()
+
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 2,
+            "clearTokenState must cancel the pending connectivity retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func rapidReachableTransitionsTriggerSingleRetry() async throws {
+        // The manager keeps at most one pending wait. A flurry of satisfied
+        // transitions after a single network-failed refresh must produce exactly
+        // one retry, not one per transition.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet)
+            default: return secondToken
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Three satisfied transitions in quick succession. Only the first should
+        // consume the armed wait; the rest find it already cleared.
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWWAN))
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        try await counter.waitFor(atLeast: 3)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 3,
+            "rapid reachable transitions must yield a single retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func failedRetryReArmsForNextConnectivityRestoration() async throws {
+        // If the connectivity-driven retry itself fails for a network reason, the
+        // wait is re-armed so the *next* restoration tries again.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2, 3: throw URLError(.networkConnectionLost) // scheduled refresh + first retry
+            default: return secondToken // second retry succeeds
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // First restoration drives a retry (invocation 3) that also fails with a
+        // network error, which re-arms the wait. The wait is cleared before the
+        // retry runs, so awaiting "armed" after invocation 3 enters the provider
+        // observes the *re-arm*, not the prior arming.
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        try await counter.waitFor(atLeast: 3)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Subscribe before the second restoration so the successful retry's
+        // broadcast is observable, then restore connectivity again. Invocation 4
+        // succeeds, proving the wait re-armed and recovered.
+        let stream = await manager.refreshes()
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+
+        let delivered = await firstElement(of: stream)
+        #expect(
+            delivered == secondToken,
+            "a network-failed retry must re-arm and recover on the next restoration"
+        )
+    }
+
     // MARK: - Test helpers
 
     /// `referenceDate` as seconds-since-1970, for minting tokens whose `iat`/`exp`
@@ -523,6 +802,20 @@ struct AuthTokenManagerRefreshTests {
     /// task simply parks on the await without ever firing.
     private func noopLifecycle() -> AppLifeCycleEvents {
         AppLifeCycleEvents(lifeCycleEvents: { Empty().eraseToAnyPublisher() })
+    }
+
+    /// Suspends until `manager` has armed its connectivity-retry wait. The arming
+    /// lands asynchronously inside the refresh-failure path, so driving a
+    /// reachability transition before it would drop the event against an unarmed
+    /// flag. Unlike a fixed yield count, this adapts to scheduling: under a
+    /// saturated cooperative pool (sibling suites running in parallel) it simply
+    /// iterates more, so it can never under-wait. It only fails to return if the
+    /// wait genuinely never arms — which is itself the bug a caller would want to
+    /// surface.
+    private func awaitConnectivityWaitArmed(_ manager: AuthTokenManager) async {
+        while await manager.isAwaitingConnectivityRetryForTesting == false {
+            await Task.yield()
+        }
     }
 
     /// Builds a manager driven by a deterministic clock and sleep gate.


### PR DESCRIPTION
# Description
Adds connectivity-driven retry to `AuthTokenManager`: when a proactive token refresh fails because the device is offline, the manager waits for connectivity to be restored and retries, instead of letting the cached token go stale until the next foreground transition or user fetch.

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- automated test suite on iOS Simulator; see Test Plan -->
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports. <!-- async/await + actor + URLError only; Swift 5.9-safe -->

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes. <!-- all new symbols are `package`/`internal`; no public API change -->
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release. <!-- JWT support in SDK/onsite -->

## Changelog / Code Overview
**As-built note:** this reuses the SDK's existing reachability signal rather than the spec's `ConnectivityMonitoring`/`NWPathMonitor` design — decided with the assignee to keep the change DRY and avoid introducing `Network.framework`.

- **`URLError+Ext.swift` (new):** `URLError.isConnectivityError` classifies the four genuine-offline codes (`.notConnectedToInternet`, `.networkConnectionLost`, `.dataNotAllowed`, `.internationalRoamingOff`). Other failures (HTTP errors, validation rejections, generic timeouts) are deliberately excluded — waiting on connectivity wouldn't address them.
- **`AuthTokenManager`:**
  - A network-classified proactive-refresh failure arms an `isAwaitingConnectivityRetry` flag (in `performScheduledRefresh()`'s `catch`).
  - The actor's already-running lifecycle subscription now also handles `.reachabilityChanged(status:)`; on the next satisfied status it consumes the flag and re-fires `performScheduledRefresh()` (which goes through the normal dedup → validate → reschedule → broadcast path).
  - "At most one pending wait" is the single bool; rapid network flapping can't queue multiple retries. Cleared by `cancelInFlightWorkAndClearCache()`, so both `clearTokenState()` (profile reset) and `registerProvider()` drop a pending retry.
  - A failed retry re-arms for the next restoration.
- No new protocol, no `connectivityWaitTask` field, no `Network.framework` import.

## Test Plan
Automated (deterministic, virtual-clock + gated reachability — no real network):

```
xcodebuild test -scheme klaviyo-swift-sdk-Package \
  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
  -only-testing:KlaviyoCoreTests
```

Five new tests in `AuthTokenManagerRefreshTests.swift`, all green (full target: 56 tests / 3 suites, no hangs):
1. Network-failed refresh retries when connectivity is restored (and `.notReachable` is ignored).
2. A non-network failure does **not** arm a connectivity retry.
3. `clearTokenState()` cancels a pending wait.
4. Rapid satisfied transitions yield a **single** retry.
5. A failed retry re-arms for the next restoration.

Tests await arming deterministically via a documented internal test-only accessor (`isAwaitingConnectivityRetryForTesting`) rather than a fixed yield count, so the reachable event can't race ahead of arming and flake under parallel load.

## Related Issues/Tickets
- [MAGE-683](https://linear.app/klaviyo/issue/MAGE-683/ios-authtokenmanager-connectivity-driven-refresh-retry)
- Stacked on `ab/MAGE-616/live-token-updates-via-refresh-stream` (PR #594).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token refresh reliability: the auth system now defers a single retry for network-classified failures, resumes automatically when connectivity is restored, avoids duplicate retries, and clears pending retries on successful refresh or explicit clears. Added network-error classification to better detect connectivity cases.
* **Tests**
  * Added deterministic tests and helpers to simulate reachability transitions and verify connectivity-driven retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->