### PR TITLE
Retry all 5xx server errors (MAGE-694)

### DIFF
--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -16,8 +16,6 @@ import Foundation
 /// `private`/`internal` enum would fail to compile on every toolchain.
 public enum HTTPStatusCode {
     public static let rateLimited = 429
-    public static let notImplemented = 501
-    public static let httpVersionNotSupported = 505
     public static let retryableServerErrorRange = 500...599
 }
 
@@ -54,17 +52,16 @@ public struct KlaviyoAPI {
         }
 
         // Consolidated retryable error handling (429 rate limit + transient 5xx server errors).
-        // The 5xx range (500–599) is treated as transient so we also retry CDN/edge failures
-        // such as Cloudflare's 520–527 codes, which originate in front of the origin servers
-        // and were the codes observed during the cannot-access-klaviyo-com incident.
-        // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are excluded because they
-        // are permanent/deterministic errors — retrying them cannot succeed, so they fall
-        // through to the non-retryable .httpError path.
+        // The entire 5xx range (500–599) is treated as transient and retried — including CDN/edge
+        // failures such as Cloudflare's 520–527 codes, which originate in front of the origin
+        // servers and were the codes observed during the cannot-access-klaviyo-com incident.
+        // We deliberately retry even 501 (Not Implemented) and 505 (HTTP Version Not Supported):
+        // for the SDK's fixed request shapes a genuine origin 501/505 is effectively unreachable,
+        // so any 5xx we actually see is edge/CDN noise during an incident — exactly what we want
+        // to retry (incident data-retention outweighs the negligible cost of a wasted retry).
         // 403 and other 4xx codes are intentionally excluded so the backend can shed load.
         let code = httpResponse.statusCode
         let isRetryableServerError = HTTPStatusCode.retryableServerErrorRange.contains(code)
