### PR TITLE
feat(KlaviyoCore): add EventBus for outbound event observation (MAGE-830)

### DIFF
--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -18,7 +18,7 @@ extension Logger {
 
 /// Manages a thread-safe buffer of recent events for replay to new subscribers.
 /// This handles race conditions where events may be published before subscribers exist.
-package final class EventBuffer {
+final class EventBuffer {
     // MARK: - Properties
 
     private struct BufferedEvent {
@@ -37,7 +37,7 @@ package final class EventBuffer {
     /// - Parameters:
     ///   - maxBufferSize: Maximum number of events to keep (default: 10)
     ///   - maxBufferAge: Maximum age of events to keep in seconds (default: 10)
-    package init(maxBufferSize: Int = 10, maxBufferAge: TimeInterval = 10) {
+    init(maxBufferSize: Int = 10, maxBufferAge: TimeInterval = 10) {
         self.maxBufferSize = maxBufferSize
         self.maxBufferAge = maxBufferAge
     }
@@ -46,7 +46,7 @@ package final class EventBuffer {
 
     /// Adds an event to the buffer, maintaining size and age limits.
     /// - Parameter event: The event to buffer
-    package func buffer(_ event: Event) {
+    func buffer(_ event: Event) {
         if #available(iOS 14.0, *) {
             Logger.eventBuffer.info("📤 Buffering event: \(event.metric.name.value, privacy: .public)")
         }
@@ -74,7 +74,7 @@ package final class EventBuffer {
 
     /// Gets recent events from the buffer (within maxBufferAge).
     /// - Returns: Array of buffered events that haven't expired
-    package func getRecentEvents() -> [Event] {
+    func getRecentEvents() -> [Event] {
         queue.sync {
             let now = ProcessInfo.processInfo.systemUptime
             let recentEvents = buffer
@@ -95,7 +95,7 @@ package final class EventBuffer {
 
     /// Clears all events from the buffer.
     /// This is useful for testing to ensure clean state between tests.
-    package func clear() {
+    func clear() {
         queue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
             self.buffer.removeAll()

--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -13,7 +13,7 @@ import OSLog
 
 @available(iOS 14.0, *)
 extension Logger {
-    fileprivate static let eventBuffer = Logger(subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoSwift", category: "Event Buffering")
+    fileprivate static let eventBuffer = Logger(subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoCore", category: "Event Buffering")
 }
 
 /// Manages a thread-safe buffer of recent events for replay to new subscribers.

--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -7,7 +7,6 @@
 
 import Combine
 import Foundation
-import KlaviyoCore
 import OSLog
 
 // MARK: - Logger
@@ -19,7 +18,7 @@ extension Logger {
 
 /// Manages a thread-safe buffer of recent events for replay to new subscribers.
 /// This handles race conditions where events may be published before subscribers exist.
-final class EventBuffer {
+package final class EventBuffer {
     // MARK: - Properties
 
     private struct BufferedEvent {
@@ -38,7 +37,7 @@ final class EventBuffer {
     /// - Parameters:
     ///   - maxBufferSize: Maximum number of events to keep (default: 10)
     ///   - maxBufferAge: Maximum age of events to keep in seconds (default: 10)
-    init(maxBufferSize: Int = 10, maxBufferAge: TimeInterval = 10) {
+    package init(maxBufferSize: Int = 10, maxBufferAge: TimeInterval = 10) {
         self.maxBufferSize = maxBufferSize
         self.maxBufferAge = maxBufferAge
     }
@@ -47,7 +46,7 @@ final class EventBuffer {
 
     /// Adds an event to the buffer, maintaining size and age limits.
     /// - Parameter event: The event to buffer
-    func buffer(_ event: Event) {
+    package func buffer(_ event: Event) {
         if #available(iOS 14.0, *) {
             Logger.eventBuffer.info("📤 Buffering event: \(event.metric.name.value, privacy: .public)")
         }
@@ -75,7 +74,7 @@ final class EventBuffer {
 
     /// Gets recent events from the buffer (within maxBufferAge).
     /// - Returns: Array of buffered events that haven't expired
-    func getRecentEvents() -> [Event] {
+    package func getRecentEvents() -> [Event] {
         queue.sync {
             let now = ProcessInfo.processInfo.systemUptime
             let recentEvents = buffer
@@ -96,7 +95,7 @@ final class EventBuffer {
 
     /// Clears all events from the buffer.
     /// This is useful for testing to ensure clean state between tests.
-    func clear() {
+    package func clear() {
         queue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
             self.buffer.removeAll()

--- a/Sources/KlaviyoCore/EventBus.swift
+++ b/Sources/KlaviyoCore/EventBus.swift
@@ -27,7 +27,7 @@ public final class EventBus: EventPublishing, EventBroadcasting {
     private let buffer: EventBuffer
 
     // `init` is accessible so tests exercise a fresh bus rather than mutating `shared`.
-    init(buffer: EventBuffer = EventBuffer(maxBufferSize: 10, maxBufferAge: 10)) {
+    init(buffer: EventBuffer = EventBuffer()) {
         self.buffer = buffer
     }
 

--- a/Sources/KlaviyoCore/EventBus.swift
+++ b/Sources/KlaviyoCore/EventBus.swift
@@ -1,0 +1,53 @@
+//
+//  EventBus.swift
+//  klaviyo-swift-sdk
+//
+
+import Combine
+
+/// Read-only view of the outbound event stream. Consumers (e.g. KlaviyoForms)
+/// depend on this rather than the concrete bus, so the implementation can change.
+public protocol EventPublishing {
+    /// Replays recently buffered events (bounded) to a new subscriber, then emits live events.
+    func eventPublisher() -> AnyPublisher<Event, Never>
+}
+
+/// Write access to the event stream. Intended for `KlaviyoSwift` only.
+public protocol EventBroadcasting {
+    func publish(_ event: Event)
+}
+
+/// Outbound event bus: KlaviyoSwift publishes enriched events; consumers observe them.
+/// Mirrors the `IdentityStore` pattern. The bounded replay buffer preserves the
+/// "event published before subscriber attaches" race fix (e.g. Opened Push at cold launch).
+public final class EventBus: EventPublishing, EventBroadcasting {
+    public static let shared = EventBus()
+
+    private let subject = PassthroughSubject<Event, Never>()
+    private let buffer: EventBuffer
+
+    // `init` is accessible so tests exercise a fresh bus rather than mutating `shared`.
+    init(buffer: EventBuffer = EventBuffer(maxBufferSize: 10, maxBufferAge: 10)) {
+        self.buffer = buffer
+    }
+
+    public func publish(_ event: Event) {
+        buffer.buffer(event)
+        subject.send(event)
+    }
+
+    public func eventPublisher() -> AnyPublisher<Event, Never> {
+        Deferred {
+            let buffered = self.buffer.getRecentEvents()
+            return self.subject
+                .prepend(buffered) // guaranteed order: replay first, then live
+        }
+        .eraseToAnyPublisher()
+    }
+
+    /// Test-support: clears the replay buffer for isolation between tests.
+    /// Not the Forms reset mechanism (that is MAGE-834).
+    package func clearBuffer() {
+        buffer.clear()
+    }
+}

--- a/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
@@ -8,7 +8,6 @@
 import Combine
 import Foundation
 import KlaviyoCore
-import KlaviyoSwift
 import OSLog
 
 class ProfileEventObserver {
@@ -24,7 +23,7 @@ class ProfileEventObserver {
 
     func startObserving() {
         guard cancellable == nil else { return }
-        cancellable = KlaviyoInternal.eventPublisher()
+        cancellable = EventBus.shared.eventPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 guard let self else { return }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -31,10 +31,6 @@ package enum KlaviyoInternal {
 
     private static var sharedStoresCancellable: Cancellable?
 
-    private static let profileEventSubject = PassthroughSubject<Event, Never>()
-    private static var profileEventCancellable: Cancellable?
-    private static let eventBuffer = EventBuffer(maxBufferSize: 10, maxBufferAge: 10)
-
     // MARK: - API Key methods
 
     // Setup the profile data subject to receive updates from the state publisher
@@ -196,41 +192,19 @@ package enum KlaviyoInternal {
 
     // MARK: - Profile Event methods
 
-    /// Publishes an event to subscribers and also buffers it for replay to future subscribers.
-    ///
+    /// Publishes an event to the KlaviyoCore event bus after enriching it with metadata.
     /// - Parameter event: the profile event to publish
     internal static func publishEvent(_ event: Event) {
-        let enrichedEvent = enrichEventWithMetadata(event)
-        eventBuffer.buffer(enrichedEvent)
-        profileEventSubject.send(enrichedEvent)
+        EventBus.shared.publish(enrichEventWithMetadata(event))
     }
 
-    /// A publisher that emits events when they are created.
-    ///
-    /// Replays recently buffered events (up to 10 events or 10 seconds old) to new subscribers,
-    /// then continues emitting new events as they are published. This handles the race condition
-    /// where events may be published before subscribers (e.g., "Opened Push" before forms initialization).
-    ///
-    /// - Returns: A publisher that emits profile events plus any buffered events
-    package static func eventPublisher() -> AnyPublisher<Event, Never> {
-        Deferred {
-            let buffered = eventBuffer.getRecentEvents()
-            return profileEventSubject
-                .prepend(buffered) // guaranteed order: replay first, then live
-        }
-        .eraseToAnyPublisher()
-    }
+    /// No-op. The event-reset mechanism moves onto KlaviyoCore in MAGE-834.
+    // TODO(MAGE-834): fold reset semantics into the KlaviyoCore stores/bus.
+    package static func resetEventSubject() {}
 
-    /// Resets the profile event subject to its initial state.
-    package static func resetEventSubject() {
-        profileEventCancellable?.cancel()
-        profileEventCancellable = nil
-    }
-
-    /// Clears the event buffer to ensure clean state between tests.
-    /// This prevents events from previous tests from being replayed in new tests.
+    /// Clears the event bus replay buffer to ensure clean state between tests.
     package static func clearEventBuffer() {
-        eventBuffer.clear()
+        EventBus.shared.clearBuffer()
     }
 
     /// Enriches an event with metadata (device info, SDK info, etc.)

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -198,8 +198,8 @@ package enum KlaviyoInternal {
         EventBus.shared.publish(enrichEventWithMetadata(event))
     }
 
-    /// No-op. The event-reset mechanism moves onto KlaviyoCore in MAGE-834.
     // TODO(MAGE-834): fold reset semantics into the KlaviyoCore stores/bus.
+    /// No-op. The event-reset mechanism moves onto KlaviyoCore in MAGE-834.
     package static func resetEventSubject() {}
 
     /// Clears the event bus replay buffer to ensure clean state between tests.

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -97,8 +97,8 @@ class EventBufferTests: XCTestCase {
         eventBuffer.buffer(Event(name: .customEvent("old_event")))
 
         // When - fill buffer to capacity
-        for i in 1...5 {
-            eventBuffer.buffer(Event(name: .customEvent("event_\(i)")))
+        for iter in 1...5 {
+            eventBuffer.buffer(Event(name: .customEvent("event_\(iter)")))
         }
 
         // Wait for async buffer operations to complete
@@ -193,8 +193,8 @@ class EventBufferTests: XCTestCase {
 
         // When - write and read concurrently
         DispatchQueue.global().async {
-            for i in 0..<50 {
-                self.eventBuffer.buffer(Event(name: .customEvent("event_\(i)")))
+            for iter in 0..<50 {
+                self.eventBuffer.buffer(Event(name: .customEvent("event_\(iter)")))
             }
             // Add small delay to allow async buffer operations to settle
             Thread.sleep(forTimeInterval: 0.25)

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -5,9 +5,8 @@
 //  Created by Ajay Subramanya on 10/7/25.
 //
 
-@testable import KlaviyoSwift
+@testable import KlaviyoCore
 import Foundation
-import KlaviyoCore
 import XCTest
 
 class EventBufferTests: XCTestCase {

--- a/Tests/KlaviyoCoreTests/EventBusTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBusTests.swift
@@ -1,0 +1,75 @@
+//
+//  EventBusTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoCore
+import Combine
+import XCTest
+
+final class EventBusTests: XCTestCase {
+    var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    // Live delivery: a subscriber receives events published after it subscribes.
+    func testPublishDeliversToLiveSubscriber() {
+        let bus = EventBus()
+        let expectation = XCTestExpectation(description: "event received")
+        var received: Event?
+
+        bus.eventPublisher()
+            .sink { received = $0; expectation.fulfill() }
+            .store(in: &cancellables)
+
+        bus.publish(Event(name: .customEvent("live_event")))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(received?.metric.name.value, "live_event")
+    }
+
+    // Race fix: events published BEFORE a subscriber attaches are replayed, in order, then live.
+    func testReplaysBufferedEventsBeforeSubscribeThenLive() {
+        let bus = EventBus()
+
+        bus.publish(Event(name: .customEvent("before_1")))
+        bus.publish(Event(name: .customEvent("before_2")))
+
+        let expectation = XCTestExpectation(description: "three events, replay then live")
+        expectation.expectedFulfillmentCount = 3
+        var names: [String] = []
+
+        bus.eventPublisher()
+            .sink { names.append($0.metric.name.value); expectation.fulfill() }
+            .store(in: &cancellables)
+
+        bus.publish(Event(name: .customEvent("after_live")))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(names, ["before_1", "before_2", "after_live"])
+    }
+
+    // Buffer bound: only the last `maxBufferSize` events are replayed.
+    func testReplayRespectsMaxBufferSize() {
+        let bus = EventBus(buffer: EventBuffer(maxBufferSize: 2, maxBufferAge: 10))
+
+        bus.publish(Event(name: .customEvent("e1")))
+        bus.publish(Event(name: .customEvent("e2")))
+        bus.publish(Event(name: .customEvent("e3")))
+
+        let expectation = XCTestExpectation(description: "only last 2 replayed")
+        expectation.expectedFulfillmentCount = 2
+        var names: [String] = []
+
+        bus.eventPublisher()
+            .sink { names.append($0.metric.name.value); expectation.fulfill() }
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(names, ["e2", "e3"])
+    }
+}

--- a/Tests/KlaviyoCoreTests/EventBusTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBusTests.swift
@@ -18,15 +18,15 @@ final class EventBusTests: XCTestCase {
 
     // Live delivery: a subscriber receives events published after it subscribes.
     func testPublishDeliversToLiveSubscriber() {
-        let bus = EventBus()
+        let eventBus = EventBus()
         let expectation = XCTestExpectation(description: "event received")
         var received: Event?
 
-        bus.eventPublisher()
+        eventBus.eventPublisher()
             .sink { received = $0; expectation.fulfill() }
             .store(in: &cancellables)
 
-        bus.publish(Event(name: .customEvent("live_event")))
+        eventBus.publish(Event(name: .customEvent("live_event")))
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(received?.metric.name.value, "live_event")
@@ -34,20 +34,20 @@ final class EventBusTests: XCTestCase {
 
     // Race fix: events published BEFORE a subscriber attaches are replayed, in order, then live.
     func testReplaysBufferedEventsBeforeSubscribeThenLive() {
-        let bus = EventBus()
+        let eventBus = EventBus()
 
-        bus.publish(Event(name: .customEvent("before_1")))
-        bus.publish(Event(name: .customEvent("before_2")))
+        eventBus.publish(Event(name: .customEvent("before_1")))
+        eventBus.publish(Event(name: .customEvent("before_2")))
 
         let expectation = XCTestExpectation(description: "three events, replay then live")
         expectation.expectedFulfillmentCount = 3
         var names: [String] = []
 
-        bus.eventPublisher()
+        eventBus.eventPublisher()
             .sink { names.append($0.metric.name.value); expectation.fulfill() }
             .store(in: &cancellables)
 
-        bus.publish(Event(name: .customEvent("after_live")))
+        eventBus.publish(Event(name: .customEvent("after_live")))
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(names, ["before_1", "before_2", "after_live"])
@@ -55,17 +55,17 @@ final class EventBusTests: XCTestCase {
 
     // Buffer bound: only the last `maxBufferSize` events are replayed.
     func testReplayRespectsMaxBufferSize() {
-        let bus = EventBus(buffer: EventBuffer(maxBufferSize: 2, maxBufferAge: 10))
+        let eventBus = EventBus(buffer: EventBuffer(maxBufferSize: 2, maxBufferAge: 10))
 
-        bus.publish(Event(name: .customEvent("e1")))
-        bus.publish(Event(name: .customEvent("e2")))
-        bus.publish(Event(name: .customEvent("e3")))
+        eventBus.publish(Event(name: .customEvent("e1")))
+        eventBus.publish(Event(name: .customEvent("e2")))
+        eventBus.publish(Event(name: .customEvent("e3")))
 
         let expectation = XCTestExpectation(description: "only last 2 replayed")
         expectation.expectedFulfillmentCount = 2
         var names: [String] = []
 
-        bus.eventPublisher()
+        eventBus.eventPublisher()
             .sink { names.append($0.metric.name.value); expectation.fulfill() }
             .store(in: &cancellables)
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -442,7 +442,7 @@ final class KlaviyoInternalTests: XCTestCase {
         )
         let testStore = Store(initialState: initialState, reducer: KlaviyoReducer())
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 publishedEvents.append(event)
             }
@@ -518,7 +518,7 @@ final class KlaviyoInternalTests: XCTestCase {
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
 
         // Subscribe to events
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 receivedEvent = event
                 expectation.fulfill()
@@ -566,7 +566,7 @@ final class KlaviyoInternalTests: XCTestCase {
         let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
 
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 receivedEvent = event
                 expectation.fulfill()
@@ -620,7 +620,7 @@ final class KlaviyoInternalTests: XCTestCase {
         let testStore = Store(initialState: testState, reducer: KlaviyoReducer())
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
 
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 receivedEvent = event
                 expectation.fulfill()
@@ -653,7 +653,7 @@ final class KlaviyoInternalTests: XCTestCase {
         let testStore = Store(initialState: testState, reducer: KlaviyoReducer())
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
 
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 receivedEvent = event
                 expectation.fulfill()
@@ -696,7 +696,7 @@ final class KlaviyoInternalTests: XCTestCase {
         let newSubscriberExpectation = XCTestExpectation(description: "New subscriber receives enriched event")
         var bufferedEvent: Event?
 
-        KlaviyoInternal.eventPublisher()
+        EventBus.shared.eventPublisher()
             .sink { event in
                 bufferedEvent = event
                 newSubscriberExpectation.fulfill()

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -431,7 +431,7 @@ final class KlaviyoInternalTests: XCTestCase {
     // MARK: - Event Publishing Tests
 
     @MainActor
-    func testEventPublisher_emitsEventWithProperties() throws {
+    func testPublishEvent_emitsEventWithProperties() throws {
         // Given: Set up a mock to capture published events
         var publishedEvents: [Event] = []
         let initialState = KlaviyoState(


### PR DESCRIPTION
# Description
Lifts outbound event observation (`publishEvent` / `eventPublisher` + the bounded replay buffer) out of the `KlaviyoInternal` facade into a new **`EventBus`** in `KlaviyoCore`, mirroring the `IdentityStore` pattern. `KlaviyoForms` now observes profile events from `KlaviyoCore` instead of importing `KlaviyoSwift`. Part of the Phase 2 effort to eliminate `KlaviyoInternal` (MAGE-828).

## Architecture

**Before** — Forms reaches into `KlaviyoInternal` (a `KlaviyoSwift` type) to observe events:

```mermaid
flowchart LR
    subgraph KS["KlaviyoSwift"]
        R["TCA reducer"] --> KI["KlaviyoInternal (facade)<br/>publishEvent · eventPublisher · EventBuffer"]
    end
    KI -->|"eventPublisher()"| PEO["ProfileEventObserver<br/>(KlaviyoForms)"]
    PEO -.->|"import KlaviyoSwift"| KI
    classDef swift fill:#e9d8fd,stroke:#805ad5;
    classDef consumer fill:#bee3f8,stroke:#3182ce;
    class R,KI swift;
    class PEO consumer;
```

**After** — `KlaviyoSwift` enriches then publishes into the Core `EventBus`; Forms observes Core:

```mermaid
flowchart LR
    subgraph KS["KlaviyoSwift"]
        R["TCA reducer"] -->|"enrichEventWithMetadata"| PE["publishEvent (shim)"]
    end
    subgraph CORE["KlaviyoCore"]
        BUS["EventBus<br/>publish · eventPublisher · replay buffer"]
    end
    PE ==>|"publish(enriched)"| BUS
    BUS -.->|"eventPublisher()"| PEO["ProfileEventObserver<br/>(KlaviyoForms)"]
    classDef swift fill:#e9d8fd,stroke:#805ad5;
    classDef core fill:#c6f6d5,stroke:#38a169;
    classDef consumer fill:#bee3f8,stroke:#3182ce;
    class R,PE swift;
    class BUS core;
    class PEO consumer;
```

The `EventBus` splits read/write like `IdentityStore`: consumers depend on `EventPublishing` (read); `KlaviyoSwift` uses `EventBroadcasting` (write). Enrichment (`enrichEventWithMetadata`) stays in `KlaviyoSwift` — the bus only ever relays already-enriched events.

### Replay-before-subscribe race (preserved)

`ProfileEventObserver` subscribes only at the IAF WebView `.handShook` lifecycle event — well after cold-launch events (`_openedPush`, `Opened App`) fire. The bounded replay buffer (10 events / 10 s, monotonic clock) bridges that gap:

```mermaid
sequenceDiagram
    participant R as Reducer (KlaviyoSwift)
    participant B as EventBus (Core)
    participant F as ProfileEventObserver (Forms)
    R->>B: publish(_openedPush) — cold launch
    Note over B: buffered (subscriber not yet attached)
    F->>B: eventPublisher() — at WebView handshake
    B-->>F: replay buffered (_openedPush) then live
```

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- full suite on iPhone 17 Pro sim, all 5 bundles -->
- [x] I have added sufficient unit/integration tests of my changes. <!-- EventBusTests: live delivery, replay-before-subscribe order, size bound -->
- [ ] I have adjusted or added new test cases to team test docs, if applicable. <!-- N/A — no behavior change -->
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] This is planned work for an upcoming release (Modularize iOS SDK epic, Phase 2). Targets `feat/modularization`, not a release branch.
- [ ] `Minor` Contains changes to the public API.

> `EventBus`, `EventPublishing`, and `EventBroadcasting` are new **public** types in `KlaviyoCore`. `EventBus.publish` is intended for `KlaviyoSwift`; consumers depend on the read-only `EventPublishing`. No change to the customer-facing `KlaviyoSDK` API. `EventBuffer` stays internal to `KlaviyoCore`.

## Changelog / Code Overview
- **New** `Sources/KlaviyoCore/EventBus.swift` — `EventPublishing`/`EventBroadcasting` protocols + `EventBus` singleton wrapping a `PassthroughSubject` and the replay buffer (`Deferred { subject.prepend(buffer.recent) }` = replay-then-live).
- **Moved** `EventBuffer` `KlaviyoSwift/Utilities/` → `KlaviyoCore/` (now `internal` to Core; thread-safety and 10/10s bounds unchanged).
- `KlaviyoInternal.publishEvent` → thin shim: `EventBus.shared.publish(enrichEventWithMetadata(event))`; removed its own subject/buffer and `eventPublisher()`. `resetEventSubject()` is a no-op stub (reset semantics deferred to MAGE-834); `clearEventBuffer()` delegates to the bus.
- `ProfileEventObserver` observes `EventBus.shared.eventPublisher()` and **drops `import KlaviyoSwift`**.

## Test Plan
- `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` → **BUILD SUCCEEDED**.
- `xcodebuild test ...` → **TEST SUCCEEDED** across KlaviyoCore, KlaviyoSwift, KlaviyoForms, KlaviyoLocation, KlaviyoSwiftExtension.
- New `EventBusTests`: `testPublishDeliversToLiveSubscriber`, `testReplaysBufferedEventsBeforeSubscribeThenLive` (the race fix), `testReplayRespectsMaxBufferSize`. `EventBufferTests` moved to `KlaviyoCoreTests` intact.

## Related Issues/Tickets
- Resolves MAGE-830
- Part of MAGE-828 (Phase 2: eliminate `KlaviyoInternal`); unblocks MAGE-834 (reset semantics), MAGE-835 (delete `KlaviyoInternal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared, Combine-based event stream for publishing and subscribing to events across the SDK.
  * New subscribers automatically receive recent events first, preserving publish order with bounded replay.
* **Bug Fixes**
  * Prevents events from being missed when a subscriber attaches after events were already published.
  * Standardized event delivery so different components observe the same stream consistently.
* **Tests**
  * Added/updated test coverage for shared publishing and replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->