### PR TITLE
feat(PUSH-834): loosen open_url scheme gate to allowlist

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -99,7 +99,9 @@ let package = Package(
         .testTarget(
             name: "KlaviyoSwiftExtensionTests",
             dependencies: [
-                "KlaviyoSwiftExtension"
+                "KlaviyoSwiftExtension",
+                // Test-only: lets the allowlist parity test compare against the KlaviyoCore copy.
+                "KlaviyoCore"
             ]
         ),
         .target(

--- a/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
@@ -16,4 +16,8 @@ import Foundation
 /// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
 /// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
 /// are silently dropped.
-package let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "smsto"]
+///
+/// Note: `smsto:` is intentionally excluded (unlike the Android SDK). iOS Messages only
+/// registers `sms:`; `smsto:` has no iOS handler, so `UIApplication.shared.open(_:)` would
+/// no-op. Use `sms:` for SMS on iOS.
+package let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms"]

--- a/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
@@ -1,0 +1,19 @@
+//
+//  URLSchemeAllowlist.swift
+//  klaviyo-swift-sdk
+//
+
+// NOTE: KlaviyoSwiftExtension carries an internal copy of this constant
+// (Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift) because that target cannot
+// depend on KlaviyoCore (NSE/share-extension sandbox restriction). The two
+// copies are intentionally kept in sync. If you change the set here, mirror
+// the change there.
+
+import Foundation
+
+/// URL schemes allowed for the `open_url` push action.
+///
+/// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
+/// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
+/// are silently dropped.
+package let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "smsto"]

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -337,6 +337,14 @@ public struct KlaviyoSDK {
                 dispatchOnMainThread(action: .openDeepLink(url))
             case .openUrl:
                 actionProperties["Button Link"] = url.absoluteString
+                guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+                    if #available(iOS 14.0, *) {
+                        Logger.notifications.warning(
+                            "Action button open_url scheme not in the allowed list; ignoring."
+                        )
+                    }
+                    break
+                }
                 dispatchOnMainThread(action: .openWebUrl(url))
             case .openApp, .none:
                 break

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -107,7 +107,9 @@ extension UNNotificationResponse {
 
         guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.warning("web_url '\(urlString)' has a scheme not in the allowed list; ignoring.")
+                Logger.notifications.warning(
+                    "web_url '\(urlString)' has a scheme not in the allowed list; ignoring."
+                )
             }
             return nil
         }

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -85,10 +85,10 @@ extension UNNotificationResponse {
     /// Returns the external web URL from a Klaviyo notification payload, if present.
     ///
     /// Reads the `web_url` field. The presence of this field indicates the tap should open
-    /// the URL in the system browser rather than route through the app's deep link handler.
+    /// the URL externally rather than route through the app's deep link handler.
     /// Returns `nil` if the field is absent, the value is not a parseable URL, or the URL's
-    /// scheme is not http(s) — non-web schemes are rejected to prevent routing back into the
-    /// app via the system URL opener.
+    /// scheme is not in ``openUrlAllowedSchemes`` — unlisted schemes are dropped silently to
+    /// prevent dangerous schemes (e.g. `javascript:`, `file:`) from being opened.
     var klaviyoWebUrl: URL? {
         guard isKlaviyoNotification else {
             return nil
@@ -105,9 +105,9 @@ extension UNNotificationResponse {
             return nil
         }
 
-        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+        guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.warning("web_url '\(urlString)' has non-web scheme; ignoring.")
+                Logger.notifications.warning("web_url '\(urlString)' has a scheme not in the allowed list; ignoring.")
             }
             return nil
         }

--- a/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
@@ -108,8 +108,8 @@ enum KlaviyoActionButtonParser {
     ///
     /// - `.openApp` actions should not have a URL
     /// - `.deepLink` actions must have a parseable URL
-    /// - `.openUrl` actions must have a parseable URL with an http(s) scheme — non-web
-    ///   schemes are rejected to prevent the system URL opener from routing back into the app
+    /// - `.openUrl` actions must have a parseable URL whose scheme is in ``openUrlAllowedSchemes`` —
+    ///   unlisted schemes (e.g. `javascript:`, `file:`, `intent:`) are rejected silently
     ///
     /// - Parameters:
     ///   - action: The action type to validate
@@ -125,7 +125,7 @@ enum KlaviyoActionButtonParser {
         case .openUrl:
             guard let urlString = url, let parsedUrl = URL(string: urlString) else { return false }
             guard let scheme = parsedUrl.scheme?.lowercased() else { return false }
-            return ["http", "https"].contains(scheme)
+            return openUrlAllowedSchemes.contains(scheme)
         }
     }
 

--- a/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
@@ -1,0 +1,19 @@
+//
+//  URLSchemeAllowlist.swift
+//  klaviyo-swift-sdk
+//
+
+// NOTE: KlaviyoCore carries the authoritative copy of this constant
+// (Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift). This internal copy exists
+// because KlaviyoSwiftExtension cannot depend on KlaviyoCore (NSE/share-extension
+// sandbox restriction). The two copies are intentionally kept in sync. If you
+// change the set here, mirror the change there.
+
+import Foundation
+
+/// URL schemes allowed for the `open_url` push action.
+///
+/// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
+/// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
+/// are silently dropped.
+let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "smsto"]

