### PR TITLE
poc: push notification data extraction (title/body/custom data/media)

### DIFF
--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		9E55C859B1262417E645B05C /* Pods_CocoapodsExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E2D5A54561D5E26A3EAB530 /* Pods_CocoapodsExample.framework */; };
 		A72D9F9A195A8E3443E80585 /* Pods_NotificationServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38257B2584AC4293FC1D91E /* Pods_NotificationServiceExtension.framework */; };
 		C40ABDBB2FA27A7C002B232D /* CocoapodsExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40ABDBA2FA27A7C002B232D /* CocoapodsExampleApp.swift */; };
+		060CAF0DA7714564A8253B08 /* PushLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C63FEC63DB47098A81B00B /* PushLogEntry.swift */; };
+		68D5A40BBABC45A2AB572AD9 /* PushLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27120992E0014EE89AB04941 /* PushLogStore.swift */; };
+		32CAB4F960734BC6A529F407 /* PushLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147CC687D9424DE59357369B /* PushLogView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +94,9 @@
 		C40ABDBA2FA27A7C002B232D /* CocoapodsExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoapodsExampleApp.swift; sourceTree = "<group>"; };
 		D38257B2584AC4293FC1D91E /* Pods_NotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC4151BFCCF5B6674A041C44 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
+		30C63FEC63DB47098A81B00B /* PushLogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogEntry.swift; path = ../../Shared/PushLogEntry.swift; sourceTree = "<group>"; };
+		27120992E0014EE89AB04941 /* PushLogStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogStore.swift; path = ../../Shared/PushLogStore.swift; sourceTree = "<group>"; };
+		147CC687D9424DE59357369B /* PushLogView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogView.swift; path = ../../Shared/PushLogView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +173,9 @@
 				7CC1C7B228D7492C0073197F /* MenuView.swift */,
 				7CC1C7B328D7492C0073197F /* MapView.swift */,
 				7CC1C7B428D7492C0073197F /* CheckoutView.swift */,
+				30C63FEC63DB47098A81B00B /* PushLogEntry.swift */,
+				27120992E0014EE89AB04941 /* PushLogStore.swift */,
+				147CC687D9424DE59357369B /* PushLogView.swift */,
 				7CC1C79928D7492C0073197F /* MenuItem.swift */,
 				7CC1C79728D7492C0073197F /* User.swift */,
 				7CC1C79428D7492B0073197F /* CocoapodsExample-Bridging-Header.h */,
@@ -416,6 +425,9 @@
 				7CC1C7B728D7492C0073197F /* MenuView.swift in Sources */,
 				7CC1C7B828D7492C0073197F /* MapView.swift in Sources */,
 				7CC1C7B928D7492C0073197F /* CheckoutView.swift in Sources */,
+				060CAF0DA7714564A8253B08 /* PushLogEntry.swift in Sources */,
+				68D5A40BBABC45A2AB572AD9 /* PushLogStore.swift in Sources */,
+				32CAB4F960734BC6A529F407 /* PushLogView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample.xcodeproj/project.pbxproj
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/CocoapodsExample.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		060CAF0DA7714564A8253B08 /* PushLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C63FEC63DB47098A81B00B /* PushLogEntry.swift */; };
 		68D5A40BBABC45A2AB572AD9 /* PushLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27120992E0014EE89AB04941 /* PushLogStore.swift */; };
 		32CAB4F960734BC6A529F407 /* PushLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147CC687D9424DE59357369B /* PushLogView.swift */; };
+		A92BB2E0E97345CA975B6A13 /* PushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3985D6B0B0E4A0BADD7069F /* PushPayload.swift */; };
+		9B997B2E581A44A48B412876 /* PushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3985D6B0B0E4A0BADD7069F /* PushPayload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +99,7 @@
 		30C63FEC63DB47098A81B00B /* PushLogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogEntry.swift; path = ../../Shared/PushLogEntry.swift; sourceTree = "<group>"; };
 		27120992E0014EE89AB04941 /* PushLogStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogStore.swift; path = ../../Shared/PushLogStore.swift; sourceTree = "<group>"; };
 		147CC687D9424DE59357369B /* PushLogView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogView.swift; path = ../../Shared/PushLogView.swift; sourceTree = "<group>"; };
+		D3985D6B0B0E4A0BADD7069F /* PushPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushPayload.swift; path = ../../Shared/PushPayload.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +179,7 @@
 				30C63FEC63DB47098A81B00B /* PushLogEntry.swift */,
 				27120992E0014EE89AB04941 /* PushLogStore.swift */,
 				147CC687D9424DE59357369B /* PushLogView.swift */,
