### PR TITLE
feat(push): decouple automatic push tracking and token forwarding (MAGE-884)

### DIFF
--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -18,7 +18,7 @@ This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Foll
 
 ## SPM Example — Automatic Push Tracking
 
-This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts into automatic push integration via the `klaviyo_automatic_push_tracking` Info.plist key. With this key set, the SDK automatically forwards device tokens and tracks push opens — no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code required in your `AppDelegate`.
+This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts into automatic push integration via two independent Info.plist keys: `klaviyo_automatic_push_tracking` (tracks push opens) and `klaviyo_automatic_token_forwarding` (forwards device tokens). With both keys set, the SDK automatically forwards device tokens and tracks push opens, so no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code is required in your `AppDelegate`.
 
 ## Which example should I use?
 

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -2,8 +2,10 @@
 //  AppDelegate.swift
 //  SPMExampleAutomatic
 //
-// Automatic push integration — no token forwarding, no notification delegate code needed.
-// The SDK handles all of that when `klaviyo_automatic_push_tracking` is set in Info.plist.
+// Automatic push integration: no token forwarding, no notification delegate code needed.
+// The SDK handles all of that when both `klaviyo_automatic_push_tracking` and
+// `klaviyo_automatic_token_forwarding` are set in Info.plist. The two flags are independent;
+// this target opts into both for the fully automatic experience.
 // For the manual integration reference (STEP1–STEP6) see Shared/AppDelegate.swift.
 //
 

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  SPMExampleAutomatic
 //
-// Automatic push integration: no token forwarding, no notification delegate code needed.
+// Automatic push integration: no token-forwarding or notification-delegate code needed.
 // The SDK handles all of that when both `klaviyo_automatic_push_tracking` and
 // `klaviyo_automatic_token_forwarding` are set in Info.plist. The two flags are independent;
 // this target opts into both for the fully automatic experience.

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
@@ -17,6 +17,8 @@
 	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
 	<key>klaviyo_automatic_push_tracking</key>
 	<true/>
+	<key>klaviyo_automatic_token_forwarding</key>
+	<true/>
 	<key>klaviyo_badge_autoclearing</key>
 	<true/>
 	<key>CFBundleURLTypes</key>

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For the fully automatic, no-boilerplate integration, enable both:
 <true/>
 ```
 
-Each flag can be enabled on its own; enable only the behavior you want.
+Each flag can be enabled on its own; enable only the behavior you want. If you enable push tracking without token forwarding, you must still collect the device token yourself (see [Option B](#option-b--manual-integration)), otherwise no token is registered with Klaviyo.
 
 #### Step 2 — Initialize the SDK and request push authorization
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For the fully automatic, no-boilerplate integration, enable both:
 <true/>
 ```
 
