### PR TITLE
fix(KlaviyoCore): retry failed/missed scheduled refresh on foreground (MAGE-735)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,10 +76,12 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
-    /// `true` while ``performScheduledRefresh()`` is mid-flight, so the foreground
-    /// "missed refresh" path (case 2 in ``handleForegroundTransition()``) can leave a
-    /// running refresh alone rather than cancelling and re-driving it. Cleared via `defer`.
-    private var isPerformingScheduledRefresh = false
+    /// Names the in-flight ``performScheduledRefresh()`` run, or `nil` when none is
+    /// mid-flight, so the foreground "missed refresh" path (case 2 in
+    /// ``handleForegroundTransition()``) can leave a running refresh alone. Keyed by a
+    /// per-run `id` (like ``inFlight``) so a stale run whose `task.value` never returns
+    /// can't leave the guard stuck or clear a newer generation's run.
+    private var activeScheduledRefreshID: UUID?
 
     /// `true` while a proactive refresh has failed for a network reason and the
     /// manager is awaiting connectivity before retrying. A single boolean (not a
@@ -309,6 +311,7 @@ package actor AuthTokenManager {
         refreshTask?.cancel()
         refreshTask = nil
         refreshAtWallClock = nil
+        activeScheduledRefreshID = nil
         isAwaitingConnectivityRetry = false
         cachedToken = nil
     }
