### PR TITLE
test(KlaviyoForms): verify JWT lands in live WebView DOM (MAGE-685)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -212,6 +212,24 @@ package actor AuthTokenManager {
         }
     }
 
+    /// Detaches the registered provider and tears down all associated token
+    /// state. Called from `KlaviyoSDK().unregisterAuthTokenProvider()` — e.g. on
+    /// user logout, where the host expects the full token lifecycle to end.
+    ///
+    /// Clears the provider reference *before* ``clearTokenState()`` so any
+    /// callbacks resolving on the cancelled tasks find no provider to call back
+    /// into. Unlike ``clearTokenState()`` — which retains the provider so the
+    /// next ``currentToken(mode:)`` can drive a fresh acquisition — this also
+    /// drops the provider, so token acquisition stops entirely until a new
+    /// provider is registered.
+    package func unregisterProvider() async {
+        provider = nil
+        await clearTokenState()
+        if #available(iOS 14.0, *) {
+            Logger.auth.info("AuthTokenManager: provider unregistered")
+        }
+    }
+
     /// Returns the current auth token, fetching one via the registered provider
     /// if the cache is empty or has gone stale.
     ///

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,6 +76,23 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
+    /// `true` while ``performScheduledRefresh()`` is mid-flight. Read by the
+    /// foreground "missed refresh" path (case 2 in ``handleForegroundTransition()``)
+    /// so a transition that lands mid-refresh leaves the in-flight refresh to
+    /// finish instead of cancelling and re-driving it.
+    ///
+    /// Why this matters: ``refreshAtWallClock`` is no longer cleared before a
+    /// fired refresh runs, so a foreground transition can match the still-set
+    /// past target while a scheduled refresh is suspended on its fetch. Cancelling
+    /// that refresh's task (as case 2 otherwise does) makes its `await task.value`
+    /// throw and *suppresses its broadcast*; re-driving would then either
+    /// double-broadcast or, with the fetch already cleared, miss it. Letting the
+    /// in-flight refresh complete yields exactly one ``refreshes()`` emission and
+    /// one reschedule. Sequential refreshes each clear the flag via the method's
+    /// `defer` before the next runs, so the failed-then-foreground retry path
+    /// (the actual fix) is unaffected.
+    private var isPerformingScheduledRefresh = false
+
     /// `true` while a proactive refresh has failed for a network reason and the
     /// manager is awaiting connectivity before retrying. A single boolean (not a
     /// task) because connectivity comes through the existing ``lifecycleCancellable``