+				D3985D6B0B0E4A0BADD7069F /* PushPayload.swift */,
 				7CC1C79928D7492C0073197F /* MenuItem.swift */,
 				7CC1C79728D7492C0073197F /* User.swift */,
 				7CC1C79428D7492B0073197F /* CocoapodsExample-Bridging-Header.h */,
@@ -406,6 +410,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				346621812A44F61500B3576C /* NotificationService.swift in Sources */,
+				9B997B2E581A44A48B412876 /* PushPayload.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -425,6 +430,7 @@
 				7CC1C7B728D7492C0073197F /* MenuView.swift in Sources */,
 				7CC1C7B828D7492C0073197F /* MapView.swift in Sources */,
 				7CC1C7B928D7492C0073197F /* CheckoutView.swift in Sources */,
+				A92BB2E0E97345CA975B6A13 /* PushPayload.swift in Sources */,
 				060CAF0DA7714564A8253B08 /* PushLogEntry.swift in Sources */,
 				68D5A40BBABC45A2AB572AD9 /* PushLogStore.swift in Sources */,
 				32CAB4F960734BC6A529F407 /* PushLogView.swift in Sources */,

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
@@ -44,6 +44,7 @@ class NotificationService: UNNotificationServiceExtension {
             )
         }
 
+        #if DEBUG
         // Access key-value pairs
         let customData = PushPayload.customData(from: request.content.userInfo)
         if customData.isEmpty {
@@ -53,6 +54,7 @@ class NotificationService: UNNotificationServiceExtension {
                 print("Key: \(pairKey), Value: \(value)")
             }
         }
+        #endif
     }
 
     override func serviceExtensionTimeWillExpire() {

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
@@ -43,6 +43,16 @@ class NotificationService: UNNotificationServiceExtension {
                 contentHandler: contentHandler
             )
         }
+
+        // Access key-value pairs
+        let userInfo = request.content.userInfo
+        if let kvPairs = userInfo["key_value_pairs"] as? [String: String] {
+            for (key, value) in kvPairs {
+                print("Key: \(key), Value: \(value)")
+            }
+        } else {
+            print("No key_value_pairs found in notification")
+        }
     }
 
     override func serviceExtensionTimeWillExpire() {

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
@@ -45,13 +45,13 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         // Access key-value pairs
-        let userInfo = request.content.userInfo
-        if let kvPairs = userInfo["key_value_pairs"] as? [String: String] {
-            for (key, value) in kvPairs {
-                print("Key: \(key), Value: \(value)")
-            }
-        } else {
+        let customData = PushPayload.customData(from: request.content.userInfo)
+        if customData.isEmpty {
             print("No key_value_pairs found in notification")
+        } else {
+            for (pairKey, value) in customData {
+                print("Key: \(pairKey), Value: \(value)")
+            }
         }
     }
 

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		207257ABB7EC42C6A237F13D /* PushLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */; };
 		4EEE71B6B8534B218132B37C /* PushLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C91D698DE7404787DBDC2E /* PushLogStore.swift */; };
 		EB72D147AEB5470C98F1989A /* PushLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAECAE6BA05E42F0B67997CA /* PushLogView.swift */; };
+		74F3315CFAA748C8ACBE8918 /* PushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCE370CBBD24755968D191E /* PushPayload.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogEntry.swift; path = ../../Shared/PushLogEntry.swift; sourceTree = "<group>"; };
 		A2C91D698DE7404787DBDC2E /* PushLogStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogStore.swift; path = ../../Shared/PushLogStore.swift; sourceTree = "<group>"; };
 		FAECAE6BA05E42F0B67997CA /* PushLogView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogView.swift; path = ../../Shared/PushLogView.swift; sourceTree = "<group>"; };
+		3BCE370CBBD24755968D191E /* PushPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushPayload.swift; path = ../../Shared/PushPayload.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +192,7 @@
 				0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */,
 				A2C91D698DE7404787DBDC2E /* PushLogStore.swift */,
 				FAECAE6BA05E42F0B67997CA /* PushLogView.swift */,
+				3BCE370CBBD24755968D191E /* PushPayload.swift */,
 				7CC1C80928D74D830073197F /* Info.plist */,
 				7CC1C82B28D74DB50073197F /* SPMExample-Bridging-Header.h */,
 			);
@@ -387,6 +390,7 @@
 				7CC1C85228D74DB60073197F /* MenuView.swift in Sources */,
 				7CC1C85328D74DB60073197F /* MapView.swift in Sources */,
 				7CC1C85428D74DB60073197F /* CheckoutView.swift in Sources */,