@@ -483,12 +486,19 @@ package actor AuthTokenManager {
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
     ///
-    /// Sets ``isPerformingScheduledRefresh`` for its duration so a concurrent
+    /// Sets ``activeScheduledRefreshID`` for its duration so a concurrent
     /// foreground transition leaves an in-flight refresh to complete (case 2).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
-        isPerformingScheduledRefresh = true
-        defer { isPerformingScheduledRefresh = false }
+        let refreshID = UUID()
+        activeScheduledRefreshID = refreshID
+        defer {
+            // Only clear if we still own the generation — a reset (or a newer run)
+            // may have rotated it while this run was suspended on `task.value`.
+            if activeScheduledRefreshID == refreshID {
+                activeScheduledRefreshID = nil
+            }
+        }
         let task = inFlight?.task ?? startFetch()
         do {
             let token = try await task.value
@@ -625,7 +635,7 @@ package actor AuthTokenManager {
         if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
             // An in-flight refresh is left to finish rather than cancelled and
             // re-driven, which would drop its broadcast or duplicate it.
-            guard !isPerformingScheduledRefresh else {
+            guard activeScheduledRefreshID == nil else {
                 if #available(iOS 14.0, *) {
                     Logger.auth.info(
                         "AuthTokenManager: foreground transition (case=missed-refresh-already-running)"

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,21 +76,9 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
-    /// `true` while ``performScheduledRefresh()`` is mid-flight. Read by the
-    /// foreground "missed refresh" path (case 2 in ``handleForegroundTransition()``)
-    /// so a transition that lands mid-refresh leaves the in-flight refresh to
-    /// finish instead of cancelling and re-driving it.
-    ///
-    /// Why this matters: ``refreshAtWallClock`` is no longer cleared before a
-    /// fired refresh runs, so a foreground transition can match the still-set
-    /// past target while a scheduled refresh is suspended on its fetch. Cancelling
-    /// that refresh's task (as case 2 otherwise does) makes its `await task.value`
-    /// throw and *suppresses its broadcast*; re-driving would then either
-    /// double-broadcast or, with the fetch already cleared, miss it. Letting the
-    /// in-flight refresh complete yields exactly one ``refreshes()`` emission and
-    /// one reschedule. Sequential refreshes each clear the flag via the method's
-    /// `defer` before the next runs, so the failed-then-foreground retry path
-    /// (the actual fix) is unaffected.
+    /// `true` while ``performScheduledRefresh()`` is mid-flight, so the foreground
+    /// "missed refresh" path (case 2 in ``handleForegroundTransition()``) can leave a
+    /// running refresh alone rather than cancelling and re-driving it. Cleared via `defer`.
     private var isPerformingScheduledRefresh = false
 
     /// `true` while a proactive refresh has failed for a network reason and the
@@ -468,12 +456,10 @@ package actor AuthTokenManager {
     /// the entire scheduled window (one long sleep, then a final short
     /// iteration that observes `remaining <= 0` and breaks).
     ///
-    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt:
-    /// a refresh that fires and then fails while the cached token is still valid
-    /// must leave the target in place so the next foreground transition can
-    /// retry it (case 2 in ``handleForegroundTransition()``). The target is
-    /// instead replaced by ``scheduleRefresh(for:)`` on a successful refresh, or
-    /// cleared by ``cancelInFlightWorkAndClearCache()`` / the foreground handler.
+    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt, so
+    /// a fired refresh that fails while the token is still valid leaves the target
+    /// in place for the next foreground transition to retry (case 2). Success
+    /// replaces it via ``scheduleRefresh(for:)``; resets clear it.
     private func sleepUntilAndRefresh(target: Date) async {
         while !Task.isCancelled {
             let remaining = target.timeIntervalSince(currentDate())
@@ -498,9 +484,7 @@ package actor AuthTokenManager {
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
     ///
     /// Sets ``isPerformingScheduledRefresh`` for its duration so a concurrent
-    /// foreground transition can detect an in-flight scheduled refresh and leave
-    /// it to complete rather than cancelling and re-driving it (see case 2 of
-    /// ``handleForegroundTransition()``).
+    /// foreground transition leaves an in-flight refresh to complete (case 2).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
         isPerformingScheduledRefresh = true
@@ -639,11 +623,8 @@ package actor AuthTokenManager {
             return
         }
         if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
-            // A scheduled refresh already running (its timer fired just before
-            // this transition) is left to finish: cancelling its task would
-            // suppress its in-flight broadcast, and re-driving risks a duplicate.
-            // It reschedules on success or leaves the marker for a later retry on
-            // failure — so the missed-refresh intent is already covered.
+            // An in-flight refresh is left to finish rather than cancelled and
+            // re-driven, which would drop its broadcast or duplicate it.
             guard !isPerformingScheduledRefresh else {
                 if #available(iOS 14.0, *) {
                     Logger.auth.info(

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,6 +76,23 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
+    /// `true` while ``performScheduledRefresh()`` is mid-flight. Read by the
+    /// foreground "missed refresh" path (case 2 in ``handleForegroundTransition()``)
+    /// so a transition that lands mid-refresh leaves the in-flight refresh to
+    /// finish instead of cancelling and re-driving it.
+    ///
+    /// Why this matters: ``refreshAtWallClock`` is no longer cleared before a
+    /// fired refresh runs, so a foreground transition can match the still-set
+    /// past target while a scheduled refresh is suspended on its fetch. Cancelling
+    /// that refresh's task (as case 2 otherwise does) makes its `await task.value`
+    /// throw and *suppresses its broadcast*; re-driving would then either
+    /// double-broadcast or, with the fetch already cleared, miss it. Letting the
+    /// in-flight refresh complete yields exactly one ``refreshes()`` emission and
+    /// one reschedule. Sequential refreshes each clear the flag via the method's
+    /// `defer` before the next runs, so the failed-then-foreground retry path
+    /// (the actual fix) is unaffected.
+    private var isPerformingScheduledRefresh = false
+
     /// `true` while a proactive refresh has failed for a network reason and the
     /// manager is awaiting connectivity before retrying. A single boolean (not a
     /// task) because connectivity comes through the existing ``lifecycleCancellable``
@@ -450,6 +467,13 @@ package actor AuthTokenManager {
     /// duration, so in the happy path the body runs at most ~2–3 times across
     /// the entire scheduled window (one long sleep, then a final short
     /// iteration that observes `remaining <= 0` and breaks).
+    ///
+    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt:
+    /// a refresh that fires and then fails while the cached token is still valid
+    /// must leave the target in place so the next foreground transition can
+    /// retry it (case 2 in ``handleForegroundTransition()``). The target is
+    /// instead replaced by ``scheduleRefresh(for:)`` on a successful refresh, or
+    /// cleared by ``cancelInFlightWorkAndClearCache()`` / the foreground handler.
     private func sleepUntilAndRefresh(target: Date) async {
         while !Task.isCancelled {
             let remaining = target.timeIntervalSince(currentDate())
@@ -457,7 +481,6 @@ package actor AuthTokenManager {
             await sleeper(UInt64(remaining * 1_000_000_000))
         }
         guard !Task.isCancelled else { return }
-        refreshAtWallClock = nil
         await performScheduledRefresh()
     }
 
@@ -473,8 +496,15 @@ package actor AuthTokenManager {
     /// before then will retry. A *network-classified* failure also arms
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
+    ///
+    /// Sets ``isPerformingScheduledRefresh`` for its duration so a concurrent
+    /// foreground transition can detect an in-flight scheduled refresh and leave
+    /// it to complete rather than cancelling and re-driving it (see case 2 of
+    /// ``handleForegroundTransition()``).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
+        isPerformingScheduledRefresh = true
+        defer { isPerformingScheduledRefresh = false }
         let task = inFlight?.task ?? startFetch()
         do {
             let token = try await task.value
@@ -609,6 +639,19 @@ package actor AuthTokenManager {
             return
         }
         if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
+            // A scheduled refresh already running (its timer fired just before
+            // this transition) is left to finish: cancelling its task would
+            // suppress its in-flight broadcast, and re-driving risks a duplicate.
+            // It reschedules on success or leaves the marker for a later retry on
+            // failure — so the missed-refresh intent is already covered.
+            guard !isPerformingScheduledRefresh else {
+                if #available(iOS 14.0, *) {
+                    Logger.auth.info(
+                        "AuthTokenManager: foreground transition (case=missed-refresh-already-running)"
+                    )
+                }
+                return
+            }
             refreshTask?.cancel()
             refreshTask = nil
             refreshAtWallClock = nil

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -486,10 +486,18 @@ package actor AuthTokenManager {
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
     ///
+    /// Bails if a refresh is already mid-flight (``activeScheduledRefreshID`` set):
+    /// the scheduled fire, the foreground "missed refresh" retry (case 2), and the
+    /// connectivity retry can all target the same still-armed refresh, and a second
+    /// run would await the shared in-flight fetch and broadcast its token a second
+    /// time. The single-flight guard here covers every caller; the foreground path
+    /// keeps its own pre-check so it doesn't tear down a live schedule.
+    ///
     /// Sets ``activeScheduledRefreshID`` for its duration so a concurrent
     /// foreground transition leaves an in-flight refresh to complete (case 2).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
+        guard activeScheduledRefreshID == nil else { return }
         let refreshID = UUID()
         activeScheduledRefreshID = refreshID
         defer {

--- a/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTestHelpers.swift
@@ -107,12 +107,31 @@ actor TokenBox {
 }
 
 /// Accumulates values delivered to a stream subscriber so tests can assert on
-/// what was — or, just as importantly, was not — received.
+/// what was — or, just as importantly, was not — received. ``waitFor(atLeast:)``
+/// lets a test *suspend* until an expected emission lands rather than spinning on
+/// `Task.yield()`: spinning keeps the waiting task runnable and can starve the
+/// consumer draining the stream, dropping the very emission under test.
 actor TokenCollector {
     private(set) var received: [String] = []
+    private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
     func append(_ token: String) {
         received.append(token)
+        waiters = waiters.compactMap { waiter in
+            if received.count >= waiter.threshold {
+                waiter.continuation.resume()
+                return nil
+            }
+            return waiter
+        }
+    }
+
+    /// Suspends until at least `threshold` values have been collected.
+    func waitFor(atLeast threshold: Int) async {
+        if received.count >= threshold { return }
+        await withCheckedContinuation { continuation in
+            waiters.append((threshold, continuation))
+        }
     }
 }
 

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -369,8 +369,9 @@ struct AuthTokenManagerRefreshTests {
 
         await releaseRefresh.open()
 
-        // Yield generously so a duplicate broadcast would have reached the subscriber
-        // before we sample, then stop the consumer and assert exactly one emission.
+        // Suspend until the broadcast lands (a duplicate would have been buffered at the
+        // same task completion), then drain and assert exactly one emission.
+        await collector.waitFor(atLeast: 1)
         for _ in 0..<200 {
             await Task.yield()
         }
@@ -383,6 +384,103 @@ struct AuthTokenManagerRefreshTests {
         )
         let invocations = await counter.value
         #expect(invocations == 2, "the in-flight fetch must be shared, not re-invoked, saw \(invocations)")
+    }
+
+    @Test
+    func concurrentConnectivityRetryDuringForegroundRetryBroadcastsOnce() async throws {
+        // A failed network refresh leaves `refreshAtWallClock` in the past *and* arms
+        // the connectivity wait — so a foreground transition (case 2) and a reachability
+        // event can both target the same still-armed refresh. The foreground retry parks
+        // a fetch in-flight; the connectivity event must not start a second overlapping
+        // `performScheduledRefresh` that awaits the shared fetch and broadcasts twice.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        // Offline at arm so the failure doesn't kick the retry immediately; flipped
+        // online below, after the foreground retry is parked in-flight.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
+        let counter = CallCounter()
+        let refreshStarted = Latch()
+        let releaseRefresh = Latch()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // scheduled refresh fails offline
+            default:
+                // Foreground-driven retry: park in-flight so a reachability event races it.
+                await refreshStarted.open()
+                await releaseRefresh.wait()
+                return secondToken
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        let stream = await manager.refreshes()
+        let collector = TokenCollector()
+        let consumer = Task {
+            for await token in stream {
+                await collector.append(token)
+            }
+        }
+
+        // Fire the scheduled refresh: invocation 2 throws, arming the connectivity wait
+        // (still offline). Await the arming so the foreground transition can't race it.
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Foreground with cache valid + target passed → case 2 starts the retry, which
+        // parks in-flight with the connectivity wait still armed.
+        lifecycleSubject.send(.foregrounded)
+        await refreshStarted.wait()
+
+        // Restore connectivity and fire the transition while the retry is parked: the
+        // connectivity path must defer to the in-flight refresh, not start a second one.
+        reachability.set(.reachableViaWiFi)
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        await releaseRefresh.open()
+
+        // Suspend until the broadcast lands (a duplicate would have been buffered at the
+        // same task completion), then drain and assert exactly one emission.
+        await collector.waitFor(atLeast: 1)
+        for _ in 0..<200 {
+            await Task.yield()
+        }
+        consumer.cancel()
+
+        let delivered = await collector.received
+        #expect(
+            delivered == [secondToken],
+            "concurrent foreground + connectivity retry must broadcast exactly once, saw \(delivered)"
+        )
+        let invocations = await counter.value
+        #expect(invocations == 3, "the retry fetch must be shared, not re-invoked, saw \(invocations)")
     }
 
     @Test

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -249,14 +249,9 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func foregroundRetriesAfterFailedScheduledRefresh() async throws {
-        // Android parity (MAGE-629): a scheduled proactive refresh that fires and
-        // *fails* while the cached token is still valid must be retried on the
-        // next foreground transition (case 2, "missed refresh"). The token is
-        // shaped so its refresh target — the 0.9-of-lifetime point, ref+480 —
-        // lands well before its staleness threshold (exp-30 = ref+510), leaving a
-        // window where the target has passed but the cache is still valid. That
-        // window is exactly what the pre-fix code stranded by nil-ing the
-        // wall-clock target before the (failed) attempt.
+        // Android parity (MAGE-629): a scheduled refresh that fires and *fails* while
+        // the token is still valid must retry on the next foreground (case 2). The
+        // token's target (ref+480) sits before its staleness threshold (exp-30 = ref+510).
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,
@@ -286,21 +281,16 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 1)
         await gate.waitUntilSleeping(atLeast: 1)
 
-        // Subscribe before the retry so its broadcast is observable.
         let stream = await manager.refreshes()
 
-        // Fire the scheduled refresh past its target: invocation 2 throws. The
-        // failure is network-classified, so it also arms the connectivity wait —
-        // which stays inert here (reachability is unknown and no transition is
-        // sent) but gives a deterministic signal that the failed refresh has fully
-        // settled before we foreground.
+        // Fire the refresh past its target; invocation 2 throws. Awaiting the armed
+        // (but inert) connectivity wait signals the failure has settled.
         clock.set(referenceDate.addingTimeInterval(485))
         await gate.release()
         try await counter.waitFor(atLeast: 2)
         await awaitConnectivityWaitArmed(manager)
 
-        // Foreground while the cache is still valid (ref+485 < exp-30 = ref+510)
-        // but the refresh target (ref+480) has passed → case 2 fires the retry.
+        // Foreground with the cache still valid but the target passed → case 2 retries.
         lifecycleSubject.send(.foregrounded)
 
         let delivered = await firstElement(of: stream)
@@ -318,13 +308,9 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce() async throws {
-        // An *in-flight* scheduled refresh must not be re-fired (nor have its
-        // broadcast lost) by a foreground transition that lands while it is still
-        // running. Because `refreshAtWallClock` is no longer cleared up front, the
-        // foreground handler's case 2 matches the still-set past target — but the
-        // `isPerformingScheduledRefresh` flag makes it leave the running refresh
-        // alone rather than cancelling and re-driving it. The in-flight refresh
-        // completes and broadcasts the token exactly once.
+        // A foreground transition during an in-flight scheduled refresh must not lose
+        // or duplicate its broadcast: case 2 leaves the running refresh alone (gated by
+        // `isPerformingScheduledRefresh`), and it completes and broadcasts exactly once.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,
@@ -348,8 +334,7 @@ struct AuthTokenManagerRefreshTests {
         await manager.registerProvider {
             let invocation = await counter.increment()
             guard invocation >= 2 else { return firstToken }
-            // The scheduled refresh: park in-flight so a foreground transition can
-            // race it before it completes.
+            // Park the scheduled refresh in-flight so the foreground can race it.
             await refreshStarted.open()
             await releaseRefresh.wait()
             return secondToken
@@ -357,27 +342,20 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 1)
         await gate.waitUntilSleeping(atLeast: 1)
 
-        // Subscribe before the refresh completes so its broadcast is observable.
         let stream = await manager.refreshes()
 
-        // Fire the scheduled refresh past its target and wait until it is parked
-        // in-flight inside the provider.
+        // Fire the refresh and wait until it is parked in-flight in the provider.
         clock.set(referenceDate.addingTimeInterval(485))
         await gate.release()
         await refreshStarted.wait()
 
-        // Foreground while the refresh is parked in flight: case 2 matches the
-        // still-set past target but sees `isPerformingScheduledRefresh` and leaves
-        // the running refresh alone (no cancel, no re-drive). Yield so the handler
-        // runs (and is gated) before we release the parked fetch.
+        // Foreground while the refresh is parked: case 2 leaves it alone. Yield so the
+        // handler runs before we release the fetch.
         lifecycleSubject.send(.foregrounded)
         for _ in 0..<100 {
             await Task.yield()
         }
 
-        // Release the parked fetch: the single in-flight refresh completes and
-        // broadcasts exactly once. The foreground transition neither suppressed
-        // it (no cancel) nor duplicated it (no re-drive).
         await releaseRefresh.open()
         let delivered = await firstElement(of: stream)
         #expect(
@@ -390,10 +368,9 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func foregroundAfterSuccessfulScheduledRefreshDoesNotRefire() async throws {
-        // The flip side of keeping `refreshAtWallClock` set across a fired
-        // refresh: once a scheduled refresh *succeeds*, it reschedules to a future
-        // target, so a later foreground transition must fall through to the
-        // still-valid no-op (case 3) rather than re-firing against a stale marker.
+        // The flip side of keeping `refreshAtWallClock` set: a *succeeded* refresh
+        // reschedules to a future target, so a later foreground falls through to
+        // the still-valid no-op (case 3) rather than re-firing.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,
@@ -419,14 +396,13 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 1)
         await gate.waitUntilSleeping(atLeast: 1)
 
-        // Fire the scheduled refresh; invocation 2 succeeds and reschedules the
-        // next refresh far in the future (secondToken's target).
+        // Fire the refresh; invocation 2 succeeds and reschedules far in the future.
         clock.set(referenceDate.addingTimeInterval(485))
         await gate.release()
         try await counter.waitFor(atLeast: 2)
         await gate.waitUntilSleeping(atLeast: 2)
 
-        // Foreground: cache is fresh and the replaced target is far ahead → no-op.
+        // Foreground: cache fresh, replaced target far ahead → no-op.
         lifecycleSubject.send(.foregrounded)
         for _ in 0..<100 {
             await Task.yield()

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -247,6 +247,198 @@ struct AuthTokenManagerRefreshTests {
         #expect(resolved == freshToken)
     }
 
+    @Test
+    func foregroundRetriesAfterFailedScheduledRefresh() async throws {
+        // Android parity (MAGE-629): a scheduled proactive refresh that fires and
+        // *fails* while the cached token is still valid must be retried on the
+        // next foreground transition (case 2, "missed refresh"). The token is
+        // shaped so its refresh target — the 0.9-of-lifetime point, ref+480 —
+        // lands well before its staleness threshold (exp-30 = ref+510), leaving a
+        // window where the target has passed but the cache is still valid. That
+        // window is exactly what the pre-fix code stranded by nil-ing the
+        // wall-clock target before the (failed) attempt.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // scheduled refresh fails
+            default: return secondToken // foreground-driven retry succeeds
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Subscribe before the retry so its broadcast is observable.
+        let stream = await manager.refreshes()
+
+        // Fire the scheduled refresh past its target: invocation 2 throws. The
+        // failure is network-classified, so it also arms the connectivity wait —
+        // which stays inert here (reachability is unknown and no transition is
+        // sent) but gives a deterministic signal that the failed refresh has fully
+        // settled before we foreground.
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Foreground while the cache is still valid (ref+485 < exp-30 = ref+510)
+        // but the refresh target (ref+480) has passed → case 2 fires the retry.
+        lifecycleSubject.send(.foregrounded)
+
+        let delivered = await firstElement(of: stream)
+        #expect(delivered == secondToken, "a failed scheduled refresh must be retried on foreground")
+
+        let cached = try await manager.currentToken(mode: .background)
+        #expect(cached == secondToken)
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 3,
+            "expected initial + failed-scheduled + foreground-retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce() async throws {
+        // An *in-flight* scheduled refresh must not be re-fired (nor have its
+        // broadcast lost) by a foreground transition that lands while it is still
+        // running. Because `refreshAtWallClock` is no longer cleared up front, the
+        // foreground handler's case 2 matches the still-set past target — but the
+        // `isPerformingScheduledRefresh` flag makes it leave the running refresh
+        // alone rather than cancelling and re-driving it. The in-flight refresh
+        // completes and broadcasts the token exactly once.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+        let refreshStarted = Latch()
+        let releaseRefresh = Latch()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            guard invocation >= 2 else { return firstToken }
+            // The scheduled refresh: park in-flight so a foreground transition can
+            // race it before it completes.
+            await refreshStarted.open()
+            await releaseRefresh.wait()
+            return secondToken
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Subscribe before the refresh completes so its broadcast is observable.
+        let stream = await manager.refreshes()
+
+        // Fire the scheduled refresh past its target and wait until it is parked
+        // in-flight inside the provider.
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        await refreshStarted.wait()
+
+        // Foreground while the refresh is parked in flight: case 2 matches the
+        // still-set past target but sees `isPerformingScheduledRefresh` and leaves
+        // the running refresh alone (no cancel, no re-drive). Yield so the handler
+        // runs (and is gated) before we release the parked fetch.
+        lifecycleSubject.send(.foregrounded)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        // Release the parked fetch: the single in-flight refresh completes and
+        // broadcasts exactly once. The foreground transition neither suppressed
+        // it (no cancel) nor duplicated it (no re-drive).
+        await releaseRefresh.open()
+        let delivered = await firstElement(of: stream)
+        #expect(
+            delivered == secondToken,
+            "the in-flight refresh must complete and broadcast despite the concurrent foreground"
+        )
+        let invocations = await counter.value
+        #expect(invocations == 2, "the in-flight fetch must be shared, not re-invoked, saw \(invocations)")
+    }
+
+    @Test
+    func foregroundAfterSuccessfulScheduledRefreshDoesNotRefire() async throws {
+        // The flip side of keeping `refreshAtWallClock` set across a fired
+        // refresh: once a scheduled refresh *succeeds*, it reschedules to a future
+        // target, so a later foreground transition must fall through to the
+        // still-valid no-op (case 3) rather than re-firing against a stale marker.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            return invocation == 1 ? firstToken : secondToken
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Fire the scheduled refresh; invocation 2 succeeds and reschedules the
+        // next refresh far in the future (secondToken's target).
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await gate.waitUntilSleeping(atLeast: 2)
+
+        // Foreground: cache is fresh and the replaced target is far ahead → no-op.
+        lifecycleSubject.send(.foregrounded)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 2,
+            "a succeeded scheduled refresh must not be re-fired on foreground, saw \(invocations)"
+        )
+    }
+
     // MARK: - registerProvider cancellation
 
     @Test

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -342,7 +342,18 @@ struct AuthTokenManagerRefreshTests {
         try await counter.waitFor(atLeast: 1)
         await gate.waitUntilSleeping(atLeast: 1)
 
+        // Collect *every* emission, not just the first: a broken guard would let the
+        // foreground also drive `performScheduledRefresh()`, and both callers awaiting
+        // the shared fetch would broadcast — a duplicate that reading one element hides.
+        // Subscribe up front (`refreshes()` installs its sink synchronously) so no
+        // broadcast is missed; the stream buffers until the consumer drains it.
         let stream = await manager.refreshes()
+        let collector = TokenCollector()
+        let consumer = Task {
+            for await token in stream {
+                await collector.append(token)
+            }
+        }
 
         // Fire the refresh and wait until it is parked in-flight in the provider.
         clock.set(referenceDate.addingTimeInterval(485))
@@ -357,10 +368,18 @@ struct AuthTokenManagerRefreshTests {
         }
 
         await releaseRefresh.open()
-        let delivered = await firstElement(of: stream)
+
+        // Yield generously so a duplicate broadcast would have reached the subscriber
+        // before we sample, then stop the consumer and assert exactly one emission.
+        for _ in 0..<200 {
+            await Task.yield()
+        }
+        consumer.cancel()
+
+        let delivered = await collector.received
         #expect(
-            delivered == secondToken,
-            "the in-flight refresh must complete and broadcast despite the concurrent foreground"
+            delivered == [secondToken],
+            "the in-flight refresh must broadcast exactly once despite the concurrent foreground, saw \(delivered)"
         )
         let invocations = await counter.value
         #expect(invocations == 2, "the in-flight fetch must be shared, not re-invoked, saw \(invocations)")

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -310,7 +310,7 @@ struct AuthTokenManagerRefreshTests {
     func concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce() async throws {
         // A foreground transition during an in-flight scheduled refresh must not lose
         // or duplicate its broadcast: case 2 leaves the running refresh alone (gated by
-        // `isPerformingScheduledRefresh`), and it completes and broadcasts exactly once.
+        // `activeScheduledRefreshID`), and it completes and broadcasts exactly once.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,


### PR DESCRIPTION
# Description
Retry a failed or missed scheduled proactive auth-token refresh on the next foreground transition, matching Android (MAGE-629). Fixes the divergence introduced by the proactive-refresh scheduling work (MAGE-625, #588).

> **Stacked on [`ab/MAGE-683/connectivity-driven-refresh-retry`](https://github.com/klaviyo/klaviyo-swift-sdk/tree/ab/MAGE-683/connectivity-driven-refresh-retry)** — review/merge that first. This PR's diff is scoped to the MAGE-735 commits below.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
**The bug:** In `AuthTokenManager.sleepUntilAndRefresh(target:)`, `refreshAtWallClock` was nil'd *before* the refresh attempt ran. The foreground handler's case-2 ("missed refresh") guard (`if let scheduled = refreshAtWallClock, currentDate() >= scheduled`) could therefore never match after a *failed* fire, so a transient failure on a still-valid token got no proactive retry until the token actually crossed `exp − leeway`.

**The fix:**
- **Stop nil-ing `refreshAtWallClock` before the attempt.** It is now replaced by `scheduleRefresh(for:)` on a successful refresh, or cleared on reset / by the foreground handler. A failed fire leaves the past target in place, so the next foreground transition retries it exactly once (case 2).
- **Add `isPerformingScheduledRefresh` and gate the foreground case-2 re-drive on it.** Because the marker now survives the fire, a foreground transition can land while a scheduled refresh is still in flight. Rather than cancelling that refresh's task (which suppresses its `refreshes()` broadcast) and re-driving it (risking a duplicate), the foreground handler leaves the in-flight refresh to complete — it broadcasts once and reschedules. This also covers the connectivity-retry-vs-foreground race.

## Test Plan
Three tests added to `AuthTokenManagerRefreshTests`, mirroring Android's `foreground retries after scheduled timer refresh fails`:
- `foregroundRetriesAfterFailedScheduledRefresh` — a network-failed scheduled refresh is retried on foreground while the token is still valid (fails on pre-fix code).
- `concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce` — a foreground transition during an in-flight refresh leaves it to complete and broadcast once, without re-invoking the provider.
- `foregroundAfterSuccessfulScheduledRefreshDoesNotRefire` — a succeeded refresh reschedules to a future target, so a later foreground is a no-op.

Run:
```
xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:KlaviyoCoreTests
```
Result: **61 tests, 0 failures.** SwiftLint + SwiftFormat clean (pre-commit passed).

## Related Issues/Tickets
- MAGE-735 (this work) · MAGE-625 / #588 (introduced the divergence) · Android parity: klaviyo-android-sdk#469 (MAGE-629)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate scheduled refreshes during foreground transitions; allow in-flight refreshes to continue and avoid duplicate broadcasts.
  * Preserve scheduled refresh targets after failed attempts so retries on next app interaction can succeed.
  * Clear stale scheduled-refresh state when cancelling in-flight work.

* **Tests**
  * Added async tests covering scheduled refresh failure, concurrency, retry and non-refire scenarios.
  * Enhanced test helper to await a specified number of token emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->