### PR TITLE
feat(KlaviyoCore): add EventDispatching contract for inbound dispatch (MAGE-831)

### DIFF
--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -1,0 +1,46 @@
+//
+//  EventDispatching.swift
+//  klaviyo-swift-sdk
+//
+
+import Foundation
+
+/// Closed vocabulary of inbound commands other modules hand to the SDK's analytics engine.
+public enum InboundCommand {
+    case aggregateEvent(AggregateEventPayload)
+    case deepLink(URL)
+}
+
+/// Inbound dispatch into the SDK's analytics engine. Implemented by `KlaviyoSwift`.
+public protocol EventDispatching {
+    func dispatch(_ command: InboundCommand)
+}
+
+/// Registration slot + forwarder for inbound dispatch. `KlaviyoSwift` registers its
+/// implementation at `KlaviyoSDK.init`; callers (e.g. `KlaviyoForms`) dispatch through `shared`.
+public final class EventDispatcher {
+    public static let shared = EventDispatcher()
+
+    private let lock = NSLock()
+    private var target: EventDispatching?
+
+    /// Register the dispatch implementation (idempotent — replaces any prior target).
+    public func register(_ target: EventDispatching) {
+        lock.lock()
+        self.target = target
+        lock.unlock()
+    }
+
+    /// Forward a command to the registered target. If none is registered, emit a loud
+    /// developer warning rather than silently dropping (buffering deferred to MAGE-833).
+    public func dispatch(_ command: InboundCommand) {
+        lock.lock()
+        let currentTarget = target
+        lock.unlock() // release before forwarding — a downstream effect may re-enter dispatch
+        if let currentTarget {
+            currentTarget.dispatch(command)
+        } else {
+            environment.emitDeveloperWarning("EventDispatcher: dispatch before registration")
+        }
+    }
+}

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -329,7 +329,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: jsonEventData))
             }
         case let .trackAggregateEvent(data):
-            KlaviyoInternal.create(aggregateEvent: data)
+            EventDispatcher.shared.dispatch(.aggregateEvent(data))
         case let .openDeepLink(url, formId, formName, buttonLabel):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
@@ -350,7 +350,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
                 }