--- a/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
@@ -16,4 +16,8 @@ import Foundation
 /// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
 /// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
 /// are silently dropped.
-let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms", "smsto"]
+///
+/// Note: `smsto:` is intentionally excluded (unlike the Android SDK). iOS Messages only
+/// registers `sms:`; `smsto:` has no iOS handler, so `UIApplication.shared.open(_:)` would
+/// no-op. Use `sms:` for SMS on iOS.
+let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms"]

--- a/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
@@ -358,7 +358,7 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
     }
 
-    // MARK: - Allowlisted non-web open_url schemes (PUSH-834)
+    // MARK: - Allowlisted non-web open_url schemes
 
     func testParseActionButtons_AcceptsOpenUrlWithMailtoScheme() {
         let userInfo: [AnyHashable: Any] = [

--- a/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
@@ -329,22 +329,17 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
     }
 
-    func testParseActionButtons_SkipsOpenUrlWithNonHttpScheme() {
+    func testParseActionButtons_SkipsOpenUrlWithBlockedScheme() {
+        // Custom app schemes and other non-allowlisted schemes must be rejected.
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
                 "action_buttons": [
                     [
-                        "id": "com.klaviyo.test.openurl_deeplink",
+                        "id": "com.klaviyo.test.openurl_custom_scheme",
                         "label": "Bad",
                         "action": "open_url",
                         "url": "klaviyotest://forms"
-                    ],
-                    [
-                        "id": "com.klaviyo.test.openurl_mailto",
-                        "label": "Also Bad",
-                        "action": "open_url",
-                        "url": "mailto:test@example.com"
                     ],
                     [
                         "id": "com.klaviyo.test.valid",
@@ -359,7 +354,131 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
         XCTAssertNotNil(result, "Should return valid buttons")
-        XCTAssertEqual(result?.count, 1, "Should skip open_url buttons with non-http(s) schemes")
+        XCTAssertEqual(result?.count, 1, "Should skip open_url buttons with blocked schemes")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    // MARK: - Allowlisted non-web open_url schemes (PUSH-834)
+
+    func testParseActionButtons_AcceptsOpenUrlWithMailtoScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.mailto",
+                        "label": "Email Us",
+                        "action": "open_url",
+                        "url": "mailto:support@example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "mailto: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.mailto")
+        XCTAssertEqual(result?.first?.url, "mailto:support@example.com")
+    }
+
+    func testParseActionButtons_AcceptsOpenUrlWithTelScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.tel",
+                        "label": "Call Us",
+                        "action": "open_url",
+                        "url": "tel:+15551234567"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "tel: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.tel")
+        XCTAssertEqual(result?.first?.url, "tel:+15551234567")
+    }
+
+    func testParseActionButtons_AcceptsOpenUrlWithSmsScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.sms",
+                        "label": "Text Us",
+                        "action": "open_url",
+                        "url": "sms:+15551234567"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "sms: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.sms")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithIntentScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.intent",
+                        "label": "Bad",
+                        "action": "open_url",
+                        "url": "intent://example"
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertEqual(result?.count, 1, "intent: should be blocked")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithJavascriptScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.js",
+                        "label": "Bad",
+                        "action": "open_url",
+                        "url": "javascript:alert(1)"
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertEqual(result?.count, 1, "javascript: should be blocked")
         XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
     }
 