@@ -450,6 +467,13 @@ package actor AuthTokenManager {
     /// duration, so in the happy path the body runs at most ~2–3 times across
     /// the entire scheduled window (one long sleep, then a final short
     /// iteration that observes `remaining <= 0` and breaks).
+    ///
+    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt:
+    /// a refresh that fires and then fails while the cached token is still valid
+    /// must leave the target in place so the next foreground transition can
+    /// retry it (case 2 in ``handleForegroundTransition()``). The target is
+    /// instead replaced by ``scheduleRefresh(for:)`` on a successful refresh, or
+    /// cleared by ``cancelInFlightWorkAndClearCache()`` / the foreground handler.
     private func sleepUntilAndRefresh(target: Date) async {
         while !Task.isCancelled {
             let remaining = target.timeIntervalSince(currentDate())
@@ -457,7 +481,6 @@ package actor AuthTokenManager {
             await sleeper(UInt64(remaining * 1_000_000_000))
         }
         guard !Task.isCancelled else { return }
-        refreshAtWallClock = nil
         await performScheduledRefresh()
     }
 
@@ -473,8 +496,15 @@ package actor AuthTokenManager {
     /// before then will retry. A *network-classified* failure also arms
     /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
+    ///
+    /// Sets ``isPerformingScheduledRefresh`` for its duration so a concurrent
+    /// foreground transition can detect an in-flight scheduled refresh and leave
+    /// it to complete rather than cancelling and re-driving it (see case 2 of
+    /// ``handleForegroundTransition()``).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
+        isPerformingScheduledRefresh = true
+        defer { isPerformingScheduledRefresh = false }
         let task = inFlight?.task ?? startFetch()
         do {
             let token = try await task.value
@@ -609,6 +639,19 @@ package actor AuthTokenManager {
             return
         }
         if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
+            // A scheduled refresh already running (its timer fired just before
+            // this transition) is left to finish: cancelling its task would
+            // suppress its in-flight broadcast, and re-driving risks a duplicate.
+            // It reschedules on success or leaves the marker for a later retry on
+            // failure — so the missed-refresh intent is already covered.
+            guard !isPerformingScheduledRefresh else {
+                if #available(iOS 14.0, *) {
+                    Logger.auth.info(
+                        "AuthTokenManager: foreground transition (case=missed-refresh-already-running)"
+                    )
+                }
+                return
+            }
             refreshTask?.cancel()
             refreshTask = nil
             refreshAtWallClock = nil

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -76,21 +76,11 @@ package actor AuthTokenManager {
     /// elapsed-sleep duration alone would fire late.
     private var refreshAtWallClock: Date?
 
-    /// `true` while ``performScheduledRefresh()`` is mid-flight. Read by the
-    /// foreground "missed refresh" path (case 2 in ``handleForegroundTransition()``)
-    /// so a transition that lands mid-refresh leaves the in-flight refresh to
-    /// finish instead of cancelling and re-driving it.
-    ///
-    /// Why this matters: ``refreshAtWallClock`` is no longer cleared before a
-    /// fired refresh runs, so a foreground transition can match the still-set
-    /// past target while a scheduled refresh is suspended on its fetch. Cancelling
-    /// that refresh's task (as case 2 otherwise does) makes its `await task.value`
-    /// throw and *suppresses its broadcast*; re-driving would then either
-    /// double-broadcast or, with the fetch already cleared, miss it. Letting the
-    /// in-flight refresh complete yields exactly one ``refreshes()`` emission and
-    /// one reschedule. Sequential refreshes each clear the flag via the method's
-    /// `defer` before the next runs, so the failed-then-foreground retry path
-    /// (the actual fix) is unaffected.
+    /// `true` while ``performScheduledRefresh()`` is mid-flight. The foreground
+    /// "missed refresh" path (case 2 in ``handleForegroundTransition()``) reads it
+    /// to leave an in-flight refresh running rather than cancelling and re-driving
+    /// it: cancelling would suppress its ``refreshes()`` broadcast, re-driving could
+    /// duplicate it. Cleared via `defer`, so sequential refreshes are unaffected.
     private var isPerformingScheduledRefresh = false
 
     /// `true` while a proactive refresh has failed for a network reason and the
@@ -468,12 +458,10 @@ package actor AuthTokenManager {
     /// the entire scheduled window (one long sleep, then a final short
     /// iteration that observes `remaining <= 0` and breaks).
     ///
-    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt:
-    /// a refresh that fires and then fails while the cached token is still valid
-    /// must leave the target in place so the next foreground transition can
-    /// retry it (case 2 in ``handleForegroundTransition()``). The target is
-    /// instead replaced by ``scheduleRefresh(for:)`` on a successful refresh, or
-    /// cleared by ``cancelInFlightWorkAndClearCache()`` / the foreground handler.
+    /// ``refreshAtWallClock`` is deliberately *not* cleared before the attempt, so
+    /// a fired refresh that fails while the token is still valid leaves the target
+    /// in place for the next foreground transition to retry (case 2). Success
+    /// replaces it via ``scheduleRefresh(for:)``; resets clear it.
     private func sleepUntilAndRefresh(target: Date) async {
         while !Task.isCancelled {
             let remaining = target.timeIntervalSince(currentDate())
@@ -498,9 +486,7 @@ package actor AuthTokenManager {
     /// re-fires this method (``handleReachabilityChange()``); other failures don't.
     ///
     /// Sets ``isPerformingScheduledRefresh`` for its duration so a concurrent
-    /// foreground transition can detect an in-flight scheduled refresh and leave
-    /// it to complete rather than cancelling and re-driving it (see case 2 of
-    /// ``handleForegroundTransition()``).
+    /// foreground transition leaves an in-flight refresh to complete (case 2).
     private func performScheduledRefresh() async {
         guard provider != nil else { return }
         isPerformingScheduledRefresh = true
@@ -639,11 +625,10 @@ package actor AuthTokenManager {
             return
         }
         if let scheduled = refreshAtWallClock, currentDate() >= scheduled {
-            // A scheduled refresh already running (its timer fired just before
-            // this transition) is left to finish: cancelling its task would
-            // suppress its in-flight broadcast, and re-driving risks a duplicate.
-            // It reschedules on success or leaves the marker for a later retry on
-            // failure — so the missed-refresh intent is already covered.
+            // A refresh already running (timer fired just before this transition)
+            // is left to finish: cancelling would suppress its broadcast, re-driving
+            // would duplicate it. It reschedules on success or leaves the marker for
+            // a later retry on failure.
             guard !isPerformingScheduledRefresh else {
                 if #available(iOS 14.0, *) {
                     Logger.auth.info(

--- a/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
+++ b/Sources/KlaviyoSwift/Klaviyo+AuthToken.swift
@@ -30,4 +30,18 @@ extension KlaviyoSDK {
             await AuthTokenManager.shared.registerProvider(provider)
         }
     }
+
+    /// Detaches a previously registered auth token provider — e.g. on user
+    /// logout.
+    ///
+    /// Clears the provider reference and tears down all associated token state:
+    /// the cached token is discarded and any scheduled proactive refresh or
+    /// in-flight fetch is cancelled. After this call, personalized in-app forms
+    /// have no token available until a new provider is registered via
+    /// ``registerAuthTokenProvider(_:)``.
+    public func unregisterAuthTokenProvider() {
+        Task {
+            await AuthTokenManager.shared.unregisterProvider()
+        }
+    }
 }

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -247,6 +247,198 @@ struct AuthTokenManagerRefreshTests {
         #expect(resolved == freshToken)
     }
 
+    @Test
+    func foregroundRetriesAfterFailedScheduledRefresh() async throws {
+        // Android parity (MAGE-629): a scheduled proactive refresh that fires and
+        // *fails* while the cached token is still valid must be retried on the
+        // next foreground transition (case 2, "missed refresh"). The token is
+        // shaped so its refresh target — the 0.9-of-lifetime point, ref+480 —
+        // lands well before its staleness threshold (exp-30 = ref+510), leaving a
+        // window where the target has passed but the cache is still valid. That
+        // window is exactly what the pre-fix code stranded by nil-ing the
+        // wall-clock target before the (failed) attempt.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            case 2: throw URLError(.notConnectedToInternet) // scheduled refresh fails
+            default: return secondToken // foreground-driven retry succeeds
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Subscribe before the retry so its broadcast is observable.
+        let stream = await manager.refreshes()
+
+        // Fire the scheduled refresh past its target: invocation 2 throws. The
+        // failure is network-classified, so it also arms the connectivity wait —
+        // which stays inert here (reachability is unknown and no transition is
+        // sent) but gives a deterministic signal that the failed refresh has fully
+        // settled before we foreground.
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Foreground while the cache is still valid (ref+485 < exp-30 = ref+510)
+        // but the refresh target (ref+480) has passed → case 2 fires the retry.
+        lifecycleSubject.send(.foregrounded)
+
+        let delivered = await firstElement(of: stream)
+        #expect(delivered == secondToken, "a failed scheduled refresh must be retried on foreground")
+
+        let cached = try await manager.currentToken(mode: .background)
+        #expect(cached == secondToken)
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 3,
+            "expected initial + failed-scheduled + foreground-retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce() async throws {
+        // An *in-flight* scheduled refresh must not be re-fired (nor have its
+        // broadcast lost) by a foreground transition that lands while it is still
+        // running. Because `refreshAtWallClock` is no longer cleared up front, the
+        // foreground handler's case 2 matches the still-set past target — but the
+        // `isPerformingScheduledRefresh` flag makes it leave the running refresh
+        // alone rather than cancelling and re-driving it. The in-flight refresh
+        // completes and broadcasts the token exactly once.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+        let refreshStarted = Latch()
+        let releaseRefresh = Latch()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            guard invocation >= 2 else { return firstToken }
+            // The scheduled refresh: park in-flight so a foreground transition can
+            // race it before it completes.
+            await refreshStarted.open()
+            await releaseRefresh.wait()
+            return secondToken
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Subscribe before the refresh completes so its broadcast is observable.
+        let stream = await manager.refreshes()
+
+        // Fire the scheduled refresh past its target and wait until it is parked
+        // in-flight inside the provider.
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        await refreshStarted.wait()
+
+        // Foreground while the refresh is parked in flight: case 2 matches the
+        // still-set past target but sees `isPerformingScheduledRefresh` and leaves
+        // the running refresh alone (no cancel, no re-drive). Yield so the handler
+        // runs (and is gated) before we release the parked fetch.
+        lifecycleSubject.send(.foregrounded)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        // Release the parked fetch: the single in-flight refresh completes and
+        // broadcasts exactly once. The foreground transition neither suppressed
+        // it (no cancel) nor duplicated it (no re-drive).
+        await releaseRefresh.open()
+        let delivered = await firstElement(of: stream)
+        #expect(
+            delivered == secondToken,
+            "the in-flight refresh must complete and broadcast despite the concurrent foreground"
+        )
+        let invocations = await counter.value
+        #expect(invocations == 2, "the in-flight fetch must be shared, not re-invoked, saw \(invocations)")
+    }
+
+    @Test
+    func foregroundAfterSuccessfulScheduledRefreshDoesNotRefire() async throws {
+        // The flip side of keeping `refreshAtWallClock` set across a fired
+        // refresh: once a scheduled refresh *succeeds*, it reschedules to a future
+        // target, so a later foreground transition must fall through to the
+        // still-valid no-op (case 3) rather than re-firing against a stale marker.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 540,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: lifecycle, clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            return invocation == 1 ? firstToken : secondToken
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        // Fire the scheduled refresh; invocation 2 succeeds and reschedules the
+        // next refresh far in the future (secondToken's target).
+        clock.set(referenceDate.addingTimeInterval(485))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        await gate.waitUntilSleeping(atLeast: 2)
+
+        // Foreground: cache is fresh and the replaced target is far ahead → no-op.
+        lifecycleSubject.send(.foregrounded)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 2,
+            "a succeeded scheduled refresh must not be re-fired on foreground, saw \(invocations)"
+        )
+    }
+
     // MARK: - registerProvider cancellation
 
     @Test

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -249,14 +249,11 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func foregroundRetriesAfterFailedScheduledRefresh() async throws {
-        // Android parity (MAGE-629): a scheduled proactive refresh that fires and
-        // *fails* while the cached token is still valid must be retried on the
-        // next foreground transition (case 2, "missed refresh"). The token is
-        // shaped so its refresh target — the 0.9-of-lifetime point, ref+480 —
-        // lands well before its staleness threshold (exp-30 = ref+510), leaving a
-        // window where the target has passed but the cache is still valid. That
-        // window is exactly what the pre-fix code stranded by nil-ing the
-        // wall-clock target before the (failed) attempt.
+        // Android parity (MAGE-629): a scheduled refresh that fires and *fails*
+        // while the token is still valid must retry on the next foreground (case 2).
+        // The token is shaped so its refresh target (ref+480) lands before the
+        // staleness threshold (exp-30 = ref+510), leaving a valid window — exactly
+        // what the pre-fix code stranded by nil-ing the target before the attempt.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,
@@ -289,11 +286,9 @@ struct AuthTokenManagerRefreshTests {
         // Subscribe before the retry so its broadcast is observable.
         let stream = await manager.refreshes()
 
-        // Fire the scheduled refresh past its target: invocation 2 throws. The
-        // failure is network-classified, so it also arms the connectivity wait —
-        // which stays inert here (reachability is unknown and no transition is
-        // sent) but gives a deterministic signal that the failed refresh has fully
-        // settled before we foreground.
+        // Fire the refresh past its target: invocation 2 throws. The network
+        // classification arms the (inert) connectivity wait, which is a
+        // deterministic signal that the failed refresh has settled before we foreground.
         clock.set(referenceDate.addingTimeInterval(485))
         await gate.release()
         try await counter.waitFor(atLeast: 2)
@@ -318,13 +313,10 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func concurrentForegroundDuringInFlightScheduledRefreshBroadcastsOnce() async throws {
-        // An *in-flight* scheduled refresh must not be re-fired (nor have its
-        // broadcast lost) by a foreground transition that lands while it is still
-        // running. Because `refreshAtWallClock` is no longer cleared up front, the
-        // foreground handler's case 2 matches the still-set past target — but the
-        // `isPerformingScheduledRefresh` flag makes it leave the running refresh
-        // alone rather than cancelling and re-driving it. The in-flight refresh
-        // completes and broadcasts the token exactly once.
+        // A foreground transition during an in-flight scheduled refresh must
+        // neither lose its broadcast nor duplicate it. Case 2 matches the still-set
+        // past target, but `isPerformingScheduledRefresh` makes it leave the running
+        // refresh alone, which completes and broadcasts exactly once.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,
@@ -366,18 +358,15 @@ struct AuthTokenManagerRefreshTests {
         await gate.release()
         await refreshStarted.wait()
 
-        // Foreground while the refresh is parked in flight: case 2 matches the
-        // still-set past target but sees `isPerformingScheduledRefresh` and leaves
-        // the running refresh alone (no cancel, no re-drive). Yield so the handler
-        // runs (and is gated) before we release the parked fetch.
+        // Foreground while the refresh is parked in flight: case 2 is gated by
+        // `isPerformingScheduledRefresh` and leaves it alone. Yield so the handler
+        // runs before we release the parked fetch.
         lifecycleSubject.send(.foregrounded)
         for _ in 0..<100 {
             await Task.yield()
         }
 
-        // Release the parked fetch: the single in-flight refresh completes and
-        // broadcasts exactly once. The foreground transition neither suppressed
-        // it (no cancel) nor duplicated it (no re-drive).
+        // Release the parked fetch: the refresh completes and broadcasts once.
         await releaseRefresh.open()
         let delivered = await firstElement(of: stream)
         #expect(
@@ -390,10 +379,9 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func foregroundAfterSuccessfulScheduledRefreshDoesNotRefire() async throws {
-        // The flip side of keeping `refreshAtWallClock` set across a fired
-        // refresh: once a scheduled refresh *succeeds*, it reschedules to a future
-        // target, so a later foreground transition must fall through to the
-        // still-valid no-op (case 3) rather than re-firing against a stale marker.
+        // The flip side of keeping `refreshAtWallClock` set: a *succeeded* refresh
+        // reschedules to a future target, so a later foreground falls through to
+        // the still-valid no-op (case 3) rather than re-firing.
         let firstToken = try makeJWT(
             issuedAt: refSeconds - 60,
             expiresAt: refSeconds + 540,

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1123,6 +1123,243 @@ struct AuthTokenManagerRefreshTests {
         )
     }
 
+    // MARK: - unregisterProvider
+
+    @Test
+    func unregisterProviderWhileIdleDropsProvider() async throws {
+        // From a settled state — token cached, refresh scheduled, nothing in
+        // flight — unregister must drop the provider and clear the cache, so the
+        // next fetch throws `.noProviderRegistered` rather than serving a stale
+        // token.
+        let token = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "first"]
+        )
+
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: noopLifecycle(), clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return token
+        }
+        try await counter.waitFor(atLeast: 1)
+        // Refresh armed (and parked) ⇒ the eager fetch has settled into the cache.
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        await manager.unregisterProvider()
+
+        await #expect(throws: AuthTokenError.noProviderRegistered) {
+            _ = try await manager.currentToken(mode: .background)
+        }
+    }
+
+    @Test
+    func unregisterProviderCancelsScheduledRefresh() async throws {
+        // Acquire a short-lived token whose refresh would fire at ref+10, then
+        // unregister. Drive virtual time past where the refresh would have fired
+        // and release its (now-cancelled) parked sleep; the provider must not be
+        // called again.
+        let token = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: noopLifecycle(), clock: clock, gate: gate)
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            await counter.increment()
+            return token
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        await manager.unregisterProvider()
+
+        clock.set(referenceDate.addingTimeInterval(40))
+        await gate.release()
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 1,
+            "unregisterProvider must cancel the scheduled refresh, saw \(invocations) invocations"
+        )
+    }
+
+    @Test
+    func unregisterProviderCancelsPendingConnectivityRetry() async throws {
+        // Arm a connectivity wait via a network-failed refresh, then unregister.
+        // The pending wait must be dropped so a later reachability restoration
+        // does not retry against the detached provider.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 40,
+            extraClaims: ["sub": "first"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        // Offline at arm so arming doesn't immediately kick; flipped online before
+        // the transition so the only thing suppressing the retry is the dropped wait.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken
+            default: throw URLError(.notConnectedToInternet)
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        clock.set(referenceDate.addingTimeInterval(10))
+        await gate.release()
+        try await counter.waitFor(atLeast: 2)
+        // Ensure the wait is genuinely armed before unregistering, so the test
+        // proves unregister *cancels* an armed wait rather than racing its arming.
+        await awaitConnectivityWaitArmed(manager)
+
+        await manager.unregisterProvider()
+
+        reachability.set(.reachableViaWiFi)
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 2,
+            "unregisterProvider must cancel the pending connectivity retry, saw \(invocations)"
+        )
+    }
+
+    @Test
+    func unregisterProviderCancelsInFlightFetchForConcurrentCaller() async throws {
+        // A caller dedup'd onto an in-flight fetch when unregister lands must not
+        // receive a token — the cancelled fetch propagates a failure to it,
+        // matching the established in-flight failure path.
+        let token = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "first"]
+        )
+
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: noopLifecycle(), clock: clock, gate: gate)
+        let counter = CallCounter()
+        let providerEntered = Latch()
+        let providerRelease = Latch()
+
+        await manager.registerProvider {
+            await counter.increment()
+            await providerEntered.open()
+            await providerRelease.wait()
+            return token
+        }
+        // The eager fetch is now suspended inside the provider, so `inFlight` is
+        // set and a concurrent caller will dedup onto it.
+        await providerEntered.wait()
+
+        // Unstructured task so the caller is not cancelled by the structured
+        // scope when we unregister; it must fail via the in-flight fetch, not
+        // its own cancellation.
+        let dedupedCaller = Task { try await manager.currentToken(mode: .background) }
+        // Let the caller reach the actor and dedup onto the in-flight fetch
+        // before we unregister.
+        for _ in 0..<50 {
+            await Task.yield()
+        }
+
+        await manager.unregisterProvider()
+
+        // Release the parked provider; the fetch's post-`provider()` cancellation
+        // checkpoint trips (the closure itself ignores cancellation), failing the
+        // shared task.
+        await providerRelease.open()
+
+        let callerResult = await dedupedCaller.result
+        #expect(
+            (try? callerResult.get()) == nil,
+            "a caller dedup'd onto a fetch cancelled by unregister must not receive a token"
+        )
+
+        let invocations = await counter.value
+        #expect(
+            invocations == 1,
+            "the concurrent caller must dedup, not start a second fetch; saw \(invocations)"
+        )
+    }
+
+    @Test
+    func reRegisterAfterUnregisterFetchesAndSchedulesAfresh() async throws {
+        // After unregister, registering a new provider must behave like a clean
+        // registration: eager fetch via the new provider and a fresh refresh
+        // schedule.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let manager = makeManager(lifeCycle: noopLifecycle(), clock: clock, gate: gate)
+
+        let firstCounter = CallCounter()
+        await manager.registerProvider {
+            await firstCounter.increment()
+            return firstToken
+        }
+        try await firstCounter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1)
+
+        await manager.unregisterProvider()
+
+        // Re-register with a distinct provider. The eager fetch must run against
+        // it (fresh invocation) and its token must be what the next call serves.
+        let secondCounter = CallCounter()
+        await manager.registerProvider {
+            await secondCounter.increment()
+            return secondToken
+        }
+        try await secondCounter.waitFor(atLeast: 1)
+        // A fresh refresh is scheduled off the new token (second parked sleep).
+        await gate.waitUntilSleeping(atLeast: 2)
+
+        let result = try await manager.currentToken(mode: .background)
+        #expect(
+            result == secondToken,
+            "re-registration must serve the new provider's token, not a stale one"
+        )
+    }
+
     // MARK: - Test helpers
 
     /// `referenceDate` as seconds-since-1970, for minting tokens whose `iat`/`exp`

