### PR TITLE
feat(push): add X-Klaviyo-Sdk-Features header to push-token-register (MAGE-764)

### DIFF
--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -254,21 +254,21 @@ public struct KlaviyoEnvironment {
             Bundle.main.object(forInfoDictionaryKey: "klaviyo_badge_autoclearing") as? Bool ?? true
         },
         sdkFeatures: {
-            // Gate on key *presence*: an absent master key means the host is on a legacy/manual
-            // integration we don't track, so no header is emitted. A present key (even `false`)
-            // means the host opted into the new integration model and should be tracked.
-            guard let rawAutoPushTracking = Bundle.main.object(
+            // Report adoption whenever the host set ANY SDK-feature Info.plist key. When none are
+            // present the host is on a legacy/manual integration we don't track, so no header is
+            // emitted. Each field is then included only if its own key is present (`.map` keeps the
+            // absent case as `nil` so the field is omitted rather than reported with a default).
+            let autoPushTracking = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
-            ) else {
-                return nil
-            }
-            // Only report token forwarding when the escape-hatch key is actually present; when it is
-            // absent, pass `nil` so the field is omitted from the header (feature not marked as used).
+            ).map { ($0 as? Bool) ?? false }
             let autoTokenForwardingDisabled = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
             ).map { ($0 as? Bool) ?? false }