--- a/Tests/KlaviyoSwiftExtensionTests/URLSchemeAllowlistParityTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/URLSchemeAllowlistParityTests.swift
@@ -1,0 +1,16 @@
+@testable import KlaviyoSwiftExtension
+import KlaviyoCore
+import XCTest
+
+/// `openUrlAllowedSchemes` is intentionally duplicated in KlaviyoCore and KlaviyoSwiftExtension
+/// because the extension target cannot depend on KlaviyoCore. This test fails if the two copies
+/// drift, which would let the NSE and the main app disagree on which `open_url` schemes are allowed.
+final class URLSchemeAllowlistParityTests: XCTestCase {
+    func testExtensionAllowlistMatchesCoreAllowlist() {
+        XCTAssertEqual(
+            KlaviyoSwiftExtension.openUrlAllowedSchemes,
+            KlaviyoCore.openUrlAllowedSchemes,
+            "openUrlAllowedSchemes copies in KlaviyoCore and KlaviyoSwiftExtension must stay in sync."
+        )
+    }
+}

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -171,6 +171,110 @@ final class DeepLinkHandlingTests: XCTestCase {
         klaviyoSwiftEnvironment.send = originalSend
     }
 
+    // MARK: - open_url with allowlisted non-web schemes (PUSH-834)
+
+    @MainActor
+    func testHandleNotificationResponseDispatchesOpenWebUrlForMailtoWebUrl() async throws {
+        let urlString = "mailto:support@example.com"
+        let expectedURL = try XCTUnwrap(URL(string: urlString))
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        let completionCalled = expectation(description: "completion handler called")
+        let actionReceived = expectation(description: "openWebUrl action received for mailto:")
+        let originalSend = klaviyoSwiftEnvironment.send
+        klaviyoSwiftEnvironment.send = { action in
+            if case let .openWebUrl(url) = action {
+                XCTAssertEqual(url, expectedURL, "Should dispatch openWebUrl with mailto: URL")
+                actionReceived.fulfill()
+                return nil
+            }
+            return originalSend(action)
+        }
+
+        let sdk = KlaviyoSDK()
+        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        })
+
+        XCTAssertTrue(result, "SDK should return true for Klaviyo notifications with web_url")
+        await fulfillment(of: [completionCalled, actionReceived], timeout: 1.0)
+
+        klaviyoSwiftEnvironment.send = originalSend
+    }
+
+    @MainActor
+    func testHandleNotificationResponseDispatchesOpenWebUrlForTelWebUrl() async throws {
+        let urlString = "tel:+15551234567"
+        let expectedURL = try XCTUnwrap(URL(string: urlString))
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        let completionCalled = expectation(description: "completion handler called")
+        let actionReceived = expectation(description: "openWebUrl action received for tel:")
+        let originalSend = klaviyoSwiftEnvironment.send
+        klaviyoSwiftEnvironment.send = { action in
+            if case let .openWebUrl(url) = action {
+                XCTAssertEqual(url, expectedURL, "Should dispatch openWebUrl with tel: URL")
+                actionReceived.fulfill()
+                return nil
+            }
+            return originalSend(action)
+        }
+
+        let sdk = KlaviyoSDK()
+        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        })
+
+        XCTAssertTrue(result, "SDK should return true for Klaviyo notifications with web_url")
+        await fulfillment(of: [completionCalled, actionReceived], timeout: 1.0)
+
+        klaviyoSwiftEnvironment.send = originalSend
+    }
+
+    @MainActor
+    func testHandleNotificationResponseDropsBlockedSchemeWebUrl() async throws {
+        // javascript: is a blocked scheme — the notification should be dropped silently
+        // (handle returns false because there's no recognized URL to act on).
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": "javascript:alert(1)"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        let sdk = KlaviyoSDK()
+
+        var openWebUrlDispatched = false
+        let originalSend = klaviyoSwiftEnvironment.send
+        klaviyoSwiftEnvironment.send = { action in
+            if case .openWebUrl = action {
+                openWebUrlDispatched = true
+            }
+            return originalSend(action)
+        }
+
+        _ = sdk.handle(notificationResponse: response, withCompletionHandler: {})
+
+        // Give time for any async dispatch to land
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertFalse(openWebUrlDispatched, "Blocked scheme must not dispatch openWebUrl")
+
+        klaviyoSwiftEnvironment.send = originalSend
+    }
+
     // MARK: - TCA State Management Tests
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -171,7 +171,7 @@ final class DeepLinkHandlingTests: XCTestCase {
         klaviyoSwiftEnvironment.send = originalSend
     }
 
