### PR TITLE
feat(examples) - MAGE-661: add SPMExampleAutomatic target with automatic push tracking

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,6 @@
 reviews:
   profile: assertive
   path_filters:
-    - "!Examples/**"
     - "!Sources/KlaviyoSwift/Vendor/**"
     - "!Tests/KlaviyoSwiftTests/Vendor/**"
     - "!**/__Snapshots__/**"

--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -14,7 +14,7 @@ pod install
 
 ## SPM Example
 
-This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Follow the steps [here](Link to swift SDK instructions) to integrate it in your app.
+This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Follow the steps [here](../../README.md#installation) to integrate it in your app.
 
 ## SPM Example — Automatic Push Tracking
 

--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -18,7 +18,7 @@ This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Foll
 
 ## SPM Example — Automatic Push Tracking
 
-This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts in to automatic push integration via the `klaviyo_automatic_push_tracking` Info.plist key. With this key set, the SDK automatically forwards device tokens and tracks push opens — no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code required in your `AppDelegate`.
+This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts into automatic push integration via the `klaviyo_automatic_push_tracking` Info.plist key. With this key set, the SDK automatically forwards device tokens and tracks push opens — no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code required in your `AppDelegate`.
 
 ## Which example should I use?
 

--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -16,6 +16,18 @@ pod install
 
 This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Follow the steps [here](Link to swift SDK instructions) to integrate it in your app.
 
+## SPM Example — Automatic Push Tracking
+
+This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts in to automatic push integration via the `klaviyo_automatic_push_tracking` Info.plist key. With this key set, the SDK automatically forwards device tokens and tracks push opens — no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code required in your `AppDelegate`.
+
+## Which example should I use?
+
+| Example | Integration style | When to choose |
+|---|---|---|
+| `SPMExample` | Manual (STEP1–STEP6) | You want full control over push delegate callbacks, or you need to handle non-Klaviyo notifications alongside Klaviyo ones. |
+| `CocoapodsExample` | Manual (CocoaPods) | Same as above, but your project uses CocoaPods instead of SPM. |
+| `SPMExampleAutomatic` | Automatic (plist opt-in) | You want zero push code in your `AppDelegate` and are happy for the SDK to handle token registration and open tracking automatically. |
+
 ## Authors
 
 Klaviyo Mobile Push Team

--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -14,7 +14,7 @@ pod install
 
 ## SPM Example
 
-This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Follow the steps [here](../../README.md#installation) to integrate it in your app.
+This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Follow the [installation steps](../../README.md#installation) to integrate it in your app.
 
 ## SPM Example — Automatic Push Tracking
 

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
@@ -26,6 +26,22 @@
 		7CC1C85228D74DB60073197F /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84B28D74DB60073197F /* MenuView.swift */; };
 		7CC1C85328D74DB60073197F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84C28D74DB60073197F /* MapView.swift */; };
 		7CC1C85428D74DB60073197F /* CheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84D28D74DB60073197F /* CheckoutView.swift */; };
