### PR TITLE
ci: include xcodeproj files in CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,6 @@ reviews:
     - "!Sources/KlaviyoSwift/Vendor/**"
     - "!Tests/KlaviyoSwiftTests/Vendor/**"
     - "!**/__Snapshots__/**"
-    - "!**/*.xcodeproj/**"
     - "!**/*.xcworkspace/**"
     - "!**/xcshareddata/**"
     - "!**/Podfile.lock"


### PR DESCRIPTION
## Summary
- Removes the `**/*.xcodeproj/**` path filter from `.coderabbit.yaml` so CodeRabbit reviews changes to the Xcode project and can catch silly mistakes there.

Mirrors the same change across the mobile SDK repos (expo klaviyo/klaviyo-expo-plugin#118, flutter klaviyo/klaviyo-flutter-sdk#104, react-native), prompted by review feedback that CodeRabbit should review the Xcode project rather than skip it.

Note: `*.xcworkspace` and `xcshareddata` remain excluded here — scope is limited to the xcodeproj filter to match the other SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated code review configuration settings.

---

**Note:** This release contains only internal configuration adjustments with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->