-    // MARK: - open_url with allowlisted non-web schemes (PUSH-834)
+    // MARK: - open_url with allowlisted non-web schemes
 
     @MainActor
     func testHandleNotificationResponseDispatchesOpenWebUrlForMailtoWebUrl() async throws {

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -189,16 +189,16 @@ final class DeepLinkHandlingTests: XCTestCase {
         let actionReceived = expectation(description: "openWebUrl action received for mailto:")
         let originalSend = klaviyoSwiftEnvironment.send
         klaviyoSwiftEnvironment.send = { action in
-            if case let .openWebUrl(url) = action {
-                XCTAssertEqual(url, expectedURL, "Should dispatch openWebUrl with mailto: URL")
+            if case let .openWebUrl(dispatchedUrl) = action {
+                XCTAssertEqual(dispatchedUrl, expectedURL, "Should dispatch openWebUrl with mailto: URL")
                 actionReceived.fulfill()
                 return nil
             }
             return originalSend(action)
         }
 
-        let sdk = KlaviyoSDK()
-        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {
             completionCalled.fulfill()
         })
 
@@ -224,16 +224,16 @@ final class DeepLinkHandlingTests: XCTestCase {
         let actionReceived = expectation(description: "openWebUrl action received for tel:")
         let originalSend = klaviyoSwiftEnvironment.send
         klaviyoSwiftEnvironment.send = { action in
-            if case let .openWebUrl(url) = action {
-                XCTAssertEqual(url, expectedURL, "Should dispatch openWebUrl with tel: URL")
+            if case let .openWebUrl(dispatchedUrl) = action {
+                XCTAssertEqual(dispatchedUrl, expectedURL, "Should dispatch openWebUrl with tel: URL")
                 actionReceived.fulfill()
                 return nil
             }
             return originalSend(action)
         }
 
-        let sdk = KlaviyoSDK()
-        let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {
             completionCalled.fulfill()
         })
 

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -244,9 +244,11 @@ final class DeepLinkHandlingTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleNotificationResponseDropsBlockedSchemeWebUrl() async throws {
-        // javascript: is a blocked scheme — the notification should be dropped silently
-        // (handle returns false because there's no recognized URL to act on).
+    func testHandleNotificationResponseDropsBlockedSchemeWebUrl() throws {
+        // javascript: is a blocked scheme — the gate is the synchronous klaviyoWebUrl
+        // property, and resolveOpenAction only dispatches .openWebUrl when it is non-nil
+        // (positive dispatch coverage in the mailto:/tel: tests above). handle still
+        // returns true: it is a valid Klaviyo notification, it just takes no open action.
         let userInfo: [AnyHashable: Any] = [
             "body": ["_k": "1"],
             "web_url": "javascript:alert(1)"
@@ -255,24 +257,11 @@ final class DeepLinkHandlingTests: XCTestCase {
 
         environment.linkHandler.unregisterCustomHandler()
 
-        let sdk = KlaviyoSDK()
+        XCTAssertNil(response.klaviyoWebUrl, "Blocked scheme must not produce a web URL")
 
-        var openWebUrlDispatched = false
-        let originalSend = klaviyoSwiftEnvironment.send
-        klaviyoSwiftEnvironment.send = { action in
-            if case .openWebUrl = action {
-                openWebUrlDispatched = true
-            }
-            return originalSend(action)
-        }
-
-        _ = sdk.handle(notificationResponse: response, withCompletionHandler: {})
-
-        // Give time for any async dispatch to land
-        try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertFalse(openWebUrlDispatched, "Blocked scheme must not dispatch openWebUrl")
-
-        klaviyoSwiftEnvironment.send = originalSend
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {})
+        XCTAssertTrue(result, "Klaviyo notification is still handled; it just takes no open action")
     }
 
     // MARK: - TCA State Management Tests

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -646,4 +646,57 @@ class KlaviyoSDKTests: XCTestCase {
             XCTAssertEqual(event.properties["Button Link"] as? String, actionURL.absoluteString)
         }
     }
+
+    func testHandleActionButtonTap_OpenUrlButtonWithBlockedSchemeDoesNotDispatch() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let actionURL = try XCTUnwrap(URL(string: "javascript:alert(1)"))
+        let actionId = "com.klaviyo.test.blocked"
+        let buttonLabel = "Bad Button"
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": "test_open_url_blocked",
+                "action_buttons": [
+                    [
+                        "id": actionId,
+                        "label": buttonLabel,
+                        "action": "open_url",
+                        "url": actionURL.absoluteString
+                    ]
+                ]
+            ]
+        ]
+
+        var capturedActions: [KlaviyoAction] = []
+        klaviyoSwiftEnvironment.send = { action in
+            capturedActions.append(action)
+            return nil
+        }
+
+        let response = try UNNotificationResponse.with(
+            userInfo: userInfo,
+            actionIdentifier: actionId
+        )
+
+        let handled = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback], timeout: 1.0)
+        XCTAssertTrue(handled)
+
+        let webUrlDispatched = capturedActions.contains { action in
+            if case .openWebUrl = action { return true }
+            return false
+        }
+        XCTAssertFalse(webUrlDispatched, "Should not dispatch .openWebUrl for a blocked scheme")
+
+        let eventAction = capturedActions.first { action in
+            if case let .enqueueEvent(event) = action {
+                return event.metric.name == ._openedPush
+            }
+            return false
+        }
+        XCTAssertNotNil(eventAction, "Tap should still be tracked even when the scheme is blocked")
+    }
 }