-Each flag can be enabled on its own; enable only the behavior you want. If you enable push tracking without token forwarding, you must still collect the device token yourself (see [Option B](#option-b--manual-integration)), otherwise no token is registered with Klaviyo.
+Each flag can be enabled on its own; enable only the behavior you want. If you enable push tracking without token forwarding, you must still collect the device token yourself and forward it in the `.set(pushToken:)` method (see [Option B](#option-b--manual-integration)), otherwise no token is registered with Klaviyo.
 
 #### Step 2 — Initialize the SDK and request push authorization
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@
 - [Push Notifications](#push-notifications)
   - [Prerequisites](#prerequisites)
   - [Option A — Automatic integration](#option-a--automatic-integration)
-    - [Step 1 — Enable automatic tracking in Info.plist](#step-1--enable-automatic-tracking-in-infoplist)
+    - [Step 1 — Enable automatic push behavior in Info.plist](#step-1--enable-automatic-push-behavior-in-infoplist)
     - [Step 2 — Initialize the SDK and request push authorization](#step-2--initialize-the-sdk-and-request-push-authorization)
-    - [Advanced: Disable automatic token forwarding](#advanced-disable-automatic-token-forwarding)
   - [Option B — Manual integration](#option-b--manual-integration)
     - [Collecting Push Tokens](#collecting-push-tokens)
     - [Request Push Notification Permission](#request-push-notification-permission)
@@ -254,12 +253,21 @@ The `create` method takes an event object as an argument. The event can be const
 
 The SDK can intercept APNs device-token callbacks and `UNUserNotificationCenter` delegate calls automatically, so you don't need to implement `didRegisterForRemoteNotificationsWithDeviceToken` or any `UNUserNotificationCenterDelegate` methods in your app delegate.
 
-#### Step 1 — Enable automatic tracking in `Info.plist`
+#### Step 1 — Enable automatic push behavior in `Info.plist`
+
+Automatic push tracking and automatic device-token forwarding are two independent opt-in flags.
+For the fully automatic, no-boilerplate integration, enable both:
 
 ```xml
+<!-- Injects a notification-delegate proxy that tracks push opens automatically -->
 <key>klaviyo_automatic_push_tracking</key>
 <true/>
+<!-- Forwards the APNs device token to Klaviyo automatically (no didRegister... code needed) -->
+<key>klaviyo_automatic_token_forwarding</key>
+<true/>
 ```
+
+Each flag can be enabled on its own; enable only the behavior you want.
 
 #### Step 2 — Initialize the SDK and request push authorization
 
@@ -300,25 +308,6 @@ func registerForPushNotifications() {
 ```
 
 > ℹ️ Silent push (`content-available`) is not intercepted automatically. If you use silent or background pushes, implement `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` in your app delegate — see [Silent Push Notifications](#silent-push-notifications).
-
-#### Advanced: Disable automatic token forwarding
-
-By default, enabling automatic push tracking also handles device token forwarding to Klaviyo automatically. If you need to retain manual control over token forwarding — for example, to share the token with multiple push providers — add the following to your `Info.plist`:
-
-```xml
-<key>klaviyo_automatic_push_tracking</key>
-<true/>
-<key>klaviyo_disable_automatic_token_forwarding</key>
-<true/>
-```
-
-Push open tracking remains active. You are responsible for forwarding the token manually by adding the following to your app delegate:
-
-```swift
-func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    KlaviyoSDK().set(pushToken: deviceToken)
-}
-```
 
 For a runnable reference, see the [SPMExampleAutomatic](Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic) target.
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ For the fully automatic, no-boilerplate integration, enable both:
 <true/>
 ```
 
-Each flag can be enabled on its own; enable only the behavior you want. If you enable push tracking without token forwarding, you must still collect the device token yourself and forward it in the `.set(pushToken:)` method (see [Option B](#option-b--manual-integration)), otherwise no token is registered with Klaviyo.
+Each flag can be enabled on its own; enable only the behavior you want. If you enable push tracking without token forwarding, you must still collect the device token yourself and forward it in the `.set(pushToken:)` method (see [Option B](#option-b--manual-integration)), otherwise no token is registered with Klaviyo. Conversely, if you enable token forwarding without push tracking, the device token is forwarded automatically, but you must implement push-open tracking yourself (see [Tracking Open Events](#tracking-open-events)).
 
 #### Step 2 — Initialize the SDK and request push authorization
 

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -254,15 +254,15 @@ public struct KlaviyoEnvironment {
             let autoPushTracking = Bundle.main.object(
                 forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
             ) as? Bool
-            let autoTokenForwardingDisabled = Bundle.main.object(
-                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
+            let autoTokenForwarding = Bundle.main.object(
+                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticTokenForwarding
             ) as? Bool
-            guard autoPushTracking != nil || autoTokenForwardingDisabled != nil else {
+            guard autoPushTracking != nil || autoTokenForwarding != nil else {
                 return nil
             }
             return SdkFeatures(
                 autoPushTracking: autoPushTracking,
-                autoTokenForwardingDisabled: autoTokenForwardingDisabled
+                autoTokenForwarding: autoTokenForwarding
             )
         },
         getLocationAuthorizationStatus: {

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -46,14 +46,14 @@ public struct SdkFeatures: Equatable {
     /// Name of the HTTP header these features are serialized into.
     public static let headerName = "X-Klaviyo-Sdk-Features"
 
-    /// Info.plist keys the host app sets to opt in to automatic push tracking behavior.
+    /// Info.plist keys the host app sets to opt in to SDK behaviors.
     /// Shared so the flag reads stay consistent across modules.
     package enum InfoPlistKey {
-        /// Master flag: when present and `true`, enables proxy delegate injection and token forwarding.
+        /// When present and `true`, enables proxy delegate injection and automatic push-open tracking.
         package static let automaticPushTracking = "klaviyo_automatic_push_tracking"
-        /// Escape hatch: when `true` (and the master is `true`), token forwarding is skipped while the
-        /// proxy stays active.
-        package static let disableAutomaticTokenForwarding = "klaviyo_disable_automatic_token_forwarding"
+        /// When present and `true`, enables automatic device-token forwarding (app-delegate swizzling).
+        /// Absent is treated as `false` (opt-in), independent of `automaticPushTracking`.
+        package static let automaticTokenForwarding = "klaviyo_automatic_token_forwarding"
     }
 
     /// Configured feature states; only features the host actually configured are present.
@@ -64,17 +64,14 @@ public struct SdkFeatures: Equatable {
     }
 
     /// - Parameters:
-    ///   - autoPushTracking: value of the master `klaviyo_automatic_push_tracking` flag, or `nil`
+    ///   - autoPushTracking: value of the `klaviyo_automatic_push_tracking` flag, or `nil`
     ///     when that key is absent from Info.plist.
-    ///   - autoTokenForwardingDisabled: value of the `klaviyo_disable_automatic_token_forwarding`
-    ///     escape hatch, or `nil` when that key is absent from Info.plist.
-    public init(autoPushTracking: Bool?, autoTokenForwardingDisabled: Bool?) {
+    ///   - autoTokenForwarding: value of the independent `klaviyo_automatic_token_forwarding`
+    ///     flag, or `nil` when that key is absent from Info.plist.
+    public init(autoPushTracking: Bool?, autoTokenForwarding: Bool?) {
         var values = [SdkFeatureKey: Bool]()
         values[.autoPushTracking] = autoPushTracking
-        // Report each flag's configured state independently. Token forwarding is considered enabled
-        // unless the escape hatch explicitly disables it; this is decoupled from the master flag so we
-        // capture how the host set each flag rather than a collapsed runtime state.
-        values[.autoPushTokenForwarding] = autoTokenForwardingDisabled.map { !$0 }
+        values[.autoPushTokenForwarding] = autoTokenForwarding
         self.init(values: values)
     }
 

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -89,41 +89,39 @@ final class KlaviyoNotificationDelegate: NSObject {
 
     // MARK: - Injection
 
-    /// Reads the opt-in flag and notification center from `KlaviyoSwiftEnvironment`,
-    /// then installs the proxy when automatic push tracking is enabled.
+    /// Reads the two independent opt-in flags and the notification center from
+    /// `KlaviyoSwiftEnvironment`, then applies each behavior on its own:
+    /// - `klaviyo_automatic_push_tracking` gates proxy injection (automatic push-open tracking).
+    /// - `klaviyo_automatic_token_forwarding` gates app-delegate swizzling (device-token forwarding).
     ///
-    /// Both dependencies are environment-injected so tests can control the plist gate
+    /// Neither flag is a prerequisite for the other, so any combination is honored.
+    ///
+    /// All dependencies are environment-injected so tests can control the plist gates
     /// and substitute a mock center without requiring an app-bundle context.
     ///
     /// Called once from `KlaviyoSDK.initialize(with:)` via
     /// `KlaviyoSwiftEnvironment.injectNotificationDelegate`.
     @MainActor
     static func injectIfEnabled() {
-        guard klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled() else {
+        if klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled() {
             if #available(iOS 14.0, *) {
-                Logger.notifications.log("Automatic push tracking is off.")
+                Logger.notifications.info(
+                    "Injecting notification delegate proxy for automatic push tracking."
+                )
             }
-            return
+            shared.inject(into: klaviyoSwiftEnvironment.notificationCenter())
+        } else if #available(iOS 14.0, *) {
+            Logger.notifications.log("Automatic push tracking is off.")
         }
 
-        if #available(iOS 14.0, *) {
-            Logger.notifications.info(
-                "Injecting notification delegate proxy for automatic push tracking."
-            )
-        }
-        shared.inject(into: klaviyoSwiftEnvironment.notificationCenter())
-
-        if klaviyoSwiftEnvironment.isAutomaticTokenForwardingDisabled() {
+        if klaviyoSwiftEnvironment.isAutomaticTokenForwardingEnabled() {
             if #available(iOS 14.0, *) {
-                Logger.notifications.log("Automatic token forwarding disabled via plist key.")
+                Logger.notifications.info("Swizzling app delegate for automatic token forwarding.")
             }
-            return
+            KlaviyoAppDelegateSwizzler.swizzleIfPossible()
+        } else if #available(iOS 14.0, *) {
+            Logger.notifications.log("Automatic token forwarding is off.")
         }
-
-        if #available(iOS 14.0, *) {
-            Logger.notifications.info("Swizzling app delegate for automatic token registration.")
-        }
-        KlaviyoAppDelegateSwizzler.swizzleIfPossible()
     }
 
     /// Installs the proxy as the notification center's active delegate and registers

--- a/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
@@ -29,10 +29,11 @@ struct KlaviyoSwiftEnvironment {
     /// `klaviyo_automatic_push_tracking` Info.plist key.
     /// Injected so tests can enable or disable the feature without modifying `Bundle.main`.
     var isAutomaticPushTrackingEnabled: () -> Bool
-    /// Returns whether the host has opted out of automatic token forwarding via the
-    /// `klaviyo_disable_automatic_token_forwarding` Info.plist key.
-    /// Injected so tests can control the escape hatch without modifying `Bundle.main`.
-    var isAutomaticTokenForwardingDisabled: () -> Bool
+    /// Returns whether the host has opted in to automatic device-token forwarding via the
+    /// `klaviyo_automatic_token_forwarding` Info.plist key. Independent of push tracking; absent
+    /// is treated as `false`.
+    /// Injected so tests can control the flag without modifying `Bundle.main`.
+    var isAutomaticTokenForwardingEnabled: () -> Bool
     /// Provides the notification center for automatic push tracking injection.
     /// Injected so tests can substitute a mock without the app-bundle context that
     /// `UNUserNotificationCenter.current()` requires.
@@ -79,9 +80,9 @@ struct KlaviyoSwiftEnvironment {
                     forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
                 ) as? Bool == true
             },
-            isAutomaticTokenForwardingDisabled: {
+            isAutomaticTokenForwardingEnabled: {
                 Bundle.main.object(
-                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.disableAutomaticTokenForwarding
+                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticTokenForwarding
                 ) as? Bool == true
             },
             notificationCenter: {

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -58,9 +58,9 @@ final class KlaviyoEndpointTests: XCTestCase {
     }
 
     func testRegisterPushTokenAttachesSdkFeaturesHeaderWhenPresent() throws {
-        // Given the host has opted into the new integration model
+        // Given the host has opted into push tracking but not token forwarding
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: true)
+            SdkFeatures(autoPushTracking: true, autoTokenForwarding: false)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
@@ -74,10 +74,10 @@ final class KlaviyoEndpointTests: XCTestCase {
         )
     }
 
-    func testRegisterPushTokenHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() throws {
-        // Given the master key is set but the escape-hatch key is absent from Info.plist
+    func testRegisterPushTokenHeaderOmitsForwardingWhenForwardingKeyAbsent() throws {
+        // Given the tracking key is set but the forwarding key is absent from Info.plist
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: nil)
+            SdkFeatures(autoPushTracking: true, autoTokenForwarding: nil)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
@@ -91,20 +91,21 @@ final class KlaviyoEndpointTests: XCTestCase {
         )
     }
 
-    func testRegisterPushTokenHeaderForEscapeHatchWithoutPrimaryFlag() throws {
-        // Given only the escape-hatch key is set (nonsensical config, captured for telemetry)
+    func testRegisterPushTokenHeaderForForwardingWithoutTracking() throws {
+        // Given only the forwarding key is set and enabled — the newly valid independent
+        // configuration where token forwarding is opted into without push tracking
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
+            SdkFeatures(autoPushTracking: nil, autoTokenForwarding: true)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
         // When
         let request = try endpoint.urlRequest()
 
-        // Then only the forwarding field is present; its presence flags the escape-hatch config
+        // Then only the forwarding field is present, reporting enabled
         XCTAssertEqual(
             request.allHTTPHeaderFields?["X-Klaviyo-Sdk-Features"],
-            "auto_push_token_forwarding=0;"
+            "auto_push_token_forwarding=1;"
         )
     }
 
@@ -124,7 +125,7 @@ final class KlaviyoEndpointTests: XCTestCase {
         // Given a non-nil SdkFeatures whose scope yields no fields (both keys absent), exercising
         // the guard-let path where headerValue(for:) itself returns nil rather than sdkFeatures().
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: nil)
+            SdkFeatures(autoPushTracking: nil, autoTokenForwarding: nil)
         }
         let endpoint = KlaviyoEndpoint.registerPushToken("test_api_key", PushTokenPayload.test)
 
@@ -138,7 +139,7 @@ final class KlaviyoEndpointTests: XCTestCase {
     func testSdkFeaturesHeaderOnlyAttachesToRegisterPushToken() throws {
         // Given the host has opted in, so the header would be produced where applicable
         environment.sdkFeatures = {
-            SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
+            SdkFeatures(autoPushTracking: true, autoTokenForwarding: true)
         }
 
         // Then no other endpoint carries the SDK-features header (some set their own

--- a/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
+++ b/Tests/KlaviyoCoreTests/SdkFeaturesTests.swift
@@ -9,9 +9,9 @@
 import XCTest
 
 final class SdkFeaturesTests: XCTestCase {
-    /// Both keys present, escape hatch off: both fields reported, forwarding on (typical opt-in).
+    /// Both keys present and on: both fields reported, forwarding on (typical full opt-in).
     func testHeaderValueTrackingOnForwardingOn() {
-        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: false)
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwarding: true)
         XCTAssertEqual(features[.autoPushTracking], true)
         XCTAssertEqual(features[.autoPushTokenForwarding], true)
         XCTAssertEqual(
@@ -20,9 +20,9 @@ final class SdkFeaturesTests: XCTestCase {
         )
     }
 
-    /// Both keys present, escape hatch set: proxy stays active but forwarding collapses to off.
-    func testHeaderValueTrackingOnForwardingDisabled() {
-        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: true)
+    /// Both keys present, forwarding off: tracking reported on, forwarding reported off.
+    func testHeaderValueTrackingOnForwardingOff() {
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwarding: false)
         XCTAssertEqual(features[.autoPushTracking], true)
         XCTAssertEqual(features[.autoPushTokenForwarding], false)
         XCTAssertEqual(
@@ -31,27 +31,27 @@ final class SdkFeaturesTests: XCTestCase {
         )
     }
 
-    /// Escape-hatch key absent: the token-forwarding field is omitted entirely.
-    func testHeaderOmitsForwardingWhenEscapeHatchKeyAbsent() {
-        let features = SdkFeatures(autoPushTracking: true, autoTokenForwardingDisabled: nil)
+    /// Forwarding key absent: the token-forwarding field is omitted entirely.
+    func testHeaderOmitsForwardingWhenForwardingKeyAbsent() {
+        let features = SdkFeatures(autoPushTracking: true, autoTokenForwarding: nil)
         XCTAssertEqual(features[.autoPushTracking], true)
         XCTAssertNil(features[.autoPushTokenForwarding])
         XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_tracking=1;")
     }
 
-    /// Master key absent, escape hatch present and off: the tracking field is omitted, and forwarding
-    /// reports enabled independent of the master flag.
-    func testHeaderOmitsTrackingWhenPrimaryKeyAbsent() {
-        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: false)
+    /// Tracking key absent, forwarding present and on: the tracking field is omitted, and forwarding
+    /// reports enabled independently — now a valid configuration.
+    func testHeaderOmitsTrackingWhenTrackingKeyAbsent() {
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwarding: true)
         XCTAssertNil(features[.autoPushTracking])
         XCTAssertEqual(features[.autoPushTokenForwarding], true)
         XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_token_forwarding=1;")
     }
 
-    /// Escape hatch set to disable without the master key (nonsensical but captured as a usage
-    /// signal): only the forwarding field is emitted, reporting disabled.
-    func testHeaderForEscapeHatchWithoutPrimaryFlag() {
-        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: true)
+    /// Forwarding present and off without the tracking key: only the forwarding field is emitted,
+    /// reporting disabled.
+    func testHeaderForForwardingOffWithoutTracking() {
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwarding: false)
         XCTAssertNil(features[.autoPushTracking])
         XCTAssertEqual(features[.autoPushTokenForwarding], false)
         XCTAssertEqual(features.headerValue(for: .pushTokenRegistration), "auto_push_token_forwarding=0;")
@@ -59,7 +59,7 @@ final class SdkFeaturesTests: XCTestCase {
 
     /// Neither key present: nothing to report; the header value is nil so callers omit the header.
     func testHeaderValueNilWhenNoKeysPresent() {
-        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwardingDisabled: nil)
+        let features = SdkFeatures(autoPushTracking: nil, autoTokenForwarding: nil)
         XCTAssertNil(features[.autoPushTracking])
         XCTAssertNil(features[.autoPushTokenForwarding])
         XCTAssertNil(features.headerValue(for: .pushTokenRegistration))

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -70,11 +70,11 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
 
     // MARK: - Plist Gating
 
-    /// Default state: push tracking off, token forwarding not disabled.
-    /// `injectIfEnabled()` must be a complete no-op — delegate stays unchanged.
-    func testInjectIfEnabledIsNoOpWhenTrackingDisabled() {
+    /// Both flags off: `injectIfEnabled()` is a no-op and the proxy delegate is never installed.
+    func testInjectIfEnabledIsNoOpWhenBothFlagsDisabled() {
         let mockCenter = MockNotificationCenter()
         klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { false }
+        klaviyoSwiftEnvironment.isAutomaticTokenForwardingEnabled = { false }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
 
         KlaviyoNotificationDelegate.injectIfEnabled()

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -230,7 +230,7 @@ extension KlaviyoSwiftEnvironment {
             // no-op: UNUserNotificationCenter.current() is unavailable in test runner
         }, isAutomaticPushTrackingEnabled: {
             false
-        }, isAutomaticTokenForwardingDisabled: {
+        }, isAutomaticTokenForwardingEnabled: {
             false
         }, notificationCenter: {
             MockNotificationCenter()


### PR DESCRIPTION
# Description
Decouples `klaviyo_automatic_push_tracking` and device-token forwarding into two fully independent opt-in Info.plist flags. Supersedes the escape-hatch design from #618 ([MAGE-799](https://linear.app/klaviyo/issue/MAGE-799)); the feature is unshipped (still on `feat/auto-push-tracking`), so there is no backward-compat cost. Resolves [MAGE-884](https://linear.app/klaviyo/issue/MAGE-884).

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- unit tests on simulator; runtime swizzle path verified manually via SPMExampleAutomatic -->
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API. <!-- new plist flag; SdkFeatures public init signature changed (feature still unshipped) -->
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
The two behaviors that were coupled under `klaviyo_automatic_push_tracking` (with a `klaviyo_disable_automatic_token_forwarding` escape hatch) are now two independent flags:

| Flag | Gates | Default when absent |
|---|---|---|
| `klaviyo_automatic_push_tracking` | proxy injection + push-open tracking | off |
| `klaviyo_automatic_token_forwarding` **(new)** | app-delegate swizzling / device-token forwarding | off (opt-in) |

- **Removed** `klaviyo_disable_automatic_token_forwarding` (`InfoPlistKey.disableAutomaticTokenForwarding`) entirely.
- **`KlaviyoNotificationDelegate.injectIfEnabled()`** now gates proxy injection and swizzling on their own flags; neither is a prerequisite for the other.
- **`SdkFeatures`**: new `InfoPlistKey.automaticTokenForwarding`; `init(autoPushTracking:autoTokenForwarding:)` reports `auto_push_token_forwarding` directly from the new opt-in key instead of the inverted escape hatch.
- **Env**: `isAutomaticTokenForwardingDisabled` -> `isAutomaticTokenForwardingEnabled`; `sdkFeatures` reader keys off the new plist key.
- **Docs/examples**: README Option A shows both keys; the "Advanced" section is rewritten as an independence matrix; `SPMExampleAutomatic/Info.plist` adds the new key so the demo still forwards tokens.

### Telemetry note (cross-platform coordination)
The `auto_push_token_forwarding` header value polarity changes: `1` now means "forwarding opted in" keyed off the new flag (previously derived from the inverted escape hatch). Must land alongside Android [MAGE-886](https://linear.app/klaviyo/issue/MAGE-886) and the backend (MAGE-764/766) so the SDKs don't diverge on flag meaning.

## Test Plan
Full suite green (`** TEST SUCCEEDED **`, 106 tests, 0 failures); SwiftLint + SwiftFormat pass. Manual matrix verified against `injectIfEnabled()`:

| `automatic_push_tracking` | `automatic_token_forwarding` | Expected |
|:---:|:---:|---|
| NO | NO | no proxy, no swizzling (default) |
| YES | NO | proxy injected, no swizzling |
| NO | YES | no proxy, swizzling forwards tokens (new; previously impossible) |
| YES | YES | proxy injected, swizzling forwards tokens |

To reproduce the new NO/YES case: run `SPMExampleAutomatic` with only `klaviyo_automatic_token_forwarding=YES`; confirm the device token registers with Klaviyo while no notification-delegate proxy is installed.

## Related Issues/Tickets
- [MAGE-884](https://linear.app/klaviyo/issue/MAGE-884) (this PR)
- Supersedes [MAGE-799](https://linear.app/klaviyo/issue/MAGE-799) / #618
- Cross-platform: [MAGE-886](https://linear.app/klaviyo/issue/MAGE-886) (Android)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a separate opt-in flag for automatic APNs device-token forwarding, alongside the existing automatic push-open tracking setting (either or both can be enabled).
* **Documentation**
  * Updated Push Notifications setup and the Swift example to use the new token-forwarding opt-in setting and clarify how the two options interact.
* **Bug Fixes**
  * Improved automatic behavior so token forwarding and push-open tracking are applied independently, matching the selected configuration.
* **Tests**
  * Updated test coverage to reflect the revised configuration semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->