### PR TITLE
refactor: fold reset semantics into Core primitives + decouple Forms teardown (MAGE-834)

### DIFF
--- a/Sources/KlaviyoCore/EventBus.swift
+++ b/Sources/KlaviyoCore/EventBus.swift
@@ -46,7 +46,7 @@ public final class EventBus: EventPublishing, EventBroadcasting {
     }
 
     /// Test-support: clears the replay buffer for isolation between tests and for the
-    /// Core reset surface (MAGE-834). Subscribers are held by consumers, not the bus,
+    /// Core reset surface. Subscribers are held by consumers, not the bus,
     /// so a reset only clears the bounded replay buffer.
     public func reset() {
         buffer.clear()

--- a/Sources/KlaviyoCore/EventBus.swift
+++ b/Sources/KlaviyoCore/EventBus.swift
@@ -48,7 +48,7 @@ public final class EventBus: EventPublishing, EventBroadcasting {
     /// Test-support: clears the replay buffer for isolation between tests and for the
     /// Core reset surface. Subscribers are held by consumers, not the bus,
     /// so a reset only clears the bounded replay buffer.
-    public func reset() {
+    package func reset() {
         buffer.clear()
     }
 }

--- a/Sources/KlaviyoCore/EventBus.swift
+++ b/Sources/KlaviyoCore/EventBus.swift
@@ -45,9 +45,10 @@ public final class EventBus: EventPublishing, EventBroadcasting {
         .eraseToAnyPublisher()
     }
 
-    /// Test-support: clears the replay buffer for isolation between tests.
-    /// Not the Forms reset mechanism (that is MAGE-834).
-    package func clearBuffer() {
+    /// Test-support: clears the replay buffer for isolation between tests and for the
+    /// Core reset surface (MAGE-834). Subscribers are held by consumers, not the bus,
+    /// so a reset only clears the bounded replay buffer.
+    public func reset() {
         buffer.clear()
     }
 }

--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -45,7 +45,7 @@ public final class EventDispatcher {
     }
 
     /// Unregister the current target (test-support / Core reset surface).
-    public func reset() {
+    package func reset() {
         lock.lock()
         target = nil
         lock.unlock()

--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -32,7 +32,7 @@ public final class EventDispatcher {
     }
 
     /// Forward a command to the registered target. If none is registered, emit a loud
-    /// developer warning rather than silently dropping (buffering deferred to MAGE-833).
+    /// developer warning rather than silently dropping (buffering is deferred follow-up work).
     public func dispatch(_ command: InboundCommand) {
         lock.lock()
         let currentTarget = target
@@ -44,7 +44,7 @@ public final class EventDispatcher {
         }
     }
 
-    /// Unregister the current target (test-support / Core reset surface, MAGE-834).
+    /// Unregister the current target (test-support / Core reset surface).
     public func reset() {
         lock.lock()
         target = nil

--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -43,4 +43,11 @@ public final class EventDispatcher {
             environment.emitDeveloperWarning("EventDispatcher: dispatch before registration")
         }
     }
+
+    /// Unregister the current target (test-support / Core reset surface, MAGE-834).
+    public func reset() {
+        lock.lock()
+        target = nil
+        lock.unlock()
+    }
 }

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -55,4 +55,9 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
     public func update(_ identity: ProfileData) {
         subject.send(identity)
     }
+
+    /// Restores the store to empty identity (test-support / Core reset surface, MAGE-834).
+    public func reset() {
+        update(ProfileData())
+    }
 }

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -57,7 +57,7 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
     }
 
     /// Restores the store to empty identity (test-support / Core reset surface).
-    public func reset() {
+    package func reset() {
         update(ProfileData())
     }
 }

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -56,7 +56,7 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
         subject.send(identity)
     }
 
-    /// Restores the store to empty identity (test-support / Core reset surface, MAGE-834).
+    /// Restores the store to empty identity (test-support / Core reset surface).
     public func reset() {
         update(ProfileData())
     }

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -64,7 +64,7 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
         subject.send(config)
     }
 