+		ABCD0001ABCD0001ABCD0001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCD0012ABCD0012ABCD0012 /* AppDelegate.swift */; };
+		ABCD0002ABCD0002ABCD0002 /* DeepLinking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340590E229CCCD520015991E /* DeepLinking.swift */; };
+		ABCD0003ABCD0003ABCD0003 /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340590E329CCCD520015991E /* DebugViewController.swift */; };
+		ABCD0004ABCD0004ABCD0004 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C83028D74DB60073197F /* User.swift */; };
+		ABCD0005ABCD0005ABCD0005 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C83528D74DB60073197F /* Cart.swift */; };
+		ABCD0006ABCD0006ABCD0006 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C82E28D74DB60073197F /* MenuItem.swift */; };
+		ABCD0007ABCD0007ABCD0007 /* KLMuncheryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84828D74DB60073197F /* KLMuncheryApp.swift */; };
+		ABCD0008ABCD0008ABCD0008 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84928D74DB60073197F /* ContentView.swift */; };
+		ABCD0009ABCD0009ABCD0009 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84A28D74DB60073197F /* LoginView.swift */; };
+		ABCD000AABCD000AABCD000A /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84B28D74DB60073197F /* MenuView.swift */; };
+		ABCD000BABCD000BABCD000B /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84C28D74DB60073197F /* MapView.swift */; };
+		ABCD000CABCD000CABCD000C /* CheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84D28D74DB60073197F /* CheckoutView.swift */; };
+		ABCD000DABCD000DABCD000D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7CC1C82C28D74DB60073197F /* Images.xcassets */; };
+		ABCD000EABCD000EABCD000E /* KlaviyoForms in Frameworks */ = {isa = PBXBuildFile; productRef = ABCD0021ABCD0021ABCD0021 /* KlaviyoForms */; };
+		ABCD000FABCD000FABCD000F /* KlaviyoLocation in Frameworks */ = {isa = PBXBuildFile; productRef = ABCD0022ABCD0022ABCD0022 /* KlaviyoLocation */; };
+		ABCD0010ABCD0010ABCD0010 /* KlaviyoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = ABCD0023ABCD0023ABCD0023 /* KlaviyoSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +105,10 @@
 		7CC1C84B28D74DB60073197F /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MenuView.swift; path = ../../Shared/MenuView.swift; sourceTree = "<group>"; };
 		7CC1C84C28D74DB60073197F /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapView.swift; path = ../../Shared/MapView.swift; sourceTree = "<group>"; };
 		7CC1C84D28D74DB60073197F /* CheckoutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckoutView.swift; path = ../../Shared/CheckoutView.swift; sourceTree = "<group>"; };
+		ABCD0012ABCD0012ABCD0012 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		ABCD0013ABCD0013ABCD0013 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ABCD0014ABCD0014ABCD0014 /* SPMExampleAutomatic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SPMExampleAutomatic.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABCD0015ABCD0015ABCD0015 /* SPMExampleAutomatic.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SPMExampleAutomatic.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +144,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ABCD0017ABCD0017ABCD0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ABCD000EABCD000EABCD000E /* KlaviyoForms in Frameworks */,
+				ABCD0010ABCD0010ABCD0010 /* KlaviyoSwift in Frameworks */,
+				ABCD000FABCD000FABCD000F /* KlaviyoLocation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -147,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				7CC1C7FA28D74D810073197F /* SPMExample */,
+				ABCD0018ABCD0018ABCD0018 /* SPMExampleAutomatic */,
 				3425CA0B2A3A635D0019E33A /* NotificationServiceExtension */,
 				7CC1C7F928D74D810073197F /* Products */,
 				3425CA252A44F14E0019E33A /* Frameworks */,
