### PR TITLE
test(KlaviyoCore): de-flake EventBuffer tests via injectable clock

### DIFF
--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -13,7 +13,10 @@ import OSLog
 
 @available(iOS 14.0, *)
 extension Logger {
-    fileprivate static let eventBuffer = Logger(subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoCore", category: "Event Buffering")
+    fileprivate static let eventBuffer = Logger(
+        subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoCore",
+        category: "Event Buffering"
+    )
 }
 
 /// Manages a thread-safe buffer of recent events for replay to new subscribers.
@@ -29,6 +32,7 @@ final class EventBuffer {
     private var buffer: [BufferedEvent] = []
     private let maxBufferSize: Int
     private let maxBufferAge: TimeInterval
+    private let clock: () -> TimeInterval
     private let queue = DispatchQueue(label: "com.klaviyo.eventBuffer", attributes: .concurrent)
 
     // MARK: - Initialization
@@ -37,9 +41,16 @@ final class EventBuffer {
     /// - Parameters:
     ///   - maxBufferSize: Maximum number of events to keep (default: 10)
     ///   - maxBufferAge: Maximum age of events to keep in seconds (default: 10)
-    init(maxBufferSize: Int = 10, maxBufferAge: TimeInterval = 10) {
+    ///   - clock: Monotonic clock source. Injectable so tests can advance time deterministically;
+    ///     defaults to `ProcessInfo.processInfo.systemUptime`.
+    init(
+        maxBufferSize: Int = 10,
+        maxBufferAge: TimeInterval = 10,
+        clock: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
         self.maxBufferSize = maxBufferSize
         self.maxBufferAge = maxBufferAge
+        self.clock = clock
     }
 
     // MARK: - Public Methods
@@ -53,13 +64,13 @@ final class EventBuffer {
 
         queue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
-            let now = ProcessInfo.processInfo.systemUptime
+            let currentTime = self.clock()
 
             // Clean old events from buffer (using monotonic clock to avoid issues with device clock changes)
-            self.buffer = self.buffer.filter { now - $0.timestamp < self.maxBufferAge }
+            self.buffer = self.buffer.filter { currentTime - $0.timestamp < self.maxBufferAge }
 
             // Add new event
-            self.buffer.append(BufferedEvent(event: event, timestamp: now))
+            self.buffer.append(BufferedEvent(event: event, timestamp: currentTime))
 
             // Keep only last N events
             if self.buffer.count > self.maxBufferSize {
@@ -76,16 +87,19 @@ final class EventBuffer {
     /// - Returns: Array of buffered events that haven't expired
     func getRecentEvents() -> [Event] {
         queue.sync {
-            let now = ProcessInfo.processInfo.systemUptime
+            let currentTime = clock()
             let recentEvents = buffer
-                .filter { now - $0.timestamp < maxBufferAge }
+                .filter { currentTime - $0.timestamp < maxBufferAge }
                 .map(\.event)
 
             if #available(iOS 14.0, *) {
                 if recentEvents.isEmpty {
                     Logger.eventBuffer.info("📭 Event buffer is empty - no events to replay")
                 } else {
-                    Logger.eventBuffer.info("📬 Replaying \(recentEvents.count) buffered event(s): \(recentEvents.map(\.metric.name.value).joined(separator: ", "), privacy: .public)")
+                    let names = recentEvents.map(\.metric.name.value).joined(separator: ", ")
+                    Logger.eventBuffer.info(
+                        "📬 Replaying \(recentEvents.count) buffered event(s): \(names, privacy: .public)"
+                    )
                 }
             }
 

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -22,6 +22,20 @@ class EventBufferTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Helpers
+
+    /// A buffer whose clock the test controls, so age-based behavior is deterministic
+    /// without sleeping real time. `buffer(_:)` is an async barrier write, so callers
+    /// must `getRecentEvents()` (a synchronous, barrier-flushing read) to pin an event's
+    /// timestamp at the current `currentTime` before advancing the clock.
+    private func makeClockedBuffer(
+        maxBufferSize: Int = 5,
+        maxBufferAge: TimeInterval = 2.0,
+        currentTime: @escaping () -> TimeInterval
+    ) -> EventBuffer {
+        EventBuffer(maxBufferSize: maxBufferSize, maxBufferAge: maxBufferAge, clock: currentTime)
+    }
+
     // MARK: - Basic Functionality Tests
 
     func testBufferStartsEmpty() {
@@ -32,16 +46,13 @@ class EventBufferTests: XCTestCase {
         XCTAssertTrue(events.isEmpty, "Buffer should start empty")
     }
 
-    func testBufferStoresEvent() async throws {
+    func testBufferStoresEvent() {
         // Given
         let event = Event(name: .customEvent("test_event"))
 
-        // When
+        // When — getRecentEvents() is a synchronous, barrier-flushing read, so it observes
+        // the preceding async buffer() write deterministically (no sleep needed).
         eventBuffer.buffer(event)
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
         let events = eventBuffer.getRecentEvents()
 
         // Then
@@ -49,7 +60,7 @@ class EventBufferTests: XCTestCase {
         XCTAssertEqual(events.first?.metric.name.value, "test_event")
     }
 
-    func testBufferStoresMultipleEvents() async throws {
+    func testBufferStoresMultipleEvents() {
         // Given
         let event1 = Event(name: .customEvent("event_1"))
         let event2 = Event(name: .customEvent("event_2"))
@@ -59,10 +70,6 @@ class EventBufferTests: XCTestCase {
         eventBuffer.buffer(event1)
         eventBuffer.buffer(event2)
         eventBuffer.buffer(event3)
-
-        // Wait for async buffer operations to complete
-        try await Task.sleep(nanoseconds: 250_000_000) // 0.25 seconds
-
         let events = eventBuffer.getRecentEvents()
 
         // Then
@@ -74,16 +81,12 @@ class EventBufferTests: XCTestCase {
 
     // MARK: - Buffer Size Limit Tests
 
-    func testBufferRespectsMaxSize() async throws {
+    func testBufferRespectsMaxSize() {
         // Given - buffer with maxSize of 5
         let events = (1...7).map { Event(name: .customEvent("event_\($0)")) }
 
         // When - buffer 7 events
         events.forEach { eventBuffer.buffer($0) }
-
-        // Wait for async buffer operations to complete
-        try await Task.sleep(nanoseconds: 250_000_000) // 0.25 seconds
-
         let recentEvents = eventBuffer.getRecentEvents()
 
         // Then - should only keep last 5
@@ -92,7 +95,7 @@ class EventBufferTests: XCTestCase {
         XCTAssertEqual(recentEvents[4].metric.name.value, "event_7", "Should keep newest events")
     }
 
-    func testBufferDropsOldestEventsWhenFull() async throws {
+    func testBufferDropsOldestEventsWhenFull() {
         // Given
         eventBuffer.buffer(Event(name: .customEvent("old_event")))
 
@@ -100,10 +103,6 @@ class EventBufferTests: XCTestCase {
         for iter in 1...5 {
             eventBuffer.buffer(Event(name: .customEvent("event_\(iter)")))
         }
-
-        // Wait for async buffer operations to complete
-        try await Task.sleep(nanoseconds: 250_000_000) // 0.25 seconds
-
         let events = eventBuffer.getRecentEvents()
 
         // Then
@@ -114,52 +113,54 @@ class EventBufferTests: XCTestCase {
 
     // MARK: - Buffer Age Limit Tests
 
-    func testBufferFiltersOldEvents() async throws {
-        // Given - buffer with 2 second age limit
-        eventBuffer.buffer(Event(name: .customEvent("old_event")))
+    func testBufferFiltersOldEvents() {
+        // Given - a buffer with a 2s age limit and a test-controlled clock
+        var clock: TimeInterval = 0
+        let buffer = makeClockedBuffer(currentTime: { clock })
+        buffer.buffer(Event(name: .customEvent("old_event")))
+        _ = buffer.getRecentEvents() // flush: pins old_event's timestamp at t=0
 
-        // When - wait for event to expire
-        try await Task.sleep(nanoseconds: 2_500_000_000) // 2.5 seconds
-
-        eventBuffer.buffer(Event(name: .customEvent("new_event")))
-        let events = eventBuffer.getRecentEvents()
+        // When - advance the clock past the age limit, then buffer a new event
+        clock = 3.0
+        buffer.buffer(Event(name: .customEvent("new_event")))
+        let events = buffer.getRecentEvents()
 
         // Then
-        XCTAssertEqual(events.count, 1, "Should only return recent event")
+        XCTAssertEqual(events.count, 1, "Should only return the recent event")
         XCTAssertEqual(events.first?.metric.name.value, "new_event")
     }
 
-    func testBufferKeepsRecentEvents() async throws {
+    func testBufferKeepsRecentEvents() {
         // Given
-        eventBuffer.buffer(Event(name: .customEvent("recent_event")))
+        var clock: TimeInterval = 0
+        let buffer = makeClockedBuffer(currentTime: { clock })
+        buffer.buffer(Event(name: .customEvent("recent_event")))
+        _ = buffer.getRecentEvents() // flush: pins recent_event's timestamp at t=0
 
-        // When - wait less than age limit
-        try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
-
-        let events = eventBuffer.getRecentEvents()
+        // When - advance less than the age limit
+        clock = 0.5
+        let events = buffer.getRecentEvents()
 
         // Then
         XCTAssertEqual(events.count, 1, "Recent event should still be in buffer")
         XCTAssertEqual(events.first?.metric.name.value, "recent_event")
     }
 
-    func testBufferMixesOldAndNewEvents() async throws {
+    func testBufferMixesOldAndNewEvents() {
         // Given
-        eventBuffer.buffer(Event(name: .customEvent("old_event")))
+        var clock: TimeInterval = 0
+        let buffer = makeClockedBuffer(currentTime: { clock })
+        buffer.buffer(Event(name: .customEvent("old_event")))
+        _ = buffer.getRecentEvents() // flush: pins old_event's timestamp at t=0
 
-        try await Task.sleep(nanoseconds: 2_500_000_000) // 2.5 seconds
-
-        eventBuffer.buffer(Event(name: .customEvent("new_event_1")))
-        eventBuffer.buffer(Event(name: .customEvent("new_event_2")))
-
-        // Wait for async buffer operations to complete
-        try await Task.sleep(nanoseconds: 250_000_000) // 0.25 seconds
-
-        // When
-        let events = eventBuffer.getRecentEvents()
+        // When - advance past the age limit, then buffer two new events
+        clock = 3.0
+        buffer.buffer(Event(name: .customEvent("new_event_1")))
+        buffer.buffer(Event(name: .customEvent("new_event_2")))
+        let events = buffer.getRecentEvents()
 
         // Then
-        XCTAssertEqual(events.count, 2, "Should only return recent events")
+        XCTAssertEqual(events.count, 2, "Should only return the recent events")
         XCTAssertTrue(events.contains { $0.metric.name.value == "new_event_1" })
         XCTAssertTrue(events.contains { $0.metric.name.value == "new_event_2" })
         XCTAssertFalse(events.contains { $0.metric.name.value == "old_event" })
@@ -196,16 +197,12 @@ class EventBufferTests: XCTestCase {
             for iter in 0..<50 {
                 self.eventBuffer.buffer(Event(name: .customEvent("event_\(iter)")))
             }
-            // Add small delay to allow async buffer operations to settle
-            Thread.sleep(forTimeInterval: 0.25)
             writeExpectation.fulfill()
         }
 
         DispatchQueue.global().async {
             for _ in 0..<50 {
                 _ = self.eventBuffer.getRecentEvents()
-                // Add tiny delay between reads to prevent tight loop
-                Thread.sleep(forTimeInterval: 0.001)
             }
             readExpectation.fulfill()
         }
@@ -217,44 +214,33 @@ class EventBufferTests: XCTestCase {
 
     // MARK: - Edge Cases
 
-    func testBufferWithZeroMaxSize() async throws {
+    func testBufferWithZeroMaxSize() {
         // Given
         let zeroBuffer = EventBuffer(maxBufferSize: 0, maxBufferAge: 10.0)
 
         // When
         zeroBuffer.buffer(Event(name: .customEvent("event")))
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
         let events = zeroBuffer.getRecentEvents()
 
         // Then
         XCTAssertTrue(events.isEmpty, "Buffer with size 0 should not store events")
     }
 
-    func testBufferWithZeroMaxAge() async throws {
+    func testBufferWithZeroMaxAge() {
         // Given
         let zeroAgeBuffer = EventBuffer(maxBufferSize: 10, maxBufferAge: 0.0)
 
         // When
         zeroAgeBuffer.buffer(Event(name: .customEvent("event")))
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
         let events = zeroAgeBuffer.getRecentEvents()
 
         // Then
         XCTAssertTrue(events.isEmpty, "Buffer with age 0 should immediately expire events")
     }
 
-    func testGetRecentEventsMultipleTimes() async throws {
+    func testGetRecentEventsMultipleTimes() {
         // Given
         eventBuffer.buffer(Event(name: .customEvent("event")))
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
 
         // When
         let events1 = eventBuffer.getRecentEvents()
@@ -267,17 +253,13 @@ class EventBufferTests: XCTestCase {
         XCTAssertEqual(events3.count, 1)
     }
 
-    func testBufferPreservesEventProperties() async throws {
+    func testBufferPreservesEventProperties() {
         // Given
         let properties = ["key1": "value1", "key2": 123] as [String: Any]
         let event = Event(name: .customEvent("test"), properties: properties)
 
         // When
         eventBuffer.buffer(event)
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
         let retrievedEvents = eventBuffer.getRecentEvents()
 
         // Then
@@ -288,17 +270,13 @@ class EventBufferTests: XCTestCase {
         XCTAssertEqual(retrievedEvent.properties["key2"] as? Int, 123)
     }
 
-    func testBufferWithOpenedPushEvent() async throws {
+    func testBufferWithOpenedPushEvent() {
         // Given - simulate real use case
         let pushProperties = ["message_id": "abc123", "campaign_id": "xyz789"] as [String: Any]
         let openedPushEvent = Event(name: ._openedPush, properties: pushProperties)
 
         // When
         eventBuffer.buffer(openedPushEvent)
-
-        // Wait for async buffer operation to complete
-        try await Task.sleep(nanoseconds: 150_000_000) // 0.15 seconds
-
         let events = eventBuffer.getRecentEvents()
 
         // Then


### PR DESCRIPTION
# Description
De-flakes `EventBufferTests` — most notably `testBufferRespectsMaxSize` — by removing timing-based synchronization. Standalone; independent of the in-progress Phase-2 stack (EventBuffer already shipped via #632), so it targets `feat/modularization` directly.

## Root cause
`EventBuffer.buffer(_:)` is an async barrier write; `getRecentEvents()` is a synchronous, barrier-flushing read. The tests waited a fixed `Task.sleep` before asserting, against a **2s wall-clock age window** (`maxBufferAge`). That sleep was:
- **unnecessary** — `getRecentEvents()`'s `queue.sync` already flushes the pending `buffer()` barrier, so the read deterministically observes the writes; and
- **harmful** — the added delay, plus CI scheduling jitter, could push total elapsed time past the 2s age window, age-evicting events the size assertions expected → intermittent failures in `testBufferRespectsMaxSize` (`count == 5` / `[0] == event_3`).

## Changes
- **`EventBuffer`**: inject the monotonic clock (`clock: () -> TimeInterval`, defaults to `ProcessInfo.processInfo.systemUptime`) — a backward-compatible, test-only seam; production behavior unchanged.
- **Age tests** (`FiltersOldEvents`, `KeepsRecentEvents`, `MixesOldAndNewEvents`): advance the injected clock instead of `Task.sleep`-ing real seconds — fully deterministic, no wall-clock dependence.
- **Size/count/edge tests**: drop the redundant "wait for async" sleeps; rely on the barrier-flushing read.
- Wrapped two pre-existing long `Logger` lines in the file to keep it lint-clean (no behavior change).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.

## Test Plan
- `EventBufferTests`: 15 tests, deterministic across repeated runs; suite time **~5.5s → ~0.07s** (the 2.5s age sleeps are gone).
- Full `KlaviyoCoreTests` bundle green (116 tests, 0 failures) — no regression from the clock seam (default preserves prior behavior).
- Pre-commit (SwiftLint/SwiftFormat/whitespace) passes; `swiftlint --strict` → 0 violations on both files.

## Related Issues/Tickets
Related to MAGE-830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event buffering and replay timing consistency, helping recent events expire and replay more predictably.
  * Made event retention behavior more reliable under concurrent use and size limits.
* **Tests**
  * Updated the event buffer test suite to use controlled time, making timing-related checks more stable and deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->