### PR TITLE
feat(forms): handle IAF openExternalUrl bridge event (PUSH-732)

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -53,6 +53,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     print("🖱️  [Form Lifecycle] Form CTA Clicked: \(event.formId)")
                     print("   Form Name: \(event.formName)")
                     print("   Button: \(buttonLabel) → \(deepLinkUrl)")
+                case let .formExternalUrlClicked(_, _, buttonLabel, url):
+                    print("🌐 [Form Lifecycle] Form External URL Clicked: \(event.formId)")
+                    print("   Form Name: \(event.formName)")
+                    print("   Button: \(buttonLabel) → \(url)")
                 }
             }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -359,25 +359,19 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
 
             // 3. Invoke lifecycle handler when form identity fields are present
-            //    buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click
-            if let formId, !formId.isEmpty,
-               let formName, !formName.isEmpty {
-                IAFPresentationManager.shared.invokeLifecycleHandler(for: .formCtaClicked(
-                    formId: formId,
-                    formName: formName,
+            invokeCtaLifecycleHandler(eventName: "openDeepLink", formId: formId, formName: formName) {
+                .formCtaClicked(
+                    formId: $0,
+                    formName: $1,
                     buttonLabel: buttonLabel ?? "",
                     deepLinkUrl: url
-                ))
-            } else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning(
-                        "openDeepLink missing metadata — skipping lifecycle callback"
-                    )
-                }
+                )
             }
         case let .openExternalUrl(url, formId, formName, buttonLabel):
             if #available(iOS 14.0, *) {
-                Logger.webViewLogger.info("Received 'openExternalUrl' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
+                Logger.webViewLogger.info(
+                    "Received 'openExternalUrl' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)"
+                )
             }
 
             // 1. Check URL exists and is non-empty — no URL means no navigation and no lifecycle event
@@ -391,35 +385,28 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
 
             // 2. Validate scheme against allowlist
-            guard URLSchemeAllowlist.isAllowed(scheme: url.scheme) else {
+            guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
                 if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)")
+                    Logger.webViewLogger.warning(
+                        "Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)"
+                    )
                 }
                 return
             }
 
-            // 3. Open URL in Safari (bypass deep link handler)
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.info("Opening external URL '\(url, privacy: .public)' in Safari")
+            // 3. Open URL externally (bypasses any registered deep link handler)
+            Task {
+                await environment.linkHandler.openExternalURL(url)
             }
-            environment.linkHandler.openExternalURL(url)
 
             // 4. Invoke lifecycle handler when form identity fields are present
-            //    buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click
-            if let formId, !formId.isEmpty,
-               let formName, !formName.isEmpty {
-                IAFPresentationManager.shared.invokeLifecycleHandler(for: .formExternalUrlClicked(
-                    formId: formId,
-                    formName: formName,
+            invokeCtaLifecycleHandler(eventName: "openExternalUrl", formId: formId, formName: formName) {
+                .formExternalUrlClicked(
+                    formId: $0,
+                    formName: $1,
                     buttonLabel: buttonLabel ?? "",
                     url: url
-                ))
-            } else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning(
-                        "openExternalUrl missing metadata — skipping lifecycle callback"
-                    )
-                }
+                )
             }
         case let .abort(reason):
             if #available(iOS 14.0, *) {
@@ -442,5 +429,26 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case .profileMutation:
             ()
         }
+    }
+
+    /// Invokes the form lifecycle handler for a CTA tap when form identity fields are present.
+    /// buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click.
+    @MainActor
+    private func invokeCtaLifecycleHandler(
+        eventName: String,
+        formId: String?,
+        formName: String?,
+        makeEvent: (_ formId: String, _ formName: String) -> FormLifecycleEvent
+    ) {
+        guard let formId, !formId.isEmpty,
+              let formName, !formName.isEmpty else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning(
+                    "\(eventName, privacy: .public) missing metadata — skipping lifecycle callback"
+                )
+            }
+            return
+        }
+        IAFPresentationManager.shared.invokeLifecycleHandler(for: makeEvent(formId, formName))
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -375,6 +375,52 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                     )
                 }
             }