-            && code != HTTPStatusCode.notImplemented
-            && code != HTTPStatusCode.httpVersionNotSupported
         if code == HTTPStatusCode.rateLimited || isRetryableServerError {
             let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -40,8 +40,12 @@ public struct KlaviyoAPI {
             return .failure(.missingOrInvalidResponse(response))
         }
 
-        // Consolidated retryable error handling (429 rate limit + 5xx server errors)
-        if [429, 500, 502, 503, 504].contains(httpResponse.statusCode) {
+        // Consolidated retryable error handling (429 rate limit + all 5xx server errors).
+        // The entire 5xx range (500–599) is treated as transient so we also retry CDN/edge
+        // failures such as Cloudflare's 520–527 codes, which originate in front of the origin
+        // servers and were the codes observed during the cannot-access-klaviyo-com incident.
+        // 403 and other 4xx codes are intentionally excluded so the backend can shed load.
+        if httpResponse.statusCode == 429 || (500...599).contains(httpResponse.statusCode) {
             let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             // Check Retry-After header for any retryable error (expected for 429, future-proofing for 5xx)

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -8,6 +8,19 @@
 import AnyCodable
 import Foundation
 
+/// Named HTTP status codes and ranges referenced by the retry logic below.
+///
+/// This enum must be `public` because its members are referenced from the default
+/// value of `KlaviyoAPI.init(send:)` — a `public init`. Swift requires any symbol
+/// referenced from a public function's default argument to also be `public`, so a
+/// `private`/`internal` enum would fail to compile on every toolchain.
+public enum HTTPStatusCode {
+    public static let rateLimited = 429
+    public static let notImplemented = 501
+    public static let httpVersionNotSupported = 505
+    public static let retryableServerErrorRange = 500...599
+}
+
 public struct KlaviyoAPI {
     public var send: (KlaviyoRequest, RequestAttemptInfo) async -> Result<Data, KlaviyoAPIError>
 
@@ -49,8 +62,10 @@ public struct KlaviyoAPI {
         // through to the non-retryable .httpError path.
         // 403 and other 4xx codes are intentionally excluded so the backend can shed load.
         let code = httpResponse.statusCode
-        let isRetryableServerError = (500...599).contains(code) && code != 501 && code != 505
-        if code == 429 || isRetryableServerError {
+        let isRetryableServerError = HTTPStatusCode.retryableServerErrorRange.contains(code)
+            && code != HTTPStatusCode.notImplemented
+            && code != HTTPStatusCode.httpVersionNotSupported
+        if code == HTTPStatusCode.rateLimited || isRetryableServerError {
             let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             // Check Retry-After header for any retryable error (expected for 429, future-proofing for 5xx)
@@ -60,7 +75,7 @@ public struct KlaviyoAPI {
             let jitter = environment.randomInt()
             let nextBackOffWithJitter = nextBackoff + jitter
 
-            if code == 429 {
+            if code == HTTPStatusCode.rateLimited {
                 requestHandler(request, urlRequest, .error(.rateLimited(retryAfter: nextBackOffWithJitter)))
                 return .failure(KlaviyoAPIError.rateLimitError(backOff: nextBackOffWithJitter))
             } else {

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -40,12 +40,17 @@ public struct KlaviyoAPI {
             return .failure(.missingOrInvalidResponse(response))
         }
 
-        // Consolidated retryable error handling (429 rate limit + all 5xx server errors).
-        // The entire 5xx range (500–599) is treated as transient so we also retry CDN/edge
-        // failures such as Cloudflare's 520–527 codes, which originate in front of the origin
-        // servers and were the codes observed during the cannot-access-klaviyo-com incident.
+        // Consolidated retryable error handling (429 rate limit + transient 5xx server errors).
+        // The 5xx range (500–599) is treated as transient so we also retry CDN/edge failures
+        // such as Cloudflare's 520–527 codes, which originate in front of the origin servers
+        // and were the codes observed during the cannot-access-klaviyo-com incident.
+        // 501 (Not Implemented) and 505 (HTTP Version Not Supported) are excluded because they
+        // are permanent/deterministic errors — retrying them cannot succeed, so they fall
+        // through to the non-retryable .httpError path.
         // 403 and other 4xx codes are intentionally excluded so the backend can shed load.
-        if httpResponse.statusCode == 429 || (500...599).contains(httpResponse.statusCode) {
+        let code = httpResponse.statusCode
+        let isRetryableServerError = (500...599).contains(code) && code != 501 && code != 505
+        if code == 429 || isRetryableServerError {
             let exponentialBackOff = Int(pow(2.0, Double(requestAttemptInfo.attemptNumber)))
             var nextBackoff: Int = exponentialBackOff
             // Check Retry-After header for any retryable error (expected for 429, future-proofing for 5xx)
@@ -55,14 +60,13 @@ public struct KlaviyoAPI {
             let jitter = environment.randomInt()
             let nextBackOffWithJitter = nextBackoff + jitter
 
-            if httpResponse.statusCode == 429 {
+            if code == 429 {
                 requestHandler(request, urlRequest, .error(.rateLimited(retryAfter: nextBackOffWithJitter)))
                 return .failure(KlaviyoAPIError.rateLimitError(backOff: nextBackOffWithJitter))
             } else {
-                let status = httpResponse.statusCode
-                let httpError = RequestStatus.error(.httpError(statusCode: status, duration: duration))
+                let httpError = RequestStatus.error(.httpError(statusCode: code, duration: duration))
                 requestHandler(request, urlRequest, httpError)
-                return .failure(.serverError(statusCode: status, backOff: nextBackOffWithJitter))
+                return .failure(.serverError(statusCode: code, backOff: nextBackOffWithJitter))
             }
         }
 

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -131,6 +131,76 @@ final class KlaviyoAPITests: XCTestCase {
         }
     }
 
+    func testNotImplemented501IsNotRetried() async throws {
+        // 501 (Not Implemented) is a permanent/deterministic error and is excluded from the
+        // retryable 5xx set — it must fall through to a non-retryable httpError.
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 501, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, 501)
+            default:
+                XCTFail("Expected a non-retryable httpError for a 501 response, got \(result)")
+            }
+        }
+    }
+
+    func testHTTPVersionNotSupported505IsNotRetried() async throws {
+        // 505 (HTTP Version Not Supported) is a permanent/deterministic error and is excluded
+        // from the retryable 5xx set — it must fall through to a non-retryable httpError.
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 505, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, 505)
+            default:
+                XCTFail("Expected a non-retryable httpError for a 505 response, got \(result)")
+            }
+        }
+    }
+
+    func testLowerBound499IsNotRetried() async throws {
+        // 499 sits just below the 5xx range and must remain a non-retryable httpError.
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 499, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, 499)
+            default:
+                XCTFail("Expected a non-retryable httpError for a 499 response, got \(result)")
+            }
+        }
+    }
+
+    func testUpperBound600IsNotRetried() async throws {
+        // 600 sits just above the 5xx range and must remain a non-retryable httpError.
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 600, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, 600)
+            default:
+                XCTFail("Expected a non-retryable httpError for a 600 response, got \(result)")
+            }
+        }
+    }
+
     func testSuccessfulResponseWithProfile() async throws {
         environment.networkSession = { NetworkSession.test(data: { request in
             XCTAssertEqual(request.httpMethod, "POST")

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -90,16 +90,18 @@ final class KlaviyoAPITests: XCTestCase {
         try await assertNotRetried(404)
     }
 
-    func testNotImplemented501IsNotRetried() async throws {
-        // 501 (Not Implemented) is a permanent/deterministic error and is excluded from the
-        // retryable 5xx set — it must fall through to a non-retryable httpError.
-        try await assertNotRetried(501)
+    func testNotImplemented501IsRetriedAsServerError() async throws {
+        // 501 (Not Implemented) is in-range and deliberately retried: for the SDK's fixed request
+        // shapes a genuine origin 501 is effectively unreachable, so any 501 we see is edge/CDN
+        // noise during an incident — exactly what we want to retry.
+        try await assertServerErrorRetried(501)
     }
 
-    func testHTTPVersionNotSupported505IsNotRetried() async throws {
-        // 505 (HTTP Version Not Supported) is a permanent/deterministic error and is excluded
-        // from the retryable 5xx set — it must fall through to a non-retryable httpError.
-        try await assertNotRetried(505)
+    func testHTTPVersionNotSupported505IsRetriedAsServerError() async throws {
+        // 505 (HTTP Version Not Supported) is in-range and deliberately retried for the same
+        // reason as 501: a genuine origin 505 is effectively unreachable for the SDK's fixed
+        // request shapes, so any 505 we see is edge/CDN noise during an incident.
+        try await assertServerErrorRetried(505)
     }
 
     func testLowerBound499IsNotRetried() async throws {

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -20,8 +20,7 @@ final class KlaviyoAPITests: XCTestCase {
 
         try await sendAndAssert(with: KlaviyoRequest(
             endpoint: .createProfile("foo", CreateProfilePayload(data: .test))
-        )
-        ) { result in
+        )) { result in
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .description)
@@ -36,7 +35,6 @@ final class KlaviyoAPITests: XCTestCase {
         }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -52,7 +50,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -68,7 +65,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -81,124 +77,39 @@ final class KlaviyoAPITests: XCTestCase {
     func testCloudflare5xxIsRetryedAsServerError() async throws {
         // Cloudflare edge codes (520–527) sit outside the legacy {500,502,503,504} allowlist.
         // They must now be classified as retryable server errors.
-        let cloudflareResponse = HTTPURLResponse(url: TEST_URL, statusCode: 522, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), cloudflareResponse)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.serverError(statusCode, backOff)):
-                XCTAssertEqual(statusCode, 522)
-                XCTAssertGreaterThan(backOff, 0)
-            default:
-                XCTFail("Expected a retryable serverError for a 522 response, got \(result)")
-            }
-        }
+        try await assertServerErrorRetried(522)
     }
 
     func testUpperBound5xxIsRetryedAsServerError() async throws {
         // The widened range is inclusive of the entire 5xx space (500–599).
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 599, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.serverError(statusCode, _)):
-                XCTAssertEqual(statusCode, 599)
-            default:
-                XCTFail("Expected a retryable serverError for a 599 response, got \(result)")
-            }
-        }
+        try await assertServerErrorRetried(599)
     }
 
     func testClientError4xxIsNotRetried() async throws {
         // 4xx codes (including 403 load-shed and 404) must remain non-retryable httpErrors.
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 404, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.httpError(statusCode, _)):
-                XCTAssertEqual(statusCode, 404)
-            default:
-                XCTFail("Expected a non-retryable httpError for a 404 response, got \(result)")
-            }
-        }
+        try await assertNotRetried(404)
     }
 
     func testNotImplemented501IsNotRetried() async throws {
         // 501 (Not Implemented) is a permanent/deterministic error and is excluded from the
         // retryable 5xx set — it must fall through to a non-retryable httpError.
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 501, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.httpError(statusCode, _)):
-                XCTAssertEqual(statusCode, 501)
-            default:
-                XCTFail("Expected a non-retryable httpError for a 501 response, got \(result)")
-            }
-        }
+        try await assertNotRetried(501)
     }
 
     func testHTTPVersionNotSupported505IsNotRetried() async throws {
         // 505 (HTTP Version Not Supported) is a permanent/deterministic error and is excluded
         // from the retryable 5xx set — it must fall through to a non-retryable httpError.
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 505, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.httpError(statusCode, _)):
-                XCTAssertEqual(statusCode, 505)
-            default:
-                XCTFail("Expected a non-retryable httpError for a 505 response, got \(result)")
-            }
-        }
+        try await assertNotRetried(505)
     }
 
     func testLowerBound499IsNotRetried() async throws {
         // 499 sits just below the 5xx range and must remain a non-retryable httpError.
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 499, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.httpError(statusCode, _)):
-                XCTAssertEqual(statusCode, 499)
-            default:
-                XCTFail("Expected a non-retryable httpError for a 499 response, got \(result)")
-            }
-        }
+        try await assertNotRetried(499)
     }
 
     func testUpperBound600IsNotRetried() async throws {
         // 600 sits just above the 5xx range and must remain a non-retryable httpError.
-        let response = HTTPURLResponse(url: TEST_URL, statusCode: 600, httpVersion: nil, headerFields: nil)!
-        environment.networkSession = { NetworkSession.test(data: { _ in
-            (Data(), response)
-        }) }
-        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
-        try await sendAndAssert(with: request) { result in
-            switch result {
-            case let .failure(.httpError(statusCode, _)):
-                XCTAssertEqual(statusCode, 600)
-            default:
-                XCTFail("Expected a non-retryable httpError for a 600 response, got \(result)")
-            }
-        }
+        try await assertNotRetried(600)
     }
 
     func testSuccessfulResponseWithProfile() async throws {
@@ -210,7 +121,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .success(data):
                 XCTAssertEqual(data.count, 0)
@@ -247,7 +157,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .registerPushToken("foo", .test))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .success(data):
                 XCTAssertEqual(data.count, 0)
