### PR TITLE
feat(emoji): 😂 KlaviyoEmoji module + 🍝 emoji pasta README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
         .library(
             name: "KlaviyoSwiftExtension",
             targets: ["KlaviyoSwiftExtension"]
+        ),
+        .library(
+            name: "KlaviyoEmoji",
+            targets: ["KlaviyoEmoji"]
         )
     ],
     dependencies: [
@@ -91,6 +95,11 @@ let package = Package(
             name: "KlaviyoSwiftExtension",
             dependencies: [],
             path: "Sources/KlaviyoSwiftExtension"
+        ),
+        .target(
+            name: "KlaviyoEmoji",
+            dependencies: ["KlaviyoSwift", "KlaviyoForms", "KlaviyoSwiftExtension"],
+            path: "Sources/KlaviyoEmoji"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,501 +1,670 @@
-# klaviyo-swift-sdk
+# 😂😂😂 klaviyo-swift-sdk 😂😂😂
+### 🍝 *the readme that asked "what if documentation but unhinged"* 🍝
 
-![CI status](https://github.com/klaviyo/klaviyo-swift-sdk/actions/workflows/swift.yml/badge.svg)
-[![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square)](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square)
-![SPM version](https://img.shields.io/github/v/release/klaviyo/klaviyo-swift-sdk)
-[![Version](https://img.shields.io/cocoapods/v/KlaviyoSwift.svg?style=flat)](http://cocoapods.org/pods/KlaviyoSwift)
-[![License](https://img.shields.io/cocoapods/l/KlaviyoSwift.svg?style=flat)](http://cocoapods.org/pods/KlaviyoSwift)
-![Minimum deployment version](https://img.shields.io/badge/minimum_iOS_deployment_target-iOS13-brightgreen)
+![CI status](https://github.com/klaviyo/klaviyo-swift-sdk/actions/workflows/swift.yml/badge.svg) [![Swift Package Manager](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square)](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square) ![SPM version](https://img.shields.io/github/v/release/klaviyo/klaviyo-swift-sdk) [![Version](https://img.shields.io/cocoapods/v/KlaviyoSwift.svg?style=flat)](http://cocoapods.org/pods/KlaviyoSwift) [![License](https://img.shields.io/cocoapods/v/KlaviyoSwift.svg?style=flat)](http://cocoapods.org/pods/KlaviyoSwift) ![Minimum deployment version](https://img.shields.io/badge/minimum_iOS_deployment_target-iOS13-brightgreen)
 
-## Contents
-- [Overview](#overview)
-- [Installation](#installation)
-- [Initialization](#initialization)
-- [Profile Identification](#profile-identification)
-  - [Reset Profile](#reset-profile)
-  - [Anonymous Tracking Notice](#anonymous-tracking-notice)
-- [Event tracking](#event-tracking)
-- [Push Notifications](#push-notifications)
-  - [Prerequisites](#prerequisites)
-  - [Collecting Push Tokens](#collecting-push-tokens)
-  - [Request Push Notification Permission](#request-push-notification-permission)
-  - [Receiving Push Notifications](#receiving-push-notifications)
-    - [Tracking Open Events](#tracking-open-events)
-    - [Deep Linking](#deep-linking)
-      - [Option 1: URL Schemes](#option-1-url-schemes)
-      - [Option 2: Universal Links](#option-2-universal-links)
-    - [Rich Push](#rich-push)
-    - [Badge Count](#badge-count)
-       - [Autoclearing](#autoclearing)
-      - [Handling Other Badging Sources](#handling-other-badging-sources)
-    - [Silent Push Notifications](#silent-push-notifications)
-    - [Custom Data](#custom-data)
-- [In-App Forms](#in-app-forms)
-  - [Prerequisites](#prerequisites)
-  - [Setup](#setup)
-    - [In-App Forms Session Configuration](#in-app-forms-session-configuration)
-  - [Unregistering from In-App Forms](#unregistering-from-in-app-forms)
-  - [Deep linking](#deep-linking-1)
-- [Additional Details](#additional-details)
-  - [Sandbox Support](#sandbox-support)
-  - [SDK Data Transfer](#sdk-data-transfer)
-  - [Retries](#retries)
-  - [License](#license)
+> 🚨🚨🚨 **SCROLL PAST THIS MESSAGE** 🚨🚨🚨
+>
+> ✋ STOP ✋ you are about to read documentation ✋
+> 🧠 this is normal 🧠 you are safe 🧠 breathe 🧘
+> 🍝 this readme contains: **603+ emojis** 🍝 **0 regrets** 😌 **1 legal section** ⚖️
+> 📜 by scrolling past this point you agree that 📜:
+> &nbsp;&nbsp;&nbsp;&nbsp; 🐦 swift is a good language 🐦
+> &nbsp;&nbsp;&nbsp;&nbsp; 😂 this sdk is very cool 😂
+> &nbsp;&nbsp;&nbsp;&nbsp; 🫵 you will integrate it today 🫵
+>
+> 🫡 thank you for your compliance 🫡
 
-## Overview
+---
 
-The Klaviyo Swift SDK allows developers to incorporate Klaviyo's analytics and push notification functionality into their iOS applications.
-The SDK assists in identifying users and tracking events via [Klaviyo Client APIs](https://developers.klaviyo.com/en/reference/api_overview).
-To reduce performance overhead, API requests are queued and sent in batches.
-The queue is persisted to local storage so that data is not lost if the device is offline or the app is terminated.
+## 🗺️ table of contents (the map to the treasure 🏴‍☠️)
 
-Once integrated, your marketing team will be able to better understand your app users' needs and send them timely messages via APNs.
+- 👁️ [overview (what even IS this)](#-overview-what-even-is-this-)
+- 📦 [installation (the necessary evil)](#-installation-the-necessary-evil-)
+- 🚀 [initialization (the one line that starts it all)](#-initialization-the-one-line-that-starts-it-all-)
+- 🪪 [who even ARE you (profile identification)](#-who-even-are-you-profile-identification-)
+  - 🔄 [bye bestie (reset profile)](#-bye-bestie-reset-profile-)
+  - 👻 [anonymous gremlin mode](#-anonymous-gremlin-mode-)
+- 📊 [they did a thing!! (event tracking)](#-they-did-a-thing-event-tracking-)
+- 🔔 [the boop (push notifications)](#-the-boop-push-notifications-)
+  - ✅ [prerequisites (ugh)](#-prerequisites-ugh-)
+  - 🪙 [gotta catch em all (push tokens)](#-gotta-catch-em-all-push-tokens-)
+  - 🙏 [pretty please (asking for permission)](#-pretty-please-asking-for-permission-)
+  - 📬 [receiving the boop](#-receiving-the-boop-)
+    - 👆👆👆 [THEY TAPPED IT OMG](#-they-tapped-it-omg-)
+    - 🕳️ [go deeper (deep linking)](#-go-deeper-deep-linking-)
+    - 🖼️ [fancy boop (rich push)](#-fancy-boop-rich-push-)
+    - 😰 [the lil red circle of anxiety (badge count)](#-the-lil-red-circle-of-anxiety-badge-count-)
+    - 🫥 [sneaky ghost boop (silent push)](#-sneaky-ghost-boop-silent-push-)
+    - 🎁 [there's more inside (custom data)](#-theres-more-inside-custom-data-)
+- 💅 [pop-ups but make them slay (in-app forms)](#-pop-ups-but-make-them-slay-in-app-forms-)
+- 🔬 [nerd corner](#-nerd-corner-)
+  - 🏖️ [the simulation (sandbox)](#-the-simulation-sandbox-)
+  - 🚿 [the flush (data transfer)](#-the-flush-data-transfer-)
+  - 🔁 [try again bestie (retries)](#-try-again-bestie-retries-)
+  - ⚖️ [the legal blorbo (license)](#-the-legal-blorbo-license-)
+- 🆘 [help me (contributing / issues)](#-help-me-)
 
-## Installation
+---
 
-1. Enable push notification capabilities in your Xcode project. The section "Enable the push notification capability" in this [Apple developer guide](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns#2980170) provides detailed instructions.
-2. If you intend to use [rich push notifications](#rich-push), [custom badge counts](#custom-badge-count), or [custom data](#custom-data), add a [Notification Service Extension](https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension) to your Xcode project. A Notification Service Extension ships as a separate bundle inside your iOS app. To add this extension to your app:
-   - Select File > New > Target in Xcode.
-   - Select the Notification Service Extension target from the iOS > Application extension section.
-   - Click Next.
-   - Specify a name and other configuration details for your app extension.
-   - Click Finish.
+## 👁️ overview (what even IS this) 👁️
 
-    > ⚠️ The deployment target of your notification service extension defaults to the latest iOS version.
-             If this exceeds your app's minimum supported iOS version, push notifications may not display attached media on older devices.
-             To avoid this, ensure the extension's minimum deployment target matches that of your app. ⚠️
+> 🧠💭 *okay so*
+> 🧠💭 *you have an iOS app* 📱
+> 🧠💭 *and you want to know what your users are doing* 🕵️
+> 🧠💭 *and you want to send them little boops* 🔔
+> 🧠💭 *and you want to show them pop-ups* 📋
+> 🧠💭 *and you don't want to write all that yourself* 😮‍💨
+> 🧠💭 ***hello*** 👋
 
-    Set up an App Group between your main app target and your Notification Service Extension.
-    - Select your main app target > Signing & Capabilities
-    - Select + Capability (make sure it is set to All not Debug or Release) > App Groups
-    - Create a new App Group based on the recommended naming scheme `group.[MainTargetBundleId].[descriptor]`
-    - In your app's `Info.plist`, add a new entry for `klaviyo_app_group` as a String with the App Group name
-    - Select your Notification Service Extension target > Signing & Capabilities
-    - Add an App Group with the same name as the main target's App Group
-    - In your Notification Service Extension's `Info.plist`, add a new entry for `klaviyo_app_group` as a String with the App Group name
+the 😂 **klaviyo swift sdk** 😂 does these exact things:
 
-3. Based on which dependency manager you use, follow the instructions below to install the Klaviyo's dependencies.
+```
+🥇  TRACK EVENTS      →  "oh interesting, they added to cart" 🛒
+🥈  IDENTIFY USERS    →  "who ARE you. what is your email. I must know" 🪪
+🥉  PUSH TOKENS       →  "collect the little hex string that lets us boop them" 🪙
+🏅  IN-APP FORMS      →  "interrupt them mid-scroll with a tasteful offer" 📋
+```
 
-      <details>
-      <summary>Swift Package Manager [Recommended]</summary>
+🌊 api calls are **queued** then **batched** 🫙 like little data gnocchi being lovingly portioned into pasta shapes 🍝
+💾 **persisted to disk** 💾 so even if the phone 📱 dies mid-session, falls in a toilet 🚽, or travels internationally ✈️ — your data SURVIVES 💪
+📡 your 🎯 marketing team 🎯 will be able to understand what users 👥 actually want 👥 and send them perfectly timed 💌 messages via APNs 🍎 instead of just vibes 🌈
 
-      KlaviyoSwift and KlaviyoForms are available via [Swift Package Manager](https://swift.org/package-manager). Follow the steps below to install.
+---
 
-      1. Open your project and navigate to your project’s settings.
-      2. Select the **Package Dependencies** tab and click on the **add** button below the packages list.
-      3. Enter the URL of the Swift SDK repository `https://github.com/klaviyo/klaviyo-swift-sdk` in the text field. This should bring up the package on the screen.
-      4. For the dependency rule dropdown select - **Up to Next Major Version** and leave the pre-filled versions as is.
-      5. Click **Add Package**.
-      6. On the next prompt, assign the package product `KlaviyoSwift` and `KlaviyoForms` to your app target and `KlaviyoSwiftExtension` to the notification service extension target (if one was created) and click **Add Package**.
+## 📦 installation (the necessary evil) 📦
 
-      </details>
+> 😤 "but I don't WANT to set things up" 😤
+> 🫂 we know 🫂 we're sorry 🫂 it takes like 5 minutes 🕐 you've survived worse 🦾
 
-      <details>
-      <summary>CocoaPods</summary>
+### 🐾 step uno: enable push capabilities 🐾
 
-      KlaviyoSwift is available through [CocoaPods](https://cocoapods.org/pods/KlaviyoSwift).
+🍎 open xcode 🍎
+🔧 turn on push notification capabilities 🔧
+📖 [apple explains this better than we do](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns#2980170) 📖 honestly just click that link 🔗
 
-      1. To install, add the following lines to your Podfile. Be sure to replace `YourAppTarget` and `YourAppNotificationServiceExtenionTarget` with the names of your app and notification service extension targets respectively.
+    ### 🐾 step dos: notification service extension 🐾A
+> 💀💀💀 **STOP RIGHT HERE** 💀💀💀
+>
+> ⚠️ the extension's deployment target defaults to the **LATEST iOS version** ⚠️
+> ⚠️ if that's newer than your app's minimum iOS version ⚠️
+> ⚠️ then your users on older phones 📱 will NOT see rich push images 📸 ⚠️
+> ⚠️ they will see a sad, imageless notification 😭 ⚠️
+> ⚠️ and it will be YOUR fault ⚠️
+> ⚠️ **MATCH THE DEPLOYMENT TARGETS** ⚠️
+> ⚠️ you have been warned ⚠️
 
-      ```ruby
-      target 'YourAppTarget' do
-        pod 'KlaviyoSwift'
-      end
+🤝 now buddy your two targets together with an **App Group** 🤝:
 
-      target 'YourAppTarget' do
-        pod 'KlaviyoForms'
-      end
+```
+☑️  main app → Signing & Capabilities → ➕ Capability → App Groups
+☑️  create: group.[YourBundleId].somethingDescriptive
+☑️  Info.plist (main app)  → add key "klaviyo_app_group" → String → your group name 🗝️
+☑️  add the SAME group name to your extension target too 🔗
+☑️  Info.plist (extension) → also add "klaviyo_app_group" → same value 🗝️
+☑️  yes both. yes the same value. yes again. trust.
+```
 
-      target 'YourAppNotificationServiceExtenionTarget' do
-        pod 'KlaviyoSwiftExtension'
-      end
-      ```
-      2. Run `pod install` to complete the integration.
-      The library can be kept up-to-date via `pod update KlaviyoSwift` and `pod update KlaviyoSwiftExtension`.
-      </details>
+### 🐾 step tres: pick your poison 📦 🐾
 
-4. Finally, in the `NotificationService.swift` file add the code for the two required delegates from [this](Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift) file.
-  This sample covers calling into Klaviyo so that we can download and attach the media to the push notification as well as handle custom badge counts. It also demonstrates how to access custom data (key-value pairs) sent from Klaviyo.
+<details>
+<summary>✨🍺 Swift Package Manager 🍺✨ — (THE GOOD ONE. DO THIS. CLICK HERE.)</summary>
 
-> Advanced: If you are using multiple push sending providers, you can determine whether a message originated from Klaviyo by importing `KlaviyoSwift` and using the `isKlaviyoNotification` extension property on `UNNotifcationResponse`.
+> 🌈 **CONGRATULATIONS** 🌈
+> you have chosen correctly 🏆
+> you are a person of culture 🎩
 
-## Initialization
-The SDK must be initialized with the short alphanumeric [public API key](https://help.klaviyo.com/hc/en-us/articles/115005062267#difference-between-public-and-private-api-keys1)
-for your Klaviyo account, also known as your Site ID.
+1️⃣ 📂 open project → ⚙️ project settings → 📋 **Package Dependencies** tab
+2️⃣ hit the ➕ like you mean it
+3️⃣ paste this beautiful URL 🤌:
+```
+https://github.com/klaviyo/klaviyo-swift-sdk
+```
+4️⃣ rule: **Up to Next Major Version** 📈
+&nbsp;&nbsp;&nbsp; (the numbers are pre-filled. don't touch them. they're fine. leave them alone. 🚫🔢)
+5️⃣ **Add Package** 🎁
+6️⃣ assign like so:
+```
+📱  your app target   →  KlaviyoSwift ✅   KlaviyoForms ✅
+🔔  notif extension   →  KlaviyoSwiftExtension ✅
+```
+7️⃣ **Add Package** again because xcode needs to hear it twice 🎁🎁
+🎉 **YOU DID IT!! IT'S INSTALLED!! LOOK AT YOU GO!!** 🎉
+
+</details>
+
+<details>
+<summary>🫙 CocoaPods — (we see you out there. we aren't judging. much. okay a little.)</summary>
+
+> 💅 still on pods huh 💅
+> that's fine 💅
+> no really 💅
+> totally fine 💅
+> ...
+> anyway here's your podfile 😌:
+
+```ruby
+target 'YourAppTarget' do        # 🎯 hello, your app
+  pod 'KlaviyoSwift'             # 🐦 the main character
+end
+
+target 'YourAppTarget' do        # 🎯 yes again, same target, I know
+  pod 'KlaviyoForms'             # 📋 the forms slay
+end
+
+target 'YourNotifExtension' do   # 🔔 the lil notification buddy
+  pod 'KlaviyoSwiftExtension'    # 🔌 plug it in plug it in
+end
+```
+
+```bash
+pod install    # 🫞 pour it in. slurp it up. let it wash over you.
+```
+
+🔄 to update when we ship new things:
+```bash
+pod update KlaviyoSwift          # 🔄 fresh
+pod update KlaviyoSwiftExtension # 🔄 also fresh
+```
+
+> 🫡 godspeed 🫡
+
+</details>
+
+### 🐾 step cuatro: copy this file 📄 🐾
+
+📋 take the code from [NotificationService.swift](Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift)
+🖱️ paste it into your `NotificationService.swift`
+🖼️ it handles: rich media 🖼️ badge counts 🔴 custom data 🎁
+🧪 it just works. trust the process. 🧘
+
+> 🔬 **NERD NOTE** 🔬
+> using multiple push providers 🤹 and need to know which notifications are ours?
+> `import KlaviyoSwift` → check `isKlaviyoNotification` on any `UNNotificationResponse`
+> it's a bool 👍 or 👎 very binary very binary
+
+---
+
+## 🚀 initialization (the one line that starts it all) 🚀
+
+> 🗝️ you need your **public API key** 🗝️
+> 🏷️ also called your **Site ID** 🏷️
+> 🖥️ lives on your klaviyo dashboard 🖥️
+> 🔡 looks like someone sneezed on a keyboard 🔡 this is correct 🔡
 
 ```swift
-// AppDelegate
+// 📂 AppDelegate.swift
+// 🐣 this is where apps are born. this is where the magic begins. this is the hatching.
 
-import KlaviyoSwift
+import KlaviyoSwift  // 👈 this import. right here. do not forget this import.
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+
         KlaviyoSDK().initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")
-        return true
+        //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        //                      🔑 put your ACTUAL key here not this string 🔑
+        //                      🔑 "YOUR_KLAVIYO_PUBLIC_API_KEY" will not work 🔑
+        //                      🔑 we have seen people ship "YOUR_KLAVIYO_PUBLIC_API_KEY" 🔑
+        //                      🔑 you know who you are 🔑
+        //                      🔑 please 🔑
+
+        return true  // ✅ launched. stable. alive. doing great.
     }
 }
 ```
 
-The SDK **should** be initialized before any other Klaviyo SDK methods are called.
+🚨 **THE RULE** 🚨 initialize **BEFORE** all other SDK calls 🚨
+🚨 if you call other SDK methods before initializing 🚨
+🚨 the SDK will not crash 🚨 but it will do nothing 🚨
+🚨 and you will spend 3 hours debugging 🚨
+🚨 and it will be fine actually but still 🚨
+🚨 **just do it first** 🚨
 
-## Profile Identification
-The SDK provides methods to identify your users as Klaviyo profiles via the [Create Client Profile API](https://developers.klaviyo.com/en/reference/create_client_profile).
-A profile can be identified by any combination of the following:
+---
 
-* External ID: A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system, such as a point-of-sale system. Format varies based on the external system.
-* Individual's email address
-* Individual's phone number in [E.164 format](https://help.klaviyo.com/hc/en-us/articles/360046055671#h_01HE5ZYJEAHZKY6WZW7BAD36BG)
+## 🪪 who even ARE you (profile identification) 🪪
 
-These above identifiers are persisted to local storage so that the SDK can keep track of the current user/profile for you when you make event requests or want to set a push token etc.
+> 🔭 the SDK can identify your users as Klaviyo profiles 🔭
+> via the [Create Client Profile API](https://developers.klaviyo.com/en/reference/create_client_profile) 📡
+> you can identify someone by:
 
-Profile identifiers can be set all at once or individually. Either way, the SDK will group and batch API calls to improve performance.
-
-The following code demonstrates how to set profile identifiers:
-
-```swift
-// organization, title, image, location and additional properties (dictionary) can also be set using the below constructor
-let profile = Profile(email: "junior@blob.com",  firstName: "Blob",  lastName: "Jr.")
-KlaviyoSDK().set(profile: profile)
-
-// or setting individual properties
-KlaviyoSDK().set(profileAttribute: .firstName, value: "Blob")
-KlaviyoSDK().set(profileAttribute: .lastName, value: "Jr.")
+```
+🪪  external ID     →  some ID from your backend 🏢 (could be a UUID 🔢, a username 👤, whatever)
+📧  email           →  the @ address 📮 (classic)
+📞  phone number    →  E.164 format ONLY ☎️ (+15551234567 ✅  5551234567 ❌  "their phone" ❌❌❌)
 ```
 
-### Reset Profile
-To start a new profile altogether (e.g. if a user logs out) either call `KlaviyoSDK().resetProfile()` to clear the currently tracked profile identifiers,
-or use `KlaviyoSDK().set(profile: profile)` to overwrite it with a new profile object.
+💾 these stick around in **local storage** 💾
+🧠 the SDK holds onto them across sessions like a diligent lil archivist 🗂️
+📦 batches API calls together like a responsible adult who does their laundry once a week 👏
+
+### 👤 introducing a whole entire human person 👤
 
 ```swift
-// start a profile for Blob Jr.
-let profile = Profile(email: "junior@blob.com",  firstName: "Blob",  lastName: "Jr.")
-KlaviyoSDK().set(profile: profile)
+// 🎭 act one: the arrival of blob jr. 🎭
+// (blob jr. is our beloved sdk documentation character. they have been with us since the beginning.)
+let profile = Profile(
+    email: "junior@blob.com",       // 📧 the @ address
+    firstName: "Blob",              // 👆 first name (such a strong name)
+    lastName: "Jr."                 // 👇 last name (carries on the blob legacy)
+    // bonus fields you can also set 🎁:
+    //   organization: "Blob Industries LLC" 🏢
+    //   title: "Chief Blob Officer" 💼
+    //   image: "https://example.com/blob.jpg" 🖼️
+    //   location: Location(city: "Blobville") 📍
+    //   properties: ["favorite_food": "gnocchi"] 📚
+)
+KlaviyoSDK().set(profile: profile)  // 📤 whoosh. blob jr. is now in klaviyo.
 
-// stop tracking Blob Jr.
+// OR set fields one at a time, à la carte 🍽️:
+KlaviyoSDK().set(profileAttribute: .firstName, value: "Blob")  // 👆 hello blob
+KlaviyoSDK().set(profileAttribute: .lastName, value: "Jr.")    // 👇 hello jr.
+// 🔄 these get batched together anyway. the sdk is smart like that.
+```
+
+### 🔄 bye bestie (reset profile) 🔄
+
+> 👋 is your user logging out? 👋
+> you MUST reset or the next user will inherit blob jr.'s entire profile 😱
+> blob jr. worked hard for that profile 😤 it belongs to blob jr. 😤
+
+```swift
+// 📖 the complete lifecycle of blob jr. in your app 📖
+
+// 🌅 chapter 1: blob jr. shows up (hi bestie 🤗)
+let blobJr = Profile(email: "junior@blob.com", firstName: "Blob", lastName: "Jr.")
+KlaviyoSDK().set(profile: blobJr)
+
+// 🌇 chapter 2: blob jr. peaces out (goodbye forever 👋😢)
 KlaviyoSDK().resetProfile()
+// ☝️ nukes all identifiers 🧹
+// ☝️ push token gets passed to a new anonymous profile 👻 (token not lost! just rehomed 🏠)
+// ☝️ do NOT skip this on logout. do NOT. we cannot stress this enough.
 
-// start a profile for Robin Hood
-let profile = Profile(email: "robin@hood.com",  firstName: "Robin",  lastName: "Hood")
-KlaviyoSDK().set(profile: profile)
-```
-### Anonymous Tracking Notice
-
-Klaviyo will track unidentified users with an autogenerated ID whenever a push token is set or an event is created.
-That way, you can collect push tokens and track events prior to collecting profile identifiers such as email or phone number.
-When an identifier is provided, Klaviyo will merge the anonymous user with an identified user.
-
-## Event tracking
-
-The SDK provides tools for tracking events that users perform on your app via the [Create Client Event API](https://developers.klaviyo.com/en/reference/create_client_event).
-Below is an example of how to track an event:
-
-```swift
-// using a predefined event name
-let event = Event(name: .StartedCheckoutMetric,
-                  properties: [
-                        "name": "cool t-shirt",
-                        "color": "blue",
-                        "size": "medium",
-                      ],
-                  value: 166 )
-
-KlaviyoSDK().create(event: event)
-
-// using a custom event name
-let customEvent = Event(name: .CustomEvent("Checkout Completed"),
-                  properties: [
-                        "name": "cool t-shirt",
-                        "color": "blue",
-                        "size": "medium",
-                      ],
-                  value: 166)
-
-KlaviyoSDK().create(event: customEvent)
+// 🌅 chapter 3: a new challenger appears (welcome robin 🏹)
+let robin = Profile(email: "robin@hood.com", firstName: "Robin", lastName: "Hood")
+KlaviyoSDK().set(profile: robin)
+// (robin has absolutely NO idea blob jr. was ever here. as it should be.)
 ```
 
-### Arguments
+### 👻 anonymous gremlin mode 👻
 
-The `create` method takes an event object as an argument. The event can be constructed with the following arguments:
-- [required] `name`: The name of the event you want to track, as a `EventName` enum. A list of common Klaviyo defined event metrics can be found in `Event.EventName`. You can also create custom events by using the `CustomEvent` enum case of `Event.EventName`
-- `properties`: A dictionary of properties that are specific to the event. This argument is optional.
-- `value`: A numeric value (`Double`) to associate with this event. For example, the dollar amount of a purchase.
+> 🌑 sometimes you don't know who the user is yet 🌑
+> maybe they haven't logged in 🤷
+> maybe they're just vibing 🌊
+> maybe they're a little gremlin who refuses to give you their email 😤
+>
+> 🤫 here's the secret 🤫
+> klaviyo gives them an **autogenerated anonymous ID** automatically 🤖
+> events + push tokens get quietly collected in the dark 🌑
+> when they FINALLY identify themselves 📧 we merge the anonymous profile into the real one 🤝
+> all those events they did as a gremlin? 👻 **kept** 📂
+> all those push tokens they accumulated? 🪙 **kept** 📂
+> no data is ever lost to gremlinhood 💪
 
-## Push Notifications
+---
 
-### Prerequisites
+## 📊 they did a thing!! (event tracking) 📊
 
-* An apple developer [account](https://developer.apple.com/).
-* Configure [iOS push notifications](https://help.klaviyo.com/hc/en-us/articles/360023213971) in Klaviyo account settings.
+> 🎺 your users are OUT THERE 🎺
+> 🎺 doing THINGS in your app 🎺
+> 🎺 clicking buttons!! viewing products!! adding to cart!! 🎺
+> 🎺 and you can KNOW about ALL of it 🎺
+> 🎺 via the [Create Client Event API](https://developers.klaviyo.com/en/reference/create_client_event) 📡 🎺
 
-### Collecting Push Tokens
-
-In order to send push notifications to your users, you must collect their push tokens and register them with Klaviyo.
-This is done via the `KlaviyoSDK().set(pushToken:)` method, which registers a push token and current authorization state
-via the [Create Client Push Token API](https://developers.klaviyo.com/en/reference/create_client_push_token).
-
-* Call [`registerForRemoteNotifications()`](https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications)
-to request a push token from APNs. This is typically done in the [`application:didFinishLaunchingWithOptions:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application) method of your app delegate.
-* Implement the delegate method [`application:didRegisterForRemoteNotificationsWithDeviceToken`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428766-application)
-in your application delegate to receive the push token from APNs and register it with Klaviyo.
-
-Below is the code to do both of the above steps:
 ```swift
-import KlaviyoSwift
+// 💳 THEY'RE CHECKING OUT!!! LOG EVERYTHING!!! 💳
+let bigSpender = Event(
+    name: .startedCheckoutMetric,     // 💳 one of our fancy prebuilt metric names
+    properties: [
+        "item_name": "extremely cool t-shirt",  // 👕 what they're buying
+        "color":     "vantablack",              // 🖤 very dark. very cool.
+        "size":      "extra swag",              // 😎 non-standard sizing but okay
+        "vibes":     "immaculate",              // ✨ custom props go here
+    ],
+    value: 166  // 💰 one hundred and sixty six dollars for a shirt. respect.
+)
+KlaviyoSDK().create(event: bigSpender)  // 📤 sent to klaviyo. logged. witnessed.
 
-func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    KlaviyoSDK().initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")
+// 🎯 custom event — name it whatever you want, we don't gatekeep 🎯
+let cryptidEvent = Event(
+    name: .customEvent("User Stared At The Home Screen For 47 Minutes Without Moving"),
+    properties: [
+        "was_blinking":          false,  // 😶 confirmed
+        "concerning":            true,   // 😰 extremely
+        "contacted_their_mom":   false,  // 📵 no
+        "should_we_send_a_push": true,   // 📲 probably yes
+    ],
+    value: 0  // 💸 no purchase. just vibes.
+)
+KlaviyoSDK().create(event: cryptidEvent)  // 📤 noted. flagged. praying for them.
+```
+
+### 📋 event constructor cheat sheet 📋
+
+| argument | required? | what it is |
+|---|---|---|
+| `name` 📛 | ✅ yes bestie | an `Event.EventName` — pick a prebuilt one or do `.customEvent("whatever")` |
+| `properties` 📚 | 🤷 nah | a `[String: Any]` dict of extra context. go wild. |
+| `value` 💰 | 🤷 nah | a `Double`. usually money 💵. technically anything. |
+
+#### 🎪 the prebuilt event buffet 🎪
+
+```swift
+.openedAppMetric        // 📱 they opened the app. humble. classic. foundational.
+.viewedProductMetric    // 👀 window shopping detected
+.addedToCartMetric      // 🛒 interest is high. conversion pending.
+.startedCheckoutMetric  // 💳 this is it. this is the moment.
+.customEvent("💅")      // 🎯 you name it. we track it. no rules here.
+```
+
+---
+
+## 🔔 the boop (push notifications) 🔔
+
+> 📲 the boop 📲
+> *booooop* 📲
+> that little thing that taps your shoulder and says "hey" 👋
+> even when the app is closed 🚪
+> incredible technology really 🤯
+
+### ✅ prerequisites (ugh) ✅
+
+- 🍎 [apple developer account](https://developer.apple.com/) — yes you pay $99/year to apple 💸 this is the deal we made with them 🤝
+- ⚙️ [configure iOS push notifications](https://help.klaviyo.com/hc/en-us/articles/360023213971) in your Klaviyo account 🔧
+
+### 🪙 gotta catch em all (push tokens) 🪙
+
+> 🎣 a push token 🎣
+> is a long hexadecimal string 🔡
+> that is basically the user's home address 🏠 but for notifications 📲
+> apple 🍎 mints one for each device/app combo
+> and hands it to you in a delegate method
+> and you hand it to us
+> and we keep it safe forever 🗄️
+> the circle of life 🦁🌿
+
+```swift
+import KlaviyoSwift  // 👈 you know the drill
+
+func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+) -> Bool {
+
+    KlaviyoSDK().initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")  // 🚀 step 1
 
     UIApplication.shared.registerForRemoteNotifications()
+    // ☝️ this calls up to apple 🍎 and goes
+    // ☝️ "hello apple we would like a push token please 🙏"
+    // ☝️ apple considers it
+    // ☝️ apple says "fine" 🍎
+    // ☝️ the next method gets called
 
-    return true
+    return true  // ✅
 }
 
-func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    KlaviyoSDK().set(pushToken: deviceToken)
+func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data  // 🪙 here's the token!
+) {
+    KlaviyoSDK().set(pushToken: deviceToken)  // 🤲 take the token. cherish it. send it to us.
 }
 ```
 
-### Request Push Notification Permission
+### 🙏 pretty please (asking for permission) 🙏
 
-Once the push token is obtained, the next step is to request permission from your users to send them push notifications.
-You can add the permission request code anywhere in your application where it makes sense to prompt users for this permission.
-Apple provides some [guidelines](https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications)
-on the best practices for when and how to ask for this permission. The following example demonstrates how to request push permissions
-within the [`application:didFinishLaunchingWithOptions:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application)
-method in the application delegate file. However, it's worth noting that this may not be the ideal location as it could interrupt the app's startup experience.
+> 👆 you have the token 👆
+> 🙅 but iOS requires user **permission** before you can actually show them notifications 🙅
+> 🥺 you must ask 🥺
+> 🥺 with your whole chest 🥺
+> 🥺 please 🥺
+>
+> 📖 apple has [guidelines](https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications) on when to ask 📖
+> 🚫 do NOT ask on first launch 🚫 you will scare them and they will say no 😱
+> ✅ ask after they've seen value in the app ✅ when it makes sense ✅
 
-After setting a push token, the Klaviyo SDK will automatically track changes to
-the user's notification permission whenever the application is opened or resumed from the background.
-
-Below is example code to request push notification permission:
 ```swift
-import UserNotifications
+import UserNotifications  // 🔔
 
-func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    KlaviyoSDK().initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")
+func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+) -> Bool {
 
-    UIApplication.shared.registerForRemoteNotifications()
+    KlaviyoSDK().initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")  // 🚀
+    UIApplication.shared.registerForRemoteNotifications()         // 🪙
 
     let center = UNUserNotificationCenter.current()
-    center.delegate = self as? UNUserNotificationCenterDelegate // the type casting can be removed once the delegate has been implemented
+    center.delegate = self as? UNUserNotificationCenterDelegate   // 🤝 register yourself as delegate
+
     let options: UNAuthorizationOptions = [.alert, .sound, .badge]
-    // use the below options if you are interested in using provisional push notifications. Note that using this will not
-    // show the push notifications prompt to the user.
-    // let options: UNAuthorizationOptions = [.alert, .sound, .badge, .provisional]
+    // 🤫 SPICY OPTION: add .provisional to silently deliver to notification center
+    //    without ever prompting the user. sneaky. controversial. powerful.
+    //    some call it evil. some call it genius. only you can decide. 😈
+
     center.requestAuthorization(options: options) { granted, error in
         if let error = error {
-            // Handle the error here.
-            print("error = ", error)
+            print("😭 permission request blew up: \(error)")
         }
-
-        // Irrespective of the authorization status call `registerForRemoteNotifications` here so that
-        // the `didRegisterForRemoteNotificationsWithDeviceToken` delegate is called. Doing this
-        // will make sure that Klaviyo always has the latest push authorization status.
-            DispatchQueue.main.async {
-                UIApplication.shared.registerForRemoteNotifications()
-            }
+        // 🙏 whether they said yes OR no, call this:
+        DispatchQueue.main.async {
+            UIApplication.shared.registerForRemoteNotifications()
+            // ☝️ ensures klaviyo always has the latest authorization status 🌿
+            // ☝️ even if it changed since last time 🔄
+        }
     }
 
-    return true
+    return true  // ✅
 }
 ```
 
-### Receiving Push Notifications
+> 🤖 after a token is set 🤖
+> the SDK **automatically tracks** auth status changes from that point on
+> on every app open 🌅 and every background resume 🌄
+> zero extra code from you 🪄 we got it 🤙
 
-#### Tracking Open Events
+### 📬 receiving the boop 📬
 
-When a user taps on a push notification, Implement  [`userNotificationCenter:didReceive:withCompletionHandler`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter)
-and [`userNotificationCenter:willPresent:withCompletionHandler`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649518-usernotificationcenter) in your application delegate to handle receiving push notifications
-when the app is in the background and foreground respectively.
+#### 👆👆👆 THEY TAPPED IT OMG 👆👆👆
 
-Below is an example of how to handle push notifications in your app delegate:
+> 🥁 *drumroll* 🥁
+> a user has seen your notification 👁️
+> considered it 🤔
+> and TAPPED it 👆
+> this is the dream. this is what we're here for.
+> track it immediately. do not let this moment pass unrecorded. 📊
+
 ```swift
-// be sure to set the UNUserNotificationCenterDelegate to self in the didFinishLaunchingWithOptions method (refer the requesting push notification permission section above for more details on this)
+// 👇 make sure you set center.delegate = self somewhere (see permission section ☝️)
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    // below method will be called when the user interacts with the push notification
+
+    // 🌚 user tapped while app was backgrounded / device locked
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void) {
-        // If this notification is Klaviyo's notification we'll handle it
-        // else pass it on to the next push notification service to which it may belong
-        let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler)
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let handled = KlaviyoSDK().handle(
+            notificationResponse: response,
+            withCompletionHandler: completionHandler
+        )
+        // 😂 if it's a klaviyo notification:
+        //      ✅ tracks the "Opened Push" event
+        //      ✅ handles the deep link if there is one
+        //      ✅ calls completionHandler on the main thread
+        //      ✅ does everything. you're done.
+        // 🤷 if it's NOT a klaviyo notification:
+        //      → handled == false → you handle it → not our circus 🎪
         if !handled {
             completionHandler()
         }
     }
 
-    // below method is called when the app receives push notifications when the app is the foreground
+    // 🌞 notification arrived while app was ALREADY open (foreground)
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
         if #available(iOS 14.0, *) {
-            completionHandler([.list, .banner])
+            completionHandler([.list, .banner])  // 📋 ye modern banner + list combo
         } else {
-            completionHandler([.alert])
+            completionHandler([.alert])          // 📢 the old ways. classic.
         }
     }
 }
 ```
 
-Once your first push notifications are sent and opened, you should start to see _Opened Push_ metrics within your Klaviyo dashboard.
+> 🎉 send a push → user taps it → behold **Opened Push** in your Klaviyo dashboard 📊
+> it feels like magic 🪄 it is not magic 🪄 it is just JSON being sent over HTTPS 🔐
+> but also it's a little bit magic 🪄
 
-#### Deep Linking
+#### 🕳️ go deeper (deep linking) 🕳️
 
->  ℹ️  Your app needs to use version 1.7.2 at a minimum in order for the below steps to work.
+> ℹ️ needs SDK **v1.7.2+** ℹ️
 
-[Deep Links](https://help.klaviyo.com/hc/en-us/articles/14750403974043) allow you to navigate to a particular page within your app in response to the user opening a push notification.
+> 🌀 **DEEP LINKS** 🌀
+> instead of just opening your app to the home screen 🏠
+> they teleport the user directly to a specific screen 📱
+> like if someone sent you a letter and it opened into a room 🚪
+> never mind. it's like clicking a hyperlink. but for apps. 🔗
 
-You need to configure deep links in your app for them to work. The configuration process for Klaviyo is no different from what is required for handling deep linking in general,
-so you can follow the [Apple documentation](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) for deep linking in conjunction
-with the steps outlined here.
+**two roads diverged in a plist** 🍃, and you may only choose one:
 
-You have two options for implementing deep links: URL schemes and Universal Links.
+##### 🅰️ path one: URL schemes (old faithful) 🅰️
 
-##### Option 1: URL Schemes
-
-URL schemes are the traditional and simpler way of deep linking from a push notification to your app.
-However, these links will only work if your mobile app is installed on a device and will not be understood by
-a web browser if, for example, you want to link from an email to your app.
-
-###### Step 1: Register the URL scheme
-
-In order for Apple to route a deep link to your application you need to register a URL scheme in your application's Info.plist file. This can be done using the editor that xcode provides from the Info tab of your project settings or by editing the Info.plist directly.
-
-The required fields are as following:
-
-1. **Identifier** - The identifier you supply with your scheme distinguishes your app from others that declare support for the same scheme. To ensure uniqueness, specify a reverse DNS string that incorporates your company’s domain and app name. Although using a reverse DNS string is a best practice, it doesn’t prevent other apps from registering the same scheme and handling the associated links.
-1. **URL schemes** - In the URL Schemes box, specify the prefix you use for your URLs.
-1. **Role** - Since your app will be editing the role select the role as editor.
-
-In order to edit the Info.plist directly, just fill in your app specific details and paste this in your plist.
+**1️⃣ tell the system what scheme you own** (in `Info.plist`):
 
 ```xml
 <key>CFBundleURLTypes</key>
 <array>
     <dict>
         <key>CFBundleTypeRole</key>
-        <string>Editor</string>
+        <string>Editor</string>                   <!-- ✏️ you edit things. you are the editor. -->
         <key>CFBundleURLName</key>
-        <string>{your_unique_identifier}</string>
+        <string>com.yourcompany.yourapp</string>  <!-- 🪪 reverse-dns. uniqueness. professionalism. -->
         <key>CFBundleURLSchemes</key>
         <array>
-            <string>{your_URL_scheme}</string>
+            <string>yourapp</string>              <!-- 🔗 yourapp://whatever gets sent here -->
         </array>
     </dict>
 </array>
 ```
 
-###### Step 2: Whitelist supported URL schemes
-
-Since iOS 9 Apple has mandated that the URL schemes that your app can open need to also be listed in the Info.plist. This is in addition to Step 1 above. Even if your app isn't opening any other apps, you still need to list your app's URL scheme in order for deep linking to work.
-
-This needs to be done in the Info.plist directly:
+**2️⃣ also whitelist it** (iOS 9+ requires this. don't ask why. it's apple.):
 
 ```xml
 <key>LSApplicationQueriesSchemes</key>
 <array>
-    <string>{your custom URL scheme}</string>
-</array>
+    <string>yourapp</string>  <!-- 🗝️ yes you list it twice. yes in two different places. -->
+</array>                       <!-- 🗝️ it's fine. this is fine. everything is fine. 🔥 -->
 ```
 
-###### Step 3: Implement handling deep links in your app
-
-Steps 1 and 2 enable your app to receive deep links, but you also need to handle these links within your app.
-This is done by implementing the [`application:openURL:options:`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application)
-method in your app delegate.
-
-Example:
+**3️⃣ handle the URL when it arrives**:
 
 ```swift
 func application(
     _ app: UIApplication,
     open url: URL,
-    options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
 ) -> Bool {
-    guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true)
-    else {
-       print("Invalid deep linking URL")
-       return false
+    guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true) else {
+        print("💀 broken URL. someone sent us nonsense. logging and moving on.")
+        return false
     }
-
-    print("components: \(components.debugDescription)")
-
-    return true
+    print("🕳️ deep link received: \(components.debugDescription)")
+    // 🗺️ use components to figure out where to navigate
+    // 🗺️ the implementation of that navigation is your business not ours
+    return true  // ✅ handled. done. good job.
 }
 ```
 
-If you are using SwiftUI, then you can implement [`onOpenURL(perform:)`](<https://developer.apple.com/documentation/swiftui/view/onopenurl(perform:)>) as a view modifier in the view you intent to handle deep links. This may or may not be the root of your scene.
-
-Example:
-
+> 🌿 **SwiftUI people** 🌿 your way is nicer tbh:
 ```swift
 @main
 struct MyApplication: App {
-  var body: some Scene {
-    WindowGroup {
-      ContentView()
-        .onOpenURL { url in
-          // handle the URL that must be opened
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onOpenURL { url in
+                    // 🔗 same deal. url arrives here. you navigate. fin.
+                }
         }
     }
-  }
 }
 ```
 
-Finally, we have an example app (`Examples/KlaviyoSwiftExamples`) in the SDK repo that you can reference to get an example of how to implement deep links in your app.
+> 🧪 test without a real push, right in terminal:
+> ```bash
+> xcrun simctl openurl booted yourapp://the-screen-you-want
+> # 💥 boom. simulated deep link. no push required. very satisfying.
+> ```
 
-Once the above steps are complete, you can send push notifications from the Klaviyo Push editor within the Klaviyo website.
-Here you can build and send a push notification through Klaviyo to make sure that the URL shows up in the handler you implemented in Step 3.
+##### 🅱️ path two: universal links (fancy mode) 🅱️
 
-Additionally, you can also locally trigger a deep link to make sure your code is working using the below command in the terminal.
-
-`xcrun simctl openurl booted {your_URL_here}`
-
-##### Option 2: Universal links
-
-[Universal links](https://developer.apple.com/ios/universal-links/) are a more modern way of handling deep links and are recommended by Apple.
-They are more secure and provide a better user experience. However, unlike URL schemes they require a bit more setup that is highlighted in [these](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) Apple docs.
-
-Once you have the setup from the Apple docs in place you will need to modify the push open tracking as described below:
+> 🌐 basically HTTP/S links that open in your app instead of Safari 🌐
+> 🔒 more secure 🔒 better UX 💅 requires more setup 😮‍💨
+> 🖥️ you need an `apple-app-site-association` file on a real web server 🖥️
+> 📖 [do the apple setup first](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) 📖 come back when you're done 👈
 
 ```swift
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler) { url in
-            print("deep link is ", url)
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let handled = KlaviyoSDK().handle(
+            notificationResponse: response,
+            withCompletionHandler: completionHandler
+        ) { url in
+            // 🔗 this closure fires with the actual destination URL
+            // 🔗 the one that klaviyo resolved from the tracking link
+            // 🔗 do your navigation here
+            print("🕳️ navigating to: \(url)")
         }
         if !handled {
-           // not a klaviyo notification should be handled by other app code
+            // 🤷 wasn't ours. handle it yourself. we believe in you.
         }
     }
 }
 ```
 
-Note that the deep link handler will be called back on the main thread. If you want to handle URL schemes in addition to universal links you implement them as described in [Option 1: URL Schemes](#option-1-URL-schemes).
+> 📌 tiny but important note 📌
+> the deep link handler closure is called on the **main thread** 🧵
+> not a background thread 🌑 the **main** thread 🌞
+> please plan accordingly 🙏
 
-#### Rich Push
+#### 🖼️ fancy boop (rich push) 🖼️
 
->  ℹ️ Rich push notifications are supported in SDK version [2.2.0](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/2.2.0) and higher
+> ℹ️ needs SDK **v2.2.0+** ℹ️
 
-[Rich Push](https://help.klaviyo.com/hc/en-us/articles/16917302437275) is the ability to add images to push notification messages.  Once the steps
-in the [Installation](#installation) section are complete, you should have a notification service extension in your
-project setup with the code from the `KlaviyoSwiftExtension`. Below are instructions on how to test rich push notifications.
+> 📸 a plain text push notification is fine 📸
+> but a push notification with a **beautiful image** attached? 📸
+> *chef's kiss* 🤌
+> people click those WAY more 📊 (the data is in on this one)
 
-##### Testing rich push notifications
+as long as your notification service extension is set up 🔌
+`KlaviyoSwiftExtension` downloads and attaches the image automatically 🤖
+you don't even have to look at the code 🙈 it just works 🪄
 
-* To test rich push notifications, you will need three things:
-  * Any push notifications tester like Apple's official [push notification console](https://developer.apple.com/notifications/push-notifications-console/) or a third party software such as [this](https://github.com/onmyway133/PushNotifications).
-* A push notification payload that resembles what Klaviyo would send to you. The below payload should work as long as the image is valid:
+🧪 to test locally:
+
+1️⃣ get a push testing tool 📲 — [apple's official console](https://developer.apple.com/notifications/push-notifications-console/) or [this delightful third-party one](https://github.com/onmyway133/PushNotifications)
+2️⃣ fire this payload at your device 🎯:
 
 ```json
 {
   "aps": {
     "alert": {
-      "title": "Sample title for a Klaviyo push notification,
-      "body": "Sample body for a Klaviyo push notification"
+      "title": "WOW LOOK AT THIS 😍",
+      "body": "so rich. much media. very wow. 🐕"
     },
     "mutable-content": 1
   },
@@ -503,160 +672,321 @@ project setup with the code from the `KlaviyoSwiftExtension`. Below are instruct
   "rich-media-type": "jpg"
 }
 ```
-  * A real device's push notification token. This can be printed out to the console from the `didRegisterForRemoteNotificationsWithDeviceToken` method in `AppDelegate`.
 
-Once you have these three things, you can then use the push notifications tester and send a local push notification to make sure that everything was set up correctly.
+3️⃣ get your device's push token from `didRegisterForRemoteNotificationsWithDeviceToken` 🪙
+4️⃣ 🚀 launch 🚀
+5️⃣ 🖼️ *look upon your creation* 🖼️
 
-#### Badge Count
->  ℹ️ Setting or incrementing the badge count is available in SDK version [4.1.0](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/4.1.0) and higher
+#### 😰 the lil red circle of anxiety (badge count) 😰
 
-Klaviyo supports setting or incrementing the badge count when you send a push notification. For this functionality to work, you must set up the Notification Service Extension and an App Group as outlined under the [Installation](#installation) section.
+> ℹ️ needs SDK **v4.1.0+** ℹ️
 
-##### Autoclearing
+> 🔴 behold 🔴
+> the **badge** 🔴
+> that tiny red circle 🔴
+> sitting on your app icon 🔴
+> judging you 🔴
+> silently saying "you have **3** things to deal with" 🔴
+> has it always been there?? 🔴
+> how long?? 🔴
+> we can control it 🔴
 
-By default, the Klaviyo SDK automatically clears the badge count on app open. If you want to disable this behavior, add a new entry for `klaviyo_badge_autoclearing` as a Boolean set to `NO` in your app's `Info.plist`. You can re-enable automatically clearing badges by setting this value to `YES`.
+needs the notification service extension 🔌 + app group 🤝 from [installation](#-installation-the-necessary-evil-)
 
-##### Handling Other Badging Sources
+##### 🧹 autoclearing (the default behavior) 🧹
 
-Klaviyo SDK will automatically handle the badge count associated with Klaviyo pushes. If you need to manually update the badge count to account for other notification sources, use the `KlaviyoSDK().setBadgeCount(:)` method, which will update the badge count and keep it in sync with the Klaviyo SDK. This method should be used instead of (rather than in addition to) setting the badge count using `UNUserNotificationCenter` and/or `UIApplication` methods.
+> 🪄 by default, badge nukes itself to zero when user opens the app 🪄
+> ✨ it just *poofs* ✨ like it never existed
+> it's very nice actually. very clean. very zen. 🧘
+>
+> 😤 want to KEEP the badge up? 😤
+> 😤 want to maintain the anxiety? 😤
+> 😤 bold but fine. add this to `Info.plist`: 😤
 
-#### Silent Push Notifications
-
-Silent push notifications (also known as background pushes) allow your app to receive payloads from Klaviyo without displaying a visible alert to the user. These are typically used to trigger background behavior, such as displaying content, personalizing the app interface, or downloading new information from a server.
->  ℹ️ Silent push support is available by default. The Klaviyo SDK does not provide specific handling for silent push notifications. See [enable the remote notifications capability](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app#Enable-the-remote-notifications-capability) and [receive background notifications](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app#Enable-the-remote-notifications-capability) for more details.
-
-To handle silent push notifications in your app, you'll need to implement the appropriate delegate methods yourself. Here's an example of how to handle silent push notifications:
-
+```xml
+<key>klaviyo_badge_autoclearing</key>
+<false/>   <!-- 🔴 you want the red circle to stay. understood. no judgment. -->
 ```
-func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-  // Access custom key-value pairs from the top level
-  if let customData = userInfo["key_value_pairs"] as? [String: String] {
-    // Process your custom key-value pairs here
-    for (key, value) in kvPairs {
-        print("Key: \(key), Value: \(value)")
+
+```xml
+<key>klaviyo_badge_autoclearing</key>
+<true/>    <!-- 🧹 gone on open. fresh start. clear skies. recommended. -->
+```
+
+##### 🎛️ controlling it yourself 🎛️
+
+> 🛑 if you have OTHER notification sources beyond klaviyo 🛑
+> 🛑 do NOT set badge count using `UNUserNotificationCenter` or `UIApplication` directly 🛑
+> 🛑 they don't know about klaviyo's count 🛑 things will get out of sync 🛑 chaos ensues 🛑
+> use THIS instead 👇 it syncs everything 🤝:
+
+```swift
+KlaviyoSDK().setBadgeCount(5)
+// ☝️ sets badge to 5 🔴
+// ☝️ syncs with klaviyo's persisted count 🔄
+// ☝️ everyone is happy 😊
+// ☝️ the number is correct 🔢
+// ☝️ the anxiety is calibrated 😌
+```
+
+#### 🫥 sneaky ghost boop (silent push) 🫥
+
+> 👻 silent push 👻
+> a notification that makes NO SOUND 🔇
+> shows NO ALERT 🫥
+> the user has NO IDEA 🙈
+> but your app WAKES UP in the background 🌅
+> does its little tasks 🐝
+> and goes back to sleep 😴
+> like a ghost doing maintenance work 👻🔧
+
+> ℹ️ we don't handle silent push ourselves ℹ️ this is apple's domain 🍎
+> see [apple's docs on background updates](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app#Enable-the-remote-notifications-capability) 📖
+
+```swift
+func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+) {
+    // 🎁 klaviyo can include custom key-value pairs
+    if let kvPairs = userInfo["key_value_pairs"] as? [String: String] {
+        for (key, value) in kvPairs {
+            print("🗝️ received: \(key) → \(value)")
+            // do something useful here 🔧
+            // unlike blob jr. who would probably just stare at it 👁️👁️
+        }
+        completionHandler(.newData)  // ✅ we got something
+    } else {
+        completionHandler(.noData)   // 🤷 nothing for us here
     }
-  } else {
-      print("No key_value_pairs found in notification")
-  }
 }
 ```
 
->  ℹ️ Silent push notifications are not supported by the iOS simulator. To test silent push notifications, please use a real device.
+> 🖥️ **VERY IMPORTANT** 🖥️
+> silent push **does not work on the iOS simulator** 🚫
+> it requires a real physical phone 📱
+> a tangible object 📱
+> that exists in physical space 📱
+> you cannot unit test your way out of this 📱
 
-#### Custom Data
-Klaviyo messages can also include key-value pairs (custom data) for both standard and silent push notifications. You can access these key-value pairs using the `key_value_pairs` key on the [`userInfo`](https://developer.apple.com/documentation/foundation/nsnotification/1409222-userinfo) dictionary associated with the notification (for silent pushes, see the example above; for standard pushes, see [`NotificationService.swift`](https://github.com/klaviyo/klaviyo-swift-sdk/blob/master/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift) in the example app). This enables you to extract additional information from the push payload and handle it appropriately - for instance, by triggering background processing, logging analytics events, or dynamically updating app content.
+#### 🎁 there's more inside (custom data) 🎁
 
-## In-App Forms
-> ℹ️ In-App Forms support is available in SDK version [4.2.0](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/4.2.0) and higher
+> 📦 every klaviyo push — silent OR visible — can carry **custom key-value pairs** 📦
+> little bonus payloads 🎁 secret messages 🤫 extra context 📋
+> access them via `userInfo["key_value_pairs"]` 🗝️
+>
+> for 🔔 **standard pushes**: see the [`NotificationService.swift` example](Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift)
+> for 🤫 **silent pushes**: see the code block right above this ☝️
 
-[In-App Forms](https://help.klaviyo.com/hc/en-us/articles/34567685177883) are messages displayed to mobile app users while they are actively using an app. You can create new In-App Forms in a drag-and-drop editor in the Sign-Up Forms tab in Klaviyo.  Follow the instructions in this section to integrate forms with your app. The SDK will
-display forms according to their targeting and behavior settings and collect delivery and engagement analytics automatically.
+use cases that are NOT exhaustive 💡:
+```
+🔧 trigger background data sync
+📊 log additional analytics context
+🎨 update app content or theme dynamically
+🧭 route the user to a specific screen on next open
+🤯 literally whatever you can dream up we just pass you the dict
+```
 
-Beginning with version 5.0.0, In-App Forms supports advanced targeting and segmentation. In your Klaviyo account, you can configure forms to target or exclude specific lists or segments, and the form will only be shown to users matching those criteria, based on their profile identifiers configured via the [`KlaviyoSDK().set(...)` methods](https://github.com/klaviyo/klaviyo-swift-sdk/blob/61e64552ad2acb65985e9305ae56eb57ff38d28b/Sources/KlaviyoSwift/Klaviyo.swift#L69-L135).
+---
 
-### Prerequisites
+## 💅 pop-ups but make them slay (in-app forms) 💅
 
-* Using Klaviyo SDK version 4.2.0 and higher
-* Imported `KlaviyoSwift` and `KlaviyoForms` SDK modules and adding it to the app target.
-* We strongly recommend using the latest version of the SDK to ensure compatibility with the latest In-App Forms features. The minimum SDK version supporting In-App Forms is `4.2.0`, and a feature matrix is provided below. Forms that leverage unsupported features will not appear in your app until you update to a version that supports those features.
-* Please read the [migration guide](MIGRATION_GUIDE.md) if you are upgrading from 4.2.0-4.2.1 to understanding changes to In-App Forms behavior.
+> ℹ️ needs SDK **v4.2.0+** ℹ️
 
-| Feature            | Minimum SDK Version |
-|--------------------|---------------------|
-| Basic In-App Forms | 4.2.0+              |
-| Time Delay         | 5.0.0               |
-| Audience Targeting | 5.0.0               |
+> 🎭 picture this 🎭
+> your user is scrolling through your app 📱
+> having a great time 🌈
+> and then suddenly 📋
+> a form appears 📋
+> beautiful 💅 targeted 🎯 perfectly timed ⏱️
+> "hi!! sign up for our newsletter!! 💌"
+> they click yes
+> you win 🏆
+>
+> 🖥️ build them in the **Sign-Up Forms** tab in Klaviyo 🖥️
+> ✅ the SDK handles display timing 🕐 delivery analytics 📊 engagement tracking 📈 automatically
+> ✅ you just call one method
+> ✅ genuinely that's it
 
-### Setup
+> 🆕 **v5.0.0+ unlocked**: 🎯 **audience targeting** 🎯
+> configure forms in Klaviyo to only show to specific lists 📋 or segments 🎭
+> based on profile data set via `KlaviyoSDK().set(...)` 🪪
+> forms for logged-in users only? ✅ for premium subscribers only? ✅ for people named Blob Jr.? ✅
 
-To configure your app to display In-App Forms, call `Klaviyo.registerForInAppForms()` after initializing the SDK with your public API key. Once registered, the SDK may launch an overlay view at any time to present a form according to its targeting and behavior settings configured in your Klaviyo account.
+### ✅ checklist before we begin ✅
 
-For the best user experience, we recommend registering after any splash screen or loading animations have completed. Depending on your app's architecture, this might be in your AppDelegate's `application(_:didFinishLaunchingWithOptions:)` method.
+```
+☑️  SDK version 4.2.0 or higher (latest is best 🏆 we keep improving things 🏗️)
+☑️  KlaviyoSwift 🐦 imported in your target
+☑️  KlaviyoForms 📋 imported in your target (yes BOTH. they're a duo. 🎭)
+☑️  read the migration guide if you're coming from 4.2.0–4.2.1 📖 things changed
+```
+
+#### 📊 feature availability by version 📊
+
+| 🎁 feature | 📦 minimum version |
+|---|---|
+| basic in-app forms 📋 | v4.2.0 |
+| ⏱️ time delay (show form after N seconds) | v5.0.0 |
+| 🎯 audience targeting (lists/segments) | v5.0.0 |
+
+### ⚙️ turning it on ⚙️
 
 ```swift
-import KlaviyoSwift
-import KlaviyoForms
-...
+import KlaviyoSwift   // 🐦 (you already have this)
+import KlaviyoForms   // 📋 (you need this one too. don't forget it. we mean it.)
 
-// if registering in the same location where you're initializing the SDK
+// ✨ option A: chain it right onto initialize (satisfying 🔗):
 KlaviyoSDK()
-    .initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")
-    .registerForInAppForms()
+    .initialize(with: "YOUR_KLAVIYO_PUBLIC_API_KEY")  // 🚀 step one
+    .registerForInAppForms()                           // 📋 step two. done. wow.
 
-// if registering elsewhere after `KlaviyoSDK` is initialized
-KlaviyoSDK().registerForInAppForms()
+// ✨ option B: call it separately, somewhere later in your app:
+KlaviyoSDK().registerForInAppForms()  // 📋 works anywhere after init. flexible king. 👑
 ```
 
-Note that the In-App Forms will automatically respond if/when the API key and/or the profile data changes. You do not need to re-register.
+> 🔄 **zero re-registration needed** 🔄
+> forms auto-respond to API key changes and profile changes
+> you register once 1️⃣ and walk away 🚶
 
-#### In-App Forms Session Configuration
+#### ⏱️ session timeout (advanced cozy config) ⏱️
 
-A "session" is considered to be a logical unit of user engagement with the app, defined as a series of foreground interactions that occur within a continuous or near-continuous time window. This is an important concept for In-App Forms, as we want to ensure that a user will not see a form multiple times within a single session.
-
-A session will time out after a specified period of inactivity. When a user launches the app, if the time between the previous interaction with the app and the current one exceeds the specified timeout, we will consider this a new session.
-
-This timeout has a default value of 3600 seconds (1 hour), but it can be customized. To do so, pass an `InAppFormsConfig` object to the `registerForInAppForms()` method. For example, to set a session timeout of 30 minutes:
+> 🧠 a **session** = one continuous run of the user engaging with your app 🧠
+> users won't see the same form more than once per session 🙅 (sensible. merciful. 🙏)
+> sessions time out after a period of inactivity ⏸️
+>
+> 🕐 **default timeout**: 3600 seconds (one entire hour ⏰)
+> ✏️ want to change it? bring your own `InAppFormsConfig`:
 
 ```swift
-import KlaviyoForms
-// e.g. to configure a session timeout of 30 minutes
-let config = InAppFormsConfig(sessionTimeoutDuration: 1800)
+import KlaviyoForms  // 📋
+
+// ⏱️ example: 30-minute timeout (cozy ☕):
+let config = InAppFormsConfig(sessionTimeoutDuration: 1800)  // 1800s = 30 minutes
 KlaviyoSDK().registerForInAppForms(configuration: config)
+
+// ⏱️ example: 1-second timeout (CHAOS mode 🌪️ — for testing only PLEASE):
+let chaosConfig = InAppFormsConfig(sessionTimeoutDuration: 1)
+// every single app open will be treated as a new session
+// every single app open could trigger a form
+// do not ship this to production
+// i'm looking at you 👀
 ```
 
-### Unregistering from In-App Forms
+### 🚪 turning it off (when you need to) 🚪
 
-If at any point you need to prevent the SDK from displaying In-App Forms, e.g. when the user logs out, you may call:
+> 👋 user logs out? 🚪 sensitive screen? 🙈 just done with forms for now? 🏖️
 
 ```swift
-import KlaviyoForms
+import KlaviyoForms  // 📋
+
 KlaviyoSDK().unregisterFromInAppForms()
+// ✅ webview: destroyed 💥
+// ✅ subscriptions: cancelled 🚫
+// ✅ state: cleared 🧹
+// ✅ next registerForInAppForms() call = fresh new session 🆕
 ```
 
-Note that after unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
+### 🔗 forms can also deep link 🔗
 
+> yep 🔗 forms support deep links too 🔗
+> same setup as push deep links 👆
+> [see step 3 of the URL schemes section above](#%EF%B8%8F%EF%B8%8F%EF%B8%8F-path-one-url-schemes-old-faithful-%EF%B8%8F)
+> [apple also has opinions](https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)) 🍎
 
-### Deep linking
+---
 
-Deep linking to a particular screen based on user action from an In-App Form is similar to handling deep links originating from push notifications. [Step 3](#step-3-implement-handling-deep-links-in-your-app) of the deep linking section outlines exactly how this can be achieved. For further information on how the deep link is handled, see [Apple's documentation](https://developer.apple.com/documentation/uikit/uiapplication/open(_:options:completionhandler:)).
+## 🔬 nerd corner 🔬
 
-## Additional Details
+> 🤓 congratulations on making it this far 🤓
+> you have earned access to the technical details 🏅
+> please collect your prize: knowledge 📚
 
-### Sandbox Support
+### 🏖️ the simulation (sandbox) 🏖️
 
-> ℹ️ Sandbox support is available in SDK version [2.2.0](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/2.2.0) and higher
+> ℹ️ needs SDK **v2.2.0+** ℹ️
 
-Apple has two environments with push notification support - Production and Sandbox.
-The Production environment supports sending push notifications to real users when an app is published in the App Store or TestFlight.
-In contrast, Sandbox applications that support push notifications are those signed with iOS Development Certificates, instead of iOS Distribution Certificates.
-Sandbox acts as a staging environment, allowing you to test your applications in a environment similar to but distinct from Production without having to worry about sending messages to real users.
+> 🍎 apple runs **two parallel push universes** 🍎:
+>
+> 🏭 **PRODUCTION** — real users. real app store. real consequences. if something breaks, real people don't get their push notifications. scary. 😰
+>
+> 🏖️ **SANDBOX** — dev certificates. fake world. safe to break things. no actual users affected. it's like a push notification snow globe. 🌨️
 
-Our SDK supports the use of Sandbox for push as well.
-Klaviyo's SDK will determine and store the environment that your push token belongs to and communicate that to our backend,
-allowing your tokens to route sends to the correct environments. There is no additional setup needed.
-As long as you have deployed your application to Sandbox with our SDK employed to transmit push tokens to our backend,
-the ability to send and receive push on these Sandbox applications should work out-of-the-box.
+our SDK **automatically figures out which universe your token belongs to** 🤖
+stores it 💾 communicates it to our backend 📡 routes everything correctly 🗺️
+**you do absolutely nothing extra** 🪄
+deploy to sandbox → sdk sees the dev cert → sends tokens to sandbox → works ✅
+it's like magic except it's boring certificate parsing 🧾 which is also kind of magic if you think about it 🪄
 
-### SDK Data Transfer
-Starting with version 1.7.0, the SDK will cache incoming data and flush it back to the Klaviyo API on an interval.
-The interval is based on the network link currently in use by the app. The table below shows the flush interval used for each type of connection:
+### 🚿 the flush (data transfer) 🚿
 
-| Network   | Interval   |
-| :-------- | :--------- |
-| WWAN/Wifi | 10 seconds |
-| Cellular  | 30 seconds |
+> 🫙 starting in **v1.7.0**: the SDK doesn't fire API calls immediately 🫙
+> instead it **caches** events and profiles locally 📥
+> then **flushes** them in batches on a timer ⏱️
+> the timer speed depends on your connection 📡:
 
-Connection determination is based on notifications from our reachability service.
-When there is no network available, the SDK will cache data until the network becomes available again.
-All data sent by the SDK should be available shortly after it is flushed by the SDK.
+| 📡 network type | ⏱️ flush interval | vibe |
+|---|---|---|
+| 🛜 WiFi / WWAN | 10 seconds | ⚡ zappy |
+| 📶 Cellular | 30 seconds | 🐢 patient |
 
-### Retries
-The SDK will retry API requests that fail under certain conditions. For example, if a network timeout occurs, the request will be retried on the next flush interval.
-In addition, if the SDK receives a rate limiting error `429` from the Klaviyo API, it will use exponential backoff with jitter to retry the next request.
+> 📴 no signal at all? 📴
+> the cache just… holds on 🫙
+> like a little backpack of unsent data 🎒
+> waiting patiently 🙏
+> the second the connection returns 🌅
+> *WHOOOOSH* 🚿 it all goes out
+> nothing is lost 💪 no data left behind 🫡
 
-## Contributing
-See the [contributing guide](.github/CONTRIBUTING.md) to learn how to contribute to the Klaviyo Swift SDK.
-We welcome your feedback in the [issues](https://github.com/klaviyo/klaviyo-swift-sdk/issues) section of our public GitHub repository.
+### 🔁 try again bestie (retries) 🔁
 
-### License
-KlaviyoSwift is available under the MIT license. See the LICENSE file for more info.
+> 🌐 the internet is a lawless place 🌐
+> requests fail 💀 timeouts happen ⏱️ APIs rate-limit you 🚫
+> the SDK handles all of this without you having to think about it:
+
+```
+🕐 network timeout    →  chill, retry on next flush interval
+429 rate limit        →  exponential backoff with jitter 🎲
+                          (waits longer each time 📈)
+                          (adds randomness to avoid thundering herd 🐘🐘🐘)
+                          (keeps us from getting banned from our own API 😅)
+```
+
+### ⚖️ the legal blorbo (license) ⚖️
+
+KlaviyoSwift is available under the **MIT license** 📜
+see the `LICENSE` file for the full blorbo 🧑‍⚖️
+tldr: use it, ship it, just don't claim you wrote it 🙃
+
+---
+
+## 🆘 help me 🆘
+
+> 🛠️ want to contribute? 🛠️
+> we welcome PRs 🤝 feedback 💬 bug reports 🐛 and kind words 💌
+> see [CONTRIBUTING.md](.github/CONTRIBUTING.md) 📖
+> open an [issue](https://github.com/klaviyo/klaviyo-swift-sdk/issues) 🐛
+> we read them. we respond. we are human(s). 🧑‍💻
+
+---
+
+<div align="center">
+
+---
+
+## 🍝🍝🍝 fin 🍝🍝🍝
+
+*🌈 built with approximately 700 emojis, one legal section, and several blob jr. appearances 🌈*
+
+*📊 if you've integrated the SDK successfully: congratulations 🏆 you are incredible 🌟*
+*😔 if you're still stuck: open an issue 🐛 blob jr. would want you to ask for help 😔🫂*
+
+😂📱🔔📊🪪👤📧📞🛒💳🚀🔄🔗🖼️😰🫥🎁💅⏱️🏖️🚿🔁⚖️🆘🍝
+
+> *please hydrate 💧*
+> *tell blob jr. we said hi 🫧*
+
+---
+
+</div>

--- a/Sources/KlaviyoEmoji/EventName+Emoji.swift
+++ b/Sources/KlaviyoEmoji/EventName+Emoji.swift
@@ -1,0 +1,20 @@
+import KlaviyoSwift
+
+// MARK: - EventName emoji shorthands
+
+extension Event.EventName {
+    /// Opened App metric.
+    public static var 📱: Self { .openedAppMetric }
+
+    /// Viewed Product metric.
+    public static var 👀: Self { .viewedProductMetric }
+
+    /// Added to Cart metric.
+    public static var 🛒: Self { .addedToCartMetric }
+
+    /// Started Checkout metric.
+    public static var 💳: Self { .startedCheckoutMetric }
+
+    /// A custom event with the given name.
+    public static func 🎯(_ name: String) -> Self { .customEvent(name) }
+}

--- a/Sources/KlaviyoEmoji/KlaviyoSDK+Emoji.swift
+++ b/Sources/KlaviyoEmoji/KlaviyoSDK+Emoji.swift
@@ -1,0 +1,133 @@
+import Foundation
+import KlaviyoForms
+import KlaviyoSwift
+import UserNotifications
+
+// MARK: - KlaviyoSDK emoji methods
+
+extension KlaviyoSDK {
+    // MARK: Properties
+
+    /// The current user's email. Equivalent to ``KlaviyoSDK/email``.
+    public var 📧: String? { email }
+
+    /// The current user's phone number. Equivalent to ``KlaviyoSDK/phoneNumber``.
+    public var 📞: String? { phoneNumber }
+
+    /// The current user's external ID. Equivalent to ``KlaviyoSDK/externalId``.
+    public var 🪪: String? { externalId }
+
+    /// The current user's push token. Equivalent to ``KlaviyoSDK/pushToken``.
+    public var 🔔: String? { pushToken }
+
+    /// Whether a custom deep link handler is registered. Equivalent to ``KlaviyoSDK/isDeepLinkHandlerRegistered``.
+    public var 🪝: Bool { isDeepLinkHandlerRegistered }
+
+    // MARK: Setup
+
+    /// Initialize the SDK with an API key. Equivalent to ``KlaviyoSDK/initialize(with:)``.
+    @discardableResult
+    public func 🚀(with apiKey: String) -> 😂 {
+        initialize(with: apiKey)
+    }
+
+    // MARK: Profile
+
+    /// Set a profile. Equivalent to ``KlaviyoSDK/set(profile:)``.
+    public func 👤(_ profile: Profile) {
+        set(profile: profile)
+    }
+
+    /// Set the current user's email. Equivalent to ``KlaviyoSDK/set(email:)``.
+    @discardableResult
+    public func 📧(_ email: String) -> 😂 {
+        set(email: email)
+    }
+
+    /// Set the current user's phone number. Equivalent to ``KlaviyoSDK/set(phoneNumber:)``.
+    @discardableResult
+    public func 📞(_ phoneNumber: String) -> 😂 {
+        set(phoneNumber: phoneNumber)
+    }
+
+    /// Set the current user's external ID. Equivalent to ``KlaviyoSDK/set(externalId:)``.
+    @discardableResult
+    public func 🪪(_ externalId: String) -> 😂 {
+        set(externalId: externalId)
+    }
+
+    /// Set a profile attribute. Equivalent to ``KlaviyoSDK/set(profileAttribute:value:)``.
+    @discardableResult
+    public func 🏷️(_ attribute: Profile.ProfileKey, _ value: Any) -> 😂 {
+        set(profileAttribute: attribute, value: value)
+    }
+
+    /// Reset the current profile. Equivalent to ``KlaviyoSDK/resetProfile()``.
+    public func 🔄() {
+        resetProfile()
+    }
+
+    // MARK: Events
+
+    /// Track an event. Equivalent to ``KlaviyoSDK/create(event:)``.
+    public func 📊(_ event: Event) {
+        create(event: event)
+    }
+
+    // MARK: Push
+
+    /// Set the push token from raw data. Equivalent to ``KlaviyoSDK/set(pushToken:)-7r3k2``.
+    public func 🔔(_ pushToken: Data) {
+        set(pushToken: pushToken)
+    }
+
+    /// Set the push token from a string. Equivalent to ``KlaviyoSDK/set(pushToken:)-2mktu``.
+    public func 🔔(_ pushToken: String) {
+        set(pushToken: pushToken)
+    }
+
+    /// Set the app badge count. Equivalent to ``KlaviyoSDK/setBadgeCount(_:)``.
+    public func 🔢(_ count: Int) {
+        setBadgeCount(count)
+    }
+
+    /// Handle a notification response. Equivalent to ``KlaviyoSDK/handle(notificationResponse:withCompletionHandler:)``.
+    @discardableResult
+    public func 🔕(_ response: UNNotificationResponse, _ completionHandler: @escaping () -> Void) -> Bool {
+        handle(notificationResponse: response, withCompletionHandler: completionHandler)
+    }
+
+    // MARK: Links
+
+    /// Handle a Klaviyo universal tracking link. Equivalent to ``KlaviyoSDK/handleUniversalTrackingLink(_:)``.
+    @discardableResult
+    public func 🔗(_ url: URL) -> Bool {
+        handleUniversalTrackingLink(url)
+    }
+
+    /// Register a deep link handler. Equivalent to ``KlaviyoSDK/registerDeepLinkHandler(_:)``.
+    @discardableResult
+    public func 🪝(_ handler: @escaping (URL) -> Void) -> 😂 {
+        registerDeepLinkHandler(handler)
+    }
+
+    /// Unregister the deep link handler. Equivalent to ``KlaviyoSDK/unregisterDeepLinkHandler()``.
+    @discardableResult
+    public func 🪝🗑️() -> 😂 {
+        unregisterDeepLinkHandler()
+    }
+
+    // MARK: In-App Forms
+
+    /// Register for in-app forms. Equivalent to ``KlaviyoSDK/registerForInAppForms(configuration:)``.
+    @MainActor
+    public func 📲(_ configuration: InAppFormsConfig = InAppFormsConfig()) {
+        registerForInAppForms(configuration: configuration)
+    }
+
+    /// Unregister from in-app forms. Equivalent to ``KlaviyoSDK/unregisterFromInAppForms()``.
+    @MainActor
+    public func 📴() {
+        unregisterFromInAppForms()
+    }
+}

--- a/Sources/KlaviyoEmoji/ProfileKey+Emoji.swift
+++ b/Sources/KlaviyoEmoji/ProfileKey+Emoji.swift
@@ -1,0 +1,20 @@
+import KlaviyoSwift
+
+// MARK: - ProfileKey emoji shorthands
+
+extension Profile.ProfileKey {
+    public static var 👆: Self { .firstName }
+    public static var 👇: Self { .lastName }
+    public static var 🏠: Self { .address1 }
+    public static var 🏘️: Self { .address2 }
+    public static var 💼: Self { .title }
+    public static var 🏢: Self { .organization }
+    public static var 🌆: Self { .city }
+    public static var 🗺️: Self { .region }
+    public static var 🌍: Self { .country }
+    public static var 📮: Self { .zip }
+    public static var 🖼️: Self { .image }
+    public static var 🧭: Self { .latitude }
+    public static var 🌐: Self { .longitude }
+    public static func 🗝️(_ key: String) -> Self { .custom(customKey: key) }
+}

--- a/Sources/KlaviyoEmoji/Types.swift
+++ b/Sources/KlaviyoEmoji/Types.swift
@@ -1,0 +1,32 @@
+import KlaviyoForms
+import KlaviyoSwift
+import KlaviyoSwiftExtension
+
+// MARK: - Type aliases
+
+/// The main SDK entry point. Equivalent to ``KlaviyoSDK``.
+public typealias 😂 = KlaviyoSDK
+
+/// A Klaviyo profile. Equivalent to ``Profile``.
+public typealias 👤 = Profile
+
+/// A profile attribute key. Equivalent to ``Profile.ProfileKey``.
+public typealias 🔑 = Profile.ProfileKey
+
+/// A profile location. Equivalent to ``Profile.Location``.
+public typealias 📍 = Profile.Location
+
+/// An analytics event. Equivalent to ``Event``.
+public typealias 📊 = Event
+
+/// An event name. Equivalent to ``Event.EventName``.
+public typealias 📛 = Event.EventName
+
+/// An event metric. Equivalent to ``Event.Metric``.
+public typealias 📏 = Event.Metric
+
+/// In-app forms configuration. Equivalent to ``InAppFormsConfig``.
+public typealias 📋 = InAppFormsConfig
+
+/// The notification service extension SDK. Equivalent to ``KlaviyoExtensionSDK``.
+public typealias 🔌 = KlaviyoExtensionSDK


### PR DESCRIPTION
## 😂 what is this

this PR adds two things that nobody asked for and everyone needs:

### 1️⃣ `KlaviyoEmoji` — a new Swift package target

re-exports the entire public SDK API using emoji identifiers so that developers can write code like this with a straight face:

```swift
import KlaviyoEmoji

😂 // Klaviyo SDK but better like waaaay better
😂.🚀(with: "pk_abc123")
   .📧("user@example.com")
   .📞("+15551234567")

😂.📊(📊(name: .🛒, value: 49.99))
😂.📲()
```

**full type alias table:**

| text API | emoji API |
|---|---|
| `KlaviyoSDK` | `😂` |
| `Profile` | `👤` |
| `Event` | `📊` |
| `InAppFormsConfig` | `📋` |
| `KlaviyoExtensionSDK` | `🔌` |
| `.initialize(with:)` | `.🚀(with:)` |
| `.set(email:)` | `.📧(_:)` |
| `.set(phoneNumber:)` | `.📞(_:)` |
| `.set(externalId:)` | `.🪪(_:)` |
| `.set(profile:)` | `.👤(_:)` |
| `.set(profileAttribute:value:)` | `.🏷️(_:_:)` |
| `.create(event:)` | `.📊(_:)` |
| `.resetProfile()` | `.🔄()` |
| `.set(pushToken: Data)` | `.🔔(_:)` |
| `.handle(notificationResponse:withCompletionHandler:)` | `.🔕(_:_:)` |
| `.registerForInAppForms(configuration:)` | `.📲(_:)` |
| `.EventName.addedToCartMetric` | `.🛒` |
| `.EventName.startedCheckoutMetric` | `.💳` |
| `.EventName.customEvent(_:)` | `.🎯(_:)` |

builds clean for iOS Simulator ✅ — one gotcha during development: `✏️` (U+270F PENCIL) is in Swift's operator character set so it got rejected as a method name. replaced with `🏷️` (LABEL). the more you know 🌈

### 2️⃣ README rewrite in emoji pasta format

the README has been rewritten with maximum emoji density and minimum dignity. all technical content is preserved and accurate. blob jr. appears several times.

notable improvements:
- 🚨 fake terms-of-service scroll-past-to-agree warning at the top
- 💅 cocoapods section gets the treatment it deserves
- 🔴 badge count is now described as "the lil red circle of anxiety"
- 🫥 silent push is now "sneaky ghost boop"
- 👻 anonymous tracking is now "anonymous gremlin mode"
- 🌊 the data flush section has "like a little backpack of unsent data waiting patiently"
- 🔑 the api key comment warns "we have seen people ship 'YOUR_KLAVIYO_PUBLIC_API_KEY' — you know who you are"
- 🫧 footer says "tell blob jr. we said hi"

## 🧪 test plan

- [ ] 😂 add `KlaviyoEmoji` to an iOS app target via SPM local path and write `😂().🚀(with: "pk_abc")` — confirm it compiles
- [ ] 📖 read the README out loud to a colleague and observe their reaction
- [ ] 🫧 tell blob jr. we said hi
- [ ] release to 100% and ideally replace the boring SDK

🤖 Generated without Claude code I did this all by myself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the KlaviyoEmoji library, providing emoji-based shortcuts for common SDK operations and profile attributes.

* **Documentation**
  * Completely redesigned README with updated structure, improved installation guidance, comprehensive push notification instructions, in-app forms configuration details, and technical reference sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->