+        case let .openExternalUrl(url, formId, formName, buttonLabel):
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Received 'openExternalUrl' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
+            }
+
+            // 1. Check URL exists and is non-empty — no URL means no navigation and no lifecycle event
+            guard let url = url, !url.absoluteString.isEmpty else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning(
+                        "CTA clicked but no external URL configured — skipping navigation"
+                    )
+                }
+                return
+            }
+
+            // 2. Validate scheme against allowlist
+            guard URLSchemeAllowlist.isAllowed(scheme: url.scheme) else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)")
+                }
+                return
+            }
+
+            // 3. Open URL in Safari (bypass deep link handler)
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.info("Opening external URL '\(url, privacy: .public)' in Safari")
+            }
+            environment.linkHandler.openExternalURL(url)
+
+            // 4. Invoke lifecycle handler when form identity fields are present
+            //    buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click
+            if let formId, !formId.isEmpty,
+               let formName, !formName.isEmpty {
+                IAFPresentationManager.shared.invokeLifecycleHandler(for: .formExternalUrlClicked(
+                    formId: formId,
+                    formName: formName,
+                    buttonLabel: buttonLabel ?? "",
+                    url: url
+                ))
+            } else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning(
+                        "openExternalUrl missing metadata — skipping lifecycle callback"
+                    )
+                }
+            }
         case let .abort(reason):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Received 'abort' event from KlaviyoJS with reason: \(reason, privacy: .public)")

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -56,12 +56,23 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     /// - `deepLinkUrl`: The deep link URL associated with the CTA.
     case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
 
+    /// Triggered when a user taps a call-to-action (CTA) button in a form
+    /// that has an external (web) URL configured.
+    ///
+    /// Fired after the SDK has initiated opening the URL in Safari. Not emitted
+    /// if no external URL is configured for the CTA.
+    ///
+    /// - `buttonLabel`: The label text of the tapped button.
+    /// - `url`: The external URL associated with the CTA.
+    case formExternalUrlClicked(formId: String, formName: String, buttonLabel: String, url: URL)
+
     /// The unique identifier of the form that triggered this event.
     public var formId: String {
         switch self {
         case let .formShown(formId, _),
              let .formDismissed(formId, _),
-             let .formCtaClicked(formId, _, _, _):
+             let .formCtaClicked(formId, _, _, _),
+             let .formExternalUrlClicked(formId, _, _, _):
             return formId
         }
     }
@@ -71,7 +82,8 @@ public enum FormLifecycleEvent: Equatable, Sendable {
         switch self {
         case let .formShown(_, formName),
              let .formDismissed(_, formName),
-             let .formCtaClicked(_, formName, _, _):
+             let .formCtaClicked(_, formName, _, _),
+             let .formExternalUrlClicked(_, formName, _, _):
             return formName
         }
     }
@@ -82,6 +94,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
         case .formShown: return "formShown"
         case .formDismissed: return "formDismissed"
         case .formCtaClicked: return "formCtaClicked"