@@ -262,5 +171,52 @@ final class KlaviyoAPITests: XCTestCase {
         let attemptInfo = try XCTUnwrap(RequestAttemptInfo(attemptNumber: 1, maxAttempts: 50))
         let result = await KlaviyoAPI().send(request, attemptInfo)
         assertion(result)
+    }
+
+    /// Stubs the network session to return `code` and asserts the request maps to a
+    /// retryable `.serverError` carrying that status code and a positive back-off.
+    func assertServerErrorRetried(_ code: Int,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) async throws {
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: code, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.serverError(statusCode, backOff)):
+                XCTAssertEqual(statusCode, code, file: file, line: line)
+                XCTAssertGreaterThan(backOff, 0, file: file, line: line)
+            default:
+                XCTFail(
+                    "Expected a retryable serverError for a \(code) response, got \(result)",
+                    file: file, line: line
+                )
+            }
+        }
+    }
+
+    /// Stubs the network session to return `code` and asserts the request maps to a
+    /// non-retryable `.httpError` carrying that status code.
+    func assertNotRetried(_ code: Int,
+                          file: StaticString = #filePath,
+                          line: UInt = #line) async throws {
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: code, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, code, file: file, line: line)
+            default:
+                XCTFail(
+                    "Expected a non-retryable httpError for a \(code) response, got \(result)",
+                    file: file, line: line
+                )
+            }
+        }
     }
 }

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -78,6 +78,59 @@ final class KlaviyoAPITests: XCTestCase {
         }
     }
 