--- a/Tests/KlaviyoFormsTests/IAFWebViewAuthTokenDOMTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewAuthTokenDOMTests.swift
@@ -1,0 +1,239 @@
+//
+//  IAFWebViewAuthTokenDOMTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Andrew Balmer on 2026-06-08.
+//
+
+@testable import KlaviyoForms
+@testable import KlaviyoSwift
+import KlaviyoCore
+import UIKit
+import WebKit
+import XCTest
+
+/// Test subclass that allows all navigation. The production
+/// `KlaviyoWebViewController.decidePolicyFor` opens any non-`InAppFormsTemplate.html`
+/// URL via `UIApplication.shared.open`; the test loads `IAFUnitTest.html`, so this
+/// override prevents an external-open attempt. It is the *only* deviation from
+/// production and is orthogonal to JWT injection — webview creation,
+/// `configureLoadScripts`, `evaluateJavaScript`, and delegate wiring are all
+/// inherited unchanged.
+private final class NavigationAllowingWebViewController: KlaviyoWebViewController {
+    override func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction
+    ) async -> WKNavigationActionPolicy {
+        .allow
+    }
+}
+
+/// Integration tests that validate the JWT lands in the DOM of the **production**
+/// `WKWebView` — the one `KlaviyoWebViewController` creates and configures via its
+/// own `configureLoadScripts()` — rather than a webview hand-built inside the test.
+///
+/// This mirrors the production object graph (`IAFPresentationManager.createFormWebView`):
+/// a real `IAFWebViewModel(authToken:)` drives a real `KlaviyoWebViewController`,
+/// which creates its own webview, registers the view model's load scripts on it,
+/// and loads a document. We then read `document.head` back through the controller's
+/// own `evaluateJavaScript`, so the assertion is against the webview the SDK would
+/// actually present. Covers both the initial-load `WKUserScript` injection and the
+/// live `pushAuthToken` refresh path (the controller is the view model's delegate,
+/// so `pushAuthToken` evaluates JS against this same webview).
+final class IAFWebViewAuthTokenDOMTests: XCTestCase {
+    // MARK: - Properties
+
+    /// Retains the window (and thus the controller + its webview) for the test's
+    /// lifetime; placing the controller on a key window makes the webview load
+    /// reliably.
+    private var window: UIWindow?
+
+    /// The webview the production controller created, captured via `webViewFactory`
+    /// so the test can drive a completing load on it (see `makeLoadedController`).
+    private var capturedWebView: WKWebView?
+
+    private static let jwtAttributeRead = "document.head.getAttribute('data-klaviyo-jwt')"
+    private static let sdkNameRead = "document.head.getAttribute('data-sdk-name')"
+
+    // MARK: - Setup / teardown
+
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Mirror the established forms-suite setup so the view model and controller
+        // build deterministically without hanging on real I/O.
+        environment = KlaviyoEnvironment.test()
+        environment.sdkName = { "swift" }
+        environment.sdkVersion = { "0.0.1" }
+        environment.cdnURL = {
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "static.klaviyo.com"
+            return components
+        }
+
+        KlaviyoInternal.resetAPIKeySubject()
+        KlaviyoInternal.resetProfileDataSubject()
+
+        let testState = KlaviyoState(
+            apiKey: "abc123",
+            queue: [],
+            requestsInFlight: [],
+            initalizationState: .initialized
+        )
+        let testStore = Store(initialState: testState, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = {
+            testStore.state.eraseToAnyPublisher()
+        }
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        window?.isHidden = true
+        window?.rootViewController = nil
+        window = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Initial-load injection (production WKUserScript path)
+
+    @MainActor
+    func testAuthTokenInjectedIntoProductionWebViewDOM() async throws {
+        let token = "header.payload.signature"
+        let (controller, _) = try await makeLoadedController(authToken: token)
+
+        let injected = try await readJWT(controller)
+        XCTAssertEqual(
+            injected,
+            token,
+            "configureLoadScripts should set data-klaviyo-jwt on the controller's own webview DOM"
+        )
+    }
+
+    @MainActor
+    func testNoAuthTokenLeavesAttributeAbsentInProductionWebViewDOM() async throws {
+        let (controller, _) = try await makeLoadedController(authToken: nil)
+
+        let jwtValue = try await readJWT(controller)
+        XCTAssertNil(jwtValue, "data-klaviyo-jwt must be absent when no token is set")
+
+        // Sanity: a different production-assembled head attribute IS present, proving
+        // configureLoadScripts ran on this webview — so the nil above is a true
+        // absence, not a webview that simply failed to inject anything.
+        let sdkName = try await controller.evaluateJavaScript(Self.sdkNameRead) as? String
+        XCTAssertEqual(sdkName, "swift", "production load scripts should have run on this webview")
+    }
+
+    // MARK: - Live-refresh push (production pushAuthToken path)
+
+    @MainActor
+    func testPushAuthTokenUpdatesProductionWebViewDOM() async throws {
+        let (controller, viewModel) = try await makeLoadedController(authToken: nil)
+
+        let before = try await readJWT(controller)
+        XCTAssertNil(before, "precondition: no token before a refresh is pushed")
+
+        // The controller is the view model's delegate (set in its init), so this
+        // evaluates JS against the controller's own webview — the production path.
+        let refreshed = "header.refreshed.signature"
+        await viewModel.pushAuthToken(refreshed)
+
+        let after = try await readJWT(controller)
+        XCTAssertEqual(
+            after,
+            refreshed,
+            "pushAuthToken should update data-klaviyo-jwt on the production webview's live DOM"
+        )
+    }
+
+    @MainActor
+    func testPushAuthTokenAppliesUpdatesInOrderInProductionWebViewDOM() async throws {
+        let (controller, viewModel) = try await makeLoadedController(authToken: nil)
+
+        let first = "header.first.signature"
+        let second = "header.second.signature"
+        await viewModel.pushAuthToken(first)
+        await viewModel.pushAuthToken(second)
+
+        let value = try await readJWT(controller)
+        XCTAssertEqual(value, second, "the last pushed token should win in the production webview's DOM")
+    }
+
+    // MARK: - Helpers
+
+    /// Builds the production controller around a real `IAFWebViewModel`, lets it
+    /// create and configure its own webview, then drives a completing document load
+    /// so the production-registered load scripts actually execute. Returns once those
+    /// scripts have run on the controller's webview.
+    ///
+    /// Why we don't rely on the controller's own `load(URLRequest(fileURL))`: under
+    /// the test bundle's web-content sandbox that file load does not complete (it
+    /// lands on an empty document), so the registered `.atDocumentEnd` user scripts
+    /// never run. We therefore capture the controller's webview via `webViewFactory`
+    /// — `configureLoadScripts()` still registers the real `viewModel.loadScripts` on
+    /// it — and force a completing main-frame load via `loadHTMLString`. Only the
+    /// document *delivery* differs from production; the injection wiring under test
+    /// (controller → its webview's content controller) is the real one.
+    @MainActor
+    private func makeLoadedController(
+        authToken: String?
+    ) async throws -> (KlaviyoWebViewController, IAFWebViewModel) {
+        let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
+        let viewModel = IAFWebViewModel(
+            url: fileUrl,
+            apiKey: "abc123",
+            profileData: nil,
+            authToken: authToken
+        )
+
+        let controller = NavigationAllowingWebViewController(viewModel: viewModel) { [weak self] in
+            let webView = Self.makeProductionLikeWebView()
+            self?.capturedWebView = webView
+            return webView
+        }
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = controller
+        window.makeKeyAndVisible() // viewDidLoad → loadUrl → configureLoadScripts registers the scripts
+        self.window = window
+
+        // Force a completing load on the controller's own (now-configured) webview.
+        let webView = try XCTUnwrap(capturedWebView, "webViewFactory should have captured the webview")
+        webView.loadHTMLString("<html><head></head><body></body></html>", baseURL: nil)
+
+        try await awaitProductionScriptsRan(controller)
+        return (controller, viewModel)
+    }
+
+    /// A webview equivalent to the production `createDefaultWebView` (which is private).
+    @MainActor
+    private static func makeProductionLikeWebView() -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+        return WKWebView(frame: .zero, configuration: config)
+    }
+
+    /// Polls until the production load scripts have executed on the controller's
+    /// webview. `data-sdk-name` is always part of `initializeLoadScripts`, so its
+    /// presence is a reliable signal the registered scripts ran on the loaded
+    /// document. The generous timeout absorbs first-load web-content-process spin-up.
+    @MainActor
+    private func awaitProductionScriptsRan(
+        _ controller: KlaviyoWebViewController,
+        timeout: TimeInterval = 30
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let sdkName = await (try? controller.evaluateJavaScript(Self.sdkNameRead)) as? String
+            if sdkName == "swift" { return }
+            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+        XCTFail("production load scripts did not run within \(timeout)s")
+    }
+
+    @MainActor
+    private func readJWT(_ controller: KlaviyoWebViewController) async throws -> String? {
+        try await controller.evaluateJavaScript(Self.jwtAttributeRead) as? String
+    }
+}


