### PR TITLE
feat(KlaviyoForms): add jwtMutation to IAF JS bridge handshake spec (MAGE-775)

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -449,6 +449,8 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             ()
         case .profileMutation:
             ()
+        case .jwtMutation:
+            ()
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -22,6 +22,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case lifecycleEvent
     case profileEvent
     case profileMutation
+    case jwtMutation
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -41,6 +42,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case lifecycleEvent
         case profileEvent
         case profileMutation
+        case jwtMutation
     }
 
     init(from decoder: Decoder) throws {
@@ -81,6 +83,8 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .profileEvent
         case .profileMutation:
             self = .profileMutation
+        case .jwtMutation:
+            self = .jwtMutation
         }
     }
 }
@@ -147,7 +151,8 @@ extension IAFNativeBridgeEvent {
             .abort(""),
             .lifecycleEvent,
             .profileEvent,
-            .profileMutation
+            .profileMutation,
+            .jwtMutation
         ]
     }
 
@@ -165,6 +170,7 @@ extension IAFNativeBridgeEvent {
         case .lifecycleEvent: return 1
         case .profileEvent: return 1
         case .profileMutation: return 1
+        case .jwtMutation: return 1
         }
     }
 
@@ -182,6 +188,7 @@ extension IAFNativeBridgeEvent {
         case .lifecycleEvent: return "lifecycleEvent"
         case .profileEvent: return "profileEvent"
         case .profileMutation: return "profileMutation"
+        case .jwtMutation: return "jwtMutation"
         }
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)


### PR DESCRIPTION
# Description
Adds the `jwtMutation` event to the in-app forms (IAF) native bridge handshake spec — a capability advertisement telling the Fender JS layer that the SDK can receive JWT token updates.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- Add `jwtMutation` case to the `IAFNativeBridgeEvent` enum (`CodingKeys`, `init(from:)`, handshake list, handshake version `1`, and string mapping).
- Handle the `.jwtMutation` case in `IAFWebViewModel` (currently a no-op placeholder).

Without this handshake entry, the Fender JS layer doesn't recognize that the SDK can receive token updates and won't activate that code path. This is the iOS equivalent of the Android change in klaviyo/klaviyo-android-sdk#466.

**Out of scope:** the full live-refresh implementation (pushing refreshed tokens into an active WebView via `window.jwtMutation(newToken)` on token refresh) is not included here — matching the Android PR, that work is tracked separately.

## Test Plan
- Unit tests in `IAFWebViewModelTests` / `IAFNativeBridgeEvent` decoding cover the new `.jwtMutation` case and its handshake spec entry.
- `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"`

## Related Issues/Tickets
- [MAGE-775](https://linear.app/klaviyo/issue/MAGE-775/featklaviyoforms-add-jwtmutation-to-iaf-js-bridge-handshake-spec)
- Android-equivalent PR: https://github.com/klaviyo/klaviyo-android-sdk/pull/466

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated in-app forms native-bridge handling to properly recognize and consume the new `jwtMutation` event.
  * Updated the handshake payload to include `jwtMutation` so it is processed as part of initialization.
* **Tests**
  * Updated handshake injection and handshake serialization tests to expect `jwtMutation` alongside existing event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->