+    func testCloudflare5xxIsRetryedAsServerError() async throws {
+        // Cloudflare edge codes (520–527) sit outside the legacy {500,502,503,504} allowlist.
+        // They must now be classified as retryable server errors.
+        let cloudflareResponse = HTTPURLResponse(url: TEST_URL, statusCode: 522, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), cloudflareResponse)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.serverError(statusCode, backOff)):
+                XCTAssertEqual(statusCode, 522)
+                XCTAssertGreaterThan(backOff, 0)
+            default:
+                XCTFail("Expected a retryable serverError for a 522 response, got \(result)")
+            }
+        }
+    }
+
+    func testUpperBound5xxIsRetryedAsServerError() async throws {
+        // The widened range is inclusive of the entire 5xx space (500–599).
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 599, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.serverError(statusCode, _)):
+                XCTAssertEqual(statusCode, 599)
+            default:
+                XCTFail("Expected a retryable serverError for a 599 response, got \(result)")
+            }
+        }
+    }
+
+    func testClientError4xxIsNotRetried() async throws {
+        // 4xx codes (including 403 load-shed and 404) must remain non-retryable httpErrors.
+        let response = HTTPURLResponse(url: TEST_URL, statusCode: 404, httpVersion: nil, headerFields: nil)!
+        environment.networkSession = { NetworkSession.test(data: { _ in
+            (Data(), response)
+        }) }
+        let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
+        try await sendAndAssert(with: request) { result in
+            switch result {
+            case let .failure(.httpError(statusCode, _)):
+                XCTAssertEqual(statusCode, 404)
+            default:
+                XCTFail("Expected a non-retryable httpError for a 404 response, got \(result)")
+            }
+        }
+    }
+
     func testSuccessfulResponseWithProfile() async throws {
         environment.networkSession = { NetworkSession.test(data: { request in
             XCTAssertEqual(request.httpMethod, "POST")

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -468,20 +468,22 @@ class APIRequestErrorHandlingTests: XCTestCase {
     }
 
     @MainActor
-    func testNoRetryOn501NotImplemented() async throws {
+    func testRetryOn501NotImplemented() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        // 501 should dequeue without retry (not a transient error)
-        environment.klaviyoAPI.send = { _, _ in .failure(.httpError(501, TEST_RETURN_DATA)) }
+        // 501 is in the retryable 5xx range (see KlaviyoAPITests.testNotImplemented501IsRetriedAsServerError)
+        environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 501, backOff: 2)) }
 
         _ = await store.send(.sendRequest)
 
-        await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
+        await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
+            $0.queue = [request]
             $0.requestsInFlight = []
+            $0.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)
         }
     }
 


