### PR TITLE
ci: fold BugBot instructions into CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,3 +19,20 @@ reviews:
     swiftlint:
       enabled: true
       config_file: ".swiftlint.yml"
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        # Cursor Bugbot Configuration
+        
+        This file configures Cursor's Bugbot for this repository.
+        
+        ## Primary Guidance
+        
+        Please read and follow the guidelines in `AGENTS.md` at the root of this repository.
+        
+        ## Repository-Specific Context
+        
+        This is the Klaviyo Swift SDK - the official iOS/Swift SDK for Klaviyo's marketing automation platform.
+        
+        - The pull request should follow the repository's PR template.


### PR DESCRIPTION
Captures `.cursor/BUGBOT.md` review guidance under `reviews.path_instructions` in `.coderabbit.yaml`, so the guidance is retained in CodeRabbit as we phase out Cursor BugBot. Follow-up to #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)