+        case .formExternalUrlClicked: return "formExternalUrlClicked"
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -71,9 +71,14 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
             self = .openDeepLink(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
         case .openExternalUrl:
-            let payload = try? container.decode(ExternalUrlEventPayload.self, forKey: .data)
+            let payload = try? container.decode(DeepLinkEventPayload.self, forKey: .data)
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
-            self = .openExternalUrl(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
+            self = .openExternalUrl(
+                url: url,
+                formId: payload?.formId,
+                formName: payload?.formName,
+                buttonLabel: payload?.buttonLabel
+            )
         case .abort:
             let data = try container.decode(AbortPayload.self, forKey: .data)
             self = .abort(data.reason)
@@ -103,14 +108,8 @@ extension IAFNativeBridgeEvent {
         let formName: String?
     }
 
+    /// Shared payload shape for CTA link events (`openDeepLink` and `openExternalUrl`).
     struct DeepLinkEventPayload: Decodable {
-        let ios: String?
-        let formId: String?
-        let formName: String?
-        let buttonLabel: String?
-    }
-
-    struct ExternalUrlEventPayload: Decodable {
         let ios: String?
         let formId: String?
         let formName: String?

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -16,6 +16,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case trackProfileEvent(Data)
     case trackAggregateEvent(Data)
     case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
+    case openExternalUrl(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
     case abort(String)
     case handShook
     case analyticsEvent
@@ -35,6 +36,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case trackProfileEvent
         case trackAggregateEvent
         case openDeepLink
+        case openExternalUrl
         case abort
         case handShook
         case analyticsEvent
@@ -68,6 +70,10 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             let payload = try? container.decode(DeepLinkEventPayload.self, forKey: .data)
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
             self = .openDeepLink(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
+        case .openExternalUrl:
+            let payload = try? container.decode(ExternalUrlEventPayload.self, forKey: .data)
+            let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
+            self = .openExternalUrl(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
         case .abort:
             let data = try container.decode(AbortPayload.self, forKey: .data)
             self = .abort(data.reason)
@@ -98,6 +104,13 @@ extension IAFNativeBridgeEvent {
     }
 
     struct DeepLinkEventPayload: Decodable {
+        let ios: String?
+        let formId: String?
+        let formName: String?
+        let buttonLabel: String?
+    }
+
+    struct ExternalUrlEventPayload: Decodable {
         let ios: String?
         let formId: String?
         let formName: String?
@@ -144,6 +157,7 @@ extension IAFNativeBridgeEvent {
             .trackProfileEvent(Data()),
             .trackAggregateEvent(Data()),
             .openDeepLink(url: nil, formId: nil, formName: nil, buttonLabel: nil),
+            .openExternalUrl(url: nil, formId: nil, formName: nil, buttonLabel: nil),
             .abort(""),
             .lifecycleEvent,
             .profileEvent,
@@ -159,6 +173,7 @@ extension IAFNativeBridgeEvent {
         case .trackProfileEvent: return 1
         case .trackAggregateEvent: return 1
         case .openDeepLink: return 2
+        case .openExternalUrl: return 1
         case .abort: return 1
         case .handShook: return 1
         case .analyticsEvent: return 1
@@ -176,6 +191,7 @@ extension IAFNativeBridgeEvent {
         case .trackProfileEvent: return "trackProfileEvent"
         case .trackAggregateEvent: return "trackAggregateEvent"
         case .openDeepLink: return "openDeepLink"
+        case .openExternalUrl: return "openExternalUrl"
         case .abort: return "abort"
         case .handShook: return "handShook"
         case .analyticsEvent: return "analyticsEvent"

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -71,8 +71,10 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
             self = .openDeepLink(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
         case .openExternalUrl:
-            let payload = try? container.decode(DeepLinkEventPayload.self, forKey: .data)
-            let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
+            // Unlike `openDeepLink` (which carries platform-split `ios`/`android` keys),
+            // the external web URL is sent as a single flat `url` field by onsite.
+            let payload = try? container.decode(ExternalUrlEventPayload.self, forKey: .data)
+            let url = payload?.url.flatMap { $0.isEmpty ? nil : URL(string: $0) }
             self = .openExternalUrl(
                 url: url,
                 formId: payload?.formId,
@@ -108,9 +110,18 @@ extension IAFNativeBridgeEvent {
         let formName: String?
     }
 
-    /// Shared payload shape for CTA link events (`openDeepLink` and `openExternalUrl`).
+    /// Payload for the `openDeepLink` CTA event, which carries platform-split deep link URLs.
     struct DeepLinkEventPayload: Decodable {
         let ios: String?
+        let formId: String?
+        let formName: String?
+        let buttonLabel: String?
+    }
+
+    /// Payload for the `openExternalUrl` CTA event. The external web URL is platform-agnostic,
+    /// so onsite sends it as a single flat `url` field (not the `ios`/`android` split used by deep links).
+    struct ExternalUrlEventPayload: Decodable {
+        let url: String?
         let formId: String?
         let formName: String?
         let buttonLabel: String?

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -48,10 +48,10 @@ extension KlaviyoSDK {
     /// The handler will be invoked when:
     /// - A form is shown (``FormLifecycleEvent/formShown(formId:formName:)``)
     /// - A form is dismissed (``FormLifecycleEvent/formDismissed(formId:formName:)``)
-    /// - A user taps a CTA in a form (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
+    /// - A user taps a CTA in a form (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)`` for deep links or ``FormLifecycleEvent/formExternalUrlClicked(formId:formName:buttonLabel:url:)`` for external URLs)
     ///
     /// Each event case carries contextual data including `formId`, `formName`, and
-    /// CTA-specific fields (`buttonLabel`, `deepLinkUrl`) where applicable.
+    /// CTA-specific fields (`buttonLabel`, `deepLinkUrl` or `url`) where applicable.
     ///
     /// The handler is called on the main thread.
     ///
@@ -64,9 +64,16 @@ extension KlaviyoSDK {
     ///     case .formDismissed(let formId, let formName):
     ///         Analytics.track("Form Dismissed", properties: ["formId": formId])
     ///     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
-    ///         Analytics.track("Form CTA Clicked", properties: [
+    ///         Analytics.track("Form CTA Clicked - Deep Link", properties: [
     ///             "formId": formId,
-    ///             "buttonLabel": buttonLabel
+    ///             "buttonLabel": buttonLabel,
+    ///             "url": deepLinkUrl.absoluteString
+    ///         ])
+    ///     case .formExternalUrlClicked(let formId, let formName, let buttonLabel, let url):
+    ///         Analytics.track("Form CTA Clicked - External URL", properties: [
+    ///             "formId": formId,
+    ///             "buttonLabel": buttonLabel,
+    ///             "url": url.absoluteString
     ///         ])
     ///     }
     /// }

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -48,7 +48,8 @@ extension KlaviyoSDK {
     /// The handler will be invoked when:
     /// - A form is shown (``FormLifecycleEvent/formShown(formId:formName:)``)
     /// - A form is dismissed (``FormLifecycleEvent/formDismissed(formId:formName:)``)
-    /// - A user taps a CTA in a form (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)`` for deep links or ``FormLifecycleEvent/formExternalUrlClicked(formId:formName:buttonLabel:url:)`` for external URLs)
+    /// - A user taps a deep link CTA (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
+    /// - A user taps an external URL CTA (``FormLifecycleEvent/formExternalUrlClicked(formId:formName:buttonLabel:url:)``)
     ///
     /// Each event case carries contextual data including `formId`, `formName`, and
     /// CTA-specific fields (`buttonLabel`, `deepLinkUrl` or `url`) where applicable.

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -449,17 +449,4 @@ final class FormLifecycleHandlerTests: XCTestCase {
         XCTAssertEqual(event.eventName, "formExternalUrlClicked")
     }
 
-    func testFormExternalUrlClickedEquality() {
-        let url1 = URL(string: "https://example.com")!
-        let url2 = URL(string: "https://example.com")!
-
-        let event1 = FormLifecycleEvent.formExternalUrlClicked(
-            formId: "form1", formName: "Form1", buttonLabel: "Click", url: url1
-        )
-        let event2 = FormLifecycleEvent.formExternalUrlClicked(
-            formId: "form1", formName: "Form1", buttonLabel: "Click", url: url2
-        )
-
-        XCTAssertEqual(event1, event2)
-    }
 }

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -405,4 +405,61 @@ final class FormLifecycleHandlerTests: XCTestCase {
         )
         XCTAssertEqual(ctaForEventName.eventName, "formCtaClicked")
     }
+
+    @MainActor
+    func testHandlerCalledForFormExternalUrlClicked() {
+        // Given
+        let expectation = expectation(description: "Handler called for formExternalUrlClicked")
+        var receivedEvent: FormLifecycleEvent?
+
+        presentationManager.registerFormLifecycleHandler { event in
+            if case .formExternalUrlClicked = event {
+                receivedEvent = event
+                expectation.fulfill()
+            }
+        }
+
+        let externalUrl = URL(string: "https://example.com")!
+
+        // When
+        presentationManager.invokeLifecycleHandler(
+            for: .formExternalUrlClicked(formId: "form123", formName: "Newsletter", buttonLabel: "Learn More", url: externalUrl)
+        )
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        guard case let .formExternalUrlClicked(formId, formName, buttonLabel, url) = receivedEvent else {
+            XCTFail("Handler should receive formExternalUrlClicked event")
+            return
+        }
+        XCTAssertEqual(formId, "form123")
+        XCTAssertEqual(formName, "Newsletter")
+        XCTAssertEqual(buttonLabel, "Learn More")
+        XCTAssertEqual(url, externalUrl)
+    }
+
+    func testFormExternalUrlClickedComputedProperties() {
+        let externalUrl = URL(string: "https://example.com")!
+        let event = FormLifecycleEvent.formExternalUrlClicked(
+            formId: "form456", formName: "Promo", buttonLabel: "Shop", url: externalUrl
+        )
+
+        XCTAssertEqual(event.formId, "form456")
+        XCTAssertEqual(event.formName, "Promo")
+        XCTAssertEqual(event.eventName, "formExternalUrlClicked")
+    }
+
+    func testFormExternalUrlClickedEquality() {
+        let url1 = URL(string: "https://example.com")!
+        let url2 = URL(string: "https://example.com")!
+
+        let event1 = FormLifecycleEvent.formExternalUrlClicked(
+            formId: "form1", formName: "Form1", buttonLabel: "Click", url: url1
+        )
+        let event2 = FormLifecycleEvent.formExternalUrlClicked(
+            formId: "form1", formName: "Form1", buttonLabel: "Click", url: url2
+        )
+
+        XCTAssertEqual(event1, event2)
+    }
 }

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -448,5 +448,4 @@ final class FormLifecycleHandlerTests: XCTestCase {
         XCTAssertEqual(event.formName, "Promo")
         XCTAssertEqual(event.eventName, "formExternalUrlClicked")
     }
-
 }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -610,8 +610,7 @@ struct IAFNativeBridgeEventTests {
         {
           "type": "openExternalUrl",
           "data": {
-            "ios": "https://example.com",
-            "android": "https://example.com",
+            "url": "https://example.com",
             "formId": "form123",
             "formName": "Newsletter",
             "buttonLabel": "Learn More"
@@ -639,8 +638,7 @@ struct IAFNativeBridgeEventTests {
         {
           "type": "openExternalUrl",
           "data": {
-            "ios": "https://example.com",
-            "android": "https://example.com",
+            "url": "https://example.com",
             "formId": "form123",
             "formName": "Newsletter"
           }
@@ -667,8 +665,7 @@ struct IAFNativeBridgeEventTests {
         {
           "type": "openExternalUrl",
           "data": {
-            "ios": "https://example.com",
-            "android": "https://example.com"
+            "url": "https://example.com"
           }
         }
         """
@@ -693,8 +690,7 @@ struct IAFNativeBridgeEventTests {
         {
           "type": "openExternalUrl",
           "data": {
-            "ios": "",
-            "android": "https://example.com",
+            "url": "",
             "formId": "form123",
             "formName": "Newsletter"
           }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -710,6 +710,5 @@ struct IAFNativeBridgeEventTests {
 
         #expect(url == nil)
     }
-
 }
 #endif

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -603,5 +603,128 @@ struct IAFNativeBridgeEventTests {
 
         #expect(aggregateEventDataDecoded == associatedValueDataDecoded)
     }
+
+    @Test
+    func testDecodeOpenExternalUrlWithButtonLabel() async throws {
+        let json = """
+        {
+          "type": "openExternalUrl",
+          "data": {
+            "ios": "https://example.com",
+            "android": "https://example.com",
+            "formId": "form123",
+            "formName": "Newsletter",
+            "buttonLabel": "Learn More"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
+            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == "form123")
+        #expect(formName == "Newsletter")
+        #expect(buttonLabel == "Learn More")
+    }
+
+    @Test
+    func testDecodeOpenExternalUrlMissingButtonLabel() async throws {
+        let json = """
+        {
+          "type": "openExternalUrl",
+          "data": {
+            "ios": "https://example.com",
+            "android": "https://example.com",
+            "formId": "form123",
+            "formName": "Newsletter"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
+            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == "form123")
+        #expect(formName == "Newsletter")
+        #expect(buttonLabel == nil)
+    }
+
+    @Test
+    func testDecodeOpenExternalUrlWithoutFormContext() async throws {
+        let json = """
+        {
+          "type": "openExternalUrl",
+          "data": {
+            "ios": "https://example.com",
+            "android": "https://example.com"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
+            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == nil)
+        #expect(formName == nil)
+        #expect(buttonLabel == nil)
+    }
+
+    @Test
+    func testDecodeOpenExternalUrlEmptyUrlNormalized() async throws {
+        let json = """
+        {
+          "type": "openExternalUrl",
+          "data": {
+            "ios": "",
+            "android": "https://example.com",
+            "formId": "form123",
+            "formName": "Newsletter"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openExternalUrl(url, _, _, _) = event else {
+            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+            return
+        }
+
+        #expect(url == nil)
+    }
+
+    @Test
+    func testHandshakeIncludesOpenExternalUrl() async throws {
+        let handshake = IAFNativeBridgeEvent.handshake
+        let data = try #require(handshake.data(using: .utf8))
+
+        struct HandshakeEvent: Codable {
+            let type: String
+            let version: Int
+        }
+
+        let events = try JSONDecoder().decode([HandshakeEvent].self, from: data)
+        let hasOpenExternalUrl = events.contains { $0.type == "openExternalUrl" }
+
+        #expect(hasOpenExternalUrl)
+    }
 }
 #endif

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"openExternalUrl","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -711,20 +711,5 @@ struct IAFNativeBridgeEventTests {
         #expect(url == nil)
     }
 
-    @Test
-    func testHandshakeIncludesOpenExternalUrl() async throws {
-        let handshake = IAFNativeBridgeEvent.handshake
-        let data = try #require(handshake.data(using: .utf8))
-
-        struct HandshakeEvent: Codable {
-            let type: String
-            let version: Int
-        }
-
-        let events = try JSONDecoder().decode([HandshakeEvent].self, from: data)
-        let hasOpenExternalUrl = events.contains { $0.type == "openExternalUrl" }
-
-        #expect(hasOpenExternalUrl)
-    }
 }
 #endif

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -353,13 +353,13 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - openExternalUrl Tests
 
     private func makeOpenExternalUrlMessage(
-        ios: String? = "https://example.com",
+        url: String? = "https://example.com",
         formId: String? = "form123",
         formName: String? = "Newsletter",
         buttonLabel: String? = "Learn More"
     ) -> MockWKScriptMessage {
         var data: [String: String] = [:]
-        data["ios"] = ios
+        data["url"] = url
         data["formId"] = formId
         data["formName"] = formName
         data["buttonLabel"] = buttonLabel
@@ -419,7 +419,7 @@ final class IAFWebViewModelTests: XCTestCase {
         defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(ios: nil))
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(url: nil))
 
         // Then
         XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not fire with nil URL")
@@ -435,7 +435,7 @@ final class IAFWebViewModelTests: XCTestCase {
         defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(ios: "javascript://alert(1)"))
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(url: "javascript://alert(1)"))
 
         // Then
         XCTAssertFalse(lifecycleEventFired, "Blocked scheme should skip navigation and lifecycle event")

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"openExternalUrl","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -350,127 +350,95 @@ final class IAFWebViewModelTests: XCTestCase {
         lifecycleTask.cancel()
     }
 
-    @MainActor
-    func testHandleOpenExternalUrlWithValidUrl() async throws {
-        // Given
-        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
-        viewModel.delegate = mockDelegate
-        let expectation = XCTestExpectation(description: "openExternalUrl handled")
-        let externalUrl = "https://example.com"
+    // MARK: - openExternalUrl Tests
 
-        var lifecycleEventFired = false
+    private func makeOpenExternalUrlMessage(
+        ios: String? = "https://example.com",
+        formId: String? = "form123",
+        formName: String? = "Newsletter",
+        buttonLabel: String? = "Learn More"
+    ) -> MockWKScriptMessage {
+        var data: [String: String] = [:]
+        data["ios"] = ios
+        data["formId"] = formId
+        data["formName"] = formName
+        data["buttonLabel"] = buttonLabel
+        let dataJson = data.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ", ")
+        return MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: "{ \"type\": \"openExternalUrl\", \"data\": { \(dataJson) } }"
+        )
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlFiresLifecycleEvent() async throws {
+        // Given
+        var receivedEvent: FormLifecycleEvent?
         IAFPresentationManager.shared.registerFormLifecycleHandler { event in
-            if case let .formExternalUrlClicked(formId, formName, _, _) = event {
-                if formId == "form123" && formName == "Newsletter" {
-                    lifecycleEventFired = true
-                    expectation.fulfill()
-                }
-            }
+            receivedEvent = event
         }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        let scriptMessage = MockWKScriptMessage(
-            name: "KlaviyoNativeBridge",
-            body: """
-            {
-              "type": "openExternalUrl",
-              "data": {
-                "ios": "\(externalUrl)",
-                "android": "\(externalUrl)",
-                "formId": "form123",
-                "formName": "Newsletter",
-                "buttonLabel": "Learn More"
-              }
-            }
-            """
-        )
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage())
 
-        viewModel.handleScriptMessage(scriptMessage)
-
-        // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
-        XCTAssertTrue(lifecycleEventFired, "Lifecycle event should be fired with form metadata")
+        // Then — the handler path is synchronous, so assert immediately
+        guard case let .formExternalUrlClicked(formId, formName, buttonLabel, url) = receivedEvent else {
+            XCTFail("Expected formExternalUrlClicked, got \(String(describing: receivedEvent))")
+            return
+        }
+        XCTAssertEqual(formId, "form123")
+        XCTAssertEqual(formName, "Newsletter")
+        XCTAssertEqual(buttonLabel, "Learn More")
+        XCTAssertEqual(url, URL(string: "https://example.com"))
     }
 
     @MainActor
-    func testHandleOpenExternalUrlWithoutFormMetadata() async throws {
+    func testHandleOpenExternalUrlWithoutFormMetadataSkipsLifecycleEvent() async throws {
         // Given
-        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
-        viewModel.delegate = mockDelegate
-        let externalUrl = "https://example.com"
-
         var lifecycleEventFired = false
         IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
             lifecycleEventFired = true
         }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        let scriptMessage = MockWKScriptMessage(
-            name: "KlaviyoNativeBridge",
-            body: """
-            {
-              "type": "openExternalUrl",
-              "data": {
-                "ios": "\(externalUrl)",
-                "android": "\(externalUrl)"
-              }
-            }
-            """
-        )
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(formId: nil, formName: nil))
 
-        viewModel.handleScriptMessage(scriptMessage)
-
-        // Then - wait briefly to confirm lifecycle event is NOT fired
-        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not be fired without form metadata")
+        // Then
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not fire without form metadata")
     }
 
     @MainActor
-    func testHandleOpenExternalUrlWithMissingUrl() async throws {
+    func testHandleOpenExternalUrlWithMissingUrlSkipsLifecycleEvent() async throws {
         // Given
-        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
-        viewModel.delegate = mockDelegate
-
         var lifecycleEventFired = false
         IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
             lifecycleEventFired = true
         }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        let scriptMessage = MockWKScriptMessage(
-            name: "KlaviyoNativeBridge",
-            body: """
-            {
-              "type": "openExternalUrl",
-              "data": {
-                "formId": "form123",
-                "formName": "Newsletter"
-              }
-            }
-            """
-        )
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(ios: nil))
 
-        viewModel.handleScriptMessage(scriptMessage)
-
-        // Then - wait briefly to confirm lifecycle event is NOT fired
-        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not be fired with nil URL")
+        // Then
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not fire with nil URL")
     }
 
     @MainActor
-    func testHandshakeIncludesOpenExternalUrl() {
+    func testHandleOpenExternalUrlWithDisallowedSchemeSkipsLifecycleEvent() async throws {
         // Given
-        let handshakeScript = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
-            .findScript(containing: "data-native-bridge-handshake")
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
         // When
-        let handshakeAttribute = handshakeScript?.source ?? ""
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(ios: "javascript://alert(1)"))
 
         // Then
-        XCTAssertTrue(
-            handshakeAttribute.contains("openExternalUrl"),
-            "Handshake should include openExternalUrl event type"
-        )
+        XCTAssertFalse(lifecycleEventFired, "Blocked scheme should skip navigation and lifecycle event")
     }
 }
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -349,6 +349,129 @@ final class IAFWebViewModelTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 5.0)
         lifecycleTask.cancel()
     }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithValidUrl() async throws {
+        // Given
+        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
+        viewModel.delegate = mockDelegate
+        let expectation = XCTestExpectation(description: "openExternalUrl handled")
+        let externalUrl = "https://example.com"
+
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { event in
+            if case let .formExternalUrlClicked(formId, formName, _, _) = event {
+                if formId == "form123" && formName == "Newsletter" {
+                    lifecycleEventFired = true
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        // When
+        let scriptMessage = MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "ios": "\(externalUrl)",
+                "android": "\(externalUrl)",
+                "formId": "form123",
+                "formName": "Newsletter",
+                "buttonLabel": "Learn More"
+              }
+            }
+            """
+        )
+
+        viewModel.handleScriptMessage(scriptMessage)
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 5.0)
+        XCTAssertTrue(lifecycleEventFired, "Lifecycle event should be fired with form metadata")
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithoutFormMetadata() async throws {
+        // Given
+        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
+        viewModel.delegate = mockDelegate
+        let externalUrl = "https://example.com"
+
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+
+        // When
+        let scriptMessage = MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "ios": "\(externalUrl)",
+                "android": "\(externalUrl)"
+              }
+            }
+            """
+        )
+
+        viewModel.handleScriptMessage(scriptMessage)
+
+        // Then - wait briefly to confirm lifecycle event is NOT fired
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not be fired without form metadata")
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithMissingUrl() async throws {
+        // Given
+        let viewModel = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
+        viewModel.delegate = mockDelegate
+
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+
+        // When
+        let scriptMessage = MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: """
+            {
+              "type": "openExternalUrl",
+              "data": {
+                "formId": "form123",
+                "formName": "Newsletter"
+              }
+            }
+            """
+        )
+
+        viewModel.handleScriptMessage(scriptMessage)
+
+        // Then - wait briefly to confirm lifecycle event is NOT fired
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not be fired with nil URL")
+    }
+
+    @MainActor
+    func testHandshakeIncludesOpenExternalUrl() {
+        // Given
+        let handshakeScript = IAFWebViewModel(url: testURL, apiKey: "test-api-key", profileData: nil)
+            .findScript(containing: "data-native-bridge-handshake")
+
+        // When
+        let handshakeAttribute = handshakeScript?.source ?? ""
+
+        // Then
+        XCTAssertTrue(
+            handshakeAttribute.contains("openExternalUrl"),
+            "Handshake should include openExternalUrl event type"
+        )
+    }
 }
 
 extension IAFWebViewModel {


### PR DESCRIPTION
## Summary

Handles the IAF `openExternalUrl` native bridge event in the iOS SDK so that in-app form CTAs configured with external/web URLs open in Safari (bypassing any registered deep link handler) rather than routing through the deep link path. Adds a new public `formExternalUrlClicked` lifecycle event so customers can differentiate external-browser CTAs from in-app deep-link CTAs in their analytics integrations.

Changes:
- `IAFNativeBridgeEvent`: new `openExternalUrl` case (decode, handshake manifest v1). Decodes via a dedicated `ExternalUrlEventPayload` that reads the flat `url` field onsite emits — **not** the platform-split `ios`/`android` shape used by `openDeepLink` (see Manual QA below)
- `FormLifecycleEvent`: new public `formExternalUrlClicked(formId:formName:buttonLabel:url:)` case
- `IAFWebViewModel`: handles the event — guards nil/empty URL, validates scheme against `openUrlAllowedSchemes`, opens via `DeepLinkHandler.openExternalURL`, fires the lifecycle event when form metadata is present; extracted a shared `invokeCtaLifecycleHandler` helper used by both CTA paths
- `KlaviyoSDK+Forms`: doc comment + example updated for the new case
- Example app: switch updated for the new case

Note: `formExternalUrlClicked` is a source-breaking addition to the public `FormLifecycleEvent` enum — consumers with exhaustive switches need a new case on upgrade. Worth a changelog callout.

## Test Plan

- Unit tests: `xcodebuild test -only-testing:KlaviyoFormsTests` — all passing
  - Decoding: new event with/without buttonLabel, without form context, empty-URL normalization — fixtures assert the real onsite `url` payload
  - Handshake: both hardcoded expectations updated to include `openExternalUrl` v1
  - Handler: lifecycle fires with metadata; skipped without metadata, with nil URL, and with a blocked scheme (`javascript://`)
  - Lifecycle: handler invocation + computed properties for the new case

- **Manual QA (completed ✅)** — on-device via local Fender:
  - **Setup:** iOS Simulator (iPhone 16 Pro, Xcode 26.5); example `SPMExample` app pointed at a local Fender **master** onsite dev server (`assetSource: development`); fender master onsite is the source of the `openExternalUrl` bridge event (`openWebUrlAction.ts`)
  - **Form:** "Tim Test Open Web URL" with an external-URL CTA
  - **Result:** tapping the external-URL CTA **opened the correct webpage in Safari**, bypassing the deep-link handler ✅
  - **Bug found & fixed during QA:** the decode originally reused `DeepLinkEventPayload` (reads the `ios` key), but onsite emits the web URL as a flat `url` field, so the URL always decoded to `nil` — the CTA guard tripped and the form dismissed without opening Safari. Fixed by adding `ExternalUrlEventPayload` (reads `url`) and correcting the test fixtures/helper, which had encoded the same wrong key (so unit tests were passing vacuously).

> CI note: the repo's `swift.yml` test job runs on `pull_request` with a `branches: ['*']` filter, which does not match this PR's slashed base branch (`feat/push-638-open-url`), so the unit-test workflow does not execute in CI for this stacked PR. Tests were verified locally (`KlaviyoFormsTests`, all green) and will run in CI once the stack lands on `master`.

## Acceptance Criteria

| ✅ Human | 🤖 AI | Criterion |
|---------|-------|-----------|
| - [x] | ✅ | IAF form CTA that emits `openExternalUrl` opens the URL in Safari — **verified on-device** (opened correct webpage; also unit-tested) |
| - [x] | ✅ | `formExternalUrlClicked` lifecycle event fires with `formId`, `formName`, `buttonLabel`, `url` when metadata is present (unit-tested against the real `url` payload) |
| - [ ] | ✅ | Existing `openDeepLink` IAF behavior is unchanged (unit-tested; not separately re-run on-device) |
| - [x] | ✅ | Unit tests: `IAFNativeBridgeEventTests` (decode of new event), `FormLifecycleHandlerTests` (lifecycle event invocation), `IAFWebViewModelTests` (handler + handshake) |
| - [x] | ✅ | Manual QA via Fender form configured with an external URL CTA |

[PUSH-732](https://linear.app/klaviyo/issue/PUSH-732/ios-sdk-handle-iaf-openexternalurl-message-bus-event)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle tracking for in-app form CTAs that open external URLs, including the form, button label, and destination URL.
  * Added support for validating allowed URL schemes before opening external links.
  * Added external URL CTA handling to the in-app form event bridge.

* **Documentation**
  * Updated lifecycle handler guidance with deep-link and external URL CTA examples.

* **Tests**
  * Added coverage for external URL events, decoding, validation, and lifecycle callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->