-    /// Restores the store to the default config (test-support / Core reset surface, MAGE-834).
+    /// Restores the store to the default config (test-support / Core reset surface).
     public func reset() {
         update(KlaviyoConfig())
     }

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -65,7 +65,7 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     }
 
     /// Restores the store to the default config (test-support / Core reset surface).
-    public func reset() {
+    package func reset() {
         update(KlaviyoConfig())
     }
 }

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -63,4 +63,9 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     public func update(_ config: KlaviyoConfig) {
         subject.send(config)
     }
+
+    /// Restores the store to the default config (test-support / Core reset surface, MAGE-834).
+    public func reset() {
+        update(KlaviyoConfig())
+    }
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -322,7 +322,6 @@ class IAFPresentationManager {
         profileEventObserver = nil
         profileEventsTask?.cancel()
         profileEventsTask = nil
-        KlaviyoInternal.resetEventSubject()
 
         do {
             try await createFormWebViewAndListen(apiKey: apiKey)
@@ -467,9 +466,6 @@ class IAFPresentationManager {
         delayedPresentationTask?.cancel()
         formEventTask = nil
         delayedPresentationTask = nil
-        KlaviyoInternal.resetAPIKeySubject()
-        KlaviyoInternal.resetProfileDataSubject()
-        KlaviyoInternal.resetEventSubject()
         destroyWebView()
     }
 }

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -160,8 +160,8 @@ package enum KlaviyoInternal {
     /// No-op. The event-reset mechanism moves onto KlaviyoCore in MAGE-834.
     package static func resetEventSubject() {}
 
-    /// Clears the event bus replay buffer to ensure clean state between tests.
-    package static func clearEventBuffer() {
+    /// Resets the event bus (clears its replay buffer) to ensure clean state between tests.
+    package static func resetEventBus() {
         EventBus.shared.reset()
     }
 

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -162,7 +162,7 @@ package enum KlaviyoInternal {
 
     /// Clears the event bus replay buffer to ensure clean state between tests.
     package static func clearEventBuffer() {
-        EventBus.shared.clearBuffer()
+        EventBus.shared.reset()
     }
 
     // MARK: - Aggregate Events methods

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -14,7 +14,10 @@ class EventBufferTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        eventBuffer = EventBuffer(maxBufferSize: 5, maxBufferAge: 2.0) // Small limits for testing
+        // Small limits for testing. The clock is frozen at 0 so events can never age out
+        // mid-test on a slow CI runner; tests that exercise age-based behavior build their
+        // own buffer via makeClockedBuffer(currentTime:) and advance the clock explicitly.
+        eventBuffer = EventBuffer(maxBufferSize: 5, maxBufferAge: 2.0, clock: { 0 })
     }
 
     override func tearDown() {

--- a/Tests/KlaviyoCoreTests/EventBusTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBusTests.swift
@@ -72,4 +72,22 @@ final class EventBusTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(names, ["e2", "e3"])
     }
+
+    // reset(): events published before reset() must NOT be replayed to new subscribers.
+    func testResetClearsReplayBuffer() {
+        let eventBus = EventBus()
+        eventBus.publish(Event(name: .customEvent("before_reset")))
+        eventBus.reset()
+
+        let expectation = XCTestExpectation(description: "only the post-reset event is delivered")
+        var names: [String] = []
+        eventBus.eventPublisher()
+            .sink { names.append($0.metric.name.value); expectation.fulfill() }
+            .store(in: &cancellables)
+
+        eventBus.publish(Event(name: .customEvent("after_reset")))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(names, ["after_reset"]) // pre-reset event was NOT replayed
+    }
 }

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -69,4 +69,21 @@ final class EventDispatcherTests: XCTestCase {
         XCTAssertTrue(first.received.isEmpty)
         XCTAssertEqual(second.received.count, 1)
     }
+
+    // reset(): after reset(), dispatch should warn and not forward to the previous target.
+    func testResetUnregistersTarget() {
+        let dispatcher = EventDispatcher()
+        let spy = SpyDispatcher()
+        dispatcher.register(spy)
+
+        dispatcher.reset()
+
+        var warnings: [String] = []
+        environment.emitDeveloperWarning = { warnings.append($0) }
+        dispatcher.dispatch(.aggregateEvent(Data()))
+
+        XCTAssertTrue(spy.received.isEmpty)           // no forward after reset
+        XCTAssertEqual(warnings.count, 1)             // hits the unregistered path
+        XCTAssertTrue(warnings[0].contains("dispatch before registration"))
+    }
 }

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -82,8 +82,8 @@ final class EventDispatcherTests: XCTestCase {
         environment.emitDeveloperWarning = { warnings.append($0) }
         dispatcher.dispatch(.aggregateEvent(Data()))
 
-        XCTAssertTrue(spy.received.isEmpty)           // no forward after reset
-        XCTAssertEqual(warnings.count, 1)             // hits the unregistered path
+        XCTAssertTrue(spy.received.isEmpty) // no forward after reset
+        XCTAssertEqual(warnings.count, 1) // hits the unregistered path
         XCTAssertTrue(warnings[0].contains("dispatch before registration"))
     }
 }

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -73,8 +73,8 @@ final class EventDispatcherTests: XCTestCase {
     // reset(): after reset(), dispatch should warn and not forward to the previous target.
     func testResetUnregistersTarget() {
         let dispatcher = EventDispatcher()
-        let spy = SpyDispatcher()
-        dispatcher.register(spy)
+        let spyDispatcher = SpyDispatcher()
+        dispatcher.register(spyDispatcher)
 
         dispatcher.reset()
 
@@ -82,7 +82,7 @@ final class EventDispatcherTests: XCTestCase {
         environment.emitDeveloperWarning = { warnings.append($0) }
         dispatcher.dispatch(.aggregateEvent(Data()))
 
-        XCTAssertTrue(spy.received.isEmpty) // no forward after reset
+        XCTAssertTrue(spyDispatcher.received.isEmpty) // no forward after reset
         XCTAssertEqual(warnings.count, 1) // hits the unregistered path
         XCTAssertTrue(warnings[0].contains("dispatch before registration"))
     }

--- a/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/IdentityStoreTests.swift
@@ -54,6 +54,16 @@ final class IdentityStoreTests: XCTestCase {
         XCTAssertEqual(received, [ProfileData(), identity])
     }
 
+    // reset(): store should return to default empty ProfileData after being updated.
+    func testResetRestoresDefaultProfileData() {
+        let store = IdentityStore()
+        store.update(ProfileData(email: "test@example.com", anonymousId: "anon-1"))
+
+        store.reset()
+
+        XCTAssertEqual(store.current, ProfileData())
+    }
+
     func testStreamDeliversAllUpdatesToConcurrentConsumersNoDrops() async {
         let store = IdentityStore()
         let updates = (0..<100).map { ProfileData(externalId: "id-\($0)") }

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -39,6 +39,17 @@ final class SDKConfigStoreTests: XCTestCase {
         XCTAssertEqual(received, [KlaviyoConfig(), KlaviyoConfig(apiKey: Self.apiKey)])
     }
 
+    // reset(): store should return to default empty KlaviyoConfig after being updated.
+    func testResetRestoresDefaultConfig() {
+        let store = SDKConfigStore()
+        store.update(KlaviyoConfig(apiKey: "company-123"))
+
+        store.reset()
+
+        XCTAssertEqual(store.current, KlaviyoConfig())
+        XCTAssertNil(store.current.apiKey)
+    }
+
     func testStreamYieldsCurrentValueThenUpdates() async {
         let store = SDKConfigStore()
         var iterator = store.stream().makeAsyncIterator()

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
@@ -1,0 +1,32 @@
+//
+//  IAFPresentationManagerTeardownTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoForms
+import KlaviyoCore
+import XCTest
+
+/// Regression guard (MAGE-834): In-App Forms teardown must NOT clobber global identity/config.
+final class IAFPresentationManagerTeardownTests: XCTestCase {
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+        IdentityStore.shared.reset()
+        SDKConfigStore.shared.reset()
+    }
+
+    @MainActor
+    func testTeardownDoesNotClobberGlobalIdentityAndConfig() {
+        let identity = ProfileData(email: "person@example.com", anonymousId: "anon-1")
+        let config = KlaviyoConfig(apiKey: "company-123")
+        IdentityStore.shared.update(identity)
+        SDKConfigStore.shared.update(config)
+
+        IAFPresentationManager.shared.destroyWebviewAndListeners()
+
+        XCTAssertEqual(IdentityStore.shared.current, identity)
+        XCTAssertEqual(SDKConfigStore.shared.current, config)
+    }
+}

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
@@ -7,9 +7,9 @@
 import KlaviyoCore
 import XCTest
 
-/// Regression guard (MAGE-834): In-App Forms teardown must NOT clobber global identity/config.
+/// Regression guard: In-App Forms teardown must NOT clobber global identity/config.
+@MainActor
 final class IAFPresentationManagerTeardownTests: XCTestCase {
-    @MainActor
     override func setUp() {
         super.setUp()
         environment = KlaviyoEnvironment.test()
@@ -17,7 +17,6 @@ final class IAFPresentationManagerTeardownTests: XCTestCase {
         SDKConfigStore.shared.reset()
     }
 
-    @MainActor
     func testTeardownDoesNotClobberGlobalIdentityAndConfig() {
         let identity = ProfileData(email: "person@example.com", anonymousId: "anon-1")
         let config = KlaviyoConfig(apiKey: "company-123")

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerTeardownTests.swift
@@ -17,6 +17,12 @@ final class IAFPresentationManagerTeardownTests: XCTestCase {
         SDKConfigStore.shared.reset()
     }
 
+    override func tearDown() {
+        IdentityStore.shared.reset()
+        SDKConfigStore.shared.reset()
+        super.tearDown()
+    }
+
     func testTeardownDoesNotClobberGlobalIdentityAndConfig() {
         let identity = ProfileData(email: "person@example.com", anonymousId: "anon-1")
         let config = KlaviyoConfig(apiKey: "company-123")

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -44,10 +44,8 @@ final class IAFWebViewModelTests: XCTestCase {
 
         KlaviyoInternal.resetAPIKeySubject()
         KlaviyoInternal.resetProfileDataSubject()
-        // resetProfileDataSubject() no longer clears the shared stores (MAGE-750); reset them
-        // explicitly so each test starts from a clean, known identity/config.
-        IdentityStore.shared.update(ProfileData())
-        SDKConfigStore.shared.update(KlaviyoConfig())
+        IdentityStore.shared.reset()
+        SDKConfigStore.shared.reset()
 
         // Reset klaviyoSwiftEnvironment state to clean test state with expected API key
         let testState = KlaviyoState(

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -99,10 +99,8 @@ final class IAFWebViewModelScriptTests: XCTestCase {
         // Reset Klaviyo state
         KlaviyoInternal.resetAPIKeySubject()
         KlaviyoInternal.resetProfileDataSubject()
-        // resetProfileDataSubject() no longer clears the shared stores (MAGE-750); reset them
-        // explicitly so each test starts clean.
-        IdentityStore.shared.update(ProfileData())
-        SDKConfigStore.shared.update(KlaviyoConfig())
+        IdentityStore.shared.reset()
+        SDKConfigStore.shared.reset()
         let testState = KlaviyoState(
             apiKey: "abc123",
             queue: [],

--- a/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
+++ b/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
@@ -67,8 +67,8 @@ final class KlaviyoLocationManagerTests: XCTestCase {
         mockApiKeyPublisher = nil
         cancellables.removeAll()
         KlaviyoInternal.resetAPIKeySubject()
-        SDKConfigStore.shared.update(KlaviyoConfig())
-        IdentityStore.shared.update(ProfileData())
+        SDKConfigStore.shared.reset()
+        IdentityStore.shared.reset()
 
         super.tearDown()
     }

--- a/Tests/KlaviyoSwiftTests/EventPublishTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventPublishTests.swift
@@ -16,13 +16,13 @@ final class EventPublishTests: XCTestCase {
         super.setUp()
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
-        EventBus.shared.clearBuffer()
+        EventBus.shared.reset()
     }
 
     override func tearDown() {
         cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
-        EventBus.shared.clearBuffer()
+        EventBus.shared.reset()
         super.tearDown()
     }
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -29,7 +29,7 @@ final class KlaviyoInternalTests: XCTestCase {
         KlaviyoInternal.resetAPIKeySubject()
         KlaviyoInternal.resetProfileDataSubject()
         KlaviyoInternal.resetEventSubject()
-        KlaviyoInternal.clearEventBuffer()
+        KlaviyoInternal.resetEventBus()
         // resetProfileDataSubject() no longer detaches the mirror or clears the stores (MAGE-750);
         // do it explicitly here so each test starts detached + empty.
         SharedStoreMirror.reset()


### PR DESCRIPTION
# Description
Gives the `KlaviyoCore` singletons a uniform `reset()` and removes the last teardown coupling from `KlaviyoForms` to `KlaviyoInternal`. IAF teardown now cancels only its own observers and touches no global SDK state. Part of Phase 2 (eliminate `KlaviyoInternal`); feeds MAGE-835.

> **Stacked PR:** targets `isobellelim/mage-833-relocate-geofence-dispatch` and auto-retargets to `feat/modularization` as the earlier Phase-2 PRs merge.

**Reframing note:** the ticket's original premise (Forms teardown "clears global identity/config + tears down the mirror") was already stale — MAGE-832 stopped `resetProfileDataSubject` from touching the stores/mirror, and no production code observes the KlaviyoInternal subjects anymore. The four `KlaviyoInternal.reset*` calls in teardown were **vestigial** (they reset private Combine relays nothing in Forms reads). This PR deletes them and formalizes a real Core reset API.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
**`feat(KlaviyoCore)` — uniform `reset()`:**
- `EventBus.reset()` (renamed from `clearBuffer()`, `package`→`public`) — clears the replay buffer.
- `EventDispatcher.reset()` — `target = nil` under the existing lock (unregister).
- `IdentityStore.reset()` / `SDKConfigStore.reset()` — restore the default (`ProfileData()` / `KlaviyoConfig()`), equal to the existing `update(default)` idiom.
- Repointed `KlaviyoInternal.clearEventBuffer` wrapper + `EventPublishTests` to `reset()`; zero `clearBuffer` references remain.

**`refactor(KlaviyoForms)` — decouple IAF teardown:**
- Removed the 4 vestigial `KlaviyoInternal.reset*` calls from `IAFPresentationManager` (`destroyWebviewAndListeners` ×3, `handleAPIKeyChange` ×1). Existing observer-nil + task-cancel cleanup is self-sufficient — the observers cancel their own EventBus/store subscriptions on deinit.
- New `IAFPresentationManagerTeardownTests` regression guard: identity/config survive teardown.
- Migrated reset-to-default test isolation to `reset()` in `IAFWebViewModelTests`, `KlaviyoWebViewControllerTests`, `KlaviyoLocationManagerTests`.

KlaviyoInternal's subjects/publishers/`reset*Subject`/`fetch*` + `KlaviyoInternalTests` are intentionally left for **MAGE-835** (facade deletion). `EventDispatcher.reset()` is added for API completeness but not wired into any shared teardown.

## Test Plan
- Full suite green: **444 tests, 0 failures** across all 5 bundles (KlaviyoCore 120 / KlaviyoSwift 218 / KlaviyoForms 60 / KlaviyoLocation 37 / KlaviyoSwiftExtension 9).
- New: 4 Core `reset()` unit tests + the teardown regression guard (passes before and after removal).
- Grep gates: no `KlaviyoInternal.reset*Subject` in `Sources`; no `clearBuffer` in `Sources`/`Tests`.
- `xcodebuild build` + `test` on `iPhone 17 Pro`.

## Related Issues/Tickets
Related to MAGE-834
Part of MAGE-828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added test-support `reset()` APIs for the event bus buffer, event dispatcher registration, identity data, and SDK configuration (including a renamed event-bus reset).
- **Bug Fixes**
  - Adjusted in-app form teardown/re-initialization so it no longer clears shared identity/config or resets internal event subjects during the webview/listener destruction path.
- **Tests**
  - Added and updated tests to verify replay buffer clearing, dispatcher reset behavior, deterministic event timing, and safer teardown/reset of shared singleton stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->