### PR TITLE
skip dependabot/ in pr-target-check

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -55,7 +55,7 @@ jobs:
               --field body="${MARKER}
           **:warning: This PR needs to target a release branch before it can merge to \`master\`.**
 
-          All changes — including hotfixes, dependency bumps, and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
+          All changes — including hotfixes and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
 
           **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch when available. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
 

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -28,7 +28,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]]; then
+          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]] || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
             gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
             exit 0


### PR DESCRIPTION
This adds more noise to what otherwise should be a simple process of updating dependencies. In practice, many dependabot changes merged to master have still been picked up by a feature branch merging in master before getting released, but this can be codified more in the sdk-release skill to double check any unowned commits on master that should be raised to the release manager's attention for determining how to remedy it (have a feature branch merge in master or cherry-pick those commits onto the release branch or merge master into the release branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated branch validation rules so automated update branches are treated as valid sources targeting the main branch, preventing the release-branch requirement label from being added/retained in these cases.
  * Refined the failure warning text shown when the check does not pass, removing outdated wording while keeping the guidance intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->