### PR TITLE
feat(push): swizzle didRegisterForRemoteNotificationsWithDeviceToken for automatic token forwarding

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
@@ -1,0 +1,280 @@
+//
+//  KlaviyoAppDelegateSwizzler.swift
+//  klaviyo-swift-sdk
+//
+//  Swizzles `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` on the host
+//  app delegate so the SDK receives push tokens automatically.
+//
+//  Created by Glenn Brannelly on 5/15/26.
+//
+
+import Foundation
+import ObjectiveC.runtime
+import OSLog
+import UIKit
+
+/// Donor class whose `klaviyo_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
+/// IMP is grafted onto the host app's `UIApplicationDelegate` class at runtime so the SDK
+/// receives device tokens without the host having to call `KlaviyoSDK().set(pushToken:)`.
+///
+/// ## Concurrency model
+///
+/// Swizzling entry points (`swizzleIfPossible()`, `performSwizzle(on:)`) are invoked from
+/// `KlaviyoNotificationDelegate.injectIfEnabled()`, which is `@MainActor`. The grafted IMP
+/// (`klaviyo_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`) is fired by
+/// iOS on the main thread per the `UIApplicationDelegate` contract. All state mutation is
+/// therefore main-thread-only, but we serialize it through `State`'s `NSLock` so the type
+/// stays safely usable from any thread — Swift 6 strict-concurrency-clean without sprinkling
+/// `MainActor.assumeIsolated` through the IMP that the Obj-C runtime invokes.
+final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
+    /// All mutable state lives behind a lock so the compiler can see it as `Sendable`.
+    /// Strict-concurrency mode flags raw `static var` declarations as global mutable state —
+    /// this wrapper keeps that requirement satisfied without sprinkling `nonisolated(unsafe)`.
+    ///
+    /// Fields:
+    /// - `didSwizzle`: one-way idempotence flag; flipped true the moment swizzling is claimed.
+    /// - `didFinishLaunchingObserver`: token for the deferred-install observer; cleared once fired.
+    /// - `swappedClasses`: classes where IMPs were exchanged (not just added), so the donor IMP
+    ///   knows it should forward to the host's original implementation rather than stop.
+    private final class State: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didSwizzle = false
+        private var didFinishLaunchingObserver: NSObjectProtocol?
+        private var swappedClasses: Set<ObjectIdentifier> = []
+
+        var swizzled: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return didSwizzle
+        }
+
+        var hasObserver: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return didFinishLaunchingObserver != nil
+        }
+
+        /// Atomically transition `didSwizzle` from false → true and report whether this caller
+        /// is the one that did it. Used by `performSwizzle(on:)` to avoid double-swizzling.
+        func claimSwizzle() -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            guard !didSwizzle else { return false }
+            didSwizzle = true
+            return true
+        }
+
+        func setObserver(_ observer: NSObjectProtocol?) {
+            lock.lock(); defer { lock.unlock() }
+            didFinishLaunchingObserver = observer
+        }
+
+        func clearObserver() {
+            lock.lock()
+            let observer = didFinishLaunchingObserver
+            didFinishLaunchingObserver = nil
+            lock.unlock()
+            // removeObserver is called outside the lock to avoid potential re-entrancy
+            // if NotificationCenter tries to acquire the same lock on the same thread.
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        func insertSwappedClass(_ identifier: ObjectIdentifier) {
+            lock.lock(); defer { lock.unlock() }
+            swappedClasses.insert(identifier)
+        }
+
+        func isSwapped(_ identifier: ObjectIdentifier) -> Bool {
+            lock.lock(); defer { lock.unlock() }
+            return swappedClasses.contains(identifier)
+        }
+    }
+
+    private static let state = State()
+
+    /// Swizzles the device-token method on `UIApplication.shared.delegate`'s class. If the
+    /// delegate is not yet available (rare; possible if the SDK is initialized very early in
+    /// app launch), defers until `UIApplication.didFinishLaunchingNotification` fires.
+    @MainActor
+    static func swizzleIfPossible() {
+        if state.swizzled { return }
+
+        if let delegate = UIApplication.shared.delegate {
+            performSwizzle(on: resolveSwizzleTargetClass(for: delegate))
+            return
+        }
+
+        // Guard against duplicate registration if `swizzleIfPossible()` is called more than
+        // once before `didFinishLaunchingNotification` fires (e.g., host calls
+        // `KlaviyoSDK().initialize(with:)` twice in `application(_:willFinishLaunching...)`).
+        // Without this, the second call would register a second observer that stays alive in
+        // `NotificationCenter` indefinitely — `state.setObserver(...)` would overwrite the
+        // stored token, losing the first reference and leaking it.
+        if state.hasObserver { return }
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: UIApplication.didFinishLaunchingNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // `assumeIsolated` asserts main-thread execution synchronously (iOS 17+).
+            // On earlier OS versions the Task hop is safe: the queue is .main so the
+            // closure already runs on the main thread, and the hop lands on MainActor
+            // before any awaited work begins.
+            if #available(iOS 17.0, *) {
+                MainActor.assumeIsolated {
+                    state.clearObserver()
+                    guard let delegate = UIApplication.shared.delegate else { return }
+                    performSwizzle(on: resolveSwizzleTargetClass(for: delegate))
+                }
+            } else {
+                Task { @MainActor in
+                    state.clearObserver()
+                    guard let delegate = UIApplication.shared.delegate else { return }
+                    performSwizzle(on: resolveSwizzleTargetClass(for: delegate))
+                }
+            }
+        }
+        state.setObserver(observer)
+    }
+
+    /// Returns the class on which we should swizzle the device-token method.
+    ///
+    /// For most hosts this is just `type(of: delegate)`. For SwiftUI hosts using
+    /// `@UIApplicationDelegateAdaptor`, however, `UIApplication.shared.delegate` is Apple's
+    /// private `SwiftUI.AppDelegate` wrapper — it doesn't actually implement the
+    /// `UIApplicationDelegate` selectors in its IMP table; it forwards them to the host's real
+    /// `AppDelegate` via Obj-C dynamic dispatch (`-forwardingTargetForSelector:`). Swizzling
+    /// the wrapper grafts our IMP onto a class that has no original method to forward to —
+    /// `UIApplication.shared.delegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
+    /// would hit our IMP and stop there, never invoking the host's own implementation.
+    ///
+    /// To preserve the host's implementation, we probe `-forwardingTargetForSelector:` for the
+    /// `didRegister` selector. If the delegate returns a non-nil object whose class actually
+    /// implements the method, we swizzle that class instead so the Obj-C runtime's forwarding
+    /// chain delivers the call to our IMP on the real implementor. If the probe returns nil
+    /// (host doesn't use a forwarding proxy, or uses `-forwardInvocation:` style forwarding
+    /// instead), we fall back to the wrapper class. The SDK still receives the token; only
+    /// the host's own method is bypassed in that fallback.
+    @MainActor
+    static func resolveSwizzleTargetClass(for delegate: any UIApplicationDelegate) -> AnyClass {
+        let originalSelector = #selector(
+            UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+        )
+        let initialClass: AnyClass = type(of: delegate)
+
+        if class_getInstanceMethod(initialClass, originalSelector) != nil {
+            return initialClass
+        }
+
+        // Forwarding-proxy fast path: ask Obj-C runtime where this selector would actually
+        // dispatch via `-forwardingTargetForSelector:`. Used by SwiftUI's
+        // `@UIApplicationDelegateAdaptor` wrapper, and any other proxy that follows the same
+        // convention.
+        if let nsDelegate = delegate as? NSObject,
+           let forwardingTarget = nsDelegate.forwardingTarget(for: originalSelector) {
+            let realClass: AnyClass = type(of: forwardingTarget as AnyObject)
+            if realClass !== initialClass,
+               class_getInstanceMethod(realClass, originalSelector) != nil {
+                if #available(iOS 14.0, *) {
+                    Logger.notifications.info("""
+                    Swizzler: \(NSStringFromClass(initialClass)) forwards \
+                    \(NSStringFromSelector(originalSelector)) to \
+                    \(NSStringFromClass(realClass)); swizzling the latter.
+                    """)
+                }
+                return realClass
+            }
+        }
+
+        // Initial class has no IMP and either no forwarding target or one whose class also
+        // doesn't implement the method. Fall back to the initial class — the swizzler will
+        // graft our IMP on it. The SDK still gets the token, but the host's own method
+        // (if reachable through some other forwarding mechanism) won't fire.
+        return initialClass
+    }
+
+    /// Installs the donor IMP on `hostClass` using one of two strategies:
+    /// - **Exchange**: host already implements the method — swap IMPs so the original selector
+    ///   hits our donor first, then the donor forwards to the host's original (now under
+    ///   `swizzledSelector`).
+    /// - **Add**: host has no implementation — install our donor directly under the original
+    ///   selector; no forwarding needed since there is no original to chain to.
+    @MainActor
+    private static func performSwizzle(on hostClass: AnyClass) {
+        let originalSelector = #selector(
+            UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+        )
+        let swizzledSelector = #selector(
+            KlaviyoAppDelegateSwizzler
+                .klaviyo_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+        )
+
+        guard let donorMethod = class_getInstanceMethod(
+            KlaviyoAppDelegateSwizzler.self, swizzledSelector
+        ) else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.error(
+                    "Swizzler donor method missing; device-token forwarding disabled."
+                )
+            }
+            return
+        }
+        guard state.claimSwizzle() else { return }
+
+        let donorIMP = method_getImplementation(donorMethod)
+        let donorTypes = method_getTypeEncoding(donorMethod)
+
+        // Always add the swizzled selector to the host class so we have a stable forwarding target.
+        class_addMethod(hostClass, swizzledSelector, donorIMP, donorTypes)
+
+        if let hostOriginal = class_getInstanceMethod(hostClass, originalSelector),
+           let hostSwizzled = class_getInstanceMethod(hostClass, swizzledSelector) {
+            // Host implements the original — exchange so calls to the original selector hit our
+            // IMP, and our forwarding call (swizzled selector) hits the host's original IMP.
+            method_exchangeImplementations(hostOriginal, hostSwizzled)
+            state.insertSwappedClass(ObjectIdentifier(hostClass))
+            if #available(iOS 14.0, *) {
+                Logger.notifications.info(
+                    "Swizzled didRegisterForRemoteNotificationsWithDeviceToken on \(hostClass)."
+                )
+            }
+        } else {
+            // Host does not implement the method — graft our IMP under the original selector
+            // directly. No forwarding required (there is no original to call).
+            class_addMethod(hostClass, originalSelector, donorIMP, donorTypes)
+            if #available(iOS 14.0, *) {
+                Logger.notifications.info(
+                    "Grafted didRegisterForRemoteNotificationsWithDeviceToken onto \(hostClass)."
+                )
+            }
+        }
+    }
+
+    /// Donor method installed onto the host AppDelegate class by `performSwizzle(on:)`.
+    /// Invoked by the Obj-C runtime on the main thread when iOS delivers the device-token
+    /// callback. Not `@MainActor` — Obj-C dynamic dispatch bypasses Swift actor isolation;
+    /// main-thread delivery is guaranteed by the `UIApplicationDelegate` contract instead.
+    @objc
+    private dynamic func klaviyo_application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        KlaviyoSDK().set(pushToken: deviceToken)
+
+        // Only forward if we exchanged with an existing host IMP. If we merely grafted our IMP
+        // (host didn't implement the method), the swizzled selector points back at us and
+        // forwarding would recurse.
+        let hostClass: AnyClass = type(of: self)
+        guard Self.state.isSwapped(ObjectIdentifier(hostClass)) else { return }
+
+        let swizzledSelector = #selector(
+            KlaviyoAppDelegateSwizzler
+                .klaviyo_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+        )
+        guard let method = class_getInstanceMethod(hostClass, swizzledSelector) else { return }
+        let hostIMP = method_getImplementation(method)
+        typealias DeviceTokenIMP = @convention(c) (NSObject, Selector, UIApplication, NSData) -> Void
+        let forwardIMP = unsafeBitCast(hostIMP, to: DeviceTokenIMP.self)
+        forwardIMP(self, swizzledSelector, application, deviceToken as NSData)
+    }
+}

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -96,6 +96,7 @@ final class KlaviyoNotificationDelegate: NSObject {
             return
         }
         shared.inject(into: klaviyoSwiftEnvironment.notificationCenter())