### PR DESCRIPTION
Widens the retryable status classification in `KlaviyoAPI.swift` from the `{429,500,502,503,504}` allowlist to `429` plus the full 5xx range (500-599). This covers transient CDN/edge failures such as Cloudflare's 520-527 codes, which were observed during the cannot-access-klaviyo-com incident and had zero overlap with the old allowlist, causing data loss for the duration of the outage. 4xx codes (including 403 load-shed) remain non-retryable so the backend can still shed load. Adds KlaviyoAPITests for a 522 Cloudflare response, the 599 upper bound, and a 404 non-retryable guard.

NOTE: required gates (xcodebuild test, SwiftLint, SwiftFormat) were NOT run locally — the Reca sandbox is Linux with no Swift/Xcode toolchain (iOS Simulator cannot run on Linux). Please rely on CI / a local macOS run to validate before merge. Per branch policy, feat/* should target the active rel/* branch. Companion circuit-breaker design is in the Linear doc 'Implementation spec: SDK circuit breaker / dormancy (MAGE-694)'.

Reca job ID: b11a3ef7-fd4a-437c-a1a7-431da69e4219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for transient failures by treating all retryable server errors in the 5xx range (500–599, including 501/505 and 522) as retryable, while keeping 4xx responses non-retryable.
  * Rate-limited (429) responses continue to retry using retry timing guidance and the existing backoff behavior.
* **New Features**
  * Added shared HTTP status code constants for consistent status handling.
* **Tests**
  * Expanded async test coverage for retry classification across 4xx/5xx boundaries, including verifying retryable statuses produce positive backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->