### PR TITLE
ci: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,178 +1,51 @@
-# ISO language code for review output (80+ locales supported)
-language: en-US
-# Free-form instruction injected into every review prompt (max 250 chars)
-tone_instructions: "Be concise and direct. Prioritize correctness and API quality over style."
-# Opt-in to experimental CodeRabbit features before general availability
-early_access: false
-
 reviews:
-  # chill = bugs/security only | assertive = full best-practices | followup = assertive + tracks unresolved prior comments
   profile: assertive
-  # Post a plain-English PR description at the top of the walkthrough comment
-  high_level_summary: true
-  # Wrap the file-by-file walkthrough in a <details> block to reduce comment length
-  collapse_walkthrough: true
-  # Generate Mermaid sequence/flow diagrams illustrating the code changes
-  sequence_diagrams: true
-  # Include a complexity score (XS–XL) to help prioritize review effort
-  estimate_code_review_effort: true
-  # Decorative poem in the walkthrough — disabled for a professional context
-  poem: false
-  # "Fortune cookie" message posted while the review is in progress — disabled
-  in_progress_fortune: false
-
-  # Global instructions prepended to every file review prompt.
-  # Tell CodeRabbit about our stack so it doesn't re-flag what CI already enforces.
-  instructions: |
-    This is a multi-module Swift SDK using The Composable Architecture (TCA).
-    SwiftLint and SwiftFormat are enforced in CI and pre-commit — do not flag formatting or style
-    issues already covered by these tools.
-    The test suite is primarily XCTest; a small number of newer files use Swift Testing (@Test,
-    #expect). Both are acceptable — do not flag XCTest patterns as problems.
-    Flag force unwraps (`!`) in Sources/** as errors. Allow them in Tests/** where appropriate.
-    Flag missing actor isolation in async/concurrent code.
-    Flag any breaking changes to public API surface.
-
-  # Minimatch globs — prefix ! to exclude a path from review entirely.
-  # CodeRabbit already auto-excludes binaries, node_modules, lock files, and dist/.
   path_filters:
-    - "!Examples/**"                      # Sample apps — not part of the SDK under review
-    - "!Sources/KlaviyoSwift/Vendor/**"   # Third-party source vendored into the module
+    - "!Examples/**"
+    - "!Sources/KlaviyoSwift/Vendor/**"
     - "!Tests/KlaviyoSwiftTests/Vendor/**"
-    - "!**/__Snapshots__/**"              # Generated snapshot reference images
-    - "!**/*.xcodeproj/**"               # Xcode project files (auto-generated)
+    - "!**/__Snapshots__/**"
+    - "!**/*.xcodeproj/**"
     - "!**/*.xcworkspace/**"
-    - "!**/xcshareddata/**"              # Xcode shared scheme/settings files
-    - "!**/Podfile.lock"                 # CocoaPods lock file
+    - "!**/xcshareddata/**"
+    - "!**/Podfile.lock"
     - "!**/Pods/**"
-    - "!TestResults*/**"                 # .xcresult bundles written by CI
-
-  # Per-path review instructions — layered on top of the global instructions above.
-  # Use these to give CodeRabbit module-specific context it can't infer from code alone.
+    - "!TestResults*/**"
   path_instructions:
     - path: "Sources/KlaviyoCore/**"
       instructions: |
         Shared internal module. Be strict about breaking changes to types or protocols that other
         modules depend on. Flag any public API additions or removals prominently.
-
     - path: "Sources/KlaviyoSwift/**"
       instructions: |
         Main analytics and push notifications module. Focus on: TCA reducer correctness,
         thread safety, actor isolation, proper error handling. Flag force unwraps and
         unhandled async errors.
-
     - path: "Sources/KlaviyoForms/**"
       instructions: |
         In-app messaging UI module. Check for: SwiftUI best practices (correct use of @State,
         @Binding, @StateObject, @EnvironmentObject), main-thread enforcement, accessibility
         modifiers, memory leaks via retain cycles in closures.
-
     - path: "Sources/KlaviyoLocation/**"
       instructions: |
         Geofencing module. Focus on: proper CLLocationManager usage, permission handling,
         background execution correctness, battery impact.
-
     - path: "Sources/KlaviyoSwiftExtension/**"
       instructions: |
         App Extension target. Flag any APIs incompatible with the app extension sandbox
         (e.g., UIApplication.shared, background tasks not allowed in extensions).
         Check for missing @available guards.
-
     - path: "Tests/**"
       instructions: |
-        Primarily XCTest — do not flag XCTest usage as a problem.
+        XCTest is the primary framework — do not flag XCTest usage as a problem.
         Swift Testing (@Test, #expect) is acceptable for new files.
         Focus on: test isolation, missing assertions, coverage of error/edge-case paths,
         and snapshot test correctness. Avoid style comments.
-
   auto_review:
-    enabled: true
-    # Re-review automatically when new commits are pushed to an open PR
-    auto_incremental_review: true
-    # Do not review draft PRs — avoids noise on WIP branches
     drafts: false
-    # PRs whose titles contain these keywords are skipped entirely
-    ignore_title_keywords:
-      - "WIP"
-      - "DO NOT MERGE"
-    # Only review PRs targeting these branches (supports regex)
     base_branches:
-      - "master"
-      - "rel/.*"  # Matches all release branches (e.g. rel/3.2.0)
-
+      - ".*"
   tools:
-    # CodeRabbit runs SwiftLint natively — point it at our existing config.
-    # It auto-deduplicates with CI: if SwiftLint already ran in the pipeline,
-    # CodeRabbit skips re-flagging the same issues.
     swiftlint:
       enabled: true
       config_file: ".swiftlint.yml"
-    # Semgrep runs static analysis rules for security and correctness patterns
-    semgrep:
-      enabled: true
-    # ShellCheck lints the .sh scripts in the repo (e.g. bump-version.sh)
-    shellcheck:
-      enabled: true
-    # Disable linters irrelevant to a Swift-only repo to reduce noise
-    ruff:
-      enabled: false  # Python linter
-    eslint:
-      enabled: false  # JavaScript/TypeScript linter
-    biome:
-      enabled: false  # JS/TS formatter+linter
-    golangci-lint:
-      enabled: false  # Go linter
-    phpstan:
-      enabled: false  # PHP linter
-
-chat:
-  # Respond to @coderabbitai commands automatically without needing a mention trigger
-  auto_reply: true
-  # ASCII/emoji decorative art in chat responses — disabled
-  art: false
-
-knowledge_base:
-  # Set to true to prevent CodeRabbit from learning from this repo's PRs/reviews
-  opt_out: false
-  # Allow CodeRabbit to search the web when answering questions in PR comments
-  web_search:
-    enabled: true
-  # auto = use repo-level learnings when relevant, fall back to org-level learnings
-  learnings:
-    scope: auto
-  # Cross-reference GitHub Issues when reviewing related PRs
-  issues:
-    scope: auto
-  # Reference past PRs when reviewing to surface related patterns or regressions
-  pull_requests:
-    scope: auto
-
-code_generation:
-  # Controls the style CodeRabbit uses when suggesting or generating doc comments
-  docstrings:
-    language: en-US
-    path_instructions:
-      - path: "**/*.swift"
-        instructions: "Use Swift doc comment style (/// for single-line, /** */ for multi-line)."
-  # Controls the style CodeRabbit uses when suggesting or generating unit tests
-  unit_tests:
-    path_instructions:
-      - path: "Tests/**"
-        instructions: "The suite is primarily XCTest. Swift Testing (@Test, #expect) is acceptable for new files."
-
-# --- Linear integration (disabled) ---
-# Uncomment to wire CodeRabbit up to Linear tickets.
-# When enabled, CodeRabbit cross-references the linked MAGE ticket during PR review
-# and checks whether the implementation covers the issue's acceptance criteria.
-# Requires team_keys to match the Linear team identifier for your org.
-#
-# chat:
-#   integrations:
-#     linear:
-#       usage: auto        # only activates when a Linear ticket is linked to the PR
-#       team_keys: ["MAGE"]
-#
-# knowledge_base:
-#   linear:
-#     usage: auto
-#     team_keys: ["MAGE"]

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,36 +11,6 @@ reviews:
     - "!**/Podfile.lock"
     - "!**/Pods/**"
     - "!TestResults*/**"
-  path_instructions:
-    - path: "Sources/KlaviyoCore/**"
-      instructions: |
-        Shared internal module. Be strict about breaking changes to types or protocols that other
-        modules depend on. Flag any public API additions or removals prominently.
-    - path: "Sources/KlaviyoSwift/**"
-      instructions: |
-        Main analytics and push notifications module. Focus on: TCA reducer correctness,
-        thread safety, actor isolation, proper error handling. Flag force unwraps and
-        unhandled async errors.
-    - path: "Sources/KlaviyoForms/**"
-      instructions: |
-        In-app messaging UI module. Check for: SwiftUI best practices (correct use of @State,
-        @Binding, @StateObject, @EnvironmentObject), main-thread enforcement, accessibility
-        modifiers, memory leaks via retain cycles in closures.
-    - path: "Sources/KlaviyoLocation/**"
-      instructions: |
-        Geofencing module. Focus on: proper CLLocationManager usage, permission handling,
-        background execution correctness, battery impact.
-    - path: "Sources/KlaviyoSwiftExtension/**"
-      instructions: |
-        App Extension target. Flag any APIs incompatible with the app extension sandbox
-        (e.g., UIApplication.shared, background tasks not allowed in extensions).
-        Check for missing @available guards.
-    - path: "Tests/**"
-      instructions: |
-        XCTest is the primary framework — do not flag XCTest usage as a problem.
-        Swift Testing (@Test, #expect) is acceptable for new files.
-        Focus on: test isolation, missing assertions, coverage of error/edge-case paths,
-        and snapshot test correctness. Avoid style comments.
   auto_review:
     drafts: false
     base_branches:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,16 +1,28 @@
+# ISO language code for review output (80+ locales supported)
 language: en-US
+# Free-form instruction injected into every review prompt (max 250 chars)
 tone_instructions: "Be concise and direct. Prioritize correctness and API quality over style."
+# Opt-in to experimental CodeRabbit features before general availability
 early_access: false
 
 reviews:
+  # chill = bugs/security only | assertive = full best-practices | followup = assertive + tracks unresolved prior comments
   profile: assertive
+  # Post a plain-English PR description at the top of the walkthrough comment
   high_level_summary: true
+  # Wrap the file-by-file walkthrough in a <details> block to reduce comment length
   collapse_walkthrough: true
+  # Generate Mermaid sequence/flow diagrams illustrating the code changes
   sequence_diagrams: true
+  # Include a complexity score (XS–XL) to help prioritize review effort
   estimate_code_review_effort: true
+  # Decorative poem in the walkthrough — disabled for a professional context
   poem: false
+  # "Fortune cookie" message posted while the review is in progress — disabled
   in_progress_fortune: false
 
+  # Global instructions prepended to every file review prompt.
+  # Tell CodeRabbit about our stack so it doesn't re-flag what CI already enforces.
   instructions: |
     This is a multi-module Swift SDK using The Composable Architecture (TCA).
     SwiftLint and SwiftFormat are enforced in CI and pre-commit — do not flag formatting or style
@@ -21,18 +33,22 @@ reviews:
     Flag missing actor isolation in async/concurrent code.
     Flag any breaking changes to public API surface.
 
+  # Minimatch globs — prefix ! to exclude a path from review entirely.
+  # CodeRabbit already auto-excludes binaries, node_modules, lock files, and dist/.
   path_filters:
-    - "!Examples/**"
-    - "!Sources/KlaviyoSwift/Vendor/**"
+    - "!Examples/**"                      # Sample apps — not part of the SDK under review
+    - "!Sources/KlaviyoSwift/Vendor/**"   # Third-party source vendored into the module
     - "!Tests/KlaviyoSwiftTests/Vendor/**"
-    - "!**/__Snapshots__/**"
-    - "!**/*.xcodeproj/**"
+    - "!**/__Snapshots__/**"              # Generated snapshot reference images
+    - "!**/*.xcodeproj/**"               # Xcode project files (auto-generated)
     - "!**/*.xcworkspace/**"
-    - "!**/xcshareddata/**"
-    - "!**/Podfile.lock"
+    - "!**/xcshareddata/**"              # Xcode shared scheme/settings files
+    - "!**/Podfile.lock"                 # CocoaPods lock file
     - "!**/Pods/**"
-    - "!TestResults*/**"
+    - "!TestResults*/**"                 # .xcresult bundles written by CI
 
+  # Per-path review instructions — layered on top of the global instructions above.
+  # Use these to give CodeRabbit module-specific context it can't infer from code alone.
   path_instructions:
     - path: "Sources/KlaviyoCore/**"
       instructions: |
@@ -71,55 +87,74 @@ reviews:
 
   auto_review:
     enabled: true
+    # Re-review automatically when new commits are pushed to an open PR
     auto_incremental_review: true
+    # Do not review draft PRs — avoids noise on WIP branches
     drafts: false
+    # PRs whose titles contain these keywords are skipped entirely
     ignore_title_keywords:
       - "WIP"
       - "DO NOT MERGE"
+    # Only review PRs targeting these branches (supports regex)
     base_branches:
       - "master"
-      - "rel/.*"
+      - "rel/.*"  # Matches all release branches (e.g. rel/3.2.0)
 
   tools:
+    # CodeRabbit runs SwiftLint natively — point it at our existing config.
+    # It auto-deduplicates with CI: if SwiftLint already ran in the pipeline,
+    # CodeRabbit skips re-flagging the same issues.
     swiftlint:
       enabled: true
       config_file: ".swiftlint.yml"
+    # Semgrep runs static analysis rules for security and correctness patterns
     semgrep:
       enabled: true
+    # ShellCheck lints the .sh scripts in the repo (e.g. bump-version.sh)
     shellcheck:
       enabled: true
+    # Disable linters irrelevant to a Swift-only repo to reduce noise
     ruff:
-      enabled: false
+      enabled: false  # Python linter
     eslint:
-      enabled: false
+      enabled: false  # JavaScript/TypeScript linter
     biome:
-      enabled: false
+      enabled: false  # JS/TS formatter+linter
     golangci-lint:
-      enabled: false
+      enabled: false  # Go linter
     phpstan:
-      enabled: false
+      enabled: false  # PHP linter
 
 chat:
+  # Respond to @coderabbitai commands automatically without needing a mention trigger
   auto_reply: true
+  # ASCII/emoji decorative art in chat responses — disabled
   art: false
 
 knowledge_base:
+  # Set to true to prevent CodeRabbit from learning from this repo's PRs/reviews
   opt_out: false
+  # Allow CodeRabbit to search the web when answering questions in PR comments
   web_search:
     enabled: true
+  # auto = use repo-level learnings when relevant, fall back to org-level learnings
   learnings:
     scope: auto
+  # Cross-reference GitHub Issues when reviewing related PRs
   issues:
     scope: auto
+  # Reference past PRs when reviewing to surface related patterns or regressions
   pull_requests:
     scope: auto
 
 code_generation:
+  # Controls the style CodeRabbit uses when suggesting or generating doc comments
   docstrings:
     language: en-US
     path_instructions:
       - path: "**/*.swift"
         instructions: "Use Swift doc comment style (/// for single-line, /** */ for multi-line)."
+  # Controls the style CodeRabbit uses when suggesting or generating unit tests
   unit_tests:
     path_instructions:
       - path: "Tests/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,126 @@
+language: en-US
+tone_instructions: "Be concise and direct. Prioritize correctness and API quality over style."
+early_access: false
+
+reviews:
+  profile: assertive
+  high_level_summary: true
+  collapse_walkthrough: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  poem: false
+  in_progress_fortune: false
+
+  instructions: |
+    This is a multi-module Swift SDK using The Composable Architecture (TCA).
+    SwiftLint and SwiftFormat are enforced in CI and pre-commit — do not flag formatting or style
+    issues already covered by these tools.
+    The test suite is primarily XCTest; a small number of newer files use Swift Testing (@Test,
+    #expect). Both are acceptable — do not flag XCTest patterns as problems.
+    Flag force unwraps (`!`) in Sources/** as errors. Allow them in Tests/** where appropriate.
+    Flag missing actor isolation in async/concurrent code.
+    Flag any breaking changes to public API surface.
+
+  path_filters:
+    - "!Examples/**"
+    - "!Sources/KlaviyoSwift/Vendor/**"
+    - "!Tests/KlaviyoSwiftTests/Vendor/**"
+    - "!**/__Snapshots__/**"
+    - "!**/*.xcodeproj/**"
+    - "!**/*.xcworkspace/**"
+    - "!**/xcshareddata/**"
+    - "!**/Podfile.lock"
+    - "!**/Pods/**"
+    - "!TestResults*/**"
+
+  path_instructions:
+    - path: "Sources/KlaviyoCore/**"
+      instructions: |
+        Shared internal module. Be strict about breaking changes to types or protocols that other
+        modules depend on. Flag any public API additions or removals prominently.
+
+    - path: "Sources/KlaviyoSwift/**"
+      instructions: |
+        Main analytics and push notifications module. Focus on: TCA reducer correctness,
+        thread safety, actor isolation, proper error handling. Flag force unwraps and
+        unhandled async errors.
+
+    - path: "Sources/KlaviyoForms/**"
+      instructions: |
+        In-app messaging UI module. Check for: SwiftUI best practices (correct use of @State,
+        @Binding, @StateObject, @EnvironmentObject), main-thread enforcement, accessibility
+        modifiers, memory leaks via retain cycles in closures.
+
+    - path: "Sources/KlaviyoLocation/**"
+      instructions: |
+        Geofencing module. Focus on: proper CLLocationManager usage, permission handling,
+        background execution correctness, battery impact.
+
+    - path: "Sources/KlaviyoSwiftExtension/**"
+      instructions: |
+        App Extension target. Flag any APIs incompatible with the app extension sandbox
+        (e.g., UIApplication.shared, background tasks not allowed in extensions).
+        Check for missing @available guards.
+
+    - path: "Tests/**"
+      instructions: |
+        Primarily XCTest — do not flag XCTest usage as a problem.
+        Swift Testing (@Test, #expect) is acceptable for new files.
+        Focus on: test isolation, missing assertions, coverage of error/edge-case paths,
+        and snapshot test correctness. Avoid style comments.
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    base_branches:
+      - "master"
+      - "rel/.*"
+
+  tools:
+    swiftlint:
+      enabled: true
+      config_file: ".swiftlint.yml"
+    semgrep:
+      enabled: true
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: false
+    eslint:
+      enabled: false
+    biome:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    phpstan:
+      enabled: false
+
+chat:
+  auto_reply: true
+  art: false
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+
+code_generation:
+  docstrings:
+    language: en-US
+    path_instructions:
+      - path: "**/*.swift"
+        instructions: "Use Swift doc comment style (/// for single-line, /** */ for multi-line)."
+  unit_tests:
+    path_instructions:
+      - path: "Tests/**"
+        instructions: "The suite is primarily XCTest. Swift Testing (@Test, #expect) is acceptable for new files."

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -159,3 +159,20 @@ code_generation:
     path_instructions:
       - path: "Tests/**"
         instructions: "The suite is primarily XCTest. Swift Testing (@Test, #expect) is acceptable for new files."
+
+# --- Linear integration (disabled) ---
+# Uncomment to wire CodeRabbit up to Linear tickets.
+# When enabled, CodeRabbit cross-references the linked MAGE ticket during PR review
+# and checks whether the implementation covers the issue's acceptance criteria.
+# Requires team_keys to match the Linear team identifier for your org.
+#
+# chat:
+#   integrations:
+#     linear:
+#       usage: auto        # only activates when a Linear ticket is linked to the PR
+#       team_keys: ["MAGE"]
+#
+# knowledge_base:
+#   linear:
+#     usage: auto
+#     team_keys: ["MAGE"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ swiftlint --fix --strict
 swiftformat .
 ```
 
+### Code Review
+
+CodeRabbit is active on this repo and auto-reviews PRs. It reads this file as a code guidelines
+source. When performing code reviews, avoid re-surfacing findings CodeRabbit may have already flagged.
+If you notice patterns worth encoding as review guidance, suggest adding them to `.coderabbit.yaml`.
+
 ### Commits & Pull Requests
 If prompted to commit, push, or open pull requests:
 


### PR DESCRIPTION
# Description
Adds a minimal `.coderabbit.yaml` to tune CodeRabbit reviews for this SDK rather than running on generic defaults.

CodeRabbit auto-reads `AGENTS.md` and `CLAUDE.md` for code guidelines — so the yaml only configures what a markdown file can't express: path exclusions, per-module review instructions, review profile, auto-review behavior, and SwiftLint config path.

Also adds a brief Code Review note to `AGENTS.md` so AI agents working locally are aware CodeRabbit is active.

## Due Diligence
_Config-only change — no source code or tests affected._

## Changelog
- **`.coderabbit.yaml`** — `profile: assertive`, path filters excluding generated/vendored files, per-module `path_instructions`, `drafts: false`, `base_branches: .*` (all branches during trial), SwiftLint pointed at `.swiftlint.yml`
- **`AGENTS.md`** — added Code Review section noting CodeRabbit is active and pointing agents to `.coderabbit.yaml` for review guidance

## Test Plan
- [ ] Merge and confirm CodeRabbit posts a walkthrough on the next non-draft PR
- [ ] Post `@coderabbitai configuration` on a PR to verify the active config matches this file
- [ ] Confirm changes to `Examples/**`, `**/__Snapshots__/**`, or vendored files are not reviewed

## Related Issues/Tickets
N/A — internal tooling improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated code review system with optimized filtering rules to streamline review coverage across build artifacts, dependencies, and generated files.

* **Documentation**
  * Updated team guidelines with code review process documentation and recommendations for integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->