### PR TITLE
ci: allow conventional-commit PR title prefixes to pass pr-target-check

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -30,6 +31,16 @@ jobs:
 
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]] || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
+            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # A conventional-commit PR title is another valid path: ci, chore, docs, or rel
+          # (case-insensitive, optional scope and breaking-change marker, e.g. "ci(workflows)!: ...")
+          TITLE_LC=$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
+          TITLE_REGEX='^(ci|chore|docs|rel)(\([^)]*\))?!?:[[:space:]]'
+          if [[ "$TITLE_LC" =~ $TITLE_REGEX ]]; then
+            echo "PR title '$PR_TITLE' has an allowed conventional-commit prefix — allowed to target master."
             gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
@@ -61,6 +72,7 @@ jobs:
 
           - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
           - If this is documentation-only work, rename your branch with a \`docs/\` prefix and this check will pass
+          - Alternatively, give the PR a conventional-commit title prefixed with \`ci:\`, \`chore:\`, \`docs:\`, or \`rel:\` (scopes like \`ci(workflows):\` also work) and this check will pass
 
           > **Override:** In exceptional circumstances, a maintainer may add the \`manual-merge\` label to bypass this check and merge directly to \`master\`. This should be used sparingly — it skips the release branch entirely and may result in changes not being included in a release or loss of commit attribution if not handled carefully.
 
@@ -69,5 +81,5 @@ jobs:
 
           gh pr edit $PR_NUMBER --repo $REPO --add-label "$LABEL"
 
-          echo "Branch '$HEAD_REF' cannot target master directly. Must use rel/*, ci/*, or docs/*. Add the manual-merge label to override."
+          echo "Branch '$HEAD_REF' cannot target master directly. Use a rel/*, ci/*, docs/*, or dependabot/* branch, a ci:/chore:/docs:/rel: PR title, or add the manual-merge label to override."
           exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ If prompted to commit, push, or open pull requests:
 | `feat/*` | New features | No — target active `rel/*` |
 | `{initials}/*` | Personal/WIP branches | No — target active `rel/*` |
 
-A required status check blocks merges to `master` from any branch not in the allowed list. The check posts a comment with retargeting instructions and applies a `needs: release branch` label. To bypass in exceptional cases, a maintainer can add the `manual-merge` label — use sparingly.
+A required status check blocks merges to `master` from any branch not in the allowed list. A conventional-commit PR title prefixed with `ci:`, `chore:`, `docs:`, or `rel:` (case-insensitive, scopes allowed) also satisfies the check. The check posts a comment with retargeting instructions and applies a `needs: release branch` label. To bypass in exceptional cases, a maintainer can add the `manual-merge` label — use sparingly.
 
 ## Architecture Overview
 


### PR DESCRIPTION
# Description
Adds a second validation path to the `pr-target-check` workflow: a PR whose title carries a conventional-commit prefix of `ci:`, `chore:`, `docs:`, or `rel:` (case-insensitive, optional scope and `!` breaking marker) may target `master` directly, alongside the existing branch-prefix allowlist.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device. — N/A, CI workflow only; regex verified locally under bash (see test plan)
- [ ] I have added sufficient unit/integration tests of my changes. — N/A, no SDK code touched
- [ ] I have adjusted or added new test cases to team test docs, if applicable. — N/A
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports. — no SDK code touched

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Repo tooling only — ships nothing in the SDK, no release plan needed.

## Changelog / Code Overview
- `.github/workflows/pr-target-check.yml`
  - PR title is passed via `env:` (`PR_TITLE`) rather than `${{ }}` interpolation into the script body, so user-controlled titles can't inject shell.
  - Title is lowercased and matched against `^(ci|chore|docs|rel)(\([^)]*\))?!?:[[:space:]]` — the regex lives in a variable because bash's `[[ =~ ]]` can't parse `[^)]` inline.
  - A space after the colon is required, per the Conventional Commits spec.
  - The workflow already triggers on `edited`, so fixing a title re-runs the check and clears the stale `needs: release branch` label.
  - Failure comment and log line updated to mention the new path (and the log now includes `dependabot/*`, which was missing).
- `AGENTS.md` — branch-naming section documents the title path.

**Reviewer call-outs (deliberate trade-offs):** the title path is self-serviceable (no maintainer gate, unlike `manual-merge`) and keys off mutable PR metadata rather than branch identity. This is intentional — the goal is flexible guardrails — but flagging `chore:`'s breadth in particular in case anyone wants to trim the prefix set.

## Test Plan
Regex verified under bash with a sample matrix:

| Title | Result |
|---|---|
| `ci: bump actions/checkout` | ✅ pass |
| `Chore: update deps` | ✅ pass |
| `docs(readme): fix typo` | ✅ pass |
| `Rel: 5.1.0` / `REL(5.1.0)!: cut release` | ✅ pass |
| `feat: new feature` | ❌ fail |
| `cirrus: something` / `chores: plural` | ❌ fail |
| `docs:no-space-after-colon` | ❌ fail |
| `circumvent the check ci: mid-string` | ❌ fail |

This PR itself exercises the new path: it's on a `ci/*` branch **and** has a `ci:` title, so the check should pass. YAML validated with `yq`.

## Related Issues/Tickets
None — follow-up hardening of the guardrail introduced with the branch-prefix check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation for merges into `master` so eligible PRs can pass with approved conventional-commit-style titles, even if the source branch name doesn’t match the usual pattern.
  * Updated the merge guidance and warning messages to reflect the expanded approval rules.

* **Documentation**
  * Clarified branch and PR target requirements, including the new title-based exception for certain PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->