+				74F3315CFAA748C8ACBE8918 /* PushPayload.swift in Sources */,
 				207257ABB7EC42C6A237F13D /* PushLogEntry.swift in Sources */,
 				4EEE71B6B8534B218132B37C /* PushLogStore.swift in Sources */,
 				EB72D147AEB5470C98F1989A /* PushLogView.swift in Sources */,

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExample.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		7CC1C85228D74DB60073197F /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84B28D74DB60073197F /* MenuView.swift */; };
 		7CC1C85328D74DB60073197F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84C28D74DB60073197F /* MapView.swift */; };
 		7CC1C85428D74DB60073197F /* CheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC1C84D28D74DB60073197F /* CheckoutView.swift */; };
+		207257ABB7EC42C6A237F13D /* PushLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */; };
+		4EEE71B6B8534B218132B37C /* PushLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C91D698DE7404787DBDC2E /* PushLogStore.swift */; };
+		EB72D147AEB5470C98F1989A /* PushLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAECAE6BA05E42F0B67997CA /* PushLogView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +92,9 @@
 		7CC1C84B28D74DB60073197F /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MenuView.swift; path = ../../Shared/MenuView.swift; sourceTree = "<group>"; };
 		7CC1C84C28D74DB60073197F /* MapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapView.swift; path = ../../Shared/MapView.swift; sourceTree = "<group>"; };
 		7CC1C84D28D74DB60073197F /* CheckoutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CheckoutView.swift; path = ../../Shared/CheckoutView.swift; sourceTree = "<group>"; };
+		0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogEntry.swift; path = ../../Shared/PushLogEntry.swift; sourceTree = "<group>"; };
+		A2C91D698DE7404787DBDC2E /* PushLogStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogStore.swift; path = ../../Shared/PushLogStore.swift; sourceTree = "<group>"; };
+		FAECAE6BA05E42F0B67997CA /* PushLogView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PushLogView.swift; path = ../../Shared/PushLogView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +187,9 @@
 				7CC1C84B28D74DB60073197F /* MenuView.swift */,
 				7CC1C84C28D74DB60073197F /* MapView.swift */,
 				7CC1C84D28D74DB60073197F /* CheckoutView.swift */,
+				0BCCEAF3975F42D4A1F4B6A7 /* PushLogEntry.swift */,
+				A2C91D698DE7404787DBDC2E /* PushLogStore.swift */,
+				FAECAE6BA05E42F0B67997CA /* PushLogView.swift */,
 				7CC1C80928D74D830073197F /* Info.plist */,
 				7CC1C82B28D74DB50073197F /* SPMExample-Bridging-Header.h */,
 			);
@@ -378,6 +387,9 @@
 				7CC1C85228D74DB60073197F /* MenuView.swift in Sources */,
 				7CC1C85328D74DB60073197F /* MapView.swift in Sources */,
 				7CC1C85428D74DB60073197F /* CheckoutView.swift in Sources */,
