### PR TITLE
fix(KlaviyoForms): load IAF WebView same-origin to fix 401 on /api/profiles/ (MAGE-787)

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -23,6 +23,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     weak var delegate: KlaviyoWebViewDelegate?
 
     let url: URL
+
+    /// API host used as the document base URL so onsite's authenticated `/api/profiles/` fetch
+    /// is same-origin, avoiding the `Origin: null` (and CORS preflight) of a `file://` load.
+    var baseURL: URL? {
+        environment.apiURL().url
+    }
+
     var loadScripts: Set<WKUserScript>? = Set<WKUserScript>()
     let messageHandlers: Set<String>? = Set(MessageHandler.allCases.map(\.rawValue))
 

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -123,8 +123,16 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
     @MainActor
     private func loadUrl() {
         configureLoadScripts()
-        let request = URLRequest(url: viewModel.url)
-        webView.load(request)
+
+        // Load the template anchored to the API origin so onsite's authenticated requests are
+        // same-origin, not `Origin: null`. Falls back to a direct load when no base URL is set.
+        if let baseURL = viewModel.baseURL,
+           let html = try? String(contentsOf: viewModel.url, encoding: .utf8) {
+            webView.loadHTMLString(html, baseURL: baseURL)
+        } else {
+            let request = URLRequest(url: viewModel.url)
+            webView.load(request)
+        }
     }
 
     @MainActor
@@ -227,8 +235,10 @@ extension KlaviyoWebViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
-        if let url = navigationAction.request.url,
-           !(url.lastPathComponent == "InAppFormsTemplate.html") {
+        // Open user-tapped links in the system browser; let everything else — including the
+        // initial template load — render in-webview. Keyed off navigation type, not the URL.
+        if navigationAction.navigationType == .linkActivated,
+           let url = navigationAction.request.url {
             let didOpenURL = await UIApplication.shared.open(url)
 
             if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -136,7 +136,9 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
                 return
             } catch {
                 if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("Failed to read template at \(templateURL); falling back to direct load: \(error)")
+                    Logger.webViewLogger.warning(
+                        "Failed to read template at \(templateURL); falling back to direct load: \(error)"
+                    )
                 }
             }
         }

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -125,14 +125,23 @@ class KlaviyoWebViewController: UIViewController, WKUIDelegate, KlaviyoWebViewDe
         configureLoadScripts()
 
         // Load the template anchored to the API origin so onsite's authenticated requests are
-        // same-origin, not `Origin: null`. Falls back to a direct load when no base URL is set.
-        if let baseURL = viewModel.baseURL,
-           let html = try? String(contentsOf: viewModel.url, encoding: .utf8) {
-            webView.loadHTMLString(html, baseURL: baseURL)
-        } else {
-            let request = URLRequest(url: viewModel.url)
-            webView.load(request)
+        // same-origin, not `Origin: null`. Falls back to a direct load when no base URL is set,
+        // or — with a warning — if the template contents can't be read, since that fallback
+        // reintroduces the `Origin: null` the base URL exists to avoid.
+        let templateURL = viewModel.url
+        if let baseURL = viewModel.baseURL {
+            do {
+                let html = try String(contentsOf: templateURL, encoding: .utf8)
+                webView.loadHTMLString(html, baseURL: baseURL)
+                return
+            } catch {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("Failed to read template at \(templateURL); falling back to direct load: \(error)")
+                }
+            }
         }
