### PR TITLE
refactor(KlaviyoSwift): compose ProfileData into KlaviyoState & wire write to IdentityStore and SDKConfigStore (MAGE-749)

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -63,6 +63,7 @@ public struct KlaviyoSDK {
     /// - Returns: a KlaviyoSDK instance
     @discardableResult
     public func initialize(with apiKey: String) -> KlaviyoSDK {
+        KlaviyoInternal.setupSharedStores()
         dispatchOnMainThread(action: .initialize(apiKey))
         return self
     }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -29,6 +29,8 @@ package enum KlaviyoInternal {
     private static var apiKeyCancellable: Cancellable?
     private static let apiKeySubject = CurrentValueSubject<APIKeyResult, Never>(.failure(.notInitialized))
 
+    private static var sharedStoresCancellable: Cancellable?
+
     private static let profileEventSubject = PassthroughSubject<Event, Never>()
     private static var profileEventCancellable: Cancellable?
     private static let eventBuffer = EventBuffer(maxBufferSize: 10, maxBufferAge: 10)
@@ -109,15 +111,26 @@ package enum KlaviyoInternal {
                     return .failure(.notInitialized)
                 }
 
-                return .success(ProfileData(
-                    email: state.email,
-                    phoneNumber: state.phoneNumber,
-                    externalId: state.externalId,
-                    anonymousId: state.anonymousId
-                ))
+                return .success(state.identity)
             }
             .removeDuplicates()
             .subscribe(profileDataSubject)
+    }
+
+    /// Mirrors initialized SDK state into the shared `KlaviyoCore` stores so other modules
+    /// (Forms, Location) can observe identity and API key without importing `KlaviyoSwift`.
+    package static func setupSharedStores() {
+        guard sharedStoresCancellable == nil else { return }
+        sharedStoresCancellable = klaviyoSwiftEnvironment.statePublisher()
+            .filter { $0.initalizationState == .initialized }
+            .map { (identity: $0.identity, apiKey: $0.apiKey) }
+            .removeDuplicates(by: { $0.identity == $1.identity && $0.apiKey == $1.apiKey })
+            // TCA dispatches state changes on the main thread, so these two sequential
+            // store writes are observed together rather than torn.
+            .sink { identity, apiKey in
+                IdentityStore.shared.update(identity)
+                SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+            }
     }
 
     /// Fetches the current profile data once.
@@ -154,6 +167,11 @@ package enum KlaviyoInternal {
         profileDataCancellable?.cancel()
         profileDataCancellable = nil
         profileDataSubject.send(.failure(.notInitialized))
+        sharedStoresCancellable?.cancel()
+        sharedStoresCancellable = nil
+        // Clear the shared stores so consumers don't read stale identity/config after reset.
+        IdentityStore.shared.update(ProfileData())
+        SDKConfigStore.shared.update(KlaviyoConfig())
     }
 
     // MARK: - Profile Event methods

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -133,10 +133,12 @@ package enum KlaviyoInternal {
             .map { (identity: $0.identity, apiKey: $0.apiKey) }
             .removeDuplicates(by: { $0.identity == $1.identity && $0.apiKey == $1.apiKey })
             // TCA dispatches state changes on the main thread, so these two sequential
-            // store writes are observed together rather than torn.
+            // store writes are observed together rather than torn. Write the config
+            // before the identity: IdentityStore.update(_:) notifies observers
+            // synchronously, so an identity observer must not see a stale apiKey.
             .sink { identity, apiKey in
-                IdentityStore.shared.update(identity)
                 SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+                IdentityStore.shared.update(identity)
             }
     }
 
