### PR TITLE
fix(push): use _k.tm ULID as dedup key for auto-tracked push open events (mage-793)

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -298,8 +298,8 @@ public struct KlaviyoSDK {
         _ notificationResponse: UNNotificationResponse,
         completionHandler: @escaping () -> Void
     ) -> Bool {
-        let requestId = notificationResponse.notification.request.identifier
-        guard KlaviyoNotificationDelegate.shared.wasAutoTracked(requestId: requestId) else {
+        let dedupKey = notificationResponse.klaviyoDedupKey
+        guard KlaviyoNotificationDelegate.shared.wasAutoTracked(dedupKey: dedupKey) else {
             return false
         }
         Task { @MainActor in completionHandler() }

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -83,8 +83,8 @@ final class KlaviyoNotificationDelegate: NSObject {
 
     private let autoTrackGuard = BoundedIDSet<String>()
 
-    func markAsAutoTracked(requestId: String) { autoTrackGuard.insert(requestId) }
-    func wasAutoTracked(requestId: String) -> Bool { autoTrackGuard.contains(requestId) }
+    func markAsAutoTracked(dedupKey: String) { autoTrackGuard.insert(dedupKey) }
+    func wasAutoTracked(dedupKey: String) -> Bool { autoTrackGuard.contains(dedupKey) }
     func clearAutoTracked() { autoTrackGuard.clear() }
 
     // MARK: - Injection
@@ -153,7 +153,7 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
             withCompletionHandler: { once() }
         )
         if wasTracked && response.actionIdentifier != UNNotificationDismissActionIdentifier {
-            markAsAutoTracked(requestId: requestId)
+            markAsAutoTracked(dedupKey: response.klaviyoDedupKey)
         }
         existingDelegate?.userNotificationCenter?(
             center, didReceive: response, withCompletionHandler: { once() }

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -82,6 +82,26 @@ extension UNNotificationResponse {
         return url
     }
 
+    // MARK: - Dedup Key
+
+    /// Returns the stable dedup key used by the auto-track guard to prevent double-firing
+    /// the `Opened Push` event when both the Klaviyo proxy delegate and a manual
+    /// `handle(notificationResponse:)` call process the same response.
+    ///
+    /// Preference order:
+    /// 1. `tm` from `_k` — a ULID unique per delivery, present in Klaviyo campaign sends.
+    /// 2. `notification.request.identifier` — OS-assigned request ID, used as a safe
+    ///    fallback if `tm` is absent.
+    var klaviyoDedupKey: String {
+        guard let userInfo = notification.request.content.userInfo as? [String: Any],
+              let klaviyoBody = userInfo["body"] as? [String: Any],
+              let kPayload = klaviyoBody["_k"] as? [String: Any],
+              let deliveryUlid = kPayload["tm"] as? String else {
+            return notification.request.identifier
+        }
+        return deliveryUlid
+    }
+
     // MARK: - Action Button Support
 
     /// Detects if the user tapped an action button (vs tapping the notification body).

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -143,26 +143,26 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
 
     // MARK: - Auto-track guard passthroughs
 
-    /// After marking a request ID as auto-tracked, `wasAutoTracked` must return true.
+    /// After marking a dedup key as auto-tracked, `wasAutoTracked` must return true.
     func testMarkAsAutoTrackedRoundTrip() {
         // Given
         let delegate = KlaviyoNotificationDelegate.shared
         defer { delegate.clearAutoTracked() }
 
         // When
-        delegate.markAsAutoTracked(requestId: "test-id")
+        delegate.markAsAutoTracked(dedupKey: "test-id")
 
         // Then
-        XCTAssertTrue(delegate.wasAutoTracked(requestId: "test-id"))
+        XCTAssertTrue(delegate.wasAutoTracked(dedupKey: "test-id"))
     }
 
-    /// A request ID that was never marked must not appear as auto-tracked.
+    /// A dedup key that was never marked must not appear as auto-tracked.
     func testWasAutoTrackedReturnsFalseForUnmarkedId() {
         // Given
         let delegate = KlaviyoNotificationDelegate.shared
         defer { delegate.clearAutoTracked() }
 
         // When / Then
-        XCTAssertFalse(delegate.wasAutoTracked(requestId: "never-marked"))
+        XCTAssertFalse(delegate.wasAutoTracked(dedupKey: "never-marked"))
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -524,7 +524,7 @@ class KlaviyoSDKTests: XCTestCase {
         }
         let push_body: [AnyHashable: Any] = ["body": ["_k": ["foo": "bar"]]]
         let response = try UNNotificationResponse.with(userInfo: push_body)
-        KlaviyoNotificationDelegate.shared.markAsAutoTracked(requestId: response.notification.request.identifier)
+        KlaviyoNotificationDelegate.shared.markAsAutoTracked(dedupKey: response.klaviyoDedupKey)
 
         // When
         let handled = klaviyo.handle(notificationResponse: response) { callback.fulfill() }
@@ -550,7 +550,7 @@ class KlaviyoSDKTests: XCTestCase {
         let wasTracked = klaviyo.handle(notificationResponse: response) { proxyCallback.fulfill() }
         XCTAssertTrue(wasTracked)
         KlaviyoNotificationDelegate.shared.markAsAutoTracked(
-            requestId: response.notification.request.identifier
+            dedupKey: response.klaviyoDedupKey
         )
         wait(for: [proxyCallback], timeout: 1.0)
 
@@ -580,7 +580,7 @@ class KlaviyoSDKTests: XCTestCase {
             "url": "https://example.com/deeplink"
         ]
         let response = try UNNotificationResponse.with(userInfo: push_body)
-        KlaviyoNotificationDelegate.shared.markAsAutoTracked(requestId: response.notification.request.identifier)
+        KlaviyoNotificationDelegate.shared.markAsAutoTracked(dedupKey: response.klaviyoDedupKey)
 
         // When
         let handled = klaviyo.handle(notificationResponse: response) { callback.fulfill() }
@@ -588,6 +588,40 @@ class KlaviyoSDKTests: XCTestCase {
         // Then
         wait(for: [callback, noDeepLink], timeout: 1.0)
         XCTAssertTrue(handled)
+    }
+
+    func testProxyThenManualHandleDedupsViaTm() throws {
+        // Given — a real Klaviyo payload with tm present
+        let proxyCallback = XCTestExpectation(description: "proxy completion fires")
+        let manualCallback = XCTestExpectation(description: "manual completion fires")
+        var enqueueCount = 0
+        klaviyoSwiftEnvironment.send = { action in
+            if case .enqueueEvent = action { enqueueCount += 1 }
+            return nil
+        }
+        let pushBody: [AnyHashable: Any] = [
+            "body": [
+                "_k": [
+                    "tm": "01KV8CN3SH8N7MM5ZYNX40QCFH",
+                    "m": "01KT4QQ8QPYH4EN7BH3BH259TD",
+                    "$message": "01KT4QQ8QPYH4EN7BH3BH259TD"
+                ]
+            ]
+        ]
+        let response = try UNNotificationResponse.with(userInfo: pushBody)
+
+        // When (proxy path) - mark using the tm-based dedup key
+        let wasTracked = klaviyo.handle(notificationResponse: response) { proxyCallback.fulfill() }
+        XCTAssertTrue(wasTracked)
+        KlaviyoNotificationDelegate.shared.markAsAutoTracked(dedupKey: response.klaviyoDedupKey)
+        wait(for: [proxyCallback], timeout: 1.0)
+        XCTAssertEqual(enqueueCount, 1, "proxy call should emit exactly one _openedPush")
+
+        // When (manual host path) — same tm key must short-circuit
+        let handled2 = klaviyo.handle(notificationResponse: response) { manualCallback.fulfill() }
+        XCTAssertTrue(handled2)
+        wait(for: [manualCallback], timeout: 1.0)
+        XCTAssertEqual(enqueueCount, 1, "manual handle must not emit a second event")
     }
 
     func testHandleShortCircuitsForActionButtonTapWhenAutoTracked() throws {
@@ -607,7 +641,7 @@ class KlaviyoSDKTests: XCTestCase {
             ]
         ]
         let response = try UNNotificationResponse.with(userInfo: push_body, actionIdentifier: actionId)
-        KlaviyoNotificationDelegate.shared.markAsAutoTracked(requestId: response.notification.request.identifier)
+        KlaviyoNotificationDelegate.shared.markAsAutoTracked(dedupKey: response.klaviyoDedupKey)
 
         // When
         let handled = klaviyo.handle(notificationResponse: response) { callback.fulfill() }

--- a/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
@@ -197,4 +197,42 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         // Assert
         XCTAssertNil(response.klaviyoDeepLinkURL)
     }
+
+    // MARK: - klaviyoDedupKey Tests
+
+    func testDedupKey_UsesTmFromKPayload() throws {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": [
+                    "tm": "01KV8CN3SH8N7MM5ZYNX40QCFH",
+                    "m": "01KT4QQ8QPYH4EN7BH3BH259TD",
+                    "$message": "01KT4QQ8QPYH4EN7BH3BH259TD"
+                ]
+            ]
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        XCTAssertEqual(response.klaviyoDedupKey, "01KV8CN3SH8N7MM5ZYNX40QCFH")
+    }
+
+    func testDedupKey_FallsBackToRequestIdentifierWhenTmAbsent() throws {
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": ["m": "01KT4QQ8QPYH4EN7BH3BH259TD", "t": 1_718_500_000]]
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        XCTAssertEqual(response.klaviyoDedupKey, response.notification.request.identifier)
+    }
+
+    func testDedupKey_FallsBackToRequestIdentifierWhenNoKlaviyoMetadata() throws {
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": ["some_field": "value"]]
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        XCTAssertEqual(response.klaviyoDedupKey, response.notification.request.identifier)
+    }
+
+    func testDedupKey_FallsBackToRequestIdentifierForNonKlaviyoPayload() throws {
+        let userInfo: [AnyHashable: Any] = ["data": ["type": "OTHER"]]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        XCTAssertEqual(response.klaviyoDedupKey, response.notification.request.identifier)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `klaviyoDedupKey` computed property on `UNNotificationResponse` that extracts `tm` from the `_k` payload as the dedup key, falling back to `notification.request.identifier` when absent
- Replaces the OS `request.identifier` with `klaviyoDedupKey` in `BoundedIDSet<String>` for the auto-track guard
- Renames `markAsAutoTracked(requestId:)` / `wasAutoTracked(requestId:)` → `dedupKey:` to reflect the changed semantics

## Test plan

- [ ] 4 unit tests in `UNNotificationResponseExtensionTests` covering `tm` extraction and fallback to `request.identifier`
- [ ] New integration test `testProxyThenManualHandleDedupsViaTm` verifying proxy→manual dedup fires exactly one event using a real `tm` ULID
- [ ] All existing double-track guard tests updated to `dedupKey:` parameter label — all tests pass, 0 failures
- [ ] Manually verified on device: push received, `$opened_push` buffered, action button deep link handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved push notification deduplication to prevent duplicate tracking events when the same notification is opened or handled through multiple paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->