+
+        webView.load(URLRequest(url: templateURL))
     }
 
     @MainActor

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewModeling.swift
@@ -12,6 +12,12 @@ import WebKit
 
 protocol KlaviyoWebViewModeling: AnyObject {
     var url: URL { get }
+
+    /// When non-`nil`, ``url``'s contents are loaded as an HTML string with this as the document
+    /// base URL, giving the document a same-origin web origin (avoiding `Origin: null`). When
+    /// `nil`, ``url`` is loaded directly.
+    var baseURL: URL? { get }
+
     var delegate: KlaviyoWebViewDelegate? { get set }
 
     /// Scripts & message handlers to be injected into the ``WKWebView`` when the website loads.
@@ -23,4 +29,11 @@ protocol KlaviyoWebViewModeling: AnyObject {
 
     @MainActor
     func handleScriptMessage(_ message: WKScriptMessage)
+}
+
+extension KlaviyoWebViewModeling {
+    /// Default: no base URL; ``url`` is loaded directly. Override to load same-origin.
+    var baseURL: URL? {
+        nil
+    }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -188,6 +188,30 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertNil(authTokenScript, "Auth token script should not be injected when authToken is nil")
     }
 
+    // MARK: - Same-origin loading
+
+    @MainActor
+    func testBaseURLMatchesAPIOriginForSameOriginRequests() async throws {
+        // Given the API host onsite calls for the authenticated /api/profiles/ request
+        environment.apiURL = {
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "a.klaviyo.com"
+            return components
+        }
+        let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
+        let apiKey = try await KlaviyoInternal.fetchAPIKey()
+        let viewModel = IAFWebViewModel(url: fileUrl, apiKey: apiKey, profileData: nil)
+
+        // Then the webview loads anchored to that origin, so onsite's authenticated fetch is
+        // same-origin (no CORS preflight / `Origin: null` → no 401).
+        XCTAssertEqual(
+            viewModel.baseURL,
+            URL(string: "https://a.klaviyo.com"),
+            "Base URL should match the API origin so the profiles fetch is same-origin"
+        )
+    }
+
     // MARK: - Klaviyo JS Tests
 
     @MainActor


### PR DESCRIPTION
# Description
Fixes a 401 on the In-App Forms authenticated `/api/profiles/` fetch on iOS by loading the form template same-origin with the Klaviyo API host, eliminating the `Origin: null` that a `file://` load produced.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Part of the JWT personalized In-App Forms feature; merges to `feat/jwts-for-personalized-forms`.

## Changelog / Code Overview
**Root cause:** The IAF `WKWebView` loaded the template from a `file://` URL, which has an opaque origin. Onsite's authenticated `GET /api/profiles/` (cross-origin, with `authorization`/`revision` headers) therefore triggered a CORS preflight carrying `Origin: null`, which the API rejects — surfacing as a 401. The token was present in the DOM and onsite was attaching it correctly; the null origin was the only blocker.

**Fix:** Load the template's HTML same-origin, anchored to the API host, so the profile fetch is same-origin (no preflight, no `Origin: null`).

- `KlaviyoWebViewModeling`: new `baseURL: URL?` protocol member (default `nil`, so other webviews are unaffected).
- `IAFWebViewModel.baseURL` returns `environment.apiURL().url`.
- `KlaviyoWebViewController.loadUrl()` uses `loadHTMLString(_:baseURL:)` when a base URL is supplied; falls back to the direct `URLRequest` load otherwise.
- `decidePolicyFor` now keys external-link handling off `navigationAction.navigationType == .linkActivated` instead of the template filename — required because same-origin loading changes the document URL to the API host, which previously misclassified the initial load as an external link and bounced it to Safari.

## Test Plan
1. Build & unit tests: `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:KlaviyoFormsTests` — all green (incl. `testBaseURLMatchesAPIOriginForSameOriginRequests`).
2. On device with a JWT-personalized form configured:
   - Trigger the in-app form; confirm it displays **in-place** (no Safari bounce).
   - Via Safari Web Inspector → Network: confirm `GET /api/profiles/` is **same-origin** (no `OPTIONS` preflight) and returns **200**.
   - Tap a CTA link in the form; confirm it still opens in the system browser.

## Related Issues/Tickets
- [MAGE-787](https://linear.app/klaviyo/issue/MAGE-787/ios-load-iaf-webview-same-origin-to-fix-401-on-authenticated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authenticated web form loading by using an optional matching base URL so `/api/profiles/` requests behave same-origin and avoid related CORS issues.
  * Updated outbound link handling to open external links in the system browser only when directly activated by the user.

* **Tests**
  * Added an async test to confirm the web form base URL matches the authenticated API origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->