### PR TITLE
feat(KlaviyoCore): add IdentityStore and SDKConfigStore (MAGE-748)

### DIFF
--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-import Foundation
 
 /// Read-only view of profile identity. Consumers depend on this rather than the
 /// concrete store so the underlying implementation can change (e.g. become an actor).
@@ -24,8 +23,10 @@ public protocol IdentityWriting {
 public final class IdentityStore: IdentityReading, IdentityWriting {
     public static let shared = IdentityStore()
 
-    /// Serializes reads and writes to the backing subject.
-    private let queue = DispatchQueue(label: "com.klaviyo.identity-store")
+    // `CurrentValueSubject` is internally synchronized, so reads and writes are thread-safe
+    // without an external lock. We deliberately avoid wrapping `send` in a lock/queue: Combine
+    // delivers to subscribers synchronously during `send`, so an external lock held across the
+    // emission would deadlock any subscriber that reads `current` in response.
     private let subject: CurrentValueSubject<ProfileData, Never>
 
     init(initialIdentity: ProfileData = ProfileData()) {
@@ -33,7 +34,7 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
     }
 
     public var current: ProfileData {
-        queue.sync { subject.value }
+        subject.value
     }
 
     public var publisher: AnyPublisher<ProfileData, Never> {
@@ -52,6 +53,6 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
     }
 
     public func update(_ identity: ProfileData) {
-        queue.sync { subject.send(identity) }
+        subject.send(identity)
     }
 }

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -1,0 +1,57 @@
+//
+//  IdentityStore.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 6/16/26.
+//
+
+import Combine
+import Foundation
+
+/// Read-only view of profile identity. Consumers depend on this rather than the
+/// concrete store so the underlying implementation can change (e.g. become an actor).
+public protocol IdentityReading {
+    var current: ProfileData { get }
+    var publisher: AnyPublisher<ProfileData, Never> { get }
+    func stream() -> AsyncStream<ProfileData>
+}
+
+/// Write access to profile identity. Intended for `KlaviyoSwift` only.
+public protocol IdentityWriting {
+    func update(_ identity: ProfileData)
+}
+
+public final class IdentityStore: IdentityReading, IdentityWriting {
+    public static let shared = IdentityStore()
+
+    /// Serializes reads and writes to the backing subject.
+    private let queue = DispatchQueue(label: "com.klaviyo.identity-store")
+    private let subject: CurrentValueSubject<ProfileData, Never>
+
+    init(initialIdentity: ProfileData = ProfileData()) {
+        subject = CurrentValueSubject(initialIdentity)
+    }
+
+    public var current: ProfileData {
+        queue.sync { subject.value }
+    }
+
+    public var publisher: AnyPublisher<ProfileData, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    public func stream() -> AsyncStream<ProfileData> {
+        AsyncStream(bufferingPolicy: .unbounded) { continuation in
+            let cancellable = subject.sink { value in
+                continuation.yield(value)
+            }
+            continuation.onTermination = { _ in
+                cancellable.cancel()
+            }
+        }
+    }
+
+    public func update(_ identity: ProfileData) {
+        queue.sync { subject.send(identity) }
+    }
+}

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -7,16 +7,25 @@
 
 import Combine
 
-/// Read-only view of SDK configuration. Consumers depend on this rather than the
-/// concrete store so the underlying implementation can change (e.g. become an actor).
+/// SDK-wide configuration
+public struct KlaviyoConfig: Equatable {
+    public var apiKey: String?
+
+    public init(apiKey: String? = nil) {
+        self.apiKey = apiKey
+    }
+}
+
+/// Read-only view of SDK configuration
 public protocol ConfigReading {
-    var apiKey: String? { get }
-    var apiKeyPublisher: AnyPublisher<String?, Never> { get }
+    var current: KlaviyoConfig { get }
+    var publisher: AnyPublisher<KlaviyoConfig, Never> { get }
+    func stream() -> AsyncStream<KlaviyoConfig>
 }
 
 /// Write access to SDK configuration. Intended for `KlaviyoSwift` only.
 public protocol ConfigWriting {
-    func updateAPIKey(_ apiKey: String?)
+    func update(_ config: KlaviyoConfig)
 }
 
 public final class SDKConfigStore: ConfigReading, ConfigWriting {
@@ -25,22 +34,33 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     // `CurrentValueSubject` is internally synchronized, so reads and writes are thread-safe
     // without an external lock. We deliberately avoid wrapping `send` in a lock/queue: Combine
     // delivers to subscribers synchronously during `send`, so an external lock held across the
-    // emission would deadlock any subscriber that reads `apiKey` in response.
-    private let apiKeySubject: CurrentValueSubject<String?, Never>
+    // emission would deadlock any subscriber that reads `current` in response.
+    private let subject: CurrentValueSubject<KlaviyoConfig, Never>
 
-    init(initialAPIKey: String? = nil) {
-        apiKeySubject = CurrentValueSubject(initialAPIKey)
+    init(initialConfig: KlaviyoConfig = KlaviyoConfig()) {
+        subject = CurrentValueSubject(initialConfig)
     }
 
-    public var apiKey: String? {
-        apiKeySubject.value
+    public var current: KlaviyoConfig {
+        subject.value
     }
 
-    public var apiKeyPublisher: AnyPublisher<String?, Never> {
-        apiKeySubject.eraseToAnyPublisher()
+    public var publisher: AnyPublisher<KlaviyoConfig, Never> {
+        subject.eraseToAnyPublisher()
     }
 
-    public func updateAPIKey(_ apiKey: String?) {
-        apiKeySubject.send(apiKey)
+    public func stream() -> AsyncStream<KlaviyoConfig> {
+        AsyncStream(bufferingPolicy: .unbounded) { continuation in
+            let cancellable = subject.sink { value in
+                continuation.yield(value)
+            }
+            continuation.onTermination = { _ in
+                cancellable.cancel()
+            }
+        }
+    }
+
+    public func update(_ config: KlaviyoConfig) {
+        subject.send(config)
     }
 }

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -1,0 +1,45 @@
+//
+//  SDKConfigStore.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 6/16/26.
+//
+
+import Combine
+import Foundation
+
+/// Read-only view of SDK configuration. Consumers depend on this rather than the
+/// concrete store so the underlying implementation can change (e.g. become an actor).
+public protocol ConfigReading {
+    var apiKey: String? { get }
+    var apiKeyPublisher: AnyPublisher<String?, Never> { get }
+}
+
+/// Write access to SDK configuration. Intended for `KlaviyoSwift` only.
+public protocol ConfigWriting {
+    func updateAPIKey(_ apiKey: String?)
+}
+
+public final class SDKConfigStore: ConfigReading, ConfigWriting {
+    public static let shared = SDKConfigStore()
+
+    /// Serializes reads and writes to the backing subject.
+    private let queue = DispatchQueue(label: "com.klaviyo.sdk-config-store")
+    private let apiKeySubject: CurrentValueSubject<String?, Never>
+
+    init(initialAPIKey: String? = nil) {
+        apiKeySubject = CurrentValueSubject(initialAPIKey)
+    }
+
+    public var apiKey: String? {
+        queue.sync { apiKeySubject.value }
+    }
+
+    public var apiKeyPublisher: AnyPublisher<String?, Never> {
+        apiKeySubject.eraseToAnyPublisher()
+    }
+
+    public func updateAPIKey(_ apiKey: String?) {
+        queue.sync { apiKeySubject.send(apiKey) }
+    }
+}

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-import Foundation
 
 /// Read-only view of SDK configuration. Consumers depend on this rather than the
 /// concrete store so the underlying implementation can change (e.g. become an actor).
@@ -23,8 +22,10 @@ public protocol ConfigWriting {
 public final class SDKConfigStore: ConfigReading, ConfigWriting {
     public static let shared = SDKConfigStore()
 
-    /// Serializes reads and writes to the backing subject.
-    private let queue = DispatchQueue(label: "com.klaviyo.sdk-config-store")
+    // `CurrentValueSubject` is internally synchronized, so reads and writes are thread-safe
+    // without an external lock. We deliberately avoid wrapping `send` in a lock/queue: Combine
+    // delivers to subscribers synchronously during `send`, so an external lock held across the
+    // emission would deadlock any subscriber that reads `apiKey` in response.
     private let apiKeySubject: CurrentValueSubject<String?, Never>
 
     init(initialAPIKey: String? = nil) {
@@ -32,7 +33,7 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     }
 
     public var apiKey: String? {
-        queue.sync { apiKeySubject.value }
+        apiKeySubject.value
     }
 
     public var apiKeyPublisher: AnyPublisher<String?, Never> {
@@ -40,6 +41,6 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     }
 
     public func updateAPIKey(_ apiKey: String?) {
-        queue.sync { apiKeySubject.send(apiKey) }
+        apiKeySubject.send(apiKey)
     }
 }

--- a/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
@@ -1,0 +1,97 @@
+//
+//  IdentityStoreTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 6/16/26.
+//
+
+import Combine
+@testable import KlaviyoCore
+import XCTest
+
+final class IdentityStoreTests: XCTestCase {
+    func testInitialStateIsEmptyProfileData() {
+        let store = IdentityStore()
+        XCTAssertEqual(store.current, ProfileData())
+    }
+
+    func testUpdateReflectsSynchronouslyOnCurrent() {
+        let store = IdentityStore()
+        let identity = ProfileData(email: "test@example.com", anonymousId: "anon-1")
+
+        store.update(identity)
+
+        XCTAssertEqual(store.current, identity)
+    }
+
+    func testUpdateEmitsOnPublisher() {
+        let store = IdentityStore()
+        let identity = ProfileData(email: "test@example.com")
+
+        var received: [ProfileData] = []
+        let cancellable = store.publisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        store.update(identity)
+
+        // CurrentValueSubject replays the current value on subscribe, then the update.
+        XCTAssertEqual(received, [ProfileData(), identity])
+    }
+
+    func testStreamEmitsUpdates() async {
+        let store = IdentityStore()
+        let identity = ProfileData(externalId: "ext-1")
+
+        let stream = store.stream()
+        store.update(identity)
+
+        var received: [ProfileData] = []
+        for await value in stream {
+            received.append(value)
+            if value == identity { break }
+        }
+
+        XCTAssertEqual(received, [ProfileData(), identity])
+    }
+
+    func testStreamDeliversAllUpdatesToConcurrentConsumersNoDrops() async {
+        let store = IdentityStore()
+        let updates = (0..<100).map { ProfileData(externalId: "id-\($0)") }
+
+        // Subscribe both consumers before any writes so all emissions are buffered.
+        let streamA = store.stream()
+        let streamB = store.stream()
+
+        for update in updates {
+            store.update(update)
+        }
+
+        func collect(_ stream: AsyncStream<ProfileData>) async -> [ProfileData] {
+            var received: [ProfileData] = []
+            for await value in stream {
+                received.append(value)
+                if value == updates.last { break }
+            }
+            return received
+        }
+
+        async let receivedA = collect(streamA)
+        async let receivedB = collect(streamB)
+        let (a, b) = await (receivedA, receivedB)
+
+        // Each consumer sees the initial empty value followed by every update, in order.
+        let expected = [ProfileData()] + updates
+        XCTAssertEqual(a, expected)
+        XCTAssertEqual(b, expected)
+    }
+}
+
+// Compile-time proof that a consumer can conform to the read interface alone,
+// with no access to `update(_:)`.
+private struct MockIdentityReader: IdentityReading {
+    var current: ProfileData
+    var publisher: AnyPublisher<ProfileData, Never>
+    func stream() -> AsyncStream<ProfileData> {
+        AsyncStream { $0.finish() }
+    }
+}

--- a/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
@@ -5,8 +5,8 @@
 //  Created by Isobelle Lim on 6/16/26.
 //
 
-import Combine
 @testable import KlaviyoCore
+import Combine
 import XCTest
 
 final class IdentityStoreTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -10,36 +10,60 @@ import Combine
 import XCTest
 
 final class SDKConfigStoreTests: XCTestCase {
-    func testInitialAPIKeyIsNil() {
+    func testInitialConfigIsEmpty() {
         let store = SDKConfigStore()
-        XCTAssertNil(store.apiKey)
+        XCTAssertEqual(store.current, KlaviyoConfig())
+        XCTAssertNil(store.current.apiKey)
     }
 
-    func testUpdateAPIKeyReflectsSynchronously() {
+    func testUpdateReflectsSynchronously() {
         let store = SDKConfigStore()
 
-        store.updateAPIKey("company-123")
+        store.update(KlaviyoConfig(apiKey: "company-123"))
 
-        XCTAssertEqual(store.apiKey, "company-123")
+        XCTAssertEqual(store.current.apiKey, "company-123")
     }
 
-    func testUpdateAPIKeyEmitsOnPublisher() {
+    func testUpdateEmitsOnPublisher() {
         let store = SDKConfigStore()
 
-        var received: [String?] = []
-        let cancellable = store.apiKeyPublisher.sink { received.append($0) }
+        var received: [KlaviyoConfig] = []
+        let cancellable = store.publisher.sink { received.append($0) }
         defer { cancellable.cancel() }
 
-        store.updateAPIKey("company-123")
+        store.update(KlaviyoConfig(apiKey: "company-123"))
 
         // CurrentValueSubject replays the current value on subscribe, then the update.
-        XCTAssertEqual(received, [nil, "company-123"])
+        XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: "company-123")])
+    }
+
+    func testStreamYieldsCurrentValueThenUpdates() async {
+        let store = SDKConfigStore()
+
+        let task = Task<[KlaviyoConfig], Never> {
+            var received: [KlaviyoConfig] = []
+            for await config in store.stream() {
+                received.append(config)
+                if received.count == 2 { break }
+            }
+            return received
+        }
+
+        // Give the stream a moment to subscribe and replay the current value.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        store.update(KlaviyoConfig(apiKey: "company-123"))
+
+        let received = await task.value
+        XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: "company-123")])
     }
 }
 
 // Compile-time proof that a consumer can conform to the read interface alone,
-// with no access to `updateAPIKey(_:)`.
+// with no access to `update(_:)`.
 private struct MockConfigReader: ConfigReading {
-    var apiKey: String?
-    var apiKeyPublisher: AnyPublisher<String?, Never>
+    var current: KlaviyoConfig
+    var publisher: AnyPublisher<KlaviyoConfig, Never>
+    func stream() -> AsyncStream<KlaviyoConfig> {
+        AsyncStream { $0.finish() }
+    }
 }

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -10,6 +10,8 @@ import Combine
 import XCTest
 
 final class SDKConfigStoreTests: XCTestCase {
+    private static let apiKey = "company-123"
+
     func testInitialConfigIsEmpty() {
         let store = SDKConfigStore()
         XCTAssertEqual(store.current, KlaviyoConfig())
@@ -19,9 +21,9 @@ final class SDKConfigStoreTests: XCTestCase {
     func testUpdateReflectsSynchronously() {
         let store = SDKConfigStore()
 
-        store.update(KlaviyoConfig(apiKey: "company-123"))
+        store.update(KlaviyoConfig(apiKey: Self.apiKey))
 
-        XCTAssertEqual(store.current.apiKey, "company-123")
+        XCTAssertEqual(store.current.apiKey, Self.apiKey)
     }
 
     func testUpdateEmitsOnPublisher() {
@@ -31,30 +33,24 @@ final class SDKConfigStoreTests: XCTestCase {
         let cancellable = store.publisher.sink { received.append($0) }
         defer { cancellable.cancel() }
 
-        store.update(KlaviyoConfig(apiKey: "company-123"))
+        store.update(KlaviyoConfig(apiKey: Self.apiKey))
 
         // CurrentValueSubject replays the current value on subscribe, then the update.
-        XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: "company-123")])
+        XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: Self.apiKey)])
     }
 
     func testStreamYieldsCurrentValueThenUpdates() async {
         let store = SDKConfigStore()
+        var iterator = store.stream().makeAsyncIterator()
 
-        let task = Task<[KlaviyoConfig], Never> {
-            var received: [KlaviyoConfig] = []
-            for await config in store.stream() {
-                received.append(config)
-                if received.count == 2 { break }
-            }
-            return received
-        }
+        // The stream replays the current value on subscribe before any update.
+        let initial = await iterator.next()
+        XCTAssertEqual(initial, KlaviyoConfig())
 
-        // Give the stream a moment to subscribe and replay the current value.
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        store.update(KlaviyoConfig(apiKey: "company-123"))
+        store.update(KlaviyoConfig(apiKey: Self.apiKey))
 
-        let received = await task.value
-        XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: "company-123")])
+        let updated = await iterator.next()
+        XCTAssertEqual(updated, KlaviyoConfig(apiKey: Self.apiKey))
     }
 }
 

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -1,0 +1,45 @@
+//
+//  SDKConfigStoreTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 6/16/26.
+//
+
+import Combine
+@testable import KlaviyoCore
+import XCTest
+
+final class SDKConfigStoreTests: XCTestCase {
+    func testInitialAPIKeyIsNil() {
+        let store = SDKConfigStore()
+        XCTAssertNil(store.apiKey)
+    }
+
+    func testUpdateAPIKeyReflectsSynchronously() {
+        let store = SDKConfigStore()
+
+        store.updateAPIKey("company-123")
+
+        XCTAssertEqual(store.apiKey, "company-123")
+    }
+
+    func testUpdateAPIKeyEmitsOnPublisher() {
+        let store = SDKConfigStore()
+
+        var received: [String?] = []
+        let cancellable = store.apiKeyPublisher.sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        store.updateAPIKey("company-123")
+
+        // CurrentValueSubject replays the current value on subscribe, then the update.
+        XCTAssertEqual(received, [nil, "company-123"])
+    }
+}
+
+// Compile-time proof that a consumer can conform to the read interface alone,
+// with no access to `updateAPIKey(_:)`.
+private struct MockConfigReader: ConfigReading {
+    var apiKey: String?
+    var apiKeyPublisher: AnyPublisher<String?, Never>
+}

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -5,8 +5,8 @@
 //  Created by Isobelle Lim on 6/16/26.
 //
 