@@ -157,11 +188,22 @@
 			isa = PBXGroup;
 			children = (
 				7CC1C7F828D74D810073197F /* SPMExample.app */,
+				ABCD0014ABCD0014ABCD0014 /* SPMExampleAutomatic.app */,
 				7CC1C80E28D74D840073197F /* SPMExampleTests.xctest */,
 				7CC1C81828D74D840073197F /* SPMExampleUITests.xctest */,
 				3425CA0A2A3A635D0019E33A /* NotificationServiceExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		ABCD0018ABCD0018ABCD0018 /* SPMExampleAutomatic */ = {
+			isa = PBXGroup;
+			children = (
+				ABCD0012ABCD0012ABCD0012 /* AppDelegate.swift */,
+				ABCD0015ABCD0015ABCD0015 /* SPMExampleAutomatic.entitlements */,
+				ABCD0013ABCD0013ABCD0013 /* Info.plist */,
+			);
+			path = SPMExampleAutomatic;
 			sourceTree = "<group>";
 		};
 		7CC1C7FA28D74D810073197F /* SPMExample */ = {
@@ -270,6 +312,28 @@
 			productReference = 7CC1C81828D74D840073197F /* SPMExampleUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		ABCD0019ABCD0019ABCD0019 /* SPMExampleAutomatic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ABCD0020ABCD0020ABCD0020 /* Build configuration list for PBXNativeTarget "SPMExampleAutomatic" */;
+			buildPhases = (
+				ABCD001BABCD001BABCD001B /* Sources */,
+				ABCD0017ABCD0017ABCD0017 /* Frameworks */,
+				ABCD001AABCD001AABCD001A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SPMExampleAutomatic;
+			packageProductDependencies = (
+				ABCD0021ABCD0021ABCD0021 /* KlaviyoForms */,
+				ABCD0022ABCD0022ABCD0022 /* KlaviyoLocation */,
+				ABCD0023ABCD0023ABCD0023 /* KlaviyoSwift */,
+			);
+			productName = SPMExampleAutomatic;
+			productReference = ABCD0014ABCD0014ABCD0014 /* SPMExampleAutomatic.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -295,6 +359,9 @@
 						CreatedOnToolsVersion = 13.4.1;
 						TestTargetID = 7CC1C7F728D74D810073197F;
 					};
+					ABCD0019ABCD0019ABCD0019 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 				};
 			};
 			buildConfigurationList = 7CC1C7F328D74D810073197F /* Build configuration list for PBXProject "SPMExample" */;
@@ -314,6 +381,7 @@
 			projectRoot = "";
 			targets = (
 				7CC1C7F728D74D810073197F /* SPMExample */,
+				ABCD0019ABCD0019ABCD0019 /* SPMExampleAutomatic */,
 				7CC1C80D28D74D840073197F /* SPMExampleTests */,
 				7CC1C81728D74D840073197F /* SPMExampleUITests */,
 				3425CA092A3A635D0019E33A /* NotificationServiceExtension */,
@@ -348,6 +416,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ABCD001AABCD001AABCD001A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ABCD000DABCD000DABCD000D /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,6 +468,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ABCD001BABCD001BABCD001B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ABCD0003ABCD0003ABCD0003 /* DebugViewController.swift in Sources */,
+				ABCD0004ABCD0004ABCD0004 /* User.swift in Sources */,
+				ABCD0001ABCD0001ABCD0001 /* AppDelegate.swift in Sources */,
+				ABCD0002ABCD0002ABCD0002 /* DeepLinking.swift in Sources */,
+				ABCD0005ABCD0005ABCD0005 /* Cart.swift in Sources */,
+				ABCD0006ABCD0006ABCD0006 /* MenuItem.swift in Sources */,
+				ABCD0007ABCD0007ABCD0007 /* KLMuncheryApp.swift in Sources */,
+				ABCD0008ABCD0008ABCD0008 /* ContentView.swift in Sources */,
+				ABCD0009ABCD0009ABCD0009 /* LoginView.swift in Sources */,
+				ABCD000AABCD000AABCD000A /* MenuView.swift in Sources */,
+				ABCD000BABCD000BABCD000B /* MapView.swift in Sources */,
+				ABCD000CABCD000CABCD000C /* CheckoutView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -719,6 +814,67 @@
 			};
 			name = Release;
 		};
+		ABCD001EABCD001EABCD001E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SPMExampleAutomatic/SPMExampleAutomatic.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SPMExampleAutomatic/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = armv7;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 5.3.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyo.spm.example.SPMExampleAutomatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		ABCD001FABCD001FABCD001F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SPMExampleAutomatic/SPMExampleAutomatic.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SPMExampleAutomatic/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = armv7;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 5.3.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyo.spm.example.SPMExampleAutomatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -767,6 +923,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		ABCD0020ABCD0020ABCD0020 /* Build configuration list for PBXNativeTarget "SPMExampleAutomatic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ABCD001EABCD001EABCD001E /* Debug */,
+				ABCD001FABCD001FABCD001F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -792,6 +957,18 @@
 		1E6B745F2E819B8B00602827 /* KlaviyoSwiftExtension */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KlaviyoSwiftExtension;
+		};
+		ABCD0021ABCD0021ABCD0021 /* KlaviyoForms */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KlaviyoForms;
+		};
+		ABCD0022ABCD0022ABCD0022 /* KlaviyoLocation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KlaviyoLocation;
+		};
+		ABCD0023ABCD0023ABCD0023 /* KlaviyoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KlaviyoSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/xcshareddata/xcschemes/SPMExampleAutomatic.xcscheme
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/xcshareddata/xcschemes/SPMExampleAutomatic.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ABCD0019ABCD0019ABCD0019"
+               BuildableName = "SPMExampleAutomatic.app"
+               BlueprintName = "SPMExampleAutomatic"
+               ReferencedContainer = "container:SPMExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ABCD0019ABCD0019ABCD0019"
+            BuildableName = "SPMExampleAutomatic.app"
+            BlueprintName = "SPMExampleAutomatic"
+            ReferencedContainer = "container:SPMExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ABCD0019ABCD0019ABCD0019"
+            BuildableName = "SPMExampleAutomatic.app"
+            BlueprintName = "SPMExampleAutomatic"
+            ReferencedContainer = "container:SPMExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -20,10 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserDefaults.standard.object(forKey: "email") as? String
     }
 
-    private var zip: String? {
-        UserDefaults.standard.object(forKey: "zip") as? String
-    }
-
     // MARK: App delegates
 
     var window: UIWindow?
@@ -32,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // Replace YOUR_PUBLIC_API_KEY with your actual Klaviyo public API key
         KlaviyoSDK()
             .initialize(with: "YOUR_PUBLIC_API_KEY")
             .registerForInAppForms()

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -1,19 +1,14 @@
 //
 //  AppDelegate.swift
-//  KlaviyoSwift
+//  SPMExampleAutomatic
 //
-//  Created by Katy Keuper on 10/05/2015.
-//  Copyright (c) 2015 Katy Keuper. All rights reserved.
-//
-// Manual push integration reference (STEP1–STEP6).
-// For the automatic push integration example (no push code in AppDelegate),
-// see SPMExampleAutomatic/AppDelegate.swift.
+// Automatic push integration — no token forwarding, no notification delegate code needed.
+// The SDK handles all of that when `klaviyo_automatic_push_tracking` is set in Info.plist.
+// For the manual integration reference (STEP1–STEP6) see Shared/AppDelegate.swift.
 //
 
 import KlaviyoForms
 import KlaviyoLocation
-// STEP1: Importing klaviyo SDK modules into your app code
-// `KlaviyoSwift` is for analytics and push notifications and `KlaviyoForms` is for presenting marketing in app forms/messages
 import KlaviyoSwift
 import SwiftUI
 import UIKit
@@ -37,15 +32,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // STEP2: Setup Klaviyo SDK with api key
         KlaviyoSDK()
             .initialize(with: "YOUR_PUBLIC_API_KEY")
-            .registerForInAppForms() // STEP2A: register for in app forms
-            .registerGeofencing() // STEP2B: register for in geofencing
+            .registerForInAppForms()
+            .registerGeofencing()
             .registerFormLifecycleHandler { event in
-                // STEP2C: [OPTIONAL] Register for form lifecycle events to track form interactions
-                // This handler is called whenever a form is shown, dismissed, or a CTA is clicked
-
                 switch event {
                 case .formShown:
                     print("🎨 [Form Lifecycle] Form Shown: \(event.formId)")
@@ -60,16 +51,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
 
-        // EXAMPLE: of how to track an event
         KlaviyoSDK().create(event: .init(name: .customEvent("Opened kLM App")))
 
-        // STEP3: register the user email with klaviyo so there is an unique way to identify your app user.
         if let email = email {
             KlaviyoSDK().set(email: email)
         }
 
-        // STEP4: Setting up push notifcations
-        howToSetupPushNotifications()
+        // Request push authorization — SDK proxy handles token forwarding and
+        // notification response tracking automatically (no delegate code needed here)
+        requestPushAuthorization()
+
+        // Deep links from push notifications are routed through this handler by the SDK proxy
+        KlaviyoSDK().registerDeepLinkHandler { [weak self] url in
+            guard let self,
+                  let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
+                  let host = components.host,
+                  let deeplink = DeepLinking(rawValue: host)
+            else {
+                print("Unhandled deep link: \(url)")
+                return
+            }
+            handle(deeplink, with: url.absoluteString)
+        }
 
         return true
     }
@@ -81,31 +84,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: Push Notification implementation
 
-    private func howToSetupPushNotifications() {
+    private func requestPushAuthorization() {
         let center = UNUserNotificationCenter.current()
-        center.delegate = self
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
-        // use the below options if you are interested in using provisional push notifications. Note that using this will not
-        // show the push notifications prompt to the user.
-        // let options: UNAuthorizationOptions = [.alert, .sound, .badge, provisional]
         center.requestAuthorization(options: options) { _, error in
             if let error = error {
-                // Handle the error here.
                 print("error = ", error)
             }
-
-            // Enable or disable features based on the authorization status.
         }
-
         UIApplication.shared.registerForRemoteNotifications()
-    }
-
-    func application(
-        _ application: UIApplication,
-        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
-    ) {
-        // STEP5: add the push device token to your Klaviyo user profile.
-        KlaviyoSDK().set(pushToken: deviceToken)
     }
 
     func application(
@@ -126,9 +113,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
-        // Access custom key-value pairs from the top level
         if let customData = userInfo["key_value_pairs"] as? [String: String] {
-            // Process your custom key-value pairs here
             for (key, value) in customData {
                 print("Key: \(key), Value: \(value)")
             }
@@ -139,11 +124,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: Deep linking implementation
 
-    // If you would like to support deep links the following delegate needs to be implemented
-    // it's upto the developer to decide what to do with the URL in this method.
-    // NOTE that for custom URI schemes if you have a path that is deeper than 1, part of it will be the host and
-    // part of it will be in path so please be careful to parse the deep link fully.
-    // Ex: klaviyo://path1/path2 would be host = path1 and path = path2
     func application(
         _ app: UIApplication,
         open url: URL,
@@ -158,7 +138,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         print("components: \(components.debugDescription)")
 
-        // Create the deep link
         guard let deeplink = DeepLinking(rawValue: host) else {
             print("Deeplink not found: \(host)")
             return false
@@ -174,53 +153,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func handle(_ deepLink: DeepLinking, with url: String) {
         switch deepLink {
         case .home:
-            // this is where we could present the home view
             break
         case .menu:
-            // this is where we could present the menu view
             break
         case .checkout:
-            // this is where we could present the checkout view
             break
         case .debug:
-            // sending debug should show the deeplink URL in code
             let debugViewController = DebugViewController()
             debugViewController.debugMessage = url
             let navigation = UINavigationController(rootViewController: debugViewController)
             window?.rootViewController?.dismiss(animated: true)
             window?.rootViewController?.present(navigation, animated: true)
-        }
-    }
-}
-
-// MARK: App delegate extensions
-
-// STEP6: Add this extension on AppDelegate for additional push notifications handling
-extension AppDelegate: UNUserNotificationCenterDelegate {
-    // below method will be called when the user interacts with the push notification
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) {
-        // If this notifiation is Klaviyo's notification we'll handle it
-        // else pass it on to the next push notification service to which it may belong
-        let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler)
-        if !handled {
-            completionHandler()
-        }
-    }
-
-    // below method is called when the app receives push notifications when the app is the foreground
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        if #available(iOS 14.0, *) {
-            completionHandler([.list, .banner])
-        } else {
-            completionHandler([.alert])
         }
     }
 }

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -120,6 +120,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             print("No key_value_pairs found in notification")
         }
+        completionHandler(.noData)
     }
 
     // MARK: Deep linking implementation

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string></string>
+		<key>UIImageName</key>
+		<string></string>
+	</dict>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>klaviyo_automatic_push_tracking</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.klaviyo.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>klaviyo</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>klaviyo</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+		<string>location</string>
+		<string>fetch</string>
+	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs location access to show your current location on the delivery map and help you find nearby delivery zones.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs location access to monitor geofences and provide location-based notifications even when the app is in the background.</string>
+	<key>UIStatusBarHidden</key>
+	<false/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/SPMExampleAutomatic.entitlements
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/SPMExampleAutomatic.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -135,6 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             print("No key_value_pairs found in notification")
         }
+        completionHandler(.noData)
     }
 
     // MARK: Deep linking implementation


### PR DESCRIPTION
## Description

Adds a new `SPMExampleAutomatic` sub-target to `SPMExample.xcodeproj` demonstrating automatic push integration via the `klaviyo_automatic_push_tracking` Info.plist key. The `AppDelegate` contains no push delegate code — no token forwarding, no `UNUserNotificationCenterDelegate` — the SDK handles it automatically. Deep link handling uses the new `registerDeepLinkHandler` API.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- **New target** `SPMExampleAutomatic` in `SPMExample.xcodeproj` — mirrors `SPMExample` but opts in to automatic push via `klaviyo_automatic_push_tracking = true` in `Info.plist`
- **New** `SPMExampleAutomatic/AppDelegate.swift` — no `UNUserNotificationCenterDelegate`, no `didRegisterForRemoteNotificationsWithDeviceToken`; uses `registerDeepLinkHandler` for push deep links
- **New** `SPMExampleAutomatic/Info.plist` — sets `klaviyo_automatic_push_tracking`, `klaviyo_app_group`, and `CFBundleIdentifier`
- **New** `SPMExampleAutomatic/SPMExampleAutomatic.entitlements` — push entitlement
- **New** `xcshareddata/xcschemes/SPMExampleAutomatic.xcscheme` — shared Xcode scheme
- **Updated** `Shared/AppDelegate.swift` — added header comment pointing to the automatic example
- **Updated** `Examples/README.md` — new section and comparison table for choosing between integration styles

> **Note on NSE:** `SPMExampleAutomatic` does not embed the `NotificationServiceExtension` because iOS requires the NSE bundle ID to be prefixed by the parent app's bundle ID (`com.klaviyo.spm.example.SPMExampleAutomatic.*`), and `SPMExample`'s existing NSE uses `com.klaviyo.spm.example.SPMExample.*`. Developers who need rich push with the automatic integration should create their own NSE with a matching prefix.

## Test Plan

1. Open `Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj`
2. Select the `SPMExampleAutomatic` scheme
3. Run on a simulator or device
4. Verify the app launches and initializes without push delegate errors
5. Confirm no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code appears in the `AppDelegate`

## Related Issues/Tickets

Closes MAGE-661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded SPM docs with an “Automatic Push Tracking” section, installation guidance, an automatic push example, and a comparison table for integration choices.

* **Examples**
  * Added an automatic push-tracking example: App lifecycle wiring, SDK init, automatic push opt-in, push registration/handling, silent-push key/value logging, deep-link routing, background modes, and development entitlements.
  * Clarified manual integration example docs and ensured silent-push handler completes properly.

* **Chores**
  * Adjusted review filtering to include example paths in review checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->