--- a/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
@@ -299,16 +299,18 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "sms:+15551234567")
     }
 
-    func testKlaviyoWebUrl_WithSmstoScheme_ReturnsURL() throws {
+    // MARK: - Blocked schemes
+
+    func testKlaviyoWebUrl_WithSmstoScheme_ReturnsNil() throws {
+        // smsto: is Android-only; iOS Messages registers sms: but not smsto:, so it is
+        // deliberately absent from the iOS allowlist and dropped here.
         let payload: [AnyHashable: Any] = [
             "body": ["_k": "some-value"],
             "web_url": "smsto:+15551234567"
         ]
         let response = try UNNotificationResponse.with(userInfo: payload)
-        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "smsto:+15551234567")
+        XCTAssertNil(response.klaviyoWebUrl)
     }
-
-    // MARK: - Blocked schemes
 
     func testKlaviyoWebUrl_WithIntentScheme_ReturnsNil() throws {
         let payload: [AnyHashable: Any] = [

--- a/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
@@ -270,7 +270,7 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "http://example.com")
     }
 
-    // MARK: - Allowlisted non-web schemes (PUSH-834)
+    // MARK: - Allowlisted non-web schemes
 
     func testKlaviyoWebUrl_WithMailtoScheme_ReturnsURL() throws {
         let payload: [AnyHashable: Any] = [
@@ -308,7 +308,7 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "smsto:+15551234567")
     }
 