@@ -177,8 +179,10 @@ package enum KlaviyoInternal {
         sharedStoresCancellable?.cancel()
         sharedStoresCancellable = nil
         // Clear the shared stores so consumers don't read stale identity/config after reset.
-        IdentityStore.shared.update(ProfileData())
+        // Write the config before the identity to match `setupSharedStores()`:
+        // IdentityStore.update(_:) notifies observers synchronously.
         SDKConfigStore.shared.update(KlaviyoConfig())
+        IdentityStore.shared.update(ProfileData())
     }
 
     // MARK: - Profile Event methods

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -102,6 +102,13 @@ package enum KlaviyoInternal {
 
     // Setup the profile data subject to receive updates from the state publisher
     private static func setupProfileDataSubject() {
+        // Keep the shared-store mirror alive alongside the profile subject. Both are torn
+        // down together in `resetProfileDataSubject()` (e.g. on In-App Forms teardown), so they
+        // must be re-established together — otherwise Forms re-init via `fetchProfileData()`
+        // would resubscribe the profile subject while the shared stores stayed empty until the
+        // host app called `initialize(with:)` again. `setupSharedStores()` is idempotent.
+        setupSharedStores()
+
         // Only set up the subscription if it hasn't already been set up
         guard profileDataCancellable == nil else { return }
 

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -105,11 +105,11 @@ struct KlaviyoState: Equatable, Codable {
         } else {
             // Legacy format: identity fields were stored at the top level.
             let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
-            self.identity = ProfileData(
-                email: try legacy.decodeIfPresent(String.self, forKey: .email),
-                phoneNumber: try legacy.decodeIfPresent(String.self, forKey: .phoneNumber),
-                externalId: try legacy.decodeIfPresent(String.self, forKey: .externalId),
-                anonymousId: try legacy.decodeIfPresent(String.self, forKey: .anonymousId)
+            identity = try ProfileData(
+                email: legacy.decodeIfPresent(String.self, forKey: .email),
+                phoneNumber: legacy.decodeIfPresent(String.self, forKey: .phoneNumber),
+                externalId: legacy.decodeIfPresent(String.self, forKey: .externalId),
+                anonymousId: legacy.decodeIfPresent(String.self, forKey: .anonymousId)
             )
         }
     }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -45,10 +45,29 @@ struct KlaviyoState: Equatable, Codable {
 
     // state related stuff
     var apiKey: String?
-    var email: String?
-    var anonymousId: String?
-    var phoneNumber: String?
-    var externalId: String?
+    var identity: ProfileData
+
+    // Computed shims forwarding to `identity.*` so the rest of KlaviyoSwift compiles unchanged.
+    var email: String? {
+        get { identity.email }
+        set { identity.email = newValue }
+    }
+
+    var phoneNumber: String? {
+        get { identity.phoneNumber }
+        set { identity.phoneNumber = newValue }
+    }
+
+    var externalId: String? {
+        get { identity.externalId }
+        set { identity.externalId = newValue }
+    }
+
+    var anonymousId: String? {
+        get { identity.anonymousId }
+        set { identity.anonymousId = newValue }
+    }
+
     var pushTokenData: PushTokenData?
 
     // queueing related stuff
@@ -64,12 +83,71 @@ struct KlaviyoState: Equatable, Codable {
 
     enum CodingKeys: CodingKey {
         case apiKey
-        case email
-        case anonymousId
-        case phoneNumber
-        case externalId
+        case identity
         case queue
         case pushTokenData
+    }
+
+    /// Legacy coding keys for migrating state files written before identity was composed into `ProfileData`.
+    private enum LegacyCodingKeys: CodingKey {
+        case email, anonymousId, phoneNumber, externalId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        apiKey = try container.decodeIfPresent(String.self, forKey: .apiKey)
+        pushTokenData = try container.decodeIfPresent(PushTokenData.self, forKey: .pushTokenData)
+        queue = try container.decodeIfPresent([KlaviyoRequest].self, forKey: .queue) ?? []
+
+        if let identity = try container.decodeIfPresent(ProfileData.self, forKey: .identity) {
+            // New format: identity is a nested object.
+            self.identity = identity
+        } else {
+            // Legacy format: identity fields were stored at the top level.
+            let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            self.identity = ProfileData(
+                email: try legacy.decodeIfPresent(String.self, forKey: .email),
+                phoneNumber: try legacy.decodeIfPresent(String.self, forKey: .phoneNumber),
+                externalId: try legacy.decodeIfPresent(String.self, forKey: .externalId),
+                anonymousId: try legacy.decodeIfPresent(String.self, forKey: .anonymousId)
+            )
+        }
+    }
+
+    init(
+        apiKey: String? = nil,
+        email: String? = nil,
+        anonymousId: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil,
+        pushTokenData: PushTokenData? = nil,
+        queue: [KlaviyoRequest],
+        requestsInFlight: [KlaviyoRequest] = [],
+        initalizationState: InitializationState = .uninitialized,
+        flushing: Bool = false,
+        flushInterval: Double = StateManagementConstants.wifiFlushInterval,
+        retryState: RetryState = .retry(StateManagementConstants.initialAttempt),
+        pendingRequests: [PendingRequest] = [],
+        pendingProfile: [Profile.ProfileKey: AnyEncodable]? = nil,
+        isProcessingDeepLink: Bool = false
+    ) {
+        self.apiKey = apiKey
+        identity = ProfileData(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            anonymousId: anonymousId
+        )
+        self.pushTokenData = pushTokenData
+        self.queue = queue
+        self.requestsInFlight = requestsInFlight
+        self.initalizationState = initalizationState
+        self.flushing = flushing
+        self.flushInterval = flushInterval
+        self.retryState = retryState
+        self.pendingRequests = pendingRequests
+        self.pendingProfile = pendingProfile
+        self.isProcessingDeepLink = isProcessingDeepLink
     }
 
     mutating func enqueueRequest(request: KlaviyoRequest) {

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -26,6 +26,8 @@ final class KlaviyoInternalTests: XCTestCase {
         KlaviyoInternal.resetProfileDataSubject()
         KlaviyoInternal.resetEventSubject()
         KlaviyoInternal.clearEventBuffer()
+        IdentityStore.shared.update(ProfileData())
+        SDKConfigStore.shared.update(KlaviyoConfig())
     }
 
     // MARK: - Profile Data Tests
@@ -804,6 +806,71 @@ final class KlaviyoInternalTests: XCTestCase {
         XCTAssertEqual(currentState.apiKey, "EXISTING_KEY", "API key should remain unchanged")
         XCTAssertEqual(currentState.pendingRequests.count, 0, "Event should not be enqueued when API key doesn't match")
         XCTAssertEqual(currentState.queue.count, 0, "Queue should remain empty")
+    }
+
+    // MARK: - Shared store wiring
+
+    @MainActor
+    func testSetupSharedStoresPushesIdentityOnChange() throws {
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        KlaviyoInternal.setupSharedStores()
+
+        _ = testStore.send(.setEmail("wired@example.com"))
+
+        let expectation = XCTestExpectation(description: "IdentityStore reflects email")
+        DispatchQueue.main.async {
+            XCTAssertEqual(IdentityStore.shared.current.email, "wired@example.com")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testSetupSharedStoresPushesAPIKeyOnChange() throws {
+        // `.test` state is already `.initialized` with apiKey "foo".
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        let expectation = XCTestExpectation(description: "SDKConfigStore reflects api key")
+        SDKConfigStore.shared.publisher
+            .dropFirst() // skip the CurrentValueSubject's initial emission
+            .sink { config in
+                if config.apiKey == "foo" { expectation.fulfill() }
+            }
+            .store(in: &cancellables)
+
+        KlaviyoInternal.setupSharedStores()
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(SDKConfigStore.shared.current.apiKey, "foo")
+    }
+
+    @MainActor
+    func testResetClearsSharedStores() throws {
+        // `.test` state is `.initialized` with apiKey "foo"; mirror it into the stores.
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        KlaviyoInternal.setupSharedStores()
+        _ = testStore.send(.setEmail("wired@example.com"))
+
+        // Confirm the stores hold real data before resetting.
+        let propagated = XCTestExpectation(description: "identity mirrored before reset")
+        DispatchQueue.main.async {
+            XCTAssertEqual(IdentityStore.shared.current.email, "wired@example.com")
+            XCTAssertEqual(SDKConfigStore.shared.current.apiKey, "foo")
+            propagated.fulfill()
+        }
+        wait(for: [propagated], timeout: 1.0)
+
+        KlaviyoInternal.resetProfileDataSubject()
+
+        XCTAssertEqual(IdentityStore.shared.current, ProfileData(),
+                       "reset must clear identity back to empty")
+        XCTAssertNil(SDKConfigStore.shared.current.apiKey,
+                     "reset must clear the API key")
     }
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -874,6 +874,38 @@ final class KlaviyoInternalTests: XCTestCase {
     }
 
     @MainActor
+    func testProfileSubjectSetupRestoresSharedStoresAfterReset() throws {
+        // Simulates In-App Forms teardown + re-init: `resetProfileDataSubject()` tears down the
+        // shared-store mirror, then Forms re-subscribes via the profile publisher (without the
+        // host app calling `initialize(with:)` again). The mirror must come back to life.
+        let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
+        klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
+
+        // Initial wiring, then teardown clears the shared stores.
+        KlaviyoInternal.setupSharedStores()
+        KlaviyoInternal.resetProfileDataSubject()
+        XCTAssertEqual(IdentityStore.shared.current, ProfileData(),
+                       "precondition: reset cleared identity")
+
+        // Re-subscribe the way Forms re-init does — no `initialize(with:)` call.
+        KlaviyoInternal.profileChangePublisher()
+            .sink { _ in }
+            .store(in: &cancellables)
+
+        _ = testStore.send(.setEmail("reinit@example.com"))
+
+        let expectation = XCTestExpectation(description: "shared stores updated after re-subscribe")
+        DispatchQueue.main.async {
+            XCTAssertEqual(IdentityStore.shared.current.email, "reinit@example.com",
+                           "identity mirror must be restored without re-initialize")
+            XCTAssertEqual(SDKConfigStore.shared.current.apiKey, "foo",
+                           "config mirror must be restored without re-initialize")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor
     func testCreateGeofenceEvent_enqueuesEventWhenAPIKeyMatches() async throws {
         // Given: SDK is initialized with matching API key
         var initialState = INITIALIZED_TEST_STATE()

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -250,11 +250,12 @@ final class KlaviyoStateTests: XCTestCase {
         )
 
         let data = try JSONEncoder().encode(state)
-        let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         XCTAssertNil(object["email"], "identity fields must not be encoded at the top level")
         XCTAssertNil(object["phoneNumber"], "identity fields must not be encoded at the top level")
         XCTAssertNil(object["externalId"], "identity fields must not be encoded at the top level")
+        XCTAssertNil(object["anonymousId"], "identity fields must not be encoded at the top level")
         let identity = try XCTUnwrap(object["identity"] as? [String: Any])
         XCTAssertEqual(identity["email"] as? String, "a@b.com")
         XCTAssertEqual(identity["anonymousId"] as? String, "anon-1")

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -193,4 +193,70 @@ final class KlaviyoStateTests: XCTestCase {
         // Fake value to test availability
         XCTAssertEqual(PushEnablement.create(from: UNAuthorizationStatus(rawValue: 50)!), .notDetermined)
     }
+
+    // MARK: - ProfileData migration
+
+    func testDecodesLegacyFlatIdentityJSON() throws {
+        let jsonString = """
+        {
+          "apiKey": "company-id",
+          "email": "a@b.com",
+          "phoneNumber": "+15555555555",
+          "externalId": "ext-1",
+          "anonymousId": "anon-1",
+          "queue": []
+        }
+        """
+        let json = Data(jsonString.utf8)
+
+        let state = try JSONDecoder().decode(KlaviyoState.self, from: json)
+
+        XCTAssertEqual(state.identity.email, "a@b.com")
+        XCTAssertEqual(state.identity.phoneNumber, "+15555555555")
+        XCTAssertEqual(state.identity.externalId, "ext-1")
+        XCTAssertEqual(state.identity.anonymousId, "anon-1")
+        XCTAssertEqual(state.apiKey, "company-id")
+    }
+
+    func testDecodesNewNestedIdentityJSON() throws {
+        let jsonString = """
+        {
+          "apiKey": "company-id",
+          "identity": {
+            "email": "a@b.com",
+            "phoneNumber": "+15555555555",
+            "externalId": "ext-1",
+            "anonymousId": "anon-1"
+          },
+          "queue": []
+        }
+        """
+        let json = Data(jsonString.utf8)
+
+        let state = try JSONDecoder().decode(KlaviyoState.self, from: json)
+
+        XCTAssertEqual(state.identity.email, "a@b.com")
+        XCTAssertEqual(state.identity.phoneNumber, "+15555555555")
+        XCTAssertEqual(state.identity.externalId, "ext-1")
+        XCTAssertEqual(state.identity.anonymousId, "anon-1")
+    }
+
+    func testEncodesIdentityAsNestedObject() throws {
+        let state = KlaviyoState(
+            apiKey: "company-id",
+            email: "a@b.com",
+            anonymousId: "anon-1",
+            queue: []
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNil(object["email"], "identity fields must not be encoded at the top level")
+        XCTAssertNil(object["phoneNumber"], "identity fields must not be encoded at the top level")
+        XCTAssertNil(object["externalId"], "identity fields must not be encoded at the top level")
+        let identity = try XCTUnwrap(object["identity"] as? [String: Any])
+        XCTAssertEqual(identity["email"] as? String, "a@b.com")
+        XCTAssertEqual(identity["anonymousId"] as? String, "anon-1")
+    }
 }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/EncodableTests/testKlaviyoState.1.json
@@ -1,7 +1,9 @@
 {
-  "anonymousId" : "foo",
-  "email" : "foo",
-  "phoneNumber" : "foo",
+  "identity" : {
+    "anonymousId" : "foo",
+    "email" : "foo",
+    "phoneNumber" : "foo"
+  },
   "pushTokenData" : {
     "deviceData" : {
       "app_build" : "1",

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -1,17 +1,18 @@
 ▿ KlaviyoState
-  ▿ anonymousId: Optional<String>
-    - some: "00000000-0000-0000-0000-000000000001"
   ▿ apiKey: Optional<String>
     - some: "foo"
-  - email: Optional<String>.none
-  - externalId: Optional<String>.none
   - flushInterval: 10.0
   - flushing: false
+  ▿ identity: ProfileData
+    ▿ anonymousId: Optional<String>
+      - some: "00000000-0000-0000-0000-000000000001"
+    - email: Optional<String>.none
+    - externalId: Optional<String>.none
+    - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
   - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
-  - phoneNumber: Optional<String>.none
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -1,17 +1,18 @@
 ▿ KlaviyoState
-  ▿ anonymousId: Optional<String>
-    - some: "00000000-0000-0000-0000-000000000001"
   ▿ apiKey: Optional<String>
     - some: "foo"
-  - email: Optional<String>.none
-  - externalId: Optional<String>.none
   - flushInterval: 10.0
   - flushing: false
+  ▿ identity: ProfileData
+    ▿ anonymousId: Optional<String>
+      - some: "00000000-0000-0000-0000-000000000001"
+    - email: Optional<String>.none
+    - externalId: Optional<String>.none
+    - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
   - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
-  - phoneNumber: Optional<String>.none
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -1,17 +1,18 @@
 ▿ KlaviyoState
-  ▿ anonymousId: Optional<String>
-    - some: "00000000-0000-0000-0000-000000000001"
   ▿ apiKey: Optional<String>
     - some: "foo"
-  - email: Optional<String>.none
-  - externalId: Optional<String>.none
   - flushInterval: 10.0
   - flushing: false
+  ▿ identity: ProfileData
+    ▿ anonymousId: Optional<String>
+      - some: "00000000-0000-0000-0000-000000000001"
+    - email: Optional<String>.none
+    - externalId: Optional<String>.none
+    - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
   - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
-  - phoneNumber: Optional<String>.none
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -1,20 +1,21 @@
 ▿ KlaviyoState
-  ▿ anonymousId: Optional<String>
-    - some: "00000000-0000-0000-0000-000000000001"
   ▿ apiKey: Optional<String>
     - some: "foo"
-  ▿ email: Optional<String>
-    - some: "test@test.com"
-  ▿ externalId: Optional<String>
-    - some: "externalId"
   - flushInterval: 10.0
   - flushing: true
+  ▿ identity: ProfileData
+    ▿ anonymousId: Optional<String>
+      - some: "00000000-0000-0000-0000-000000000001"
+    ▿ email: Optional<String>
+      - some: "test@test.com"
+    ▿ externalId: Optional<String>
+      - some: "externalId"
+    ▿ phoneNumber: Optional<String>
+      - some: "phoneNumber"
   - initalizationState: InitializationState.initialized
   - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
-  ▿ phoneNumber: Optional<String>
-    - some: "phoneNumber"
   ▿ pushTokenData: Optional<PushTokenData>
     ▿ some: PushTokenData
       ▿ deviceData: MetaData


### PR DESCRIPTION
# Description

Replaces the four flat identity fields in `KlaviyoState` with a single composed `identity: ProfileData`, then wires `KlaviyoInternal` to mirror initialized SDK state into the shared `KlaviyoCore` stores (`IdentityStore`, `SDKConfigStore`). This is MAGE-749, building on the stores added in #617 (MAGE-748).

Note: this is increasing the surface area/responsibility of KlaviyoInternal but this is only an intermediary state as we are getting rid of it altogether in phase 2.

This tackles phase 1.4 and 1.5 tasks as outlined [here](https://linear.app/klaviyo/document/networking-modularization-klaviyoswift-klaviyocore-a94705520b07)

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No public `KlaviyoSDK` API change. On-disk `KlaviyoState` JSON migrates losslessly (see Test Plan). Targets `feat/identity-to-core`, not `master` — versioning is settled when that feature branch lands.

## Changelog / Code Overview

**`KlaviyoState` composes `ProfileData`** (`Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift`)
- Four flat stored fields (`email`/`phoneNumber`/`externalId`/`anonymousId`) replaced by a single `var identity: ProfileData`.
- Computed shims forward to `identity.*`, so no other file in `KlaviyoSwift` changed.
- `Codable`: encodes `identity` as a nested object; `init(from:)` decodes the new nested key **or** legacy flat keys, so existing on-disk state upgrades with no data loss.
- Custom memberwise init preserves the exact existing flat-parameter signature, so all call sites/tests compile unchanged.
- Snapshot fixtures regenerated (flat → nested `identity` only; no value changes).

**`KlaviyoInternal` mirrors state into the shared stores** (`Sources/KlaviyoSwift/KlaviyoInternal.swift`, `Sources/KlaviyoSwift/Klaviyo.swift`)
- New `setupSharedStores()` subscribes to the TCA state publisher, filters to `.initialized`, dedupes, and pushes `state.identity` → `IdentityStore.shared` and `KlaviyoConfig(apiKey:)` → `SDKConfigStore.shared`. Called from `initialize(with:)`.
- `resetProfileDataSubject()` now also tears down the mirror and clears both stores to empty, so consumers can't read stale identity/config after a Forms teardown.
- `setupProfileDataSubject()` simplified to return `state.identity` directly.

**Why:** makes `KlaviyoCore` the stable contract so `KlaviyoForms`/`KlaviyoLocation` can later observe identity/API key without importing `KlaviyoSwift` (MAGE-750). The `KlaviyoInternal` mirror is a deliberate, transitional write-bridge while TCA remains the canonical state owner; it is slated for removal when an actor-based owner replaces TCA.

## Test Plan

Automated (run on iPhone 17 Pro simulator):
- `make test-library` → **TEST SUCCEEDED**, all bundles green (232 in `KlaviyoSwiftTests`, plus Core/Forms/Location/Extension).
- New `KlaviyoStateTests`: `testDecodesLegacyFlatIdentityJSON`, `testDecodesNewNestedIdentityJSON`, `testEncodesIdentityAsNestedObject` — verify lossless migration both directions and nested-only encoding.
- New `KlaviyoInternalTests`: `testSetupSharedStoresPushesIdentityOnChange`, `testSetupSharedStoresPushesAPIKeyOnChange`, `testResetClearsSharedStores`.

Manual upgrade check (recommended before merge): install a build on the prior SDK version, set identity, upgrade to this build, confirm identity/API key persist (legacy flat JSON → nested migration).

### Known follow-ups (not blocking this draft)
- `swiftformat .` was **not** run locally (not installed in this environment); `swiftlint --fix --strict` did run. Please run swiftformat before marking ready.
- `KlaviyoState.swift` now exceeds SwiftLint `type_body_length`/`file_length`. Currently silent (the `.swiftlint.yml` `included: Source` path doesn't resolve), but would become build-blocking if that config is corrected — consider a scoped `// swiftlint:disable` or a tracking note.
- Wiring tests are timing-coupled to TCA's synchronous `Store.send`/`@Published` delivery (assert inside `DispatchQueue.main.async`). Deterministic today; worth hardening later.
- `resetProfileDataSubject()` now does two jobs (profile-subject reset + store teardown); a dedicated `tearDownSharedStores()` would read cleaner. Left per the plan.

## Related Issues/Tickets
- MAGE-749 (this PR)
- Builds on #617 (MAGE-748: add IdentityStore & SDKConfigStore)
- Unblocks MAGE-750 (migrate Forms/Location observers to KlaviyoCore)
- Spec: Networking Modularization — KlaviyoSwift → KlaviyoCore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SDK startup to sync identity and configuration with shared in-memory stores earlier in the initialization flow.

* **Bug Fixes**
  * Enhanced reset behavior to fully clear identity/config mirrors and prevent stale values after reset and re-subscribe.
  * Added seamless backward compatibility for persisted state by supporting both legacy (flat) and new (nested) identity formats.

* **Tests**
  * Added coverage for shared-store wiring, reset/sync behavior, and legacy/new identity state migration and encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->