+				207257ABB7EC42C6A237F13D /* PushLogEntry.swift in Sources */,
+				4EEE71B6B8534B218132B37C /* PushLogStore.swift in Sources */,
+				EB72D147AEB5470C98F1989A /* PushLogView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -142,14 +142,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        // "Background Processing" pushes still carry a visible alert under aps.alert
-        let alert = (userInfo["aps"] as? [String: Any])?["alert"] as? [String: Any]
-        PushLogStore.shared.record(
-            source: .background,
-            title: alert?["title"] as? String ?? "",
-            body: alert?["body"] as? String ?? "",
-            customData: customData
-        )
+        // When the app is active, `willPresent` already handled the visible alert and logged
+        // this same delivery to the Push Log — avoid double-logging (and mislabeling) it here.
+        if application.applicationState != .active {
+            // "Background Processing" pushes still carry a visible alert under aps.alert
+            let alert = (userInfo["aps"] as? [String: Any])?["alert"] as? [String: Any]
+            PushLogStore.shared.record(
+                source: .background,
+                title: alert?["title"] as? String ?? "",
+                body: alert?["body"] as? String ?? "",
+                customData: customData
+            )
+        }
 
         // Do your background work here (refresh data, etc.), then always call the completion
         // handler so iOS can measure your app's background efficiency.

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -136,6 +136,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) {
         // Access custom key-value pairs from the top level
         let customData = PushPayload.customData(from: userInfo)
+        #if DEBUG
         if customData.isEmpty {
             print("No key_value_pairs found in notification")
         } else {
@@ -144,6 +145,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print("Key: \(pairKey), Value: \(value)")
             }
         }
+        #endif
 
         // A visible alert delivered while the app is active also triggers `willPresent`, which
         // already logs it — skip here to avoid a duplicate entry. Silent pushes (no alert) never
@@ -257,7 +259,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         // Extract the visible title/body from a standard (non-silent) push
         let title = notification.request.content.title
         let body = notification.request.content.body
+        #if DEBUG
         print("📬 [Foreground Push] Title: \(title), Body: \(body)")
+        #endif
 
         PushLogStore.shared.record(
             source: .foreground,

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -101,11 +101,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         // STEP5: add the push device token to your Klaviyo user profile.
-        
-        // Print the token as a hex string for debugging
+
+        #if DEBUG
+        // Print the token as a hex string for debugging. The token is a device identifier, so
+        // this is intentionally Debug-only and never runs in a Release build.
         let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
         print("📱 APNs device token: \(tokenString)")
-        
+        #endif
+
         KlaviyoSDK().set(pushToken: deviceToken)
     }
 
@@ -124,35 +127,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // This fires for both silent pushes and "Background Processing" pushes (content-available: 1,
     // enabled from the Behaviors tab of a Klaviyo push message) whether the app is foregrounded,
-    // backgrounded, or not running. Background wakes are best-effort and only testable on a
-    // physical device — the Simulator does not deliver them.
+    // backgrounded, or terminated by the system. Background wakes are best-effort and only
+    // testable on a physical device — the Simulator does not deliver them.
     func application(
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
         // Access custom key-value pairs from the top level
-        let customData = userInfo["key_value_pairs"] as? [String: String] ?? [:]
+        let customData = PushPayload.customData(from: userInfo)
         if customData.isEmpty {
             print("No key_value_pairs found in notification")
         } else {
             // Process your custom key-value pairs here
-            for (key, value) in customData {
-                print("Key: \(key), Value: \(value)")
+            for (pairKey, value) in customData {
+                print("Key: \(pairKey), Value: \(value)")
             }
         }
 
-        // When the app is active, `willPresent` already handled the visible alert and logged
-        // this same delivery to the Push Log — avoid double-logging (and mislabeling) it here.
-        if application.applicationState != .active {
-            // "Background Processing" pushes still carry a visible alert under aps.alert
-            let alert = (userInfo["aps"] as? [String: Any])?["alert"] as? [String: Any]
-            PushLogStore.shared.record(
-                source: .background,
-                title: alert?["title"] as? String ?? "",
-                body: alert?["body"] as? String ?? "",
-                customData: customData
-            )
+        // A visible alert delivered while the app is active also triggers `willPresent`, which
+        // already logs it — skip here to avoid a duplicate entry. Silent pushes (no alert) never
+        // trigger `willPresent`, so they must always be logged from this method regardless of
+        // app state.
+        let hasVisibleAlert = PushPayload.hasVisibleAlert(userInfo)
+        guard hasVisibleAlert, application.applicationState == .active else {
+            let (title, body) = PushPayload.alertTitleAndBody(from: userInfo)
+            // Only call the completion handler once the entry is actually persisted — the app
+            // could be suspended immediately after fetchCompletionHandler runs, and the store's
+            // write happens on an async main-queue hop.
+            PushLogStore.shared.record(source: .background, title: title, body: body, customData: customData) {
+                completionHandler(.newData)
+            }
+            return
         }
 
         // Do your background work here (refresh data, etc.), then always call the completion
@@ -231,7 +237,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             source: .tapped,
             title: content.title,
             body: content.body,
-            customData: content.userInfo["key_value_pairs"] as? [String: String] ?? [:]
+            customData: PushPayload.customData(from: content.userInfo)
         )
 
         // If this notifiation is Klaviyo's notification we'll handle it
@@ -257,7 +263,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             source: .foreground,
             title: title,
             body: body,
-            customData: notification.request.content.userInfo["key_value_pairs"] as? [String: String] ?? [:]
+            customData: PushPayload.customData(from: notification.request.content.userInfo)
         )
 
         if #available(iOS 14.0, *) {

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -101,6 +101,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         // STEP5: add the push device token to your Klaviyo user profile.
+        
+        // Print the token as a hex string for debugging
+        let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
+        print("📱 APNs device token: \(tokenString)")
+        
         KlaviyoSDK().set(pushToken: deviceToken)
     }
 
@@ -117,20 +122,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: Silent Push Notification implementation
 
+    // This fires for both silent pushes and "Background Processing" pushes (content-available: 1,
+    // enabled from the Behaviors tab of a Klaviyo push message) whether the app is foregrounded,
+    // backgrounded, or not running. Background wakes are best-effort and only testable on a
+    // physical device — the Simulator does not deliver them.
     func application(
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
         // Access custom key-value pairs from the top level
-        if let customData = userInfo["key_value_pairs"] as? [String: String] {
+        let customData = userInfo["key_value_pairs"] as? [String: String] ?? [:]
+        if customData.isEmpty {
+            print("No key_value_pairs found in notification")
+        } else {
             // Process your custom key-value pairs here
             for (key, value) in customData {
                 print("Key: \(key), Value: \(value)")
             }
-        } else {
-            print("No key_value_pairs found in notification")
         }
+
+        // "Background Processing" pushes still carry a visible alert under aps.alert
+        let alert = (userInfo["aps"] as? [String: Any])?["alert"] as? [String: Any]
+        PushLogStore.shared.record(
+            source: .background,
+            title: alert?["title"] as? String ?? "",
+            body: alert?["body"] as? String ?? "",
+            customData: customData
+        )
+
+        // Do your background work here (refresh data, etc.), then always call the completion
+        // handler so iOS can measure your app's background efficiency.
+        completionHandler(.newData)
     }
 
     // MARK: Deep linking implementation
@@ -199,6 +222,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
+        let content = response.notification.request.content
+        PushLogStore.shared.record(
+            source: .tapped,
+            title: content.title,
+            body: content.body,
+            customData: content.userInfo["key_value_pairs"] as? [String: String] ?? [:]
+        )
+
         // If this notifiation is Klaviyo's notification we'll handle it
         // else pass it on to the next push notification service to which it may belong
         let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler)
@@ -213,6 +244,18 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        // Extract the visible title/body from a standard (non-silent) push
+        let title = notification.request.content.title
+        let body = notification.request.content.body
+        print("📬 [Foreground Push] Title: \(title), Body: \(body)")
+
+        PushLogStore.shared.record(
+            source: .foreground,
+            title: title,
+            body: body,
+            customData: notification.request.content.userInfo["key_value_pairs"] as? [String: String] ?? [:]
+        )
+
         if #available(iOS 14.0, *) {
             completionHandler([.list, .banner])
         } else {

--- a/Examples/KlaviyoSwiftExamples/Shared/MenuView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/MenuView.swift
@@ -6,6 +6,7 @@ struct MenuView: View {
     @State private var menuItems: [MenuItem] = []
     @State private var showingMap = false
     @State private var showingCheckout = false
+    @State private var showingPushLog = false
 
     var body: some View {
         NavigationStack {
@@ -25,6 +26,12 @@ struct MenuView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Log Out", systemImage: "rectangle.portrait.and.arrow.right") {
                         logout()
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Push Log", systemImage: "bell") {
+                        showingPushLog = true
                     }
                 }
 
@@ -73,6 +80,9 @@ struct MenuView: View {
         }
         .sheet(isPresented: $showingCheckout) {
             CheckoutView(cartItems: $appState.cartItems)
+        }
+        .sheet(isPresented: $showingPushLog) {
+            PushLogView()
         }
     }
 

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogEntry.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogEntry.swift
@@ -1,0 +1,31 @@
+//
+//  PushLogEntry.swift
+//  KlaviyoSwift
+//
+
+import Foundation
+
+/// A single push notification captured for display in the example app's Push Log screen.
+struct PushLogEntry: Identifiable, Codable, Equatable {
+    enum Source: String, Codable {
+        case foreground = "Foreground"
+        case background = "Background"
+        case tapped = "Tapped"
+    }
+
+    let id: UUID
+    let receivedAt: Date
+    let source: Source
+    let title: String
+    let body: String
+    let customData: [String: String]
+
+    init(source: Source, title: String, body: String, customData: [String: String]) {
+        id = UUID()
+        receivedAt = Date()
+        self.source = source
+        self.title = title
+        self.body = body
+        self.customData = customData
+    }
+}

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
@@ -1,0 +1,53 @@
+//
+//  PushLogStore.swift
+//  KlaviyoSwift
+//
+
+import Foundation
+
+/// Keeps a lightly-persisted history of push notifications received by the app so the Push Log
+/// screen can display each notification's title, body, and custom data without needing to
+/// reproduce the push or dig through the Xcode console.
+final class PushLogStore: ObservableObject {
+    static let shared = PushLogStore()
+
+    @Published private(set) var entries: [PushLogEntry] = []
+
+    private let storageKey = "com.klaviyo.example.pushLog"
+    private let maxEntries = 50
+
+    private init() {
+        entries = load()
+    }
+
+    func record(source: PushLogEntry.Source, title: String, body: String, customData: [String: String]) {
+        let entry = PushLogEntry(source: source, title: title, body: body, customData: customData)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            entries.insert(entry, at: 0)
+            if entries.count > maxEntries {
+                entries.removeLast(entries.count - maxEntries)
+            }
+            save()
+        }
+    }
+
+    func clear() {
+        entries = []
+        save()
+    }
+
+    private func load() -> [PushLogEntry] {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([PushLogEntry].self, from: data)
+        else {
+            return []
+        }
+        return decoded
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+}

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
@@ -19,13 +19,17 @@ final class PushLogStore: ObservableObject {
 
     private init() {
         // `shared` can be first touched from a background thread (e.g. didReceiveRemoteNotification),
-        // and `entries` is @Published — only assign it on the main thread.
+        // and `entries` is @Published, so it must only be mutated on the main thread. Hydrate
+        // asynchronously rather than with `DispatchQueue.main.sync` — synchronously blocking here
+        // while still inside `static let shared`'s one-time initialization lock can deadlock
+        // against the main thread if it accesses `shared` at the same moment (it would be waiting
+        // on this lock while this initializer waits on the main thread to be free).
         let loadedEntries = load()
         if Thread.isMainThread {
             entries = loadedEntries
         } else {
-            DispatchQueue.main.sync {
-                self.entries = loadedEntries
+            DispatchQueue.main.async { [weak self] in
+                self?.entries = loadedEntries
             }
         }
     }

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
@@ -3,6 +3,7 @@
 //  KlaviyoSwift
 //
 
+import Combine
 import Foundation
 
 /// Keeps a lightly-persisted history of push notifications received by the app so the Push Log
@@ -20,34 +21,60 @@ final class PushLogStore: ObservableObject {
         entries = load()
     }
 
-    func record(source: PushLogEntry.Source, title: String, body: String, customData: [String: String]) {
+    /// `completion` fires only after the entry has been appended and saved — callers that need to
+    /// guarantee persistence before finishing background work (e.g. before calling APNs'
+    /// `completionHandler`) should wait for it rather than assuming this returns synchronously.
+    func record(
+        source: PushLogEntry.Source,
+        title: String,
+        body: String,
+        customData: [String: String],
+        completion: (() -> Void)? = nil
+    ) {
         let entry = PushLogEntry(source: source, title: title, body: body, customData: customData)
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self else {
+                completion?()
+                return
+            }
             entries.insert(entry, at: 0)
             if entries.count > maxEntries {
                 entries.removeLast(entries.count - maxEntries)
             }
             save()
+            completion?()
         }
     }
 
     func clear() {
-        entries = []
-        save()
+        // Dispatch through the same queue as `record` so a clear can't race a push that's
+        // already mid-flight — whichever was invoked first is guaranteed to run first.
+        DispatchQueue.main.async { [weak self] in
+            self?.entries = []
+            self?.save()
+        }
     }
 
     private func load() -> [PushLogEntry] {
+        // Push payloads can carry sensitive custom data (promo codes, identifiers, etc.) — only
+        // persist across launches in Debug builds. Release builds keep this in-memory only for
+        // the current session.
+        #if DEBUG
         guard let data = UserDefaults.standard.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode([PushLogEntry].self, from: data)
         else {
             return []
         }
         return decoded
+        #else
+        return []
+        #endif
     }
 
     private func save() {
+        #if DEBUG
         guard let data = try? JSONEncoder().encode(entries) else { return }
         UserDefaults.standard.set(data, forKey: storageKey)
+        #endif
     }
 }

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogStore.swift
@@ -18,7 +18,16 @@ final class PushLogStore: ObservableObject {
     private let maxEntries = 50
 
     private init() {
-        entries = load()
+        // `shared` can be first touched from a background thread (e.g. didReceiveRemoteNotification),
+        // and `entries` is @Published — only assign it on the main thread.
+        let loadedEntries = load()
+        if Thread.isMainThread {
+            entries = loadedEntries
+        } else {
+            DispatchQueue.main.sync {
+                self.entries = loadedEntries
+            }
+        }
     }
 
     /// `completion` fires only after the entry has been appended and saved — callers that need to

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogView.swift
@@ -85,8 +85,8 @@ private struct PushLogRow: View {
 
             if !entry.customData.isEmpty {
                 VStack(alignment: .leading, spacing: 2) {
-                    ForEach(entry.customData.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
-                        Text("\(key): \(value)")
+                    ForEach(entry.customData.sorted(by: { $0.key < $1.key }), id: \.key) { customKey, value in
+                        Text("\(customKey): \(value)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }

--- a/Examples/KlaviyoSwiftExamples/Shared/PushLogView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushLogView.swift
@@ -1,0 +1,99 @@
+//
+//  PushLogView.swift
+//  KlaviyoSwift
+//
+
+import SwiftUI
+
+/// Displays a table (`List`) of push notifications the example app has received or handled —
+/// the title, body, and any custom key-value pairs — matching the data extracted in
+/// `AppDelegate`'s `UNUserNotificationCenterDelegate` and background-push handling.
+struct PushLogView: View {
+    @ObservedObject private var store = PushLogStore.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.entries.isEmpty {
+                    emptyState
+                } else {
+                    List {
+                        ForEach(store.entries) { entry in
+                            PushLogRow(entry: entry)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Push Log")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Clear", role: .destructive) { store.clear() }
+                        .disabled(store.entries.isEmpty)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "bell.slash")
+                .font(.system(size: 40))
+                .foregroundColor(.secondary)
+            Text("No Push Notifications Yet")
+                .font(.headline)
+            Text("Received pushes will appear here with their title, body, and custom data.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct PushLogRow: View {
+    let entry: PushLogEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(entry.source.rawValue)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(Color.accentColor.opacity(0.15))
+                    .clipShape(Capsule())
+
+                Spacer()
+
+                Text(entry.receivedAt, style: .time)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(entry.title.isEmpty ? "(no title)" : entry.title)
+                .font(.headline)
+
+            Text(entry.body.isEmpty ? "(no body)" : entry.body)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            if !entry.customData.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(entry.customData.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                        Text("\(key): \(value)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Examples/KlaviyoSwiftExamples/Shared/PushPayload.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/PushPayload.swift
@@ -1,0 +1,36 @@
+//
+//  PushPayload.swift
+//  KlaviyoSwift
+//
+
+import Foundation
+
+/// Shared parsing helpers for the raw APNs `userInfo` dictionary, so the "key_value_pairs" key and
+/// its expected shape are defined in one place instead of being repeated at every call site.
+enum PushPayload {
+    static let keyValuePairsKey = "key_value_pairs"
+
+    static func customData(from userInfo: [AnyHashable: Any]) -> [String: String] {
+        userInfo[keyValuePairsKey] as? [String: String] ?? [:]
+    }
+
+    /// `aps.alert` can be a dictionary (`{ "title": ..., "body": ... }`) or a plain string
+    /// (body text only, no title) — normalize both shapes to a single title/body pair.
+    static func alertTitleAndBody(from userInfo: [AnyHashable: Any]) -> (title: String, body: String) {
+        let alert = (userInfo["aps"] as? [String: Any])?["alert"]
+        switch alert {
+        case let dict as [String: Any]:
+            return (dict["title"] as? String ?? "", dict["body"] as? String ?? "")
+        case let text as String:
+            return ("", text)
+        default:
+            return ("", "")
+        }
+    }
+
+    /// Whether this payload carries a visible alert at all. Pushes without one (truly silent
+    /// pushes) never trigger `willPresent`, regardless of app state.
+    static func hasVisibleAlert(_ userInfo: [AnyHashable: Any]) -> Bool {
+        (userInfo["aps"] as? [String: Any])?["alert"] != nil
+    }
+}

--- a/PUSH_NOTIFICATION_DATA_GUIDE.md
+++ b/PUSH_NOTIFICATION_DATA_GUIDE.md
@@ -1,0 +1,129 @@
+# Extracting Title, Body, Custom Data, and Media from Klaviyo Push Notifications (iOS)
+
+This guide shows how to read the title, body, custom key-value pairs, and media (rich push) from a
+push notification sent through Klaviyo, using the Klaviyo Swift SDK.
+
+## Which push type are you handling?
+
+| Type | Visible alert? | Wakes app in background? | Delegate method(s) |
+|---|---|---|---|
+| Standard push | Yes | No | `willPresent` (foreground) / `didReceive` (tapped) |
+| Standard push + Background Processing | Yes | Yes | Same as above, **plus** `didReceiveRemoteNotification` |
+| Silent push | No | Yes | `didReceiveRemoteNotification` only |
+
+"Background Processing" is a toggle in the Klaviyo push editor's **Behaviors** tab. It adds
+`content-available: 1` to an otherwise normal, visible push so your app also gets a background wake
+alongside the alert — it is not a silent push.
+
+## Prerequisites
+
+- [Push Notifications capability](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns#2980170) enabled in Xcode.
+- Background Modes → **Remote notifications** enabled (needed for Background Processing and silent push).
+- For rich media only: a Notification Service Extension + shared App Group. See
+  [README § Installation](README.md#installation), step 2.
+
+## 1. Title & body (any visible push)
+
+Nothing to "extract" here — `UNNotification` already carries `title`/`body`. Implement the delegate:
+
+```swift
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    // Called when the user taps the notification
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let handled = KlaviyoSDK().handle(notificationResponse: response, withCompletionHandler: completionHandler)
+        if !handled {
+            completionHandler()
+        }
+    }
+
+    // Called when a push arrives while the app is in the foreground
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if #available(iOS 14.0, *) {
+            completionHandler([.list, .banner])
+        } else {
+            completionHandler([.alert])
+        }
+    }
+}
+```
+
+`title`/`body` are readable any time via `notification.request.content.title` / `.body`, or
+`response.notification.request.content.title` / `.body` in the tap handler.
+
+## 2. Custom data + background wake (Background Processing / silent push)
+
+```swift
+func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+) {
+    if let customData = userInfo["key_value_pairs"] as? [String: String] {
+        for (key, value) in customData {
+            print("Key: \(key), Value: \(value)")
+        }
+    } else {
+        print("No key_value_pairs found in notification")
+    }
+
+    completionHandler(.newData) // or .noData / .failed
+}
+```
+
+> ⚠️ **Always call `completionHandler`.** Skipping it risks iOS throttling future background wakes to
+> your app — this method exists specifically so iOS can measure how efficiently you use the time it grants.
+
+> ⚠️ Test on a **physical device**. The Simulator does not deliver silent-push or Background-Processing
+> wakes, so this method will never fire there.
+
+## 3. Rich media (images & videos)
+
+Handled automatically once the Notification Service Extension + App Group from Prerequisites are in
+place — see the working reference implementation:
+[`NotificationService.swift`](Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift).
+No extra code is needed to trigger it; Klaviyo's push payload carries the media, and the extension
+downloads and attaches it before the notification displays.
+
+Test payloads (send via a real device token — printed from `didRegisterForRemoteNotificationsWithDeviceToken`):
+
+**Image:**
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Sample title for a Klaviyo push notification",
+      "body": "Sample body for a Klaviyo push notification"
+    },
+    "mutable-content": 1
+  },
+  "rich-media": "https://picsum.photos/200/300.jpg",
+  "rich-media-type": "jpg"
+}
+```
+
+**Video:**
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "Video Push Notification",
+      "body": "Check out this video content"
+    },
+    "mutable-content": 1
+  },
+  "rich-media": "https://example.com/videos/mp4/your_video.mp4",
+  "rich-media-type": "mp4"
+}
+```
+
+## Reference
+
+Full documentation: [README § Push Notifications](README.md#push-notifications)

--- a/PUSH_NOTIFICATION_DATA_GUIDE.md
+++ b/PUSH_NOTIFICATION_DATA_GUIDE.md
@@ -80,7 +80,7 @@ func application(
 
 > ⚠️ **Always call `completionHandler`.** Skipping it risks iOS throttling future background wakes to
 > your app — this method exists specifically so iOS can measure how efficiently you use the time it grants.
-
+>
 > ⚠️ Test on a **physical device**. The Simulator does not deliver silent-push or Background-Processing
 > wakes, so this method will never fire there.
 
@@ -95,6 +95,7 @@ downloads and attaches it before the notification displays.
 Test payloads (send via a real device token — printed from `didRegisterForRemoteNotificationsWithDeviceToken`):
 
 **Image:**
+
 ```json
 {
   "aps": {
@@ -110,6 +111,7 @@ Test payloads (send via a real device token — printed from `didRegisterForRemo
 ```
 
 **Video:**
+
 ```json
 {
   "aps": {


### PR DESCRIPTION
## Summary
- PoC for a customer: extracting title, body, custom key-value pairs, and rich media from Klaviyo push notifications on iOS.
- `PUSH_NOTIFICATION_DATA_GUIDE.md` — standalone, README-accurate walkthrough, safe to hand to the customer as-is.
- Example app (`SPMExample`/`CocoapodsExample`) — working implementation: `AppDelegate.swift` wires up the extraction from the guide, plus a `PushLogView`/`PushLogStore` (SwiftUI `List`) so received pushes are visible in-app instead of only in the console.
- Fixes a real pre-existing bug along the way: `didReceiveRemoteNotification` never called `completionHandler`, which risks iOS throttling background pushes.

## Test plan
- [ ] Build & run `SPMExample` on a physical device (Simulator can't deliver background/content-available/rich-media pushes)
- [ ] Send a standard push, foreground and backgrounded — confirm title/body appear in console + Push Log
- [ ] Send a push with `content-available: 1` + custom `key_value_pairs` — confirm background entry appears, no throttling on repeated sends
- [ ] Send a rich-media (`mutable-content: 1`) push — confirm image/video attaches

## Demo 

https://github.com/user-attachments/assets/5203e26e-97e4-45db-a3f6-476d36199490




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Push Log” screen in the Swift examples to view, inspect, and clear recent push notification entries.
  * Push interactions are now captured across foreground, background, and tap events with source, timestamp, title/body, and custom key-value data.
* **Bug Fixes**
  * Improved debug logging for incoming notifications and made push-log recording more reliable and main-thread safe.
* **Documentation**
  * Added an iOS push-notification guide covering custom data extraction, notification handling flows, and rich-media setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->