-    // MARK: - Blocked schemes (PUSH-834)
+    // MARK: - Blocked schemes
 
     func testKlaviyoWebUrl_WithIntentScheme_ReturnsNil() throws {
         let payload: [AnyHashable: Any] = [

--- a/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
@@ -261,15 +261,6 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         XCTAssertNil(response.klaviyoWebUrl)
     }
 
-    func testKlaviyoWebUrl_WithMailtoScheme_ReturnsNil() throws {
-        let payload: [AnyHashable: Any] = [
-            "body": ["_k": "some-value"],
-            "web_url": "mailto:test@example.com"
-        ]
-        let response = try UNNotificationResponse.with(userInfo: payload)
-        XCTAssertNil(response.klaviyoWebUrl)
-    }
-
     func testKlaviyoWebUrl_WithHttpScheme_ReturnsURL() throws {
         let payload: [AnyHashable: Any] = [
             "body": ["_k": "some-value"],
@@ -277,5 +268,72 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         ]
         let response = try UNNotificationResponse.with(userInfo: payload)
         XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "http://example.com")
+    }
+
+    // MARK: - Allowlisted non-web schemes (PUSH-834)
+
+    func testKlaviyoWebUrl_WithMailtoScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "mailto:test@example.com"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "mailto:test@example.com")
+    }
+
+    func testKlaviyoWebUrl_WithTelScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "tel:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "tel:+15551234567")
+    }
+
+    func testKlaviyoWebUrl_WithSmsScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "sms:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "sms:+15551234567")
+    }
+
+    func testKlaviyoWebUrl_WithSmstoScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "smsto:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "smsto:+15551234567")
+    }
+
+    // MARK: - Blocked schemes (PUSH-834)
+
+    func testKlaviyoWebUrl_WithIntentScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "intent://scan/#Intent;scheme=zxing;package=com.example;end"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithJavascriptScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "javascript:alert(1)"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithFileScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "file:///etc/passwd"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
     }
 }


### PR DESCRIPTION
## Summary
Loosen the open_url action's http/https gate to an allowlist supporting mailto:, tel:, sms: in addition to web schemes. No dispatch changes needed (UIApplication.shared.open is already scheme-agnostic).

Note: smsto: is intentionally NOT on the iOS allowlist (it is on Android's). iOS Messages registers sms: but has no smsto: handler, so smsto: would no-op; it is rejected at the gate instead.

## Changes
- Loosen three input gates (DeepLinkHandler, UNNotificationResponse+Klaviyo, KlaviyoActionButtonParser) to accept allowlist
- Add shared URLSchemeAllowlist constant (package visibility in KlaviyoCore; internal mirror in KlaviyoSwiftExtension due to module dependencies); a parity test keeps the two copies in sync
- Allowlist: http, https, mailto, tel, sms (smsto excluded, Android-only)
- Block intent:, android-app:, javascript:, file:, content:, data: (scheme validation)
- On blocked scheme: drop silently (existing nil-return fall-through behavior)

## Test Plan
- Full test suite passes; new/updated tests: allowlisted schemes accepted, blocked schemes rejected, .openWebUrl dispatched for mailto:/tel:, smsto: rejected, KlaviyoCore/KlaviyoSwiftExtension allowlist parity

### Manual testing (real device)
Verified end to end by sending push notifications through the production web interface and tapping on a physical device:

| web_url value | Result |
|---|---|
| `tel:+18005551234` | Opens Phone (call prompt) ✅ |
| `mailto:support@example.com?subject=Hi&body=Hello` | Opens Mail composer (To/subject/body pre-filled) ✅ |
| `sms:+18005551234?body=Test%20message` | Opens Messages (body pre-filled) ✅ |
| `https://example.com` | Opens Safari ✅ |
| `smsto:+18005551234` | Dropped at gate + logged; no dead-end app open ✅ (Android-only scheme) |
| `javascript:` / `file://` / `intent://` / `geo:` | Dropped at gate, no crash ✅ |

`_openedPush` tracking fires on the allowed cases. Reject path logs `web_url '...' has a scheme not in the allowed list; ignoring.`

The smsto: case is what surfaced this: on iOS it originally passed the gate but then no-oped in UIApplication.shared.open, leaving the user in the app. Dropping it from the iOS allowlist makes the rejection explicit and logged.

## Related
Part of PUSH-834 (multi-repo). Also see Android and fender PRs, plus app backend PR klaviyo/app#123425 (loosens the server-side web_url validation that would otherwise reject these schemes at save time).

https://linear.app/klaviyo/issue/PUSH-834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded supported `open_url` and notification `web_url` handling to include allowlisted non-web schemes: `mailto:`, `tel:`, and `sms:`.

* **Bug Fixes**
  * Added URL scheme validation for `open_url` action buttons and notification `web_url`, silently ignoring blocked schemes (e.g., `javascript:`, `intent:`, `file:`) while preserving tracking.
  * On iOS 14+, rejected schemes now log a warning.

* **Tests**
  * Expanded test coverage for allowlisted and blocked schemes, including allowlist parity checks between the two SDK components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->