### PR TITLE
refactor(forms): route trackProfileEvent through EventDispatcher.createEvent lane

### DIFF
--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -7,6 +7,7 @@ import Foundation
 
 /// Closed vocabulary of inbound commands other modules hand to the SDK's analytics engine.
 public enum InboundCommand {
+    case createEvent(Event)
     case aggregateEvent(AggregateEventPayload)
     case deepLink(URL)
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -8,7 +8,6 @@
 import Combine
 import Foundation
 import KlaviyoCore
-import KlaviyoSwift
 import OSLog
 import WebKit
 
@@ -326,7 +325,9 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case let .trackProfileEvent(data):
             if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                let metricName = jsonEventData["metric"] as? String {
-                KlaviyoSDK().create(event: Event(name: .customEvent(metricName), properties: jsonEventData))
+                EventDispatcher.shared.dispatch(
+                    .createEvent(Event(name: .customEvent(metricName), properties: jsonEventData))
+                )
             }
         case let .trackAggregateEvent(data):
             EventDispatcher.shared.dispatch(.aggregateEvent(data))

--- a/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/KlaviyoWebViewController.swift
@@ -328,8 +328,6 @@ private class ScriptDelegateWrapper: NSObject, WKScriptMessageHandler {
 
 #if DEBUG
 
-@testable import KlaviyoSwift
-
 func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewController {
     let viewController = KlaviyoWebViewController(viewModel: viewModel)
 
@@ -356,7 +354,9 @@ func createKlaviyoWebPreview(viewModel: KlaviyoWebViewModeling) -> UIViewControl
 @available(iOS 17.0, *)
 #Preview("Klaviyo Form") {
     let apiKey = "" // ⬅️ use a company ID that has a live form
-    _ = klaviyoSwiftEnvironment.send(.initialize(apiKey))
+    // Seed the canonical Core config store directly instead of booting the KlaviyoSwift
+    // analytics engine — keeps KlaviyoForms free of a KlaviyoSwift import.
+    SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
     let indexHtmlFileUrl = try! ResourceLoader.getResourceUrl(path: "InAppFormsTemplate", type: "html")
     let viewModel = IAFWebViewModel(url: indexHtmlFileUrl, apiKey: apiKey, profileData: nil)
     return createKlaviyoWebPreview(viewModel: viewModel)

--- a/Sources/KlaviyoLocation/GeofenceService.swift
+++ b/Sources/KlaviyoLocation/GeofenceService.swift
@@ -7,7 +7,6 @@
 
 import CoreLocation
 import KlaviyoCore
-import KlaviyoSwift
 import OSLog
 
 protocol GeofenceServiceProvider {

--- a/Sources/KlaviyoLocation/Models/Geofence.swift
+++ b/Sources/KlaviyoLocation/Models/Geofence.swift
@@ -8,7 +8,6 @@
 import CoreLocation
 import Foundation
 import KlaviyoCore
-import KlaviyoSwift
 
 /// Represents a Klaviyo geofence
 struct Geofence: Equatable, Hashable, Codable {

--- a/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
@@ -10,6 +10,8 @@ import KlaviyoCore
 struct KlaviyoEventDispatcher: EventDispatching {
     func dispatch(_ command: InboundCommand) {
         switch command {
+        case let .createEvent(event):
+            dispatchOnMainThread(action: .enqueueEvent(event))
         case let .aggregateEvent(payload):
             dispatchOnMainThread(action: .enqueueAggregateEvent(payload))
         case let .deepLink(deepLinkURL):

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -44,6 +44,24 @@ final class EventDispatcherTests: XCTestCase {
         }
     }
 
+    func testDispatchForwardsCreateEvent() {
+        let dispatcher = EventDispatcher()
+        let spyDispatcher = SpyDispatcher()
+        dispatcher.register(spyDispatcher)
+
+        let event = Event(name: .customEvent("Viewed Product"), properties: ["foo": "bar"])
+        dispatcher.dispatch(.createEvent(event))
+
+        guard spyDispatcher.received.count == 1 else {
+            return XCTFail("expected 1 command, got \(spyDispatcher.received.count)")
+        }
+        guard case let .createEvent(received) = spyDispatcher.received[0] else {
+            return XCTFail("expected .createEvent")
+        }
+        XCTAssertEqual(received.metric.name, .customEvent("Viewed Product"))
+        XCTAssertEqual(received.properties["foo"] as? String, "bar")
+    }
+
     func testDispatchWithoutRegistrationWarnsAndDoesNotForward() {
         let dispatcher = EventDispatcher()
         let spy = SpyDispatcher() // created but intentionally NOT registered

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -19,6 +19,12 @@ private class TestKlaviyoWebViewController: KlaviyoWebViewController {
     }
 }
 
+// Captures inbound commands dispatched through the Core `EventDispatcher` lane.
+private final class SpyDispatcher: EventDispatching {
+    private(set) var received: [InboundCommand] = []
+    func dispatch(_ command: InboundCommand) { received.append(command) }
+}
+
 final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Properties
 
@@ -347,6 +353,39 @@ final class IAFWebViewModelTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 5.0)
         lifecycleTask.cancel()
+    }
+
+    @MainActor
+    func testTrackProfileEventDispatchesCreateEvent() throws {
+        // Given - a spy registered as the inbound-dispatch target
+        let spyDispatcher = SpyDispatcher()
+        EventDispatcher.shared.register(spyDispatcher)
+        defer { EventDispatcher.shared.reset() }
+
+        // When - JS sends a trackProfileEvent bridge message
+        let scriptMessage = MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: """
+            {
+              "type": "trackProfileEvent",
+              "data": {
+                "metric": "Viewed Product",
+                "foo": "bar"
+              }
+            }
+            """
+        )
+        viewModel.handleScriptMessage(scriptMessage)
+
+        // Then - it routes through the EventDispatcher lane as .createEvent (no KlaviyoSwift dependency)
+        guard spyDispatcher.received.count == 1 else {
+            return XCTFail("expected 1 command, got \(spyDispatcher.received.count)")
+        }
+        guard case let .createEvent(event) = spyDispatcher.received[0] else {
+            return XCTFail("expected .createEvent, got \(spyDispatcher.received[0])")
+        }
+        XCTAssertEqual(event.metric.name, .customEvent("Viewed Product"))
+        XCTAssertEqual(event.properties["foo"] as? String, "bar")
     }
 }
 


### PR DESCRIPTION
# Description
Adds a `createEvent` inbound command to the Core `EventDispatcher` and routes In-App Forms profile-event tracking through it, removing the last internal-reach `import KlaviyoSwift` from `KlaviyoForms`.

This dispatch lane **should have been added alongside `aggregateEvent` and `deepLink`** in the earlier `EventDispatching` contract work (MAGE-831) — it was simply missed, which left `IAFWebViewModel` still reaching into KlaviyoSwift via `KlaviyoSDK().create(event:)`. This PR closes that gap using the exact same pattern already established for the other inbound commands.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

_Note: `InboundCommand` is `public` but is cross-module dispatch plumbing, not consumer-facing API; adding the `createEvent` case is additive._

## Changelog / Code Overview
- **KlaviyoCore:** add `InboundCommand.createEvent(Event)` to the dispatch vocabulary (beside `aggregateEvent`/`deepLink`).
- **KlaviyoSwift:** `KlaviyoEventDispatcher` handles `.createEvent` → `.enqueueEvent`, mirroring `KlaviyoSDK.create(event:)`.
- **KlaviyoForms:** `IAFWebViewModel` dispatches `trackProfileEvent` through `EventDispatcher.shared` instead of `KlaviyoSDK().create(event:)`; drops `import KlaviyoSwift`.
- **KlaviyoForms:** DEBUG webview preview seeds the canonical Core `SDKConfigStore` directly instead of booting KlaviyoSwift via `@testable import`. Only the public-API `KlaviyoSDK+Forms` extension keeps `import KlaviyoSwift`, by design.
- **KlaviyoLocation (bonus):** remove unused `import KlaviyoSwift` from `GeofenceService.swift` and `Geofence.swift`.
- **Tests:** `.createEvent` forwarding (`EventDispatcherTests`) + `trackProfileEvent` routes through the dispatcher (`IAFWebViewModelTests`).

## Test Plan
1. `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` — build succeeds.
2. `xcodebuild test ... -only-testing:KlaviyoCoreTests/EventDispatcherTests -only-testing:KlaviyoFormsTests/IAFWebViewModelTests` — 5 + 12 tests pass.
3. `grep -rn "import KlaviyoSwift" Sources/KlaviyoForms` returns only `KlaviyoSDK+Forms.swift`.

## Related Issues/Tickets
Follow-on to the `EventDispatching` contract work (MAGE-831) that introduced the `aggregateEvent`/`deepLink` inbound commands. No dedicated ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dispatching a dedicated “create event” command end-to-end.
* **Bug Fixes**
  * Updated in-app form bridge handling to route event creation through the shared dispatcher.
  * Refreshed the in-app form debug preview to use the current SDK configuration store.
  * Updated location module dependencies/imports for consistent logging setup.
* **Tests**
  * Added/expanded tests to verify create-event forwarding for core dispatching and in-app form bridge events, including correct event name and properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->