+            guard autoPushTracking != nil || autoTokenForwardingDisabled != nil else {
+                return nil
+            }
             return SdkFeatures(
-                autoPushTrackingEnabled: (rawAutoPushTracking as? Bool) ?? false,
+                autoPushTracking: autoPushTracking,
                 autoTokenForwardingDisabled: autoTokenForwardingDisabled
             )
         },

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -23,6 +23,7 @@ public struct KlaviyoEnvironment {
         getNotificationSettings: @escaping () async -> PushEnablement,
         getBackgroundSetting: @escaping () -> PushBackground,
         getBadgeAutoClearingSetting: @escaping () async -> Bool,
+        sdkFeatures: @escaping () -> SdkFeatures? = { nil },
         getLocationAuthorizationStatus: @escaping () -> CLAuthorizationStatus,
         startReachability: @escaping () throws -> Void,
         stopReachability: @escaping () -> Void,
@@ -55,6 +56,7 @@ public struct KlaviyoEnvironment {
         self.getNotificationSettings = getNotificationSettings
         self.getBackgroundSetting = getBackgroundSetting
         self.getBadgeAutoClearingSetting = getBadgeAutoClearingSetting
+        self.sdkFeatures = sdkFeatures
         self.getLocationAuthorizationStatus = getLocationAuthorizationStatus
         self.startReachability = startReachability
         self.stopReachability = stopReachability
@@ -119,6 +121,10 @@ public struct KlaviyoEnvironment {
     public var getNotificationSettings: () async -> PushEnablement
     public var getBackgroundSetting: () -> PushBackground
     public var getBadgeAutoClearingSetting: () async -> Bool
+    /// Reads the automatic-push-tracking feature flags for adoption telemetry. Returns `nil` when the
+    /// host app has not set the `klaviyo_automatic_push_tracking` Info.plist key at all, signaling a
+    /// legacy/manual integration that should not be tracked (no header is sent).
+    public var sdkFeatures: () -> SdkFeatures?
     public var getLocationAuthorizationStatus: () -> CLAuthorizationStatus
 
     public var startReachability: () throws -> Void
@@ -246,6 +252,25 @@ public struct KlaviyoEnvironment {
         },
         getBadgeAutoClearingSetting: {
             Bundle.main.object(forInfoDictionaryKey: "klaviyo_badge_autoclearing") as? Bool ?? true
+        },
+        sdkFeatures: {
+            // Gate on key *presence*: an absent master key means the host is on a legacy/manual
+            // integration we don't track, so no header is emitted. A present key (even `false`)
+            // means the host opted into the new integration model and should be tracked.
+            guard let rawAutoPushTracking = Bundle.main.object(
+                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
+            ) else {
+                return nil
+            }
+            // Only report token forwarding when the escape-hatch key is actually present; when it is
+            // absent, pass `nil` so the field is omitted from the header (feature not marked as used).
+            let autoTokenForwardingDisabled = Bundle.main.object(
+                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
+            ).map { ($0 as? Bool) ?? false }
+            return SdkFeatures(
+                autoPushTrackingEnabled: (rawAutoPushTracking as? Bool) ?? false,
+                autoTokenForwardingDisabled: autoTokenForwardingDisabled
+            )
         },
         getLocationAuthorizationStatus: {
             if #available(iOS 14.0, *) {

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -121,9 +121,6 @@ public struct KlaviyoEnvironment {
     public var getNotificationSettings: () async -> PushEnablement
     public var getBackgroundSetting: () -> PushBackground
     public var getBadgeAutoClearingSetting: () async -> Bool
-    /// Reads the automatic-push-tracking feature flags for adoption telemetry. Returns `nil` when the
-    /// host app has not set the `klaviyo_automatic_push_tracking` Info.plist key at all, signaling a
-    /// legacy/manual integration that should not be tracked (no header is sent).
     public var sdkFeatures: () -> SdkFeatures?
     public var getLocationAuthorizationStatus: () -> CLAuthorizationStatus
 
@@ -254,10 +251,6 @@ public struct KlaviyoEnvironment {
             Bundle.main.object(forInfoDictionaryKey: "klaviyo_badge_autoclearing") as? Bool ?? true
         },
         sdkFeatures: {
-            // Report adoption whenever the host set ANY SDK-feature Info.plist key. When none are
-            // present the host is on a legacy/manual integration we don't track, so no header is
-            // emitted. Each field is then included only if its own key is present (`.map` keeps the
-            // absent case as `nil` so the field is omitted rather than reported with a default).
             let autoPushTracking = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
             ).map { ($0 as? Bool) ?? false }

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -253,10 +253,10 @@ public struct KlaviyoEnvironment {
         sdkFeatures: {
             let autoPushTracking = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
-            ).map { ($0 as? Bool) ?? false }
+            ) as? Bool
             let autoTokenForwardingDisabled = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
-            ).map { ($0 as? Bool) ?? false }
+            ) as? Bool
             guard autoPushTracking != nil || autoTokenForwardingDisabled != nil else {
                 return nil
             }

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -8,12 +8,13 @@
 
 import Foundation
 
-/// Snapshot of the automatic-push-tracking feature flags reported to the backend for
-/// adoption telemetry. Serialized into the `X-Klaviyo-Sdk-Features` header.
+/// Snapshot of the SDK feature flags reported to the backend for adoption telemetry, serialized
+/// into the `X-Klaviyo-Sdk-Features` header.
 ///
-/// A feature is only reported when the host app actually set its Info.plist key. Fields whose
-/// key is absent are omitted from the header entirely (the feature is "not marked as used")
-/// rather than reported with a default value.
+/// Each feature reports its own configured state independently, so the backend gets a faithful
+/// signal of how the host set each flag. A feature is only reported when the host actually set its
+/// Info.plist key; fields whose key is absent are omitted from the header (the feature is "not
+/// marked as used") rather than reported with a default value.
 public struct SdkFeatures: Equatable {
     /// Name of the HTTP header these features are serialized into on push-token registration.
     public static let headerName = "X-Klaviyo-Sdk-Features"
@@ -28,35 +29,37 @@ public struct SdkFeatures: Equatable {
         package static let disableAutomaticTokenForwarding = "klaviyo_disable_automatic_token_forwarding"
     }
 
-    /// Whether the master automatic-push-tracking flag is enabled. Always reported (the header is
-    /// only built when the master key is present).
-    public let autoPushTracking: Bool
-    /// Effective token-forwarding state, or `nil` when the escape-hatch key is absent from Info.plist.
-    /// When `nil` the field is omitted from the header rather than reported, so the backend must treat
-    /// its absence as "unknown / not reported" — never as `false`.
+    /// Master automatic-push-tracking flag, or `nil` when the key is absent from Info.plist
+    /// (the field is then omitted from the header).
+    public let autoPushTracking: Bool?
+    /// Whether automatic token forwarding is enabled (i.e. the escape hatch is not set), independent
+    /// of the master flag. `nil` when the escape-hatch key is absent from Info.plist, in which case the
+    /// field is omitted from the header, so the backend must treat its absence as "unknown", not `false`.
     public let autoPushTokenForwarding: Bool?
 
     /// - Parameters:
-    ///   - autoPushTrackingEnabled: value of the master `klaviyo_automatic_push_tracking` flag.
+    ///   - autoPushTracking: value of the master `klaviyo_automatic_push_tracking` flag, or `nil`
+    ///     when that key is absent from Info.plist.
     ///   - autoTokenForwardingDisabled: value of the `klaviyo_disable_automatic_token_forwarding`
-    ///     escape hatch, or `nil` when that key is absent from Info.plist (forwarding is then unreported).
-    public init(autoPushTrackingEnabled: Bool, autoTokenForwardingDisabled: Bool?) {
-        autoPushTracking = autoPushTrackingEnabled
-        if let autoTokenForwardingDisabled {
-            // Token forwarding is only active when tracking is on and the escape hatch is not set.
-            autoPushTokenForwarding = autoPushTrackingEnabled && !autoTokenForwardingDisabled
-        } else {
-            autoPushTokenForwarding = nil
-        }
+    ///     escape hatch, or `nil` when that key is absent from Info.plist.
+    public init(autoPushTracking: Bool?, autoTokenForwardingDisabled: Bool?) {
+        self.autoPushTracking = autoPushTracking
+        // Report each flag's configured state independently. Token forwarding is considered enabled
+        // unless the escape hatch explicitly disables it; this is decoupled from the master flag so we
+        // capture how the host set each flag rather than a collapsed runtime state.
+        autoPushTokenForwarding = autoTokenForwardingDisabled.map { !$0 }
     }
 
     /// Value for the `X-Klaviyo-Sdk-Features` header, e.g. `auto_push_tracking=1; auto_push_token_forwarding=0;`.
     /// Only features whose Info.plist key was set are included; unset features are omitted.
     public var headerValue: String {
-        var fields = ["auto_push_tracking=\(autoPushTracking ? 1 : 0)"]
+        var fields: [String] = []
+        if let autoPushTracking {
+            fields.append("auto_push_tracking=\(autoPushTracking ? 1 : 0)")
+        }
         if let autoPushTokenForwarding {
             fields.append("auto_push_token_forwarding=\(autoPushTokenForwarding ? 1 : 0)")
         }
-        return fields.joined(separator: "; ") + ";"
+        return fields.isEmpty ? "" : fields.joined(separator: "; ") + ";"
     }
 }

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -59,7 +59,7 @@ public struct SdkFeatures: Equatable {
     /// Configured feature states; only features the host actually configured are present.
     private let values: [SdkFeatureKey: Bool]
 
-    public init(values: [SdkFeatureKey: Bool]) {
+    package init(values: [SdkFeatureKey: Bool]) {
         self.values = values
     }
 

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -1,0 +1,62 @@
+//
+//  SdkFeatures.swift
+//  KlaviyoCore
+//
+//  Models the SDK feature flags reported via the `X-Klaviyo-Sdk-Features` header on the
+//  push-token-register request, used for SDK adoption telemetry.
+//
+
+import Foundation
+
+/// Snapshot of the automatic-push-tracking feature flags reported to the backend for
+/// adoption telemetry. Serialized into the `X-Klaviyo-Sdk-Features` header.
+///
+/// A feature is only reported when the host app actually set its Info.plist key. Fields whose
+/// key is absent are omitted from the header entirely (the feature is "not marked as used")
+/// rather than reported with a default value.
+public struct SdkFeatures: Equatable {
+    /// Name of the HTTP header these features are serialized into on push-token registration.
+    public static let headerName = "X-Klaviyo-Sdk-Features"
+
+    /// Info.plist keys the host app sets to opt in to automatic push tracking behavior.
+    /// Shared so the flag reads stay consistent across modules.
+    package enum InfoPlistKey {
+        /// Master flag: when present and `true`, enables proxy delegate injection and token forwarding.
+        package static let automaticPushTracking = "klaviyo_automatic_push_tracking"
+        /// Escape hatch: when `true` (and the master is `true`), token forwarding is skipped while the
+        /// proxy stays active.
+        package static let disableAutomaticTokenForwarding = "klaviyo_disable_automatic_token_forwarding"
+    }
+
+    /// Whether the master automatic-push-tracking flag is enabled. Always reported (the header is
+    /// only built when the master key is present).
+    public let autoPushTracking: Bool
+    /// Effective token-forwarding state, or `nil` when the escape-hatch key is absent from Info.plist.
+    /// When `nil` the field is omitted from the header rather than reported, so the backend must treat
+    /// its absence as "unknown / not reported" — never as `false`.
+    public let autoPushTokenForwarding: Bool?
+
+    /// - Parameters:
+    ///   - autoPushTrackingEnabled: value of the master `klaviyo_automatic_push_tracking` flag.
+    ///   - autoTokenForwardingDisabled: value of the `klaviyo_disable_automatic_token_forwarding`
+    ///     escape hatch, or `nil` when that key is absent from Info.plist (forwarding is then unreported).
+    public init(autoPushTrackingEnabled: Bool, autoTokenForwardingDisabled: Bool?) {
+        autoPushTracking = autoPushTrackingEnabled
+        if let autoTokenForwardingDisabled {
+            // Token forwarding is only active when tracking is on and the escape hatch is not set.
+            autoPushTokenForwarding = autoPushTrackingEnabled && !autoTokenForwardingDisabled
+        } else {
+            autoPushTokenForwarding = nil
+        }
+    }
+
+    /// Value for the `X-Klaviyo-Sdk-Features` header, e.g. `auto_push_tracking=1; auto_push_token_forwarding=0;`.
+    /// Only features whose Info.plist key was set are included; unset features are omitted.
+    public var headerValue: String {
+        var fields = ["auto_push_tracking=\(autoPushTracking ? 1 : 0)"]
+        if let autoPushTokenForwarding {
+            fields.append("auto_push_token_forwarding=\(autoPushTokenForwarding ? 1 : 0)")
+        }
+        return fields.joined(separator: "; ") + ";"
+    }
+}

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -80,8 +80,8 @@ public struct SdkFeatures: Equatable {
 
     /// The configured state of a feature, or `nil` when the host never set it (the feature is
     /// then omitted from the header, so the backend must treat its absence as "unknown", not `false`).
-    public subscript(key: SdkFeatureKey) -> Bool? {
-        values[key]
+    public subscript(featureKey: SdkFeatureKey) -> Bool? {
+        values[featureKey]
     }
 
     /// Value for the `X-Klaviyo-Sdk-Features` header on requests in the given scope, e.g.
@@ -90,7 +90,7 @@ public struct SdkFeatures: Equatable {
     public func headerValue(for scope: SdkFeatureScope) -> String? {
         let fields = SdkFeatureKey.allCases
             .filter { $0.scope == scope }
-            .compactMap { key in values[key].map { "\(key.rawValue)=\($0 ? 1 : 0)" } }
+            .compactMap { featureKey in values[featureKey].map { "\(featureKey.rawValue)=\($0 ? 1 : 0)" } }
         return fields.isEmpty ? nil : fields.joined(separator: "; ") + ";"
     }
 }

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -2,21 +2,48 @@
 //  SdkFeatures.swift
 //  KlaviyoCore
 //
-//  Models the SDK feature flags reported via the `X-Klaviyo-Sdk-Features` header on the
-//  push-token-register request, used for SDK adoption telemetry.
+//  Models the SDK feature flags reported via the `X-Klaviyo-Sdk-Features` header,
+//  used for SDK adoption telemetry.
 //
 
 import Foundation
+
+/// The request surface a feature is reported on. Each endpoint that carries the
+/// `X-Klaviyo-Sdk-Features` header reports only the features belonging to its scope.
+///
+/// Kept separate from `KlaviyoEndpoint` cases so multiple endpoints can share a scope.
+public enum SdkFeatureScope: Equatable, CaseIterable {
+    /// Reported on the push-token-register request.
+    case pushTokenRegistration
+}
+
+/// Catalog of reportable SDK features: each case pairs a feature's wire name (the raw value,
+/// serialized into the header) with the scope it is reported on.
+///
+/// Adding a feature means adding a case here and assigning its scope; a feature is never
+/// serialized onto requests outside its scope.
+public enum SdkFeatureKey: String, CaseIterable {
+    case autoPushTracking = "auto_push_tracking"
+    case autoPushTokenForwarding = "auto_push_token_forwarding"
+
+    /// The request surface this feature is reported on.
+    var scope: SdkFeatureScope {
+        switch self {
+        case .autoPushTracking, .autoPushTokenForwarding:
+            return .pushTokenRegistration
+        }
+    }
+}
 
 /// Snapshot of the SDK feature flags reported to the backend for adoption telemetry, serialized
 /// into the `X-Klaviyo-Sdk-Features` header.
 ///
 /// Each feature reports its own configured state independently, so the backend gets a faithful
-/// signal of how the host set each flag. A feature is only reported when the host actually set its
-/// Info.plist key; fields whose key is absent are omitted from the header (the feature is "not
-/// marked as used") rather than reported with a default value.
+/// signal of how the host set each flag. A feature is only present in the snapshot when the host
+/// actually set its Info.plist key; features whose key is absent are omitted from the header
+/// (the feature is "not marked as used") rather than reported with a default value.
 public struct SdkFeatures: Equatable {
-    /// Name of the HTTP header these features are serialized into on push-token registration.
+    /// Name of the HTTP header these features are serialized into.
     public static let headerName = "X-Klaviyo-Sdk-Features"
 
     /// Info.plist keys the host app sets to opt in to automatic push tracking behavior.
@@ -29,13 +56,12 @@ public struct SdkFeatures: Equatable {
         package static let disableAutomaticTokenForwarding = "klaviyo_disable_automatic_token_forwarding"
     }
 
-    /// Master automatic-push-tracking flag, or `nil` when the key is absent from Info.plist
-    /// (the field is then omitted from the header).
-    public let autoPushTracking: Bool?
-    /// Whether automatic token forwarding is enabled (i.e. the escape hatch is not set), independent
-    /// of the master flag. `nil` when the escape-hatch key is absent from Info.plist, in which case the
-    /// field is omitted from the header, so the backend must treat its absence as "unknown", not `false`.
-    public let autoPushTokenForwarding: Bool?
+    /// Configured feature states; only features the host actually configured are present.
+    private let values: [SdkFeatureKey: Bool]
+
+    public init(values: [SdkFeatureKey: Bool]) {
+        self.values = values
+    }
 
     /// - Parameters:
     ///   - autoPushTracking: value of the master `klaviyo_automatic_push_tracking` flag, or `nil`
@@ -43,23 +69,28 @@ public struct SdkFeatures: Equatable {
     ///   - autoTokenForwardingDisabled: value of the `klaviyo_disable_automatic_token_forwarding`
     ///     escape hatch, or `nil` when that key is absent from Info.plist.
     public init(autoPushTracking: Bool?, autoTokenForwardingDisabled: Bool?) {
-        self.autoPushTracking = autoPushTracking
+        var values = [SdkFeatureKey: Bool]()
+        values[.autoPushTracking] = autoPushTracking
         // Report each flag's configured state independently. Token forwarding is considered enabled
         // unless the escape hatch explicitly disables it; this is decoupled from the master flag so we
         // capture how the host set each flag rather than a collapsed runtime state.
-        autoPushTokenForwarding = autoTokenForwardingDisabled.map { !$0 }
+        values[.autoPushTokenForwarding] = autoTokenForwardingDisabled.map { !$0 }
+        self.init(values: values)
     }
 
-    /// Value for the `X-Klaviyo-Sdk-Features` header, e.g. `auto_push_tracking=1; auto_push_token_forwarding=0;`.
-    /// Only features whose Info.plist key was set are included; unset features are omitted.
-    public var headerValue: String {
-        var fields: [String] = []
-        if let autoPushTracking {
-            fields.append("auto_push_tracking=\(autoPushTracking ? 1 : 0)")
-        }
-        if let autoPushTokenForwarding {
-            fields.append("auto_push_token_forwarding=\(autoPushTokenForwarding ? 1 : 0)")
-        }
-        return fields.isEmpty ? "" : fields.joined(separator: "; ") + ";"
+    /// The configured state of a feature, or `nil` when the host never set it (the feature is
+    /// then omitted from the header, so the backend must treat its absence as "unknown", not `false`).
+    public subscript(key: SdkFeatureKey) -> Bool? {
+        values[key]
+    }
+
+    /// Value for the `X-Klaviyo-Sdk-Features` header on requests in the given scope, e.g.
+    /// `auto_push_tracking=1; auto_push_token_forwarding=0;`. Only configured features belonging
+    /// to the scope are included; returns `nil` when there are none, so callers omit the header.
+    public func headerValue(for scope: SdkFeatureScope) -> String? {
+        let fields = SdkFeatureKey.allCases
+            .filter { $0.scope == scope }
+            .compactMap { key in values[key].map { "\(key.rawValue)=\($0 ? 1 : 0)" } }
+        return fields.isEmpty ? nil : fields.joined(separator: "; ") + ";"
     }
 }

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -23,12 +23,20 @@ public enum KlaviyoEndpoint: Equatable, Codable {
         static let profileInfo = "X-Klaviyo-Profile-Info"
         static let clickEventTimestamp = "X-Klaviyo-Click-Event-Timestamp"
         static let apiFilters = "X-Klaviyo-API-Filters"
+        static let sdkFeatures = SdkFeatures.headerName
     }
 
     public var headers: [String: String] {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent:
+        case .createProfile, .createEvent, .unregisterPushToken, .aggregateEvent:
             return [:]
+        case .registerPushToken:
+            // Only report SDK-feature adoption when the host has opted into the new integration
+            // model (i.e. set the Info.plist flag). Absent flag => no header, no backend tracking.
+            guard let features = environment.sdkFeatures() else {
+                return [:]
+            }
+            return [HeaderKey.sdkFeatures: features.headerValue]
         case let .fetchGeofences(_, latitude, longitude):
             var headers = [String: String]()
             if let latitude, let longitude {

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -31,8 +31,6 @@ public enum KlaviyoEndpoint: Equatable, Codable {
         case .createProfile, .createEvent, .unregisterPushToken, .aggregateEvent:
             return [:]
         case .registerPushToken:
-            // Only report SDK-feature adoption when the host has opted into the new integration
-            // model (i.e. set the Info.plist flag). Absent flag => no header, no backend tracking.
             guard let value = environment.sdkFeatures()?.headerValue(for: .pushTokenRegistration) else {
                 return [:]
             }

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -33,10 +33,10 @@ public enum KlaviyoEndpoint: Equatable, Codable {
         case .registerPushToken:
             // Only report SDK-feature adoption when the host has opted into the new integration
             // model (i.e. set the Info.plist flag). Absent flag => no header, no backend tracking.
-            guard let features = environment.sdkFeatures() else {
+            guard let value = environment.sdkFeatures()?.headerValue(for: .pushTokenRegistration) else {
                 return [:]
             }
-            return [HeaderKey.sdkFeatures: features.headerValue]
+            return [HeaderKey.sdkFeatures: value]
         case let .fetchGeofences(_, latitude, longitude):
             var headers = [String: String]()
             if let latitude, let longitude {

--- a/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
@@ -75,11 +75,13 @@ struct KlaviyoSwiftEnvironment {
                 }
             },
             isAutomaticPushTrackingEnabled: {
-                Bundle.main.object(forInfoDictionaryKey: "klaviyo_automatic_push_tracking") as? Bool == true
+                Bundle.main.object(
+                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
+                ) as? Bool == true
             },
             isAutomaticTokenForwardingDisabled: {
                 Bundle.main.object(
-                    forInfoDictionaryKey: "klaviyo_disable_automatic_token_forwarding"
+                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
                 ) as? Bool == true
             },
             notificationCenter: {

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -57,6 +57,74 @@ final class KlaviyoEndpointTests: XCTestCase {
         XCTAssertNotNil(request.httpBody)
     }
 
+    func testRegisterPushTokenAttachesSdkFeaturesHeaderWhenPresent() throws {
+        // Given the host has opted into the new integration model
+        environment.sdkFeatures = {
+            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: true)
+        }
+        let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(
+            request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
+            "auto_push_tracking=1; auto_push_token_forwarding=0;"
+        )
+    }
+
+    func testRegisterPushTokenHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() throws {
+        // Given the master key is set but the escape-hatch key is absent from Info.plist
+        environment.sdkFeatures = {
+            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: nil)
+        }
+        let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then only the master field is present; token forwarding is omitted entirely
+        XCTAssertEqual(
+            request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
+            "auto_push_tracking=1;"
+        )
+    }
+
+    func testRegisterPushTokenOmitsSdkFeaturesHeaderWhenAbsent() throws {
+        // Given the host has not set the Info.plist flag (legacy/manual integration)
+        environment.sdkFeatures = { nil }
+        let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertNil(request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"])
+    }
+
+    func testSdkFeaturesHeaderOnlyAttachesToRegisterPushToken() throws {
+        // Given the host has opted in, so the header would be produced where applicable
+        environment.sdkFeatures = {
+            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: false)
+        }
+
+        // Then no other endpoint carries the SDK-features header
+        let otherEndpoints: [KlaviyoEndpoint] = [
+            .createProfile("test_api_key", CreateProfilePayload(data: ProfilePayload.test)),
+            .createEvent("test_api_key", CreateEventPayload(data: CreateEventPayload.Event(name: "test_event"))),
+            .unregisterPushToken("test_api_key", UnregisterPushTokenPayload(pushToken: "test_token", anonymousId: "anon-id")),
+            .aggregateEvent("test_api_key", Data("test_payload".utf8))
+        ]
+        for endpoint in otherEndpoints {
+            let request = try endpoint.urlRequest()
+            XCTAssertNil(
+                request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
+                "Unexpected SDK-features header on \(endpoint)"
+            )
+        }
+    }
+
     func testUnregisterPushTokenEndpointUrlRequest() throws {
         // Given
         let apiKey = "test_api_key"

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -91,7 +91,7 @@ final class KlaviyoEndpointTests: XCTestCase {
         )
     }
 
-    func testRegisterPushTokenHeaderForEscapeHatchWithoutMaster() throws {
+    func testRegisterPushTokenHeaderForEscapeHatchWithoutPrimaryFlag() throws {
         // Given only the escape-hatch key is set (nonsensical config, captured for telemetry)
         environment.sdkFeatures = {
             SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
@@ -111,6 +111,21 @@ final class KlaviyoEndpointTests: XCTestCase {
     func testRegisterPushTokenOmitsSdkFeaturesHeaderWhenAbsent() throws {
         // Given the host has not set the Info.plist flag (legacy/manual integration)
         environment.sdkFeatures = { nil }
+        let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertNil(request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"])
+    }
+
+    func testRegisterPushTokenOmitsSdkFeaturesHeaderWhenNoScopedFieldsConfigured() throws {
+        // Given a non-nil SdkFeatures whose scope yields no fields (both keys absent), exercising
+        // the guard-let path where headerValue(for:) itself returns nil rather than sdkFeatures().
+        environment.sdkFeatures = {
+            SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: nil)
+        }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
         // When

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -60,7 +60,7 @@ final class KlaviyoEndpointTests: XCTestCase {
     func testRegisterPushTokenAttachesSdkFeaturesHeaderWhenPresent() throws {
         // Given the host has opted into the new integration model
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: true)
+            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: true)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
@@ -77,7 +77,7 @@ final class KlaviyoEndpointTests: XCTestCase {
     func testRegisterPushTokenHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() throws {
         // Given the master key is set but the escape-hatch key is absent from Info.plist
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: nil)
+            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: nil)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
@@ -88,6 +88,23 @@ final class KlaviyoEndpointTests: XCTestCase {
         XCTAssertEqual(
             request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
             "auto_push_tracking=1;"
+        )
+    }
+
+    func testRegisterPushTokenHeaderForEscapeHatchWithoutMaster() throws {
+        // Given only the escape-hatch key is set (nonsensical config, captured for telemetry)
+        environment.sdkFeatures = {
+            SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
+        }
+        let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then only the forwarding field is present; its presence flags the escape-hatch config
+        XCTAssertEqual(
+            request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
+            "auto_push_token_forwarding=0;"
         )
     }
 
@@ -106,7 +123,7 @@ final class KlaviyoEndpointTests: XCTestCase {
     func testSdkFeaturesHeaderOnlyAttachesToRegisterPushToken() throws {
         // Given the host has opted in, so the header would be produced where applicable
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: false)
+            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
         }
 
         // Then no other endpoint carries the SDK-features header

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -126,12 +126,27 @@ final class KlaviyoEndpointTests: XCTestCase {
             SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
         }
 
-        // Then no other endpoint carries the SDK-features header
+        // Then no other endpoint carries the SDK-features header (some set their own
+        // headers, so only the SDK-features key is asserted absent)
+        let trackingLink = URL(string: "https://email.klaviyo.com/ct/test")!
         let otherEndpoints: [KlaviyoEndpoint] = [
             .createProfile("test_api_key", CreateProfilePayload(data: ProfilePayload.test)),
-            .createEvent("test_api_key", CreateEventPayload(data: CreateEventPayload.Event(name: "test_event"))),
-            .unregisterPushToken("test_api_key", UnregisterPushTokenPayload(pushToken: "test_token", anonymousId: "anon-id")),
-            .aggregateEvent("test_api_key", Data("test_payload".utf8))
+            .createEvent(
+                "test_api_key",
+                CreateEventPayload(data: CreateEventPayload.Event(name: "test_event"))
+            ),
+            .unregisterPushToken(
+                "test_api_key",
+                UnregisterPushTokenPayload(pushToken: "test_token", anonymousId: "anon-id")
+            ),
+            .aggregateEvent("test_api_key", Data("test_payload".utf8)),
+            .fetchGeofences("test_api_key", latitude: 42.0, longitude: -71.0),
+            .resolveDestinationURL(trackingLink: trackingLink, profileInfo: ProfilePayload.test),
+            .logTrackingLinkClicked(
+                trackingLink: trackingLink,
+                clickTime: Date(),
+                profileInfo: ProfilePayload.test
+            )
         ]
         for endpoint in otherEndpoints {
             let request = try endpoint.urlRequest()

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -41,7 +41,7 @@ final class SdkFeaturesTests: XCTestCase {
 
     /// Master key absent, escape hatch present and off: the tracking field is omitted, and forwarding
     /// reports enabled independent of the master flag.
-    func testHeaderOmitsTrackingWhenMasterKeyAbsent() {
+    func testHeaderOmitsTrackingWhenPrimaryKeyAbsent() {
         let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: false)
         XCTAssertNil(features[.autoPushTracking])
         XCTAssertEqual(features[.autoPushTokenForwarding], true)
@@ -50,7 +50,7 @@ final class SdkFeaturesTests: XCTestCase {
 
     /// Escape hatch set to disable without the master key (nonsensical but captured as a usage
     /// signal): only the forwarding field is emitted, reporting disabled.
-    func testHeaderForEscapeHatchWithoutMaster() {
+    func testHeaderForEscapeHatchWithoutPrimaryFlag() {
         let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
         XCTAssertNil(features[.autoPushTracking])
         XCTAssertEqual(features[.autoPushTokenForwarding], false)

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -1,0 +1,51 @@
+//
+//  SdkFeaturesTests.swift
+//  KlaviyoCoreTests
+//
+//  Created by Glenn Brannelly on 7/7/26.
+//
+
+@testable import KlaviyoCore
+import XCTest
+
+final class SdkFeaturesTests: XCTestCase {
+    /// Master on, escape hatch present and off: both fields reported, forwarding on (typical opt-in).
+    func testHeaderValueTrackingOnForwardingOn() {
+        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: false)
+        XCTAssertTrue(features.autoPushTracking)
+        XCTAssertEqual(features.autoPushTokenForwarding, true)
+        XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=1;")
+    }
+
+    /// Master on, escape hatch present and set: proxy stays active but forwarding collapses to off.
+    func testHeaderValueTrackingOnForwardingDisabled() {
+        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: true)
+        XCTAssertTrue(features.autoPushTracking)
+        XCTAssertEqual(features.autoPushTokenForwarding, false)
+        XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=0;")
+    }
+
+    /// Escape-hatch key absent: the token-forwarding field is omitted entirely (not marked as used),
+    /// rather than reported with a default value.
+    func testHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() {
+        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: nil)
+        XCTAssertTrue(features.autoPushTracking)
+        XCTAssertNil(features.autoPushTokenForwarding)
+        XCTAssertEqual(features.headerValue, "auto_push_tracking=1;")
+    }
+
+    /// Master off, escape-hatch key absent: only the master field is reported.
+    func testHeaderTrackingOffForwardingKeyAbsent() {
+        let features = SdkFeatures(autoPushTrackingEnabled: false, autoTokenForwardingDisabled: nil)
+        XCTAssertFalse(features.autoPushTracking)
+        XCTAssertNil(features.autoPushTokenForwarding)
+        XCTAssertEqual(features.headerValue, "auto_push_tracking=0;")
+    }
+
+    /// The escape hatch is a no-op when the master is off; forwarding can never be on without tracking.
+    func testForwardingIsOffWheneverTrackingIsOff() {
+        let features = SdkFeatures(autoPushTrackingEnabled: false, autoTokenForwardingDisabled: false)
+        XCTAssertEqual(features.autoPushTokenForwarding, false)
+        XCTAssertEqual(features.headerValue, "auto_push_tracking=0; auto_push_token_forwarding=0;")
+    }
+}

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -9,43 +9,53 @@
 import XCTest
 
 final class SdkFeaturesTests: XCTestCase {
-    /// Master on, escape hatch present and off: both fields reported, forwarding on (typical opt-in).
+    /// Both keys present, escape hatch off: both fields reported, forwarding on (typical opt-in).
     func testHeaderValueTrackingOnForwardingOn() {
-        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: false)
-        XCTAssertTrue(features.autoPushTracking)
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
+        XCTAssertEqual(features.autoPushTracking, true)
         XCTAssertEqual(features.autoPushTokenForwarding, true)
         XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=1;")
     }
 
-    /// Master on, escape hatch present and set: proxy stays active but forwarding collapses to off.
+    /// Both keys present, escape hatch set: proxy stays active but forwarding collapses to off.
     func testHeaderValueTrackingOnForwardingDisabled() {
-        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: true)
-        XCTAssertTrue(features.autoPushTracking)
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: true)
+        XCTAssertEqual(features.autoPushTracking, true)
         XCTAssertEqual(features.autoPushTokenForwarding, false)
         XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=0;")
     }
 
-    /// Escape-hatch key absent: the token-forwarding field is omitted entirely (not marked as used),
-    /// rather than reported with a default value.
+    /// Escape-hatch key absent: the token-forwarding field is omitted entirely.
     func testHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() {
-        let features = SdkFeatures(autoPushTrackingEnabled: true, autoTokenForwardingDisabled: nil)
-        XCTAssertTrue(features.autoPushTracking)
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: nil)
+        XCTAssertEqual(features.autoPushTracking, true)
         XCTAssertNil(features.autoPushTokenForwarding)
         XCTAssertEqual(features.headerValue, "auto_push_tracking=1;")
     }
 
-    /// Master off, escape-hatch key absent: only the master field is reported.
-    func testHeaderTrackingOffForwardingKeyAbsent() {
-        let features = SdkFeatures(autoPushTrackingEnabled: false, autoTokenForwardingDisabled: nil)
-        XCTAssertFalse(features.autoPushTracking)
-        XCTAssertNil(features.autoPushTokenForwarding)
-        XCTAssertEqual(features.headerValue, "auto_push_tracking=0;")
+    /// Master key absent, escape hatch present and off: the tracking field is omitted, and forwarding
+    /// reports enabled independent of the master flag.
+    func testHeaderOmitsTrackingWhenMasterKeyAbsent() {
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: false)
+        XCTAssertNil(features.autoPushTracking)
+        XCTAssertEqual(features.autoPushTokenForwarding, true)
+        XCTAssertEqual(features.headerValue, "auto_push_token_forwarding=1;")
     }
 
-    /// The escape hatch is a no-op when the master is off; forwarding can never be on without tracking.
-    func testForwardingIsOffWheneverTrackingIsOff() {
-        let features = SdkFeatures(autoPushTrackingEnabled: false, autoTokenForwardingDisabled: false)
+    /// Escape hatch set to disable without the master key (nonsensical but captured as a usage
+    /// signal): only the forwarding field is emitted, reporting disabled.
+    func testHeaderForEscapeHatchWithoutMaster() {
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
+        XCTAssertNil(features.autoPushTracking)
         XCTAssertEqual(features.autoPushTokenForwarding, false)
-        XCTAssertEqual(features.headerValue, "auto_push_tracking=0; auto_push_token_forwarding=0;")
+        XCTAssertEqual(features.headerValue, "auto_push_token_forwarding=0;")
+    }
+
+    /// Neither key present: nothing to report; the header value is empty.
+    func testHeaderValueEmptyWhenNoKeysPresent() {
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: nil)
+        XCTAssertNil(features.autoPushTracking)
+        XCTAssertNil(features.autoPushTokenForwarding)
+        XCTAssertEqual(features.headerValue, "")
     }
 }

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -87,10 +87,10 @@ final class SdkFeaturesTests: XCTestCase {
         let serialized = SdkFeatureScope.allCases
             .compactMap { allOn.headerValue(for: $0) }
             .joined()
-        for key in SdkFeatureKey.allCases {
+        for featureKey in SdkFeatureKey.allCases {
             XCTAssertEqual(
-                serialized.components(separatedBy: "\(key.rawValue)=").count - 1, 1,
-                "\(key.rawValue) should be serialized in exactly one scope"
+                serialized.components(separatedBy: "\(featureKey.rawValue)=").count - 1, 1,
+                "\(featureKey.rawValue) should be serialized in exactly one scope"
             )
         }
     }

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -12,50 +12,86 @@ final class SdkFeaturesTests: XCTestCase {
     /// Both keys present, escape hatch off: both fields reported, forwarding on (typical opt-in).
     func testHeaderValueTrackingOnForwardingOn() {
         let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
-        XCTAssertEqual(features.autoPushTracking, true)
-        XCTAssertEqual(features.autoPushTokenForwarding, true)
-        XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=1;")
+        XCTAssertEqual(features[.autoPushTracking], true)
+        XCTAssertEqual(features[.autoPushTokenForwarding], true)
+        XCTAssertEqual(
+            features.headerValue(for: .pushTokenRegistration),
+            "auto_push_tracking=1; auto_push_token_forwarding=1;"
+        )
     }
 
     /// Both keys present, escape hatch set: proxy stays active but forwarding collapses to off.
     func testHeaderValueTrackingOnForwardingDisabled() {
         let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: true)
-        XCTAssertEqual(features.autoPushTracking, true)
-        XCTAssertEqual(features.autoPushTokenForwarding, false)
-        XCTAssertEqual(features.headerValue, "auto_push_tracking=1; auto_push_token_forwarding=0;")
+        XCTAssertEqual(features[.autoPushTracking], true)
+        XCTAssertEqual(features[.autoPushTokenForwarding], false)
+        XCTAssertEqual(
+            features.headerValue(for: .pushTokenRegistration),
+            "auto_push_tracking=1; auto_push_token_forwarding=0;"
+        )
     }
 
     /// Escape-hatch key absent: the token-forwarding field is omitted entirely.
     func testHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() {
         let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: nil)
-        XCTAssertEqual(features.autoPushTracking, true)
-        XCTAssertNil(features.autoPushTokenForwarding)
-        XCTAssertEqual(features.headerValue, "auto_push_tracking=1;")
+        XCTAssertEqual(features[.autoPushTracking], true)
+        XCTAssertNil(features[.autoPushTokenForwarding])
+        XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_tracking=1;")
     }
 
     /// Master key absent, escape hatch present and off: the tracking field is omitted, and forwarding
     /// reports enabled independent of the master flag.
     func testHeaderOmitsTrackingWhenMasterKeyAbsent() {
         let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: false)
-        XCTAssertNil(features.autoPushTracking)
-        XCTAssertEqual(features.autoPushTokenForwarding, true)
-        XCTAssertEqual(features.headerValue, "auto_push_token_forwarding=1;")
+        XCTAssertNil(features[.autoPushTracking])
+        XCTAssertEqual(features[.autoPushTokenForwarding], true)
+        XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_token_forwarding=1;")
     }
 
     /// Escape hatch set to disable without the master key (nonsensical but captured as a usage
     /// signal): only the forwarding field is emitted, reporting disabled.
     func testHeaderForEscapeHatchWithoutMaster() {
         let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
-        XCTAssertNil(features.autoPushTracking)
-        XCTAssertEqual(features.autoPushTokenForwarding, false)
-        XCTAssertEqual(features.headerValue, "auto_push_token_forwarding=0;")
+        XCTAssertNil(features[.autoPushTracking])
+        XCTAssertEqual(features[.autoPushTokenForwarding], false)
+        XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_token_forwarding=0;")
     }
 
-    /// Neither key present: nothing to report; the header value is empty.
-    func testHeaderValueEmptyWhenNoKeysPresent() {
+    /// Neither key present: nothing to report; the header value is nil so callers omit the header.
+    func testHeaderValueNilWhenNoKeysPresent() {
         let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: nil)
-        XCTAssertNil(features.autoPushTracking)
-        XCTAssertNil(features.autoPushTokenForwarding)
-        XCTAssertEqual(features.headerValue, "")
+        XCTAssertNil(features[.autoPushTracking])
+        XCTAssertNil(features[.autoPushTokenForwarding])
+        XCTAssertNil(features.headerValue(for: .pushTokenRegistration))
+    }
+
+    /// Serialization follows the catalog's declaration order regardless of construction order,
+    /// keeping the header field ordering deterministic.
+    func testHeaderValueOrderingIsDeterministic() {
+        let features = SdkFeatures(values: [
+            .autoPushTokenForwarding: false,
+            .autoPushTracking: true
+        ])
+        XCTAssertEqual(
+            features.headerValue(for: .pushTokenRegistration),
+            "auto_push_tracking=1; auto_push_token_forwarding=0;"
+        )
+    }
+
+    /// Every feature in the catalog must belong to a scope; serializing a full snapshot for each
+    /// scope collectively covers all features, so none can silently go unreported.
+    func testEveryFeatureIsSerializedInExactlyOneScope() {
+        let allOn = SdkFeatures(values: .init(
+            uniqueKeysWithValues: SdkFeatureKey.allCases.map { ($0, true) }
+        ))
+        let serialized = SdkFeatureScope.allCases
+            .compactMap { allOn.headerValue(for: $0) }
+            .joined()
+        for key in SdkFeatureKey.allCases {
+            XCTAssertEqual(
+                serialized.components(separatedBy: "\(key.rawValue)=").count - 1, 1,
+                "\(key.rawValue) should be serialized in exactly one scope"
+            )
+        }
     }
 }


### PR DESCRIPTION
# Description
Adds an `X-Klaviyo-Sdk-Features` header to the push-token-register request for SDK adoption telemetry, reporting how the host app configured the automatic push tracking flags. Feature reporting is modeled as a scoped catalog so future features can target different endpoints.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Merges into `feat/auto-push-tracking` and ships with the automatic push tracking feature; no public (integrator-facing) API changes.

## Changelog / Code Overview
- New `SdkFeatures` model in `Sources/KlaviyoCore/Models/`:
  - `SdkFeatureKey` catalogs reportable features; each case pairs its wire name with a `SdkFeatureScope` (currently only `.pushTokenRegistration`), so a feature can never be serialized onto an endpoint outside its scope. Adding a future feature (including ones reported on other endpoints, e.g. `client/events`) is a new key + scope case.
  - Each feature reports its raw configured state independently, and only when its Info.plist key is actually set; absent keys are omitted from the header so the backend can distinguish "configured false" from "not configured".
- `environment.sdkFeatures` reads the `klaviyo_automatic_push_tracking` and `klaviyo_disable_automatic_token_forwarding` Info.plist keys; `KlaviyoEndpoint.headers` attaches the header for `.registerPushToken` only (via `headerValue(for: .pushTokenRegistration)`), omitting it entirely when nothing is configured.
- Header format: `auto_push_tracking=1; auto_push_token_forwarding=0;` with deterministic field ordering.
- Chose an environment-computed header over adding an associated value to the `registerPushToken` case because `KlaviyoEndpoint` is Codable and persisted in the request queue; changing the case encoding would wipe persisted state on upgrade.

## Test Plan
- Unit tests (`SdkFeaturesTests`, `KlaviyoEndpointTests`) cover header serialization for each flag combination, nil-vs-false omission semantics, deterministic ordering, every-feature-has-exactly-one-scope invariant, and that no endpoint other than push-token-register carries the header.
- Manual (verified via Proxyman, screenshots on MAGE-764):
  1. Set `klaviyo_automatic_push_tracking = YES` and `klaviyo_disable_automatic_token_forwarding = YES` in the test app Info.plist, register a push token, observe `auto_push_tracking=1; auto_push_token_forwarding=0;` on `POST /client/push-tokens/`.
  2. Set `klaviyo_automatic_push_tracking = NO` (escape hatch unset), observe `auto_push_tracking=0;`.
  3. Remove both keys, observe no `X-Klaviyo-Sdk-Features` header.

## Related Issues/Tickets
Resolves MAGE-764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDK feature-flag reporting via the `X-Klaviyo-Sdk-Features` header on push token registration requests.
  * App configuration now supports providing feature flags for automatic push tracking and token forwarding.
* **Bug Fixes**
  * Feature information is only included for the applicable request type, and omitted when no scoped settings are available.
  * Header formatting and deterministic field ordering are consistent.
* **Tests**
  * Added unit tests covering header serialization, scoping behavior, and endpoint exclusivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->