### PR DESCRIPTION
# Description
Adds an integration test that validates the JWT auth token lands on `document.head` as `data-klaviyo-jwt` in the **production** `WKWebView` — the one `KlaviyoWebViewController` actually creates and configures via its own `configureLoadScripts()` — rather than a webview hand-built inside the test.

> **Revised after review.** The first version of this test built its own `WKWebView`/config and injected a hand-picked script, which bypassed the production object graph (it would stay green even if the real controller→webview wiring broke). This version drives the real controller so the assertion is against the webview the SDK would present.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
New file `Tests/KlaviyoFormsTests/IAFWebViewAuthTokenDOMTests.swift` (tests only). It mirrors the production path (`IAFPresentationManager.createFormWebView`): a real `IAFWebViewModel(authToken:)` drives a real `KlaviyoWebViewController`, which creates its own webview and registers `viewModel.loadScripts` on it via `configureLoadScripts()`. The test reads `document.head` back through the controller's own `evaluateJavaScript`.

- `testAuthTokenInjectedIntoProductionWebViewDOM` — token set ⇒ `data-klaviyo-jwt` present on the controller's webview DOM.
- `testNoAuthTokenLeavesAttributeAbsentInProductionWebViewDOM` — no token ⇒ `data-klaviyo-jwt` absent, while `data-sdk-name` IS present (proves the production scripts ran, so the nil is a true absence).
- `testPushAuthTokenUpdatesProductionWebViewDOM` — real `pushAuthToken(_:)` (the controller is the view model's delegate) updates the live DOM.
- `testPushAuthTokenAppliesUpdatesInOrderInProductionWebViewDOM` — last write wins.

### Test-environment note (why a forced load)
Production's `webView.load(URLRequest(fileURL))` does **not** complete under the test bundle's web-content sandbox — it lands on an empty document, so the registered `.atDocumentEnd` user scripts never run (works in the app because the app can read its own bundle; `loadFileURL(_:allowingReadAccessTo:)` is used nowhere). The test therefore captures the controller's webview via `webViewFactory` — `configureLoadScripts()` still registers the **real** load scripts on it — and forces a completing main-frame load with `loadHTMLString`. Only the document *delivery* differs from production; the injection wiring under test (controller → its own webview's content controller, and `pushAuthToken` → the controller's webview) is the real one. The only other deviation is a `decidePolicyFor → .allow` subclass (mirrors the existing `TestKlaviyoWebViewController`), orthogonal to injection.

## Test Plan
```
xcodebuild test -scheme klaviyo-swift-sdk-Package \
  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
  -only-testing:KlaviyoFormsTests
```
All `KlaviyoFormsTests` pass (incl. the 4 new cases).

## Related Issues/Tickets
- [MAGE-685](https://linear.app/klaviyo/issue/MAGE-685/ios-public-unregisterauthtokenprovider-api) (hardens DOM-level coverage for MAGE-616's injection)
- Stacked on `ab/MAGE-685/unregister-auth-token-provider` (this PR targets that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
