### PR TITLE
fix(push): prefer deep_link over web_url when both are present

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -226,10 +226,17 @@ public struct KlaviyoSDK {
         } else {
             // Regular notification body tap
             create(event: Event(name: ._openedPush, properties: properties))
-            if let webUrl = notificationResponse.klaviyoWebUrl {
-                dispatchOnMainThread(action: .openWebUrl(webUrl))
-            } else if let url = notificationResponse.klaviyoDeepLinkURL {
+            // Deep link wins when both are present. The composer enforces a single action
+            // type at creation, so this only matters for direct-API or test-tooling sends.
+            if let url = notificationResponse.klaviyoDeepLinkURL {
+                if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
+                    Logger.notifications.warning(
+                        "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
+                    )
+                }
                 dispatchOnMainThread(action: .openDeepLink(url))
+            } else if let webUrl = notificationResponse.klaviyoWebUrl {
+                dispatchOnMainThread(action: .openWebUrl(webUrl))
             }
         }
 
@@ -269,11 +276,14 @@ public struct KlaviyoSDK {
             handleActionButtonTap(notificationResponse: notificationResponse, properties: properties)
         } else {
             create(event: Event(name: ._openedPush, properties: properties))
-            if let webUrl = notificationResponse.klaviyoWebUrl {
-                // External web URL: open in system browser. The deepLinkHandler closure
-                // is intentionally bypassed (it's for deep links only).
-                dispatchOnMainThread(action: .openWebUrl(webUrl))
-            } else if let url = notificationResponse.klaviyoDeepLinkURL {
+            // Deep link wins when both are present. The composer enforces a single action
+            // type at creation, so this only matters for direct-API or test-tooling sends.
+            if let url = notificationResponse.klaviyoDeepLinkURL {
+                if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
+                    Logger.notifications.warning(
+                        "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
+                    )
+                }
                 if let deepLinkHandler = deepLinkHandler {
                     Task { @MainActor in
                         deepLinkHandler(url)
@@ -281,6 +291,10 @@ public struct KlaviyoSDK {
                 } else {
                     dispatchOnMainThread(action: .openDeepLink(url))
                 }
+            } else if let webUrl = notificationResponse.klaviyoWebUrl {
+                // External web URL: open in system browser. The deepLinkHandler closure
+                // is intentionally bypassed (it's for deep links only).
+                dispatchOnMainThread(action: .openWebUrl(webUrl))
             }
         }
         Task { @MainActor in

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -226,18 +226,7 @@ public struct KlaviyoSDK {
         } else {
             // Regular notification body tap
             create(event: Event(name: ._openedPush, properties: properties))
-            // Deep link wins when both are present. The composer enforces a single action
-            // type at creation, so this only matters for direct-API or test-tooling sends.
-            if let url = notificationResponse.klaviyoDeepLinkURL {
-                if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
-                    Logger.notifications.warning(
-                        "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
-                    )
-                }
-                dispatchOnMainThread(action: .openDeepLink(url))
-            } else if let webUrl = notificationResponse.klaviyoWebUrl {
-                dispatchOnMainThread(action: .openWebUrl(webUrl))
-            }
+            resolveOpenAction(for: notificationResponse, deepLinkHandler: nil)
         }
 
         Task { @MainActor in
@@ -276,26 +265,7 @@ public struct KlaviyoSDK {
             handleActionButtonTap(notificationResponse: notificationResponse, properties: properties)
         } else {
             create(event: Event(name: ._openedPush, properties: properties))
-            // Deep link wins when both are present. The composer enforces a single action
-            // type at creation, so this only matters for direct-API or test-tooling sends.
-            if let url = notificationResponse.klaviyoDeepLinkURL {
-                if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
-                    Logger.notifications.warning(
-                        "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
-                    )
-                }
-                if let deepLinkHandler = deepLinkHandler {
-                    Task { @MainActor in
-                        deepLinkHandler(url)
-                    }
-                } else {
-                    dispatchOnMainThread(action: .openDeepLink(url))
-                }
-            } else if let webUrl = notificationResponse.klaviyoWebUrl {
-                // External web URL: open in system browser. The deepLinkHandler closure
-                // is intentionally bypassed (it's for deep links only).
-                dispatchOnMainThread(action: .openWebUrl(webUrl))
-            }
+            resolveOpenAction(for: notificationResponse, deepLinkHandler: deepLinkHandler)
         }
         Task { @MainActor in
             completionHandler()
@@ -307,6 +277,36 @@ public struct KlaviyoSDK {
     ///
     /// This method:
     /// - Tracks a `$opened_push` event with button properties (Button Label, Button Action, Button Link)
+    /// Resolves the open action for a body tap: deep link, web URL, or neither.
+    ///
+    /// Deep link wins when both are present. The composer enforces a single action
+    /// type at creation, so this only matters for direct-API or test-tooling sends.
+    ///
+    /// When `deepLinkHandler` is non-nil, the deep link is delivered to that closure
+    /// instead of being dispatched as an `.openDeepLink` action. External web URLs
+    /// always route through `.openWebUrl` and intentionally bypass the closure.
+    private func resolveOpenAction(
+        for notificationResponse: UNNotificationResponse,
+        deepLinkHandler: ((URL) -> Void)?
+    ) {
+        if let url = notificationResponse.klaviyoDeepLinkURL {
+            if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
+                Logger.notifications.warning(
+                    "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
+                )
+            }
+            if let deepLinkHandler = deepLinkHandler {
+                Task { @MainActor in
+                    deepLinkHandler(url)
+                }
+            } else {
+                dispatchOnMainThread(action: .openDeepLink(url))
+            }
+        } else if let webUrl = notificationResponse.klaviyoWebUrl {
+            dispatchOnMainThread(action: .openWebUrl(webUrl))
+        }
+    }
+
     /// - Handles action-specific deep links (or falls back to default notification URL)
     ///
     /// - Parameters:

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -289,7 +289,7 @@ public struct KlaviyoSDK {
         for notificationResponse: UNNotificationResponse,
         deepLinkHandler: ((URL) -> Void)?
     ) {
-        if let url = notificationResponse.klaviyoDeepLinkURL {
+        if let deepLinkURL = notificationResponse.klaviyoDeepLinkURL {
             if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
                 Logger.notifications.warning(
                     "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
@@ -297,10 +297,10 @@ public struct KlaviyoSDK {
             }
             if let deepLinkHandler = deepLinkHandler {
                 Task { @MainActor in
-                    deepLinkHandler(url)
+                    deepLinkHandler(deepLinkURL)
                 }
             } else {
-                dispatchOnMainThread(action: .openDeepLink(url))
+                dispatchOnMainThread(action: .openDeepLink(deepLinkURL))
             }
         } else if let webUrl = notificationResponse.klaviyoWebUrl {
             dispatchOnMainThread(action: .openWebUrl(webUrl))

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -550,8 +550,10 @@ class KlaviyoSDKTests: XCTestCase {
         XCTAssertTrue(deepLinkDispatched, "Deep link path must remain unchanged when web_url is absent")
     }
 
-    func testHandleBodyTap_WebUrlTakesPrecedenceOverDeepLink() throws {
-        // Defensive: if backend ever ships both web_url and url, web_url wins.
+    func testHandleBodyTap_DeepLinkTakesPrecedenceOverWebUrl() throws {
+        // Defensive: if backend ever ships both web_url and url, the deep link wins so
+        // the user stays in the host app. The composer UI enforces a single action type
+        // at creation, so this only fires via direct-API or test-tooling sends.
         let callback = XCTestExpectation(description: "callback is made")
         let webURL = try XCTUnwrap(URL(string: "https://example.com/sale"))
         let deepURL = try XCTUnwrap(URL(string: "myapp://path"))
@@ -575,17 +577,17 @@ class KlaviyoSDKTests: XCTestCase {
 
         wait(for: [callback], timeout: 1.0)
 
-        let webUrlDispatched = capturedActions.contains { action in
-            if case let .openWebUrl(dispatchedUrl) = action { return dispatchedUrl == webURL }
-            return false
-        }
-        XCTAssertTrue(webUrlDispatched)
-
         let deepLinkDispatched = capturedActions.contains { action in
-            if case .openDeepLink = action { return true }
+            if case let .openDeepLink(dispatchedUrl) = action { return dispatchedUrl == deepURL }
             return false
         }
-        XCTAssertFalse(deepLinkDispatched)
+        XCTAssertTrue(deepLinkDispatched)
+
+        let webUrlDispatched = capturedActions.contains { action in
+            if case .openWebUrl = action { return true }
+            return false
+        }
+        XCTAssertFalse(webUrlDispatched)
     }
 
     func testHandleActionButtonTap_OpenUrlButton() throws {


### PR DESCRIPTION
# Description

Reverses the precedence chosen in #580 so a payload with both `url` (deep link) and `web_url` routes through the deep link path. Aligns iOS with the Android side of PUSH-637 ([Android PR #448](https://github.com/klaviyo/klaviyo-android-sdk/pull/448)).

> [!NOTE]
> **This is an edge case that should not occur in normal customer flows.** The fender composer ([`PushDeepLinkingSection.tsx`](https://github.com/klaviyo/fender/blob/master/client/shared/mobile-content-builder/src/push/components/editorPanel/PushDeepLinkingSection.tsx)) uses a single `openAction` SelectBox with mutually-exclusive conditional rendering, so a marketer cannot populate both `url` and `web_url` on the same variation. The rule only matters for direct Send-Push API calls or test tooling like `fcm-push-cli` / payload editors. For that edge path, keeping the user inside the host app via the deep link is more conservative than diverting to an external browser.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- `Klaviyo.swift`: both `handle(notificationResponse:)` overloads now check `klaviyoDeepLinkURL` first; if present, log a warning when `klaviyoWebUrl` is also set, then dispatch `openDeepLink`. Only when no deep link is present does `openWebUrl` fire.
- `KlaviyoSDKTests.swift`: rename `testHandleBodyTap_WebUrlTakesPrecedenceOverDeepLink` to `testHandleBodyTap_DeepLinkTakesPrecedenceOverWebUrl` and assert the inverted behavior.

Warning is logged via `Logger.notifications.warning` so misconfigurations remain debuggable.

## Test Plan

### Automated (unit tests)
- [x] `xcodebuild test -only-testing:KlaviyoSwiftTests/KlaviyoSDKTests` passes locally
- [x] New `testHandleBodyTap_DeepLinkTakesPrecedenceOverWebUrl` asserts deep link dispatch and absence of `openWebUrl` when both fields are present

### Manual QA

Run against `klaviyo-ios-test-app` on iPhone 16 Pro simulator (iOS 18.6), with local SPM dependency pointed at this branch. Payloads sent via `apns-cli` against the APNs sandbox (`apns-cli/payloads/push-638-open-url/`).

| ✅ | Scenario | Payload | Expected | Result |
|---|---|---|---|---|
| ✅ | **Dual-field precedence (NEW behavior)** — both `url` and `web_url` set | `edge-weburl-precedence.json` | Deep links to forms screen, **not** Safari; warning logged | Passed |
| ✅ | Body tap with `web_url` only | `body-openurl.json` | Safari opens to klaviyo.com | Passed |
| ✅ | Body tap with `url` only — regression | `regression-deeplink.json` | App deep links to forms screen; no Safari | Passed |
| ✅ | Action button `open_url` ("Visit Klaviyo") | `button-openurl.json` | Safari opens to klaviyo.com | Passed |
| ✅ | Action button `deep_link` ("Deep Link") — regression | `button-openurl.json` | App opens to forms screen (`klaviyotest://forms`); no Safari | Passed |
| ✅ | Action button `open_app` ("Open App") | `button-openurl.json` | App launches, no URL handling, no Safari | Passed |
| ✅ | Empty `web_url` (`""`) | `edge-empty-url.json` | App launches to default state; no Safari; no crash | Passed |

## Related Issues/Tickets

- Android counterpart: https://github.com/klaviyo/klaviyo-android-sdk/pull/448
- Original iOS open_url PR: #580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep links now correctly take precedence over web URLs when both are present in notification payloads.
  * Added informational logging on iOS 14+ to indicate when a deep link takes precedence and a web URL is ignored.

* **Refactor**
  * Consolidated notification tap routing logic to eliminate code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->