-                KlaviyoInternal.handleDeepLink(url: url)
+                EventDispatcher.shared.dispatch(.deepLink(url))
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -29,9 +29,11 @@ func dispatchOnMainThread(action: KlaviyoAction) {
 ///
 /// From there you can you can call the additional methods below to track events and profile.
 public struct KlaviyoSDK {
+    private static let registerEventDispatcher: Void = EventDispatcher.shared.register(KlaviyoEventDispatcher())
+
     /// Default initializer for the Klaviyo SDK.
     public init() {
-        EventDispatcher.shared.register(KlaviyoEventDispatcher())
+        _ = Self.registerEventDispatcher
     }
 
     private var state: KlaviyoState {

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -30,7 +30,9 @@ func dispatchOnMainThread(action: KlaviyoAction) {
 /// From there you can you can call the additional methods below to track events and profile.
 public struct KlaviyoSDK {
     /// Default initializer for the Klaviyo SDK.
-    public init() {}
+    public init() {
+        EventDispatcher.shared.register(KlaviyoEventDispatcher())
+    }
 
     private var state: KlaviyoState {
         klaviyoSwiftEnvironment.state()

--- a/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
@@ -1,0 +1,19 @@
+//
+//  KlaviyoEventDispatcher.swift
+//  klaviyo-swift-sdk
+//
+
+import KlaviyoCore
+
+/// KlaviyoSwift's TCA-backed implementation of the Core `EventDispatching` contract.
+/// Routes inbound commands to the existing `KlaviyoInternal` dispatch methods.
+struct KlaviyoEventDispatcher: EventDispatching {
+    func dispatch(_ command: InboundCommand) {
+        switch command {
+        case let .aggregateEvent(payload):
+            KlaviyoInternal.create(aggregateEvent: payload)
+        case let .deepLink(url):
+            KlaviyoInternal.handleDeepLink(url: url)
+        }
+    }
+}

--- a/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
@@ -12,8 +12,8 @@ struct KlaviyoEventDispatcher: EventDispatching {
         switch command {
         case let .aggregateEvent(payload):
             KlaviyoInternal.create(aggregateEvent: payload)
-        case let .deepLink(url):
-            KlaviyoInternal.handleDeepLink(url: url)
+        case let .deepLink(deepLinkURL):
+            KlaviyoInternal.handleDeepLink(url: deepLinkURL)
         }
     }
 }

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -33,7 +33,9 @@ final class EventDispatcherTests: XCTestCase {
         dispatcher.dispatch(.aggregateEvent(payload))
         dispatcher.dispatch(.deepLink(url))
 
-        XCTAssertEqual(spy.received.count, 2)
+        guard spy.received.count == 2 else {
+            return XCTFail("expected 2 commands, got \(spy.received.count)")
+        }
         guard case let .aggregateEvent(received) = spy.received[0], received == payload else {
             return XCTFail("expected .aggregateEvent(payload)")
         }
@@ -44,6 +46,7 @@ final class EventDispatcherTests: XCTestCase {
 
     func testDispatchWithoutRegistrationWarnsAndDoesNotForward() {
         let dispatcher = EventDispatcher()
+        let spy = SpyDispatcher() // created but intentionally NOT registered
         var warnings: [String] = []
         environment.emitDeveloperWarning = { warnings.append($0) }
 
@@ -51,6 +54,7 @@ final class EventDispatcherTests: XCTestCase {
 
         XCTAssertEqual(warnings.count, 1)
         XCTAssertTrue(warnings[0].contains("dispatch before registration"))
+        XCTAssertTrue(spy.received.isEmpty)
     }
 
     func testReRegisterReplacesTarget() {

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -1,0 +1,68 @@
+//
+//  EventDispatcherTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoCore
+import Foundation
+import XCTest
+
+final class EventDispatcherTests: XCTestCase {
+    private final class SpyDispatcher: EventDispatching {
+        private(set) var received: [InboundCommand] = []
+        func dispatch(_ command: InboundCommand) { received.append(command) }
+    }
+
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+    }
+
+    override func tearDown() {
+        environment = KlaviyoEnvironment.test()
+        super.tearDown()
+    }
+
+    func testDispatchForwardsToRegisteredTarget() {
+        let dispatcher = EventDispatcher()
+        let spy = SpyDispatcher()
+        dispatcher.register(spy)
+
+        let payload = Data("agg".utf8)
+        let url = URL(string: "https://example.com")!
+        dispatcher.dispatch(.aggregateEvent(payload))
+        dispatcher.dispatch(.deepLink(url))
+
+        XCTAssertEqual(spy.received.count, 2)
+        guard case let .aggregateEvent(received) = spy.received[0], received == payload else {
+            return XCTFail("expected .aggregateEvent(payload)")
+        }
+        guard case let .deepLink(received) = spy.received[1], received == url else {
+            return XCTFail("expected .deepLink(url)")
+        }
+    }
+
+    func testDispatchWithoutRegistrationWarnsAndDoesNotForward() {
+        let dispatcher = EventDispatcher()
+        var warnings: [String] = []
+        environment.emitDeveloperWarning = { warnings.append($0) }
+
+        dispatcher.dispatch(.deepLink(URL(string: "https://example.com")!))
+
+        XCTAssertEqual(warnings.count, 1)
+        XCTAssertTrue(warnings[0].contains("dispatch before registration"))
+    }
+
+    func testReRegisterReplacesTarget() {
+        let dispatcher = EventDispatcher()
+        let first = SpyDispatcher()
+        let second = SpyDispatcher()
+        dispatcher.register(first)
+        dispatcher.register(second)
+
+        dispatcher.dispatch(.aggregateEvent(Data()))
+
+        XCTAssertTrue(first.received.isEmpty)
+        XCTAssertEqual(second.received.count, 1)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -280,6 +280,24 @@ class KlaviyoSDKTests: XCTestCase {
         XCTAssertFalse(middleUResult, "Should return false for path with /u/ in the middle")
     }
 
+    // MARK: - EventDispatcher Registration Tests
+
+    func testKlaviyoSDKInitRegistersAggregateEventDispatch() {
+        _ = KlaviyoSDK() // registration happens in init
+        let payload = Data("agg".utf8)
+        let expectation = setupActionAssertion(expectedAction: .enqueueAggregateEvent(payload))
+        EventDispatcher.shared.dispatch(.aggregateEvent(payload))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testKlaviyoSDKInitRegistersDeepLinkDispatch() {
+        _ = KlaviyoSDK()
+        let url = URL(string: "https://example.com")!
+        let expectation = setupActionAssertion(expectedAction: .openDeepLink(url))
+        EventDispatcher.shared.dispatch(.deepLink(url))
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - Deep Link Handler Registration Tests
 
     func testRegisterDeepLinkHandler() {


### PR DESCRIPTION
# Description
Adds an inbound **`EventDispatching`** contract to `KlaviyoCore` so `KlaviyoForms` dispatches aggregate events and deep links through Core instead of reaching into `KlaviyoInternal`. Second step of Phase 2 (eliminate `KlaviyoInternal`, MAGE-828); inbound counterpart to the MAGE-830 EventBus.

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- full suite, all 5 bundles -->
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable. <!-- N/A — no behavior change -->
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] This is planned work for an upcoming release (Modularize iOS SDK, Phase 2). Targets `feat/modularization`.
- [ ] `Minor` Contains changes to the public API.

> New **public** types in `KlaviyoCore` (`EventDispatching`, `InboundCommand`, `EventDispatcher`). No change to the customer-facing `KlaviyoSDK` API.

## Changelog / Code Overview
- **New** `KlaviyoCore/EventDispatching.swift`: `InboundCommand` enum (`aggregateEvent`, `deepLink`), `EventDispatching` protocol, and `EventDispatcher.shared` — a lock-guarded registration slot. Unregistered dispatch emits a loud `emitDeveloperWarning` (never a silent no-op); no pre-registration buffer.
- **`KlaviyoSwift`**: `KlaviyoEventDispatcher` conformer routes commands to the existing `KlaviyoInternal.create(aggregateEvent:)` / `handleDeepLink(url:)`; registered idempotently at **`KlaviyoSDK.init`** (decoupled from `initialize(apiKey:)`).
- **`KlaviyoForms`** `IAFWebViewModel`: aggregate-event + deep-link dispatch now go through `EventDispatcher.shared` (no longer `KlaviyoInternal`).

**Scope notes:** no `.event` case and no buffer (both YAGNI — the public `create(event:)` path is unchanged, and buffering/geofence are deferred to MAGE-833). Independent of MAGE-830 (`EventBuffer`/`EventBus` untouched). Design + plan are attached to the Linear ticket.

## Test Plan
- `xcodebuild build/test -scheme klaviyo-swift-sdk-Package` → BUILD + TEST SUCCEEDED across all 5 bundles.
- `EventDispatcherTests`: forwards-to-target, unregistered-warns-and-doesn't-forward, re-register-replaces.
- `KlaviyoSDKTests`: after `KlaviyoSDK()`, dispatching `.aggregateEvent`/`.deepLink` produces `.enqueueAggregateEvent`/`.openDeepLink` on the store.

## Related Issues/Tickets
- Resolves MAGE-831
- Part of MAGE-828 (eliminate `KlaviyoInternal`); depends on MAGE-829. Follow-ups: MAGE-833 (geofence + buffering), MAGE-835 (delete `KlaviyoInternal`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared event dispatch flow to handle inbound analytics (aggregate event) and deep-link commands consistently.
  * SDK initialization now automatically registers the dispatcher so these events are processed after startup.

* **Bug Fixes**
  * Improved event routing by dispatching through a centralized handler rather than direct internal calls.
  * Added a developer warning when commands are sent before a handler is registered.

* **Tests**
  * Added tests for command forwarding, registration replacement behavior, and SDK initialization wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->