-import Combine
 @testable import KlaviyoCore
+import Combine
 import XCTest
 
 final class SDKConfigStoreTests: XCTestCase {


### PR DESCRIPTION
# Description
Adds two singleton observable stores to `KlaviyoCore` — `IdentityStore` (profile identity) and `SDKConfigStore` (SDK configuration, starting with the company API key) — so other modules can observe identity/API-key state without importing `KlaviyoSwift`. Additive only; nothing is wired up or migrated in this PR.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Minor` Contains changes to the public API.
- [x] This is planned work for an upcoming release.

New `public` API surface is added to `KlaviyoCore` but no existing behavior changes. The stores are not yet read or written by any module — that happens in the follow-up tickets below.

## Changelog / Code Overview
Part of **Phase 1** of the [Networking Modularization spec](https://linear.app/klaviyo/document/networking-modularization-klaviyoswift-klaviyocore-a94705520b07), which moves identity + API-key state out of the `KlaviyoSwift` monolith into `KlaviyoCore` so `KlaviyoForms` and `KlaviyoLocation` no longer import `KlaviyoSwift` just to observe that state.

**New files**
- `Sources/KlaviyoCore/IdentityStore.swift`
  - `IdentityReading` (`current`, `publisher`, `stream()`) / `IdentityWriting` (`update(_:)`) protocols
  - `IdentityStore` singleton (`.shared`) — source of truth for `ProfileData`
- `Sources/KlaviyoCore/SDKConfigStore.swift`
  - `ConfigReading` (`apiKey`, `apiKeyPublisher`) / `ConfigWriting` (`updateAPIKey(_:)`) protocols
  - `SDKConfigStore` singleton (`.shared`) — source of truth for the company API key
- Unit tests for both stores in `Tests/KlaviyoCoreTests/`

**Design decisions** (resolved during implementation, per the ticket)
- **Two stores, not one.** The API key is SDK *configuration* (set once at init, ~one per app, stable for the app lifetime), not profile *identity* (per-user, frequently nil, changes on identify/reset). Splitting them gives honest naming, lets API-key-only consumers (`CompanyObserver`, `KlaviyoLocationManager`) depend on config alone, and gives future config (region/host, feature flags) a home. This overrides the spec's original single bundled `IdentityStore`.
- **Read/write protocol split: adopted.** Consumers depend only on the read interface; the writing side stays with `KlaviyoSwift`. This documents the one-directional dependency (`KlaviyoSwift` writes, everyone else reads) and lets the implementation change later (e.g. become an actor) without touching consumers. Tests include `MockIdentityReader` / `MockConfigReader` that conform to the reading protocols only — a compile-time proof that read consumers get no write access.
- **`@_spi` write enforcement: deferred.** Compiler-level enforcement of the write boundary (so same-package `KlaviyoForms`/`KlaviyoLocation` can't call writes) is deferred to a possible follow-up commit on this branch; the protocol split already documents intent.
- **Thread safety via serial `DispatchQueue`, not an actor.** Reads are synchronous by design (`current` / `apiKey`), matching how consumers will use them; an actor would force `await` on every read and break that contract. The protocol split keeps an actor migration open for later if async reads become acceptable.

### How this fits the broader modularization
| Ticket | Role |
| -- | -- |
| MAGE-747 ✅ | Promote `ProfileData` + `SDKError` to `KlaviyoCore` (merged — blocker for this PR) |
| **MAGE-748 (this PR)** | Add `IdentityStore` + `SDKConfigStore` to `KlaviyoCore` — the shared source of truth |
| MAGE-749 | Refactor `KlaviyoState` to compose `ProfileData`; wire `KlaviyoInternal` to push state into these stores |
| MAGE-750 | Migrate `KlaviyoForms` / `KlaviyoLocation` observers to read from these stores, dropping their `KlaviyoSwift` import for identity/config |

Once consumers read from `KlaviyoCore` (749 + 750), `KlaviyoSwift` internals (TCA store, `KlaviyoState` shape, queue, flush) become private implementation details — unblocking Phase 2 (`Event` to `KlaviyoCore`) and Phase 3 (queue/retry/networking extraction) as module-contained changes.

## Test Plan
`make test-library` (run via `xcodebuild test` on iPhone 17 Pro simulator). New tests, all passing:
- Initial state: `IdentityStore.current` is empty `ProfileData`, `SDKConfigStore.apiKey` is `nil`
- `update(_:)` / `updateAPIKey(_:)` reflect synchronously on `current` / `apiKey`
- Updates emit on `publisher` / `apiKeyPublisher` (current value replayed on subscribe, then the update)
- `stream()` emits updates
- `stream()` delivers all updates to concurrent consumers with no dropped emissions (100 updates × 2 consumers)
- `MockIdentityReader` / `MockConfigReader` compile while conforming to the reading protocols only

## Related Issues/Tickets
- [MAGE-748](https://linear.app/klaviyo/issue/MAGE-748/add-identitystore-and-sdkconfigstore-to-klaviyocore) (this PR)
- Parent: [MAGE-746](https://linear.app/klaviyo/issue/MAGE-746) · blocked by [MAGE-747](https://linear.app/klaviyo/issue/MAGE-747) (merged) · blocks [MAGE-749](https://linear.app/klaviyo/issue/MAGE-749), [MAGE-750](https://linear.app/klaviyo/issue/MAGE-750)
- Spec: [Networking Modularization — KlaviyoSwift → KlaviyoCore](https://linear.app/klaviyo/document/networking-modularization-klaviyoswift-klaviyocore-a94705520b07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an identity management store that exposes the current user profile plus reactive updates through publisher-style and async streaming interfaces.
  * Added an SDK configuration store for the API key with synchronous access and real-time update streams.
* **Tests**
  * Added unit tests verifying initial state, synchronous updates, replay behavior for publisher/async streams, and correct concurrent stream consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->