+        KlaviyoAppDelegateSwizzler.swizzleIfPossible()
     }
 
     /// Installs the proxy as the notification center's active delegate and registers

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -1,0 +1,96 @@
+//
+//  KlaviyoAppDelegateSwizzlerTests.swift
+//  KlaviyoSwiftTests
+//
+//  Coverage for `KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for:)` — specifically
+//  the SwiftUI `@UIApplicationDelegateAdaptor` case where `UIApplication.shared.delegate` is
+//  a private SwiftUI wrapper that forwards selectors to the host's real AppDelegate via
+//  `-forwardingTargetForSelector:`.
+//
+
+@testable import KlaviyoSwift
+import ObjectiveC.runtime
+import Testing
+import UIKit
+
+@MainActor
+struct KlaviyoAppDelegateSwizzlerTests {
+    // MARK: - Test doubles
+
+    /// A direct UIApplicationDelegate implementor — mimics the simplest host case where the
+    /// user's `AppDelegate` is the actual `UIApplication.shared.delegate`.
+    private final class DirectAppDelegate: NSObject, UIApplicationDelegate {
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {}
+    }
+
+    /// A NSObject that doesn't implement `application:didRegister...` in its IMP table but
+    /// forwards selectors to an inner host delegate via `-forwardingTargetForSelector:`.
+    /// This mirrors how SwiftUI's `@UIApplicationDelegateAdaptor` wrapper behaves.
+    private final class ForwardingProxyDelegate: NSObject, UIApplicationDelegate {
+        let inner: DirectAppDelegate
+
+        init(inner: DirectAppDelegate) {
+            self.inner = inner
+        }
+
+        override func forwardingTarget(for aSelector: Selector!) -> Any? {
+            inner.responds(to: aSelector) ? inner : super.forwardingTarget(for: aSelector)
+        }
+
+        override func responds(to aSelector: Selector!) -> Bool {
+            super.responds(to: aSelector) || inner.responds(to: aSelector)
+        }
+    }
+
+    /// A NSObject that doesn't implement the method and doesn't expose a forwarding target.
+    /// Mirrors the fallback case where the SDK should still graft onto the wrapper class.
+    private final class OpaqueDelegate: NSObject, UIApplicationDelegate {}
+
+    // MARK: - Helpers
+
+    private let didRegisterSelector = #selector(
+        UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+    )
+
+    // MARK: - Tests
+
+    @Test
+    func resolveTargetDirectImplementor() {
+        let delegate = DirectAppDelegate()
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
+        #expect(resolved == DirectAppDelegate.self)
+    }
+
+    @Test
+    func resolveTargetForwardingProxy() {
+        // The proxy has no `didRegister` IMP of its own; its inner DirectAppDelegate does.
+        // The resolver must follow `-forwardingTargetForSelector:` and return the inner class
+        // so the IMP exchange intercepts the real implementor rather than the wrapper.
+        let inner = DirectAppDelegate()
+        let proxy = ForwardingProxyDelegate(inner: inner)
+
+        #expect(
+            class_getInstanceMethod(ForwardingProxyDelegate.self, didRegisterSelector) == nil,
+            "Proxy class must not have the method in its IMP table; otherwise we're not testing the forwarding path"
+        )
+        #expect(
+            proxy.responds(to: didRegisterSelector),
+            "Proxy must respond via forwarding for this test to be meaningful"
+        )
+
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
+        #expect(resolved == DirectAppDelegate.self)
+    }
+
+    @Test
+    func resolveTargetOpaqueDelegate() {
+        // No forwarding, no IMP — resolver falls back to the initial class so the swizzler
+        // can still graft our IMP somewhere and the SDK receives the token.
+        let opaque = OpaqueDelegate()
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
+        #expect(resolved == OpaqueDelegate.self)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -10,11 +10,11 @@
 
 @testable import KlaviyoSwift
 import ObjectiveC.runtime
-import Testing
 import UIKit
+import XCTest
 
 @MainActor
-struct KlaviyoAppDelegateSwizzlerTests {
+final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // MARK: - Test doubles
 
     /// A direct UIApplicationDelegate implementor — mimics the simplest host case where the
@@ -57,40 +57,37 @@ struct KlaviyoAppDelegateSwizzlerTests {
 
     // MARK: - Tests
 
-    @Test
-    func resolveTargetDirectImplementor() {
+    func testResolveTargetDirectImplementor() {
         let delegate = DirectAppDelegate()
         let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
-        #expect(resolved == DirectAppDelegate.self)
+        XCTAssertTrue(resolved == DirectAppDelegate.self)
     }
 
-    @Test
-    func resolveTargetForwardingProxy() {
+    func testResolveTargetForwardingProxy() {
         // The proxy has no `didRegister` IMP of its own; its inner DirectAppDelegate does.
         // The resolver must follow `-forwardingTargetForSelector:` and return the inner class
         // so the IMP exchange intercepts the real implementor rather than the wrapper.
         let inner = DirectAppDelegate()
         let proxy = ForwardingProxyDelegate(inner: inner)
 
-        #expect(
-            class_getInstanceMethod(ForwardingProxyDelegate.self, didRegisterSelector) == nil,
+        XCTAssertNil(
+            class_getInstanceMethod(ForwardingProxyDelegate.self, didRegisterSelector),
             "Proxy class must not have the method in its IMP table; otherwise we're not testing the forwarding path"
         )
-        #expect(
+        XCTAssertTrue(
             proxy.responds(to: didRegisterSelector),
             "Proxy must respond via forwarding for this test to be meaningful"
         )
 
         let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
-        #expect(resolved == DirectAppDelegate.self)
+        XCTAssertTrue(resolved == DirectAppDelegate.self)
     }
 
-    @Test
-    func resolveTargetOpaqueDelegate() {
+    func testResolveTargetOpaqueDelegate() {
         // No forwarding, no IMP — resolver falls back to the initial class so the swizzler
         // can still graft our IMP somewhere and the SDK receives the token.
         let opaque = OpaqueDelegate()
         let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
-        #expect(resolved == OpaqueDelegate.self)
+        XCTAssertTrue(resolved == OpaqueDelegate.self)
     }
 }


### PR DESCRIPTION
# Description

Adds `KlaviyoAppDelegateSwizzler` so hosts that opt in via `klaviyo_automatic_push_tracking = YES` no longer need to call `KlaviyoSDK().set(pushToken:)` manually — the SDK intercepts `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` at the Obj-C runtime layer and forwards the token automatically.

In addition to the code comments, I created a doc explaining how the swizzler works under the hood: https://docs.google.com/document/d/1GCZqC4Cag-yCResYonjLhTb2kLLwKOV-7QYvYGEI9zw/edit?usp=sharing

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No public API changes. Behavior is gated by `klaviyo_automatic_push_tracking` Info.plist key; hosts without the key see zero behavior change.


## Changelog / Code Overview

**New: `Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift`**

Donor class that grafts a Klaviyo IMP onto the host's `UIApplicationDelegate` class at SDK init time. Handles three host configurations:

1. **Standard UIKit AppDelegate that implements `didRegister`** — `method_exchangeImplementations` swaps IMPs so calls hit our donor first, then chain to the host's original.
2. **Standard UIKit AppDelegate that does not implement `didRegister`** — `class_addMethod` grafts our donor directly under the original selector.
3. **SwiftUI `@UIApplicationDelegateAdaptor` hosts** — `UIApplication.shared.delegate` is Apple's private wrapper that forwards selectors to the host's real AppDelegate via `-forwardingTargetForSelector:`. `resolveSwizzleTargetClass(for:)` walks the forwarding chain so we swizzle the real implementor, not the wrapper.

Also handles the deferred-install case where `UIApplication.shared.delegate` is nil at SDK init time — registers a one-shot observer for `UIApplication.didFinishLaunchingNotification` and swizzles then.

Idempotent across repeat `initialize()` calls via a one-way `didSwizzle` flag in the private `State` singleton (`NSLock`-protected for Swift 6 strict concurrency).

**Modified: `Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift`**

One-line addition to `injectIfEnabled()` to call `KlaviyoAppDelegateSwizzler.swizzleIfPossible()` after `inject(into:)`. Both share the same plist gate.

**New: `Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift`**

Swift Testing coverage for `resolveSwizzleTargetClass(for:)` — the genuinely non-trivial logic in this file. Three scenarios:
- Direct implementor → returns initial class
- Forwarding proxy (SwiftUI case) → returns inner class
- Opaque delegate → falls back to initial class

`performSwizzle` and the donor IMP are intentionally not unit-tested — they mutate global Obj-C runtime state irreversibly per process and are better verified once manually in the example app. See "Out of scope" below.


## Test Plan

**Automated:**
- [x] `make test-library` passes (Swift Testing, iPhone 17 Pro / iOS 26)
- [x] `swiftlint --strict` passes
- [x] `swiftformat` passes via pre-commit
- [x] Builds clean on iOS 18.6 simulator (locally available)
- [ ] CI confirms builds and tests pass on iOS 15.2 and 16.4

**Manual (recommended once MAGE-657 is also merged to `feat/auto-push-tracking`):**
1. SPMExample: set `klaviyo_automatic_push_tracking = YES` in Info.plist
2. Remove any manual `KlaviyoSDK().set(pushToken:)` call
3. Launch app, grant notification permission, observe log: `Swizzled didRegisterForRemoteNotificationsWithDeviceToken on <AppDelegate>`
4. Confirm push token reaches Klaviyo (check profile in dashboard)
5. Repeat with a SwiftUI `@UIApplicationDelegateAdaptor` host — should see the forwarding log line as well


## Out of scope

Documented per the ticket:
- Other AppDelegate methods (`didReceiveRemoteNotification:fetchCompletionHandler:`, `didFailToRegisterForRemoteNotificationsWithError:`) — push opens are handled by the proxy in MAGE-657; silent push stays manual.
- Hosts using `-forwardInvocation:` without `-forwardingTargetForSelector:` — resolver returns the wrapper class; SDK still gets the token but host's method bypassed. SwiftUI uses `forwardingTarget` so the common case is covered.
- Test coverage for `performSwizzle` exchange/add paths and deferred install — intentional, see PR body above.


## Related Issues/Tickets

Resolves MAGE-659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic push token registration: the SDK now seamlessly handles device token setup with Klaviyo without requiring manual configuration in your app delegate.

* **Tests**
  * Added test coverage for automatic push token registration across different app delegate implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->