### PR TITLE
feat: add create client subscription API

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,4 +52,5 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
+    - sms
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,9 @@ let package = Package(
     targets: [
         .target(
             name: "KlaviyoCore",
-            dependencies: [.product(name: "AnyCodable", package: "AnyCodable")],
+            dependencies: [
+                .product(name: "AnyCodable", package: "AnyCodable")
+            ],
             path: "Sources/KlaviyoCore"
         ),
         .testTarget(
@@ -51,7 +53,10 @@ let package = Package(
         ),
         .target(
             name: "KlaviyoSwift",
-            dependencies: [.product(name: "AnyCodable", package: "AnyCodable"), "KlaviyoCore"],
+            dependencies: [
+                .product(name: "AnyCodable", package: "AnyCodable"),
+                "KlaviyoCore"
+            ],
             path: "Sources/KlaviyoSwift",
             resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
@@ -71,7 +76,10 @@ let package = Package(
         ),
         .target(
             name: "KlaviyoForms",
-            dependencies: ["KlaviyoSwift"],
+            dependencies: [
+                "KlaviyoSwift",
+                "KlaviyoCore"
+            ],
             path: "Sources/KlaviyoForms",
             resources: [
                 .process("InAppForms/Assets"),

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
   - [Unregistering from Geofencing](#unregistering-from-geofencing)
 - [Additional Details](#additional-details)
   - [Sandbox Support](#sandbox-support)
+  - [Logging](#logging)
   - [SDK Data Transfer](#sdk-data-transfer)
   - [Retries](#retries)
 - [Contributing](#contributing)
@@ -935,6 +936,20 @@ Klaviyo's SDK will determine and store the environment that your push token belo
 allowing your tokens to route sends to the correct environments. There is no additional setup needed.
 As long as you have deployed your application to Sandbox with our SDK employed to transmit push tokens to our backend,
 the ability to send and receive push on these Sandbox applications should work out-of-the-box.
+
+### Logging
+The SDK logs diagnostic information to the system console via `os.Logger`. Logging is enabled by default
+and can be toggled at runtime:
+
+```swift
+KlaviyoSDK().setLoggingEnabled(false) // silence all SDK logging
+KlaviyoSDK().setLoggingEnabled(true)  // re-enable logging
+KlaviyoSDK().isLoggingEnabled         // check the current setting
+```
+
+Disabling logging silences all log output from the `KlaviyoSwift`, `KlaviyoCore`, `KlaviyoForms`,
+and `KlaviyoLocation` modules. It does not affect `KlaviyoSwiftExtension`, which runs in a separate
+app-extension process.
 
 ### SDK Data Transfer
 Starting with version 1.7.0, the SDK will cache incoming data and flush it back to the Klaviyo API on an interval.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   - [Anonymous Tracking Notice](#anonymous-tracking-notice)
 - [Event tracking](#event-tracking)
   - [Arguments](#arguments)
+- [List Subscriptions](#list-subscriptions)
+  - [Arguments](#arguments-1)
 - [Push Notifications](#push-notifications)
   - [Prerequisites](#prerequisites)
   - [Collecting Push Tokens](#collecting-push-tokens)
@@ -232,6 +234,51 @@ The `create` method takes an event object as an argument. The event can be const
 - [required] `name`: The name of the event you want to track, as a `EventName` enum. A list of common Klaviyo defined event metrics can be found in `Event.EventName`. You can also create custom events by using the `CustomEvent` enum case of `Event.EventName`
 - `properties`: A dictionary of properties that are specific to the event. This argument is optional.
 - `value`: A numeric value (`Double`) to associate with this event. For example, the dollar amount of a purchase.
+
+## List Subscriptions
+
+The SDK can create a subscription and consent record for email, SMS, and Whatsapp channels based on the profile's email and phone number attributes — via the [Create Client Subscription API](https://developers.klaviyo.com/en/reference/create_client_subscription). One of either email or phone number must be provided. WhatsApp BSUID support is coming soon.
+
+Set the profile's email and/or phone number **before** subscribing. A subscribe call that requests a channel whose identifier has not been set is not enqueued (a developer warning is logged).
+
+Profiles can be opted into multiple channels — for example email marketing, SMS marketing, and SMS transactional. Specify the channel(s) to subscribe by providing a `channels` value on `Subscription`. If you include `channels`, only those channels will be subscribed. If you use `Subscription.allAvailableMarketing` (no `subscriptions` object is sent), subscriptions are defaulted to `MARKETING`.
+
+Subscriptions to push notifications are not created through this API — use the existing [`set(pushToken:)`](#collecting-push-tokens) registration path instead.
+
+```swift
+KlaviyoSDK().set(email: "johnpork@demo.com")
+KlaviyoSDK().set(phoneNumber: "+15005550006")
+
+// Subscribe to a list, defaulting to MARKETING consent for every channel
+// available from the identifiers you've set:
+KlaviyoSDK().create(subscription: .allAvailableMarketing(listId: "XXXXXX"))
+
+// Or request specific channels and consent types:
+let subscription = Subscription(
+    listId: "XXXXXX",
+    channels: .init(
+        email: .marketing,
+        sms: [.marketing, .transactional],
+        whatsapp: [.marketing, .transactional]
+    ),
+    customSource: "iOS in-app form"
+)
+KlaviyoSDK().create(subscription: subscription)
+```
+### Arguments
+
+The `create(subscription:)` method takes a `Subscription`. Construct one with either:
+
+- `Subscription.allAvailableMarketing(listId:customSource:)` — omits the `subscriptions` object so the API defaults to `MARKETING` consent for every channel available from the profile's identifiers.
+- `Subscription(listId:channels:customSource:)` — sends a `subscriptions` object for only the channels you name. `channels` is required on this initializer so a broad grant is never the result of an omitted argument.
+
+`Subscription.Channels` takes optional `email`, `sms`, and `whatsapp` values. Each channel exposes only the consent sub-types the API supports for it — pass one value (e.g. `.marketing`) or multiple (e.g. `[.marketing, .transactional]`):
+
+The consent types per channel include:
+- `email`: `.marketing`, `.openTracking`
+- `sms` / `whatsapp`: `.marketing`, `.transactional`
+
+`customSource` is an optional free-text label describing where the signup originated (e.g. a form or screen name), stored as the consent record's source.
 
 ## Push Notifications
 

--- a/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
@@ -1,0 +1,54 @@
+//
+//  CreateSubscriptionPayload.swift
+//
+//
+//  Created by Aahil Nishad on 7/7/26.
+//
+
+import Foundation
+
+public struct CreateSubscriptionPayload: Equatable, Codable {
+    public let data: SubscriptionData
+
+    public init(listId: String, profile: ProfilePayload, customSource: String? = nil) {
+        data = SubscriptionData(listId: listId, profile: profile, customSource: customSource)
+    }
+
+    public struct SubscriptionData: Equatable, Codable {
+        public var type = "subscription"
+        public let attributes: Attributes
+        public let relationships: Relationships
+
+        public init(listId: String, profile: ProfilePayload, customSource: String?) {
+            attributes = Attributes(customSource: customSource, profile: .init(data: profile))
+            relationships = Relationships(list: .init(data: .init(id: listId)))
+        }
+
+        public struct Attributes: Equatable, Codable {
+            public let customSource: String?
+            public let profile: Profile
+
+            enum CodingKeys: String, CodingKey {
+                case customSource = "custom_source"
+                case profile
+            }
+
+            public struct Profile: Equatable, Codable {
+                public let data: ProfilePayload
+            }
+        }
+
+        public struct Relationships: Equatable, Codable {
+            public let list: ListRelationship
+
+            public struct ListRelationship: Equatable, Codable {
+                public let data: ListData
+
+                public struct ListData: Equatable, Codable {
+                    public var type = "list"
+                    public let id: String
+                }
+            }
+        }
+    }
+}

--- a/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
@@ -15,7 +15,7 @@ public struct CreateSubscriptionPayload: Equatable, Codable {
     }
 
     public struct SubscriptionData: Equatable, Codable {
-        public var type = "subscription"
+        public let type = "subscription"
         public let attributes: Attributes
         public let relationships: Relationships
 
@@ -45,7 +45,7 @@ public struct CreateSubscriptionPayload: Equatable, Codable {
                 public let data: ListData
 
                 public struct ListData: Equatable, Codable {
-                    public var type = "list"
+                    public let type = "list"
                     public let id: String
                 }
             }

--- a/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
@@ -8,9 +8,7 @@
 import AnyCodable
 import Foundation
 
-/**
- Internal structure which has details not needed by the API.
- */
+/// Internal structure which has details not needed by the API.
 public struct ProfilePayload: Equatable, Codable {
     var type = "profile"
     public struct Attributes: Equatable, Codable {
@@ -25,6 +23,7 @@ public struct ProfilePayload: Equatable, Codable {
         public var image: String?
         public var location: Location?
         public var properties: AnyCodable
+        public var subscriptions: SubscriptionChannels?
         enum CodingKeys: String, CodingKey {
             case email
             case phoneNumber = "phone_number"
@@ -37,19 +36,23 @@ public struct ProfilePayload: Equatable, Codable {
             case image
             case location
             case properties
+            case subscriptions
         }
 
-        public init(email: String? = nil,
-                    phoneNumber: String? = nil,
-                    externalId: String? = nil,
-                    firstName: String? = nil,
-                    lastName: String? = nil,
-                    organization: String? = nil,
-                    title: String? = nil,
-                    image: String? = nil,
-                    location: Location? = nil,
-                    properties: [String: Any]? = nil,
-                    anonymousId: String) {
+        public init(
+            email: String? = nil,
+            phoneNumber: String? = nil,
+            externalId: String? = nil,
+            firstName: String? = nil,
+            lastName: String? = nil,
+            organization: String? = nil,
+            title: String? = nil,
+            image: String? = nil,
+            location: Location? = nil,
+            properties: [String: Any]? = nil,
+            subscriptions: SubscriptionChannels? = nil,
+            anonymousId: String
+        ) {
             self.email = email
             self.phoneNumber = phoneNumber
             self.externalId = externalId
@@ -60,6 +63,7 @@ public struct ProfilePayload: Equatable, Codable {
             self.image = image
             self.location = location
             self.properties = AnyCodable(properties ?? [:])
+            self.subscriptions = subscriptions
             self.anonymousId = anonymousId
         }
 
@@ -73,15 +77,17 @@ public struct ProfilePayload: Equatable, Codable {
             public var region: String?
             public var zip: String?
             public var timezone: String?
-            public init(address1: String? = nil,
-                        address2: String? = nil,
-                        city: String? = nil,
-                        country: String? = nil,
-                        latitude: Double? = nil,
-                        longitude: Double? = nil,
-                        region: String? = nil,
-                        zip: String? = nil,
-                        timezone: String? = nil) {
+            public init(
+                address1: String? = nil,
+                address2: String? = nil,
+                city: String? = nil,
+                country: String? = nil,
+                latitude: Double? = nil,
+                longitude: Double? = nil,
+                region: String? = nil,
+                zip: String? = nil,
+                timezone: String? = nil
+            ) {
                 self.address1 = address1
                 self.address2 = address2
                 self.city = city
@@ -97,17 +103,20 @@ public struct ProfilePayload: Equatable, Codable {
 
     public var attributes: Attributes
 
-    public init(email: String? = nil,
-                phoneNumber: String? = nil,
-                externalId: String? = nil,
-                firstName: String? = nil,
-                lastName: String? = nil,
-                organization: String? = nil,
-                title: String? = nil,
-                image: String? = nil,
-                location: Attributes.Location? = nil,
-                properties: [String: Any]? = nil,
-                anonymousId: String) {
+    public init(
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        organization: String? = nil,
+        title: String? = nil,
+        image: String? = nil,
+        location: Attributes.Location? = nil,
+        properties: [String: Any]? = nil,
+        subscriptions: SubscriptionChannels? = nil,
+        anonymousId: String
+    ) {
         attributes = Attributes(
             email: email,
             phoneNumber: phoneNumber,
@@ -119,6 +128,7 @@ public struct ProfilePayload: Equatable, Codable {
             image: image,
             location: location,
             properties: properties,
+            subscriptions: subscriptions,
             anonymousId: anonymousId
         )
     }

--- a/Sources/KlaviyoCore/Models/APIModels/SubscriptionChannels.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/SubscriptionChannels.swift
@@ -1,0 +1,72 @@
+//
+//  SubscriptionChannels.swift
+//
+//
+//  Created by Aahil Nishad on 7/14/26.
+//
+
+import Foundation
+
+/// `subscriptions` object on a profile: one entry per channel. Each channel exposes only the consent
+/// sub-types the API supports for it — email: `marketing` + `open_tracking`; SMS and WhatsApp:
+/// `marketing` + `transactional`. Every consent value is `{ "consent": "SUBSCRIBED" }`.
+public struct SubscriptionChannels: Equatable, Codable {
+    public let email: EmailConsent?
+    public let sms: MarketingTransactionalConsent?
+    public let whatsapp: MarketingTransactionalConsent?
+
+    public init(
+        email: EmailConsent? = nil,
+        sms: MarketingTransactionalConsent? = nil,
+        whatsapp: MarketingTransactionalConsent? = nil
+    ) {
+        self.email = email
+        self.sms = sms
+        self.whatsapp = whatsapp
+    }
+}
+
+public struct SubscriptionConsent: Equatable, Codable {
+    public let consent: String
+
+    private init(consent: String) {
+        self.consent = consent
+    }
+
+    public static let subscribed = SubscriptionConsent(
+        consent: "SUBSCRIBED"
+    )
+}
+
+/// EMAIL channel consent: `marketing` and/or `open_tracking`.
+public struct EmailConsent: Equatable, Codable {
+    public let marketing: SubscriptionConsent?
+    public let openTracking: SubscriptionConsent?
+
+    enum CodingKeys: String, CodingKey {
+        case marketing
+        case openTracking = "open_tracking"
+    }
+
+    public init(
+        marketing: SubscriptionConsent? = nil,
+        openTracking: SubscriptionConsent? = nil
+    ) {
+        self.marketing = marketing
+        self.openTracking = openTracking
+    }
+}
+
+/// SMS and WhatsApp channel consent: `marketing` and/or `transactional`.
+public struct MarketingTransactionalConsent: Equatable, Codable {
+    public let marketing: SubscriptionConsent?
+    public let transactional: SubscriptionConsent?
+
+    public init(
+        marketing: SubscriptionConsent? = nil,
+        transactional: SubscriptionConsent? = nil
+    ) {
+        self.marketing = marketing
+        self.transactional = transactional
+    }
+}

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -15,6 +15,7 @@ public enum KlaviyoEndpoint: Equatable, Codable {
     case registerPushToken(_ apiKey: String, _ payload: PushTokenPayload)
     case unregisterPushToken(_ apiKey: String, _ payload: UnregisterPushTokenPayload)
     case aggregateEvent(_ apiKey: String, _ payload: AggregateEventPayload)
+    case createSubscription(_ apiKey: String, _ payload: CreateSubscriptionPayload)
     case resolveDestinationURL(trackingLink: URL, profileInfo: ProfilePayload)
     case logTrackingLinkClicked(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
     case fetchGeofences(_ apiKey: String, latitude: Double?, longitude: Double?)
@@ -27,7 +28,12 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     public var headers: [String: String] {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent:
+        case .createProfile,
+             .createEvent,
+             .registerPushToken,
+             .unregisterPushToken,
+             .aggregateEvent,
+             .createSubscription:
             return [:]
         case let .fetchGeofences(_, latitude, longitude):
             var headers = [String: String]()
@@ -58,7 +64,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
              let .createEvent(apiKey, _),
              let .registerPushToken(apiKey, _),
              let .unregisterPushToken(apiKey, _),
-             let .aggregateEvent(apiKey, _):
+             let .aggregateEvent(apiKey, _),
+             let .createSubscription(apiKey, _):
             return [URLQueryItem(name: "company_id", value: apiKey)]
         case let .fetchGeofences(apiKey, _, _):
             return [
@@ -72,7 +79,12 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     var httpMethod: HTTPMethod {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent:
+        case .createProfile,
+             .createEvent,
+             .registerPushToken,
+             .unregisterPushToken,
+             .aggregateEvent,
+             .createSubscription:
             return .post
         case .resolveDestinationURL, .logTrackingLinkClicked, .fetchGeofences:
             return .get
@@ -81,7 +93,13 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     public func baseURL() throws -> URL {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent, .fetchGeofences:
+        case .createProfile,
+             .createEvent,
+             .registerPushToken,
+             .unregisterPushToken,
+             .aggregateEvent,
+             .createSubscription,
+             .fetchGeofences:
             guard environment.apiURL().scheme != nil,
                   environment.apiURL().host != nil,
                   let url = environment.apiURL().url else {
@@ -124,6 +142,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
             return "/client/push-token-unregister/"
         case .aggregateEvent:
             return "/onsite/track-analytics"
+        case .createSubscription:
+            return "/client/subscriptions"
         case let .resolveDestinationURL(trackingLink, _), let .logTrackingLinkClicked(trackingLink, _, _):
             return trackingLink.path
         case .fetchGeofences:
@@ -151,6 +171,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
             return try environment.encodeJSON(payload)
         case let .aggregateEvent(_, payload):
             return payload
+        case let .createSubscription(_, payload):
+            return try environment.encodeJSON(payload)
         case .resolveDestinationURL, .logTrackingLinkClicked, .fetchGeofences:
             return nil
         }

--- a/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
+++ b/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
@@ -49,6 +49,7 @@ public struct SDKRequest: Identifiable, Equatable {
         case resolveDestinationURL(trackingLink: URL)
         case logTrackingLinkClicked(trackingLink: URL, clickTime: Date)
         case fetchGeofences
+        case createSubscription(listId: String, ProfileInfo)
 
         fileprivate static func fromEndpoint(request: KlaviyoRequest) -> RequestType {
             switch request.endpoint {
@@ -87,6 +88,15 @@ public struct SDKRequest: Identifiable, Equatable {
                 return .logTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
             case .fetchGeofences:
                 return .fetchGeofences
+            case let .createSubscription(_, payload):
+                let attrs = payload.data.attributes.profile.data.attributes
+                return .createSubscription(
+                    listId: payload.data.relationships.list.data.id,
+                    ProfileInfo(email: attrs.email,
+                                phoneNumber: attrs.phoneNumber,
+                                externalId: attrs.externalId,
+                                anonymousId: attrs.anonymousId)
+                )
             }
         }
     }

--- a/Sources/KlaviyoCore/Utils/Logger+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/Logger+Ext.swift
@@ -5,7 +5,39 @@
 //  Created by Andrew Balmer on 7/25/25.
 //
 
+import Foundation
 import OSLog
+
+// MARK: - Logging Configuration
+
+/// Thread-safe global logging toggle for the Klaviyo SDK.
+///
+/// When logging is disabled, all `Logger` instances across every module
+/// return `Logger(OSLog.disabled)`, which the OS optimises to a no-op.
+package final class KlaviyoLogConfig: @unchecked Sendable {
+    package static let shared = KlaviyoLogConfig()
+
+    private let lock = NSLock()
+    private var _isLoggingEnabled: Bool = true
+
+    private init() {}
+
+    /// Whether logging is currently enabled across all Klaviyo SDK modules.
+    package var isLoggingEnabled: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _isLoggingEnabled
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _isLoggingEnabled = newValue
+        }
+    }
+}
+
+// MARK: - Logger Convenience Initializers
 
 @available(iOS 14.0, *)
 extension Logger {
@@ -21,14 +53,22 @@ extension Logger {
 @available(iOS 14.0, *)
 extension Logger {
     /// Logger for ``Codable`` events (JSON encoding & decoding)
-    static let codable = Logger(category: "Encoding/Decoding Logger")
+    static var codable: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Encoding/Decoding Logger") : Logger(OSLog.disabled)
+    }
 
     /// Logger for networking events
-    static let networking = Logger(category: "Networking")
+    static var networking: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Networking") : Logger(OSLog.disabled)
+    }
 
     /// Logger for app navigation and deep linking events
-    static let navigation = Logger(category: "Linking and Navigation")
+    static var navigation: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Linking and Navigation") : Logger(OSLog.disabled)
+    }
 
     /// Logger for notification category management
-    static let notifications = Logger(category: "Notifications")
+    static var notifications: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Notifications") : Logger(OSLog.disabled)
+    }
 }

--- a/Sources/KlaviyoCore/Utils/LoggerClient.swift
+++ b/Sources/KlaviyoCore/Utils/LoggerClient.swift
@@ -16,7 +16,10 @@ public struct LoggerClient {
     }
 
     public var error: (String) -> Void
-    public static let production = Self(error: { message in os_log("%{public}s", type: .error, message) })
+    public static let production = Self(error: { message in
+        guard KlaviyoLogConfig.shared.isLoggingEnabled else { return }
+        os_log("%{public}s", type: .error, message)
+    })
 }
 
 @usableFromInline
@@ -28,6 +31,7 @@ func runtimeWarn(
     line: UInt? = nil
 ) {
     #if DEBUG
+    guard KlaviyoLogConfig.shared.isLoggingEnabled else { return }
     let message = message()
     let category = category ?? "Runtime Warning"
     #if canImport(os)

--- a/Sources/KlaviyoForms/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoForms/Utilities/Logger+Ext.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew Balmer on 1/28/25.
 //
 
+import KlaviyoCore
 import OSLog
 
 @available(iOS 14.0, *)
@@ -21,13 +22,19 @@ extension Logger {
 @available(iOS 14.0, *)
 extension Logger {
     /// Logger for Javascript console log messages from a WKWebView relayed to the native layer.
-    static let webViewConsoleLogger = Logger(category: "WKWebView Console Log Relay")
+    static var webViewConsoleLogger: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "WKWebView Console Log Relay") : Logger(OSLog.disabled)
+    }
 
     /// Logger for WKWebView related events.
     ///
     /// - Note: Javascript console logs relayed to the native layer should be handled by the ``webViewConsoleLogger``.
-    static let webViewLogger = Logger(category: "WKWebView Event Handling")
+    static var webViewLogger: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "WKWebView Event Handling") : Logger(OSLog.disabled)
+    }
 
     /// Logger for filesystem operations.
-    static let filesystem = Logger(category: "Filesystem")
+    static var filesystem: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Filesystem") : Logger(OSLog.disabled)
+    }
 }

--- a/Sources/KlaviyoLocation/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoLocation/Utilities/Logger+Ext.swift
@@ -5,12 +5,15 @@
 //  Created by Andrew Balmer on 10/8/24.
 //
 
+import KlaviyoCore
 import OSLog
 
 @available(iOS 14.0, *)
 extension Logger {
-    private static var subsystem = Bundle.main.bundleIdentifier ?? ""
+    private static var subsystem = "com.klaviyo.klaviyo-swift-sdk.klaviyoLocation"
 
     /// Logs events related to location services.
-    static let geoservices = Logger(subsystem: subsystem, category: "geoservices")
+    static var geoservices: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(subsystem: subsystem, category: "geoservices") : Logger(OSLog.disabled)
+    }
 }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -166,6 +166,23 @@ public struct KlaviyoSDK {
         dispatchOnMainThread(action: .enqueueEvent(event))
     }
 
+    /// Creates a subscription and consent record for the email, SMS, and/or WhatsApp channels.
+    ///
+    /// This method subscribes the currently tracked profile to the specified Klaviyo list.
+    /// The profile must have at least an email address or phone number set (email keys the email
+    /// channel; phone number keys the SMS and WhatsApp channels).
+    ///
+    /// Use ``Subscription/allAvailableMarketing(listId:customSource:)`` to grant MARKETING consent on
+    /// the channels the profile has identifiers for (email and SMS), or the
+    /// ``Subscription/init(listId:channels:customSource:)`` initializer with a ``Subscription/Channels``
+    /// value to name specific channels and sub-types.
+    ///
+    /// - Parameter subscription: A ``Subscription`` with the list ID, the channels to request consent
+    ///   for, and an optional `customSource` label.
+    public func create(subscription: Subscription) {
+        dispatchOnMainThread(action: .enqueueSubscription(subscription))
+    }
+
     /// Set the current user's push token. This will be associated with profile and can be used to send them push notifications.
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -56,6 +56,31 @@ public struct KlaviyoSDK {
         state.pushTokenData?.pushToken
     }
 
+    /// Whether logging is currently enabled for the Klaviyo SDK.
+    ///
+    /// Logging is enabled by default. When disabled, all `os.Logger` output,
+    /// legacy `LoggerClient` error logging, and runtime warnings are silenced.
+    public var isLoggingEnabled: Bool {
+        KlaviyoLogConfig.shared.isLoggingEnabled
+    }
+
+    /// Enable or disable logging for the Klaviyo SDK.
+    ///
+    /// When disabled, all log output across KlaviyoCore, KlaviyoSwift,
+    /// KlaviyoForms, and KlaviyoLocation is silenced. Re-enabling restores
+    /// logging immediately.
+    ///
+    /// - Note: This setting does not affect `KlaviyoSwiftExtension`, which runs
+    ///   in a separate app-extension process where this in-memory toggle does
+    ///   not apply.
+    /// - Parameter enabled: Pass `true` to enable logging, `false` to disable.
+    /// - Returns: The current `KlaviyoSDK` instance, for chaining.
+    @discardableResult
+    public func setLoggingEnabled(_ enabled: Bool) -> KlaviyoSDK {
+        KlaviyoLogConfig.shared.isLoggingEnabled = enabled
+        return self
+    }
+
     /// Initialize the swift SDK with the given api key.
     /// NOTE: if the SDK has been initialized previously this will result in the profile
     /// information being reset and the token data being reassigned (see ``resetProfile()`` for details.)

--- a/Sources/KlaviyoSwift/Models/Subscription.swift
+++ b/Sources/KlaviyoSwift/Models/Subscription.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Represents a subscription request to subscribe a profile to a Klaviyo list.
-public struct Subscription: Equatable {
+public struct Subscription: Equatable, Sendable {
     /// The ID of the Klaviyo list to subscribe the profile to.
     public let listId: String
 
@@ -26,7 +26,7 @@ public struct Subscription: Equatable {
     /// exposes only the consent sub-types it supports, so invalid combinations (transactional email,
     /// open-tracking SMS) don't compile. Combine sub-types with array-literal syntax, e.g.
     /// `.init(sms: [.marketing, .transactional])`.
-    public struct Channels: Equatable {
+    public struct Channels: Equatable, Sendable {
         /// Consent sub-types to request on the EMAIL channel.
         public let email: Email?
         /// Consent sub-types to request on the SMS channel.
@@ -41,7 +41,7 @@ public struct Subscription: Equatable {
         }
 
         /// Consent sub-types supported on the EMAIL channel.
-        public struct Email: OptionSet, Equatable {
+        public struct Email: OptionSet, Equatable, Sendable {
             public let rawValue: Int
             public init(rawValue: Int) { self.rawValue = rawValue }
 
@@ -52,7 +52,7 @@ public struct Subscription: Equatable {
         }
 
         /// Consent sub-types supported on the SMS and WhatsApp channels.
-        public struct Messaging: OptionSet, Equatable {
+        public struct Messaging: OptionSet, Equatable, Sendable {
             public let rawValue: Int
             public init(rawValue: Int) { self.rawValue = rawValue }
 

--- a/Sources/KlaviyoSwift/Models/Subscription.swift
+++ b/Sources/KlaviyoSwift/Models/Subscription.swift
@@ -1,0 +1,91 @@
+//
+//  Subscription.swift
+//
+//
+//  Created by Aahil Nishad on 7/7/26.
+//
+
+import Foundation
+
+/// Represents a subscription request to subscribe a profile to a Klaviyo list.
+public struct Subscription: Equatable {
+    /// The ID of the Klaviyo list to subscribe the profile to.
+    public let listId: String
+
+    /// The channels to request consent for, or `nil` to defer to the server's default of MARKETING
+    /// consent on every identified channel. `nil` is only reachable through
+    /// ``allAvailableMarketing(listId:customSource:)`` — the public initializer requires channels so a
+    /// broad grant is never the result of an omitted argument.
+    public let channels: Channels?
+
+    /// Free-text label describing where this signup originated (e.g. a form or screen name).
+    /// Stored as the consent record's `$source`, pass an explicit value to override, or `nil` to omit it entirely.
+    public let customSource: String?
+
+    /// The channels to request consent for. Mirrors the API's `subscriptions` object: each channel
+    /// exposes only the consent sub-types it supports, so invalid combinations (transactional email,
+    /// open-tracking SMS) don't compile. Combine sub-types with array-literal syntax, e.g.
+    /// `.init(sms: [.marketing, .transactional])`.
+    public struct Channels: Equatable {
+        /// Consent sub-types to request on the EMAIL channel.
+        public let email: Email?
+        /// Consent sub-types to request on the SMS channel.
+        public let sms: Messaging?
+        /// Consent sub-types to request on the WhatsApp channel.
+        public let whatsapp: Messaging?
+
+        public init(email: Email? = nil, sms: Messaging? = nil, whatsapp: Messaging? = nil) {
+            self.email = email
+            self.sms = sms
+            self.whatsapp = whatsapp
+        }
+
+        /// Consent sub-types supported on the EMAIL channel.
+        public struct Email: OptionSet, Equatable {
+            public let rawValue: Int
+            public init(rawValue: Int) { self.rawValue = rawValue }
+
+            /// Email marketing consent.
+            public static let marketing = Email(rawValue: 1 << 0)
+            /// Email open-tracking consent.
+            public static let openTracking = Email(rawValue: 1 << 1)
+        }
+
+        /// Consent sub-types supported on the SMS and WhatsApp channels.
+        public struct Messaging: OptionSet, Equatable {
+            public let rawValue: Int
+            public init(rawValue: Int) { self.rawValue = rawValue }
+
+            /// Marketing consent.
+            public static let marketing = Messaging(rawValue: 1 << 0)
+            /// Transactional messaging consent.
+            public static let transactional = Messaging(rawValue: 1 << 1)
+        }
+    }
+
+    /// Creates a subscription request for the given channels.
+    /// - Parameters:
+    ///   - listId: The ID of the Klaviyo list to subscribe the profile to.
+    ///   - channels: The channels and sub-types to request consent for.
+    ///   - customSource: Optional signup-source label stored as the consent record's `$source`.
+    ///     Omitted from the request when `nil` (the default).
+    public init(listId: String, channels: Channels, customSource: String? = nil) {
+        self.init(listId: listId, channels: .some(channels), customSource: customSource)
+    }
+
+    private init(listId: String, channels: Channels?, customSource: String?) {
+        self.listId = listId
+        self.channels = channels
+        self.customSource = customSource
+    }
+
+    /// Creates a subscription that grants MARKETING consent on every channel the profile has an
+    /// identifier for (email → email marketing, phone → SMS marketing). Mirrors the server's default
+    /// behavior when no `subscriptions` object is sent, but requesting it is a deliberate call.
+    /// - Parameters:
+    ///   - listId: The ID of the Klaviyo list to subscribe the profile to.
+    ///   - customSource: Optional signup-source label stored as the consent record's `$source`.
+    public static func allAvailableMarketing(listId: String, customSource: String? = nil) -> Subscription {
+        Subscription(listId: listId, channels: nil, customSource: customSource)
+    }
+}

--- a/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
@@ -1,0 +1,46 @@
+//
+//  SubscriptionAPIExtension.swift
+//
+//
+//  Created by Aahil Nishad on 7/14/26.
+//
+
+import Foundation
+import KlaviyoCore
+
+extension Subscription.Channels {
+    /// Whether the requested channels need an email identifier on the profile.
+    var needsEmail: Bool {
+        email?.isEmpty == false
+    }
+
+    /// Whether the requested channels need a phone number identifier on the profile.
+    var needsPhone: Bool {
+        sms?.isEmpty == false || whatsapp?.isEmpty == false
+    }
+
+    /// Maps the requested channels to the API's `subscriptions` object, or `nil` when no sub-types
+    /// were named (nothing to send).
+    var toAPIModel: SubscriptionChannels? {
+        let emailConsent = email.flatMap { set -> EmailConsent? in
+            guard !set.isEmpty else { return nil }
+            return EmailConsent(
+                marketing: set.contains(.marketing) ? .subscribed : nil,
+                openTracking: set.contains(.openTracking) ? .subscribed : nil
+            )
+        }
+        let smsConsent = messagingConsent(sms)
+        let whatsappConsent = messagingConsent(whatsapp)
+
+        guard emailConsent != nil || smsConsent != nil || whatsappConsent != nil else { return nil }
+        return SubscriptionChannels(email: emailConsent, sms: smsConsent, whatsapp: whatsappConsent)
+    }
+
+    private func messagingConsent(_ set: Messaging?) -> MarketingTransactionalConsent? {
+        guard let set, !set.isEmpty else { return nil }
+        return MarketingTransactionalConsent(
+            marketing: set.contains(.marketing) ? .subscribed : nil,
+            transactional: set.contains(.transactional) ? .subscribed : nil
+        )
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -15,7 +15,13 @@ enum ErrorHandlingConstants {
 extension KlaviyoEndpoint {
     var maxRetries: Int {
         switch self {
-        case .createProfile, .registerPushToken, .unregisterPushToken, .createEvent, .aggregateEvent, .logTrackingLinkClicked:
+        case .createProfile,
+             .registerPushToken,
+             .unregisterPushToken,
+             .createEvent,
+             .aggregateEvent,
+             .logTrackingLinkClicked,
+             .createSubscription:
             return 50
         case .resolveDestinationURL, .fetchGeofences:
             return 1

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -27,6 +27,7 @@ struct KlaviyoState: Equatable, Codable {
         case setEmail(String)
         case setExternalId(String)
         case setPhoneNumber(String)
+        case subscription(Subscription)
     }
 
     struct PushTokenData: Equatable, Codable {
@@ -312,6 +313,63 @@ struct KlaviyoState: Equatable, Codable {
             anonymousId: anonymousId
         )
         let endpoint = KlaviyoEndpoint.unregisterPushToken(apiKey, payload)
+        return KlaviyoRequest(endpoint: endpoint)
+    }
+
+    /// Validates the requested channels against the profile's identifiers and builds the create-subscription
+    /// request. Emits a developer warning and returns `nil` when the request should not be enqueued.
+    func buildSubscriptionRequest(apiKey: String, anonymousId: String, subscription: Subscription) -> KlaviyoRequest? {
+        let channels: SubscriptionChannels?
+        if let requestedChannels = subscription.channels {
+            if requestedChannels.needsEmail, email == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires an email for the requested channels, but email is not set."
+                )
+                return nil
+            }
+            if requestedChannels.needsPhone, phoneNumber == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires a phone number for the requested channels, " +
+                        "but phone number is not set."
+                )
+                return nil
+            }
+
+            guard let mappedChannels = requestedChannels.toAPIModel else {
+                environment.emitDeveloperWarning(
+                    "Subscription channels were provided but none were enabled; request was not enqueued."
+                )
+                return nil
+            }
+            channels = mappedChannels
+        } else {
+            // allAvailableMarketing: omit the subscriptions object so the server defaults to marketing;
+            // requires at least one identifier to key channels on.
+            guard email != nil || phoneNumber != nil else {
+                environment.emitDeveloperWarning(
+                    "Subscription requires at least one identifier the API can key channels on, " +
+                        "but no identifiers are set."
+                )
+                return nil
+            }
+            channels = nil
+        }
+
+        let profile = ProfilePayload(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            subscriptions: channels,
+            anonymousId: anonymousId
+        )
+
+        let payload = CreateSubscriptionPayload(
+            listId: subscription.listId,
+            profile: profile,
+            customSource: subscription.customSource
+        )
+
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
         return KlaviyoRequest(endpoint: endpoint)
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -113,6 +113,9 @@ enum KlaviyoAction: Equatable {
     /// when there is an profile to be sent to klaviyo it's added to the queue
     case enqueueProfile(Profile)
 
+    /// when there is a subscription to be sent to klaviyo it's added to the queue
+    case enqueueSubscription(Subscription)
+
     /// when setting individual profile props
     case setProfileProperty(Profile.ProfileKey, AnyEncodable)
 
@@ -144,10 +147,37 @@ enum KlaviyoAction: Equatable {
         case let .enqueueEvent(event) where event.metric.name == ._openedPush || event.metric.isGeofenceEvent:
             return false
 
-        case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setBadgeCount, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
+        case .enqueueAggregateEvent,
+             .enqueueEvent,
+             .enqueueProfile,
+             .enqueueSubscription,
+             .resetProfile,
+             .resetStateAndDequeue,
+             .setBadgeCount,
+             .setEmail,
+             .setExternalId,
+             .setPhoneNumber,
+             .setProfileProperty,
+             .setPushEnablement,
+             .setPushToken:
             return true
 
-        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .syncBadgeCount, .trackingLinkReceived, .trackingLinkDestinationResolved, .trackingLinkResolutionFailed, .openDeepLink, .deepLinkProcessingCompleted:
+        case .cancelInFlightRequests,
+             .completeInitialization,
+             .deQueueCompletedResults,
+             .flushQueue,
+             .initialize,
+             .networkConnectivityChanged,
+             .requestFailed,
+             .sendRequest,
+             .start,
+             .stop,
+             .syncBadgeCount,
+             .trackingLinkReceived,
+             .trackingLinkDestinationResolved,
+             .trackingLinkResolutionFailed,
+             .openDeepLink,
+             .deepLinkProcessingCompleted:
             return false
         }
     }
@@ -237,6 +267,8 @@ struct KlaviyoReducer: ReducerProtocol {
                         await send(.setExternalId(externalId))
                     case let .setPhoneNumber(phoneNumber):
                         await send(.setPhoneNumber(phoneNumber))
+                    case let .subscription(subscription):
+                        await send(.enqueueSubscription(subscription))
                     }
                 }
                 await send(.start)
@@ -518,6 +550,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 baseEffect,
                 .fireAndForget { KlaviyoInternal.publishEvent(event) }
             ])
+
         case let .enqueueAggregateEvent(payload):
             guard case .initialized = state.initalizationState,
                   let apiKey = state.apiKey
@@ -596,6 +629,26 @@ struct KlaviyoReducer: ReducerProtocol {
                 request = KlaviyoRequest(
                     endpoint: KlaviyoEndpoint.createProfile(apiKey, CreateProfilePayload(data: profilePayload))
                 )
+            }
+            state.enqueueRequest(request: request)
+
+            return .none
+
+        case let .enqueueSubscription(subscription):
+            guard case .initialized = state.initalizationState,
+                  let apiKey = state.apiKey,
+                  let anonymousId = state.anonymousId
+            else {
+                state.pendingRequests.append(.subscription(subscription))
+                return .none
+            }
+
+            guard let request = state.buildSubscriptionRequest(
+                apiKey: apiKey,
+                anonymousId: anonymousId,
+                subscription: subscription
+            ) else {
+                return .none
             }
             state.enqueueRequest(request: request)
 

--- a/Sources/KlaviyoSwift/Utilities/EventBuffer.swift
+++ b/Sources/KlaviyoSwift/Utilities/EventBuffer.swift
@@ -14,7 +14,9 @@ import OSLog
 
 @available(iOS 14.0, *)
 extension Logger {
-    fileprivate static let eventBuffer = Logger(subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoSwift", category: "Event Buffering")
+    fileprivate static var eventBuffer: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(subsystem: "com.klaviyo.klaviyo-swift-sdk.klaviyoSwift", category: "Event Buffering") : Logger(OSLog.disabled)
+    }
 }
 
 /// Manages a thread-safe buffer of recent events for replay to new subscribers.

--- a/Sources/KlaviyoSwift/Utilities/Logger+Ext.swift
+++ b/Sources/KlaviyoSwift/Utilities/Logger+Ext.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew Balmer on 5/27/25.
 //
 
+import KlaviyoCore
 import OSLog
 
 @available(iOS 14.0, *)
@@ -21,14 +22,22 @@ extension Logger {
 @available(iOS 14.0, *)
 extension Logger {
     /// Logger for ``Codable`` events (JSON encoding & decoding)
-    static let codableLogger = Logger(category: "Encoding/Decoding Logger")
+    static var codableLogger: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Encoding/Decoding Logger") : Logger(OSLog.disabled)
+    }
 
     /// Logger for state events that run through the reducer
-    static let stateLogger = Logger(category: "State logger")
+    static var stateLogger: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "State logger") : Logger(OSLog.disabled)
+    }
 
     /// Logger for notification events.
-    static let notifications = Logger(category: "Notifications logger")
+    static var notifications: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Notifications logger") : Logger(OSLog.disabled)
+    }
 
     /// Logger for app navigation and deep linking events
-    static let navigation = Logger(category: "Linking and Navigation")
+    static var navigation: Logger {
+        KlaviyoLogConfig.shared.isLoggingEnabled ? Logger(category: "Linking and Navigation") : Logger(OSLog.disabled)
+    }
 }

--- a/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
+++ b/Sources/KlaviyoSwift/Vendor/ComposableArchitecture/Misc.swift
@@ -29,6 +29,7 @@
 //
 import Foundation
 import Combine
+import KlaviyoCore
 #if canImport(os)
   import os
 #endif
@@ -46,7 +47,6 @@ final class Box<Wrapped> {
   }
 }
 
-@_transparent
 @usableFromInline
 @inline(__always)
 func runtimeWarn(
@@ -56,6 +56,7 @@ func runtimeWarn(
   line: UInt? = nil
 ) {
   #if DEBUG
+    guard KlaviyoLogConfig.shared.isLoggingEnabled else { return }
     let message = message()
     let category = category ?? "Runtime Warning"
       #if canImport(os)

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -283,4 +283,138 @@ final class KlaviyoEndpointTests: XCTestCase {
         let geofenceEventUrlRequest = try geofenceEventRequest.urlRequest(attemptInfo: attemptInfo)
         XCTAssertEqual(geofenceEventUrlRequest.value(forHTTPHeaderField: "revision"), "2026-01-15")
     }
+
+    // MARK: - Create Subscription Tests
+
+    func testCreateSubscriptionEndpointUrlRequest() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.test
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/client/subscriptions")
+        XCTAssertEqual(request.url?.query, "company_id=test_api_key")
+        XCTAssertNotNil(request.httpBody)
+
+        let body = try XCTUnwrap(request.httpBody)
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        XCTAssertNil(attributes["custom_source"])
+
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        XCTAssertNil(
+            profileAttrs["subscriptions"],
+            "omitting channels must omit subscriptions so the API can default to MARKETING"
+        )
+    }
+
+    func testCreateSubscriptionEndpointWithChannels() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.testWithChannels
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/client/subscriptions")
+        XCTAssertEqual(request.url?.query, "company_id=test_api_key")
+        XCTAssertNotNil(request.httpBody)
+
+        let body = try XCTUnwrap(request.httpBody, "createSubscription request must include an httpBody")
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+
+        let relationships = try XCTUnwrap(data["relationships"] as? [String: Any])
+        let list = try XCTUnwrap(relationships["list"] as? [String: Any])
+        let listData = try XCTUnwrap(list["data"] as? [String: Any])
+        XCTAssertEqual(listData["type"] as? String, "list")
+        XCTAssertEqual(listData["id"] as? String, "test-list-id")
+
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        XCTAssertNil(attributes["list_id"], "list must be a relationship, not a flat attribute")
+        XCTAssertNil(
+            attributes["subscriptions"],
+            "consent must be nested inside the profile, not at top level"
+        )
+        XCTAssertEqual(attributes["custom_source"] as? String, "unit-test")
+
+        // attributes.profile.data.attributes.subscriptions.email.marketing.consent == "SUBSCRIBED"
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        let subscriptions = try XCTUnwrap(profileAttrs["subscriptions"] as? [String: Any])
+
+        // Email: marketing + open_tracking.
+        let email = try XCTUnwrap(subscriptions["email"] as? [String: Any])
+        XCTAssertEqual((email["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((email["open_tracking"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+
+        // SMS: marketing + transactional.
+        let sms = try XCTUnwrap(subscriptions["sms"] as? [String: Any])
+        XCTAssertEqual((sms["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((sms["transactional"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+
+        // WhatsApp: marketing + transactional.
+        let whatsapp = try XCTUnwrap(subscriptions["whatsapp"] as? [String: Any])
+        XCTAssertEqual((whatsapp["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((whatsapp["transactional"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+    }
+
+    func testCreateSubscriptionEndpointWithPartialChannels() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.testWithPartialChannels
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        let body = try XCTUnwrap(request.httpBody, "createSubscription request must include an httpBody")
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        let subscriptions = try XCTUnwrap(profileAttrs["subscriptions"] as? [String: Any])
+
+        // Only the requested sub-type is present.
+        let sms = try XCTUnwrap(subscriptions["sms"] as? [String: Any])
+        XCTAssertEqual((sms["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertNil(sms["transactional"], "unrequested sms.transactional must be absent from the payload")
+
+        // Unrequested channels are entirely absent.
+        XCTAssertNil(subscriptions["email"], "unrequested email channel must be absent from the payload")
+        XCTAssertNil(subscriptions["whatsapp"], "unrequested whatsapp channel must be absent from the payload")
+    }
+
+    func testCreateSubscriptionEndpointRevision() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.test
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+        let attemptInfo = try RequestAttemptInfo(attemptNumber: 1, maxAttempts: 50)
+        let request = KlaviyoRequest(endpoint: endpoint)
+
+        // When
+        let urlRequest = try request.urlRequest(attemptInfo: attemptInfo)
+
+        // Then
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "revision"), "2026-01-15")
+    }
 }

--- a/Tests/KlaviyoCoreTests/KlaviyoLogConfigTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoLogConfigTests.swift
@@ -1,0 +1,112 @@
+//
+//  KlaviyoLogConfigTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoCore
+import OSLog
+import XCTest
+
+@available(iOS 14.0, *)
+final class KlaviyoLogConfigTests: XCTestCase {
+    override func tearDown() {
+        // Always restore default state after each test
+        KlaviyoLogConfig.shared.isLoggingEnabled = true
+        super.tearDown()
+    }
+
+    // MARK: - Default State
+
+    func testDefaultIsEnabled() {
+        XCTAssertTrue(KlaviyoLogConfig.shared.isLoggingEnabled)
+    }
+
+    // MARK: - Toggle Behavior
+
+    func testDisableLogging() {
+        KlaviyoLogConfig.shared.isLoggingEnabled = false
+        XCTAssertFalse(KlaviyoLogConfig.shared.isLoggingEnabled)
+    }
+
+    func testReEnableLogging() {
+        KlaviyoLogConfig.shared.isLoggingEnabled = false
+        XCTAssertFalse(KlaviyoLogConfig.shared.isLoggingEnabled)
+
+        KlaviyoLogConfig.shared.isLoggingEnabled = true
+        XCTAssertTrue(KlaviyoLogConfig.shared.isLoggingEnabled)
+    }
+
+    // MARK: - Logger Instances
+
+    func testLoggersReturnRealLoggerWhenEnabled() {
+        KlaviyoLogConfig.shared.isLoggingEnabled = true
+
+        let logger = Logger.networking
+        // A real logger will have a non-disabled log; verify it doesn't crash
+        // and that it's different from a disabled logger.
+        // We can't directly compare Logger instances, but we can verify the
+        // computed property returns without error.
+        _ = logger
+    }
+
+    func testLoggersReturnDisabledLoggerWhenDisabled() {
+        KlaviyoLogConfig.shared.isLoggingEnabled = false
+
+        // These should all return Logger(OSLog.disabled) without crashing
+        let codable = Logger.codable
+        let networking = Logger.networking
+        let navigation = Logger.navigation
+        let notifications = Logger.notifications
+
+        // Verify they don't crash when called
+        codable.info("This should be silenced")
+        networking.info("This should be silenced")
+        navigation.info("This should be silenced")
+        notifications.info("This should be silenced")
+    }
+
+    // MARK: - Thread Safety
+
+    func testConcurrentAccess() {
+        let iterations = 1000
+        let expectation = expectation(description: "Concurrent access completes")
+        expectation.expectedFulfillmentCount = iterations * 2
+
+        let queue = DispatchQueue(label: "test.concurrent", attributes: .concurrent)
+
+        for _ in 0..<iterations {
+            queue.async {
+                KlaviyoLogConfig.shared.isLoggingEnabled = false
+                expectation.fulfill()
+            }
+            queue.async {
+                _ = KlaviyoLogConfig.shared.isLoggingEnabled
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
+    func testConcurrentToggleDoesNotCrash() {
+        let iterations = 500
+        let expectation = expectation(description: "Concurrent toggle completes")
+        expectation.expectedFulfillmentCount = iterations * 2
+
+        let queue = DispatchQueue(label: "test.concurrent.toggle", attributes: .concurrent)
+
+        for i in 0..<iterations {
+            queue.async {
+                KlaviyoLogConfig.shared.isLoggingEnabled = (i % 2 == 0)
+                expectation.fulfill()
+            }
+            queue.async {
+                // Access a logger while toggling
+                _ = Logger.networking
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+}

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -209,3 +209,39 @@ extension ProfilePayload {
         anonymousId: "foo"
     )
 }
+
+extension CreateSubscriptionPayload {
+    static let test = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(email: "test@example.com", anonymousId: "anon-id")
+    )
+
+    static let testWithChannels = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(
+            email: "test@example.com",
+            phoneNumber: "+15005550006",
+            subscriptions: SubscriptionChannels(
+                email: EmailConsent(marketing: .subscribed, openTracking: .subscribed),
+                sms: MarketingTransactionalConsent(marketing: .subscribed, transactional: .subscribed),
+                whatsapp: MarketingTransactionalConsent(marketing: .subscribed, transactional: .subscribed)
+            ),
+            anonymousId: "anon-id"
+        ),
+        customSource: "unit-test"
+    )
+
+    /// A single sub-type on a single channel, to verify partial combinations serialize correctly:
+    /// the requested sub-type is present and every unrequested channel/sub-type is absent.
+    static let testWithPartialChannels = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(
+            email: "test@example.com",
+            phoneNumber: "+15005550006",
+            subscriptions: SubscriptionChannels(
+                sms: MarketingTransactionalConsent(marketing: .subscribed)
+            ),
+            anonymousId: "anon-id"
+        )
+    )
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -27,6 +27,7 @@ class KlaviyoSDKTests: XCTestCase {
 
     override func tearDown() async throws {
         environment = KlaviyoEnvironment.test()
+        klaviyo.setLoggingEnabled(true)
     }
 
     func setupActionAssertion(expectedAction: KlaviyoAction, file: StaticString = #filePath, line: UInt = #line) -> XCTestExpectation {
@@ -303,6 +304,30 @@ class KlaviyoSDKTests: XCTestCase {
     func testIsDeepLinkHandlerRegisteredInitialState() {
         let freshSDK = KlaviyoSDK()
         XCTAssertFalse(freshSDK.isDeepLinkHandlerRegistered, "New SDK instance should have no handler registered")
+    }
+
+    // MARK: - Logging Toggle Tests
+
+    func testLoggingEnabledByDefault() {
+        XCTAssertTrue(klaviyo.isLoggingEnabled, "Logging should be enabled by default")
+    }
+
+    func testSetLoggingDisabled() {
+        klaviyo.setLoggingEnabled(false)
+        XCTAssertFalse(klaviyo.isLoggingEnabled, "Logging should be disabled after setLoggingEnabled(false)")
+    }
+
+    func testSetLoggingReEnabled() {
+        klaviyo.setLoggingEnabled(false)
+        XCTAssertFalse(klaviyo.isLoggingEnabled)
+
+        klaviyo.setLoggingEnabled(true)
+        XCTAssertTrue(klaviyo.isLoggingEnabled, "Logging should be re-enabled after setLoggingEnabled(true)")
+    }
+
+    func testSetLoggingEnabledIsChainable() {
+        let result = klaviyo.setLoggingEnabled(false)
+        XCTAssertNotNil(result, "setLoggingEnabled should return a KlaviyoSDK instance for chaining")
     }
 
     // MARK: - Push Action Button Tests

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -778,4 +778,275 @@ class StateManagementTests: XCTestCase {
             $0.flushing = false
         }
     }
+
+    // MARK: - enqueueSubscription
+
+    @MainActor
+    func testEnqueueSubscription() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionWithChannels() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription(
+            listId: "list-123",
+            channels: .init(email: .marketing, sms: .marketing)
+        )
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(
+                email: "test@example.com",
+                phoneNumber: "+15005550006",
+                subscriptions: SubscriptionChannels(
+                    email: EmailConsent(marketing: .subscribed),
+                    sms: MarketingTransactionalConsent(marketing: .subscribed)
+                ),
+                anonymousId: anonymousId
+            )
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    /// Overrides `environment.emitDeveloperWarning` with an expectation that fulfills only when a
+    /// warning containing `fragment` fires, pinning down which guard in enqueueSubscription was taken.
+    @MainActor
+    private func expectSubscriptionWarning(
+        containing fragment: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "developer warning containing: \(fragment)")
+        environment.emitDeveloperWarning = { message in
+            XCTAssertTrue(
+                message.contains(fragment),
+                "expected warning containing \"\(fragment)\" but got \"\(message)\"",
+                file: file,
+                line: line
+            )
+            expectation.fulfill()
+        }
+        return expectation
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionWhenInitializingReplaysAfterCompleteInitialization() async throws {
+        var initialState = INITILIZING_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.subscription(subscription)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS) {
+            $0.enqueueRequest(request: request)
+        }
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionMissingIdentifiersDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "at least one identifier")
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription.allAvailableMarketing(listId: "list-123")))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPendingSetEmailBeforeSubscriptionSucceedsOnReplay() async throws {
+        let initialState = INITILIZING_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        let email = "test@example.com"
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+
+        var stateWithEmail = initialState
+        stateWithEmail.email = email
+        let profileRequest = stateWithEmail.buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
+        let subscriptionPayload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: email, anonymousId: anonymousId)
+        )
+        let subscriptionRequest = KlaviyoRequest(
+            endpoint: .createSubscription(apiKey, subscriptionPayload)
+        )
+
+        await store.send(.setEmail(email)) {
+            $0.pendingRequests = [.setEmail(email)]
+        }
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.setEmail(email), .subscription(subscription)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        await store.receive(.setEmail(email), timeout: TIMEOUT_NANOSECONDS) {
+            $0.email = email
+            $0.enqueueRequest(request: profileRequest)
+        }
+
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS) {
+            $0.enqueueRequest(request: subscriptionRequest)
+        }
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPendingSubscriptionBeforeSetEmailDropsSubscriptionOnReplay() async throws {
+        let expectation = expectSubscriptionWarning(containing: "at least one identifier")
+        let initialState = INITILIZING_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        let email = "test@example.com"
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+
+        var stateWithEmail = initialState
+        stateWithEmail.email = email
+        let profileRequest = stateWithEmail.buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.subscription(subscription)]
+        }
+        await store.send(.setEmail(email)) {
+            $0.pendingRequests = [.subscription(subscription), .setEmail(email)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        // FIFO: subscription replays before setEmail, so identifier validation fails.
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS)
+        await fulfillment(of: [expectation])
+
+        await store.receive(.setEmail(email), timeout: TIMEOUT_NANOSECONDS) {
+            $0.email = email
+            $0.enqueueRequest(request: profileRequest)
+        }
+
+        XCTAssertFalse(
+            store.state.queue.contains { request in
+                if case .createSubscription = request.endpoint { return true }
+                return false
+            }
+        )
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionAllAvailableMarketingWithPhoneOnly() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(phoneNumber: "+15005550006", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionEmptyChannelsDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "none were enabled")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init())))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionEmailChannelWithoutEmailDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "requires an email")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init(email: .marketing))))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPhoneChannelWithoutPhoneDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "requires a phone number")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init(sms: .marketing))))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
 }


### PR DESCRIPTION
# Description
Adds a public `KlaviyoSDK.create(subscription:)` API that enqueues `POST /client/subscriptions` so integrators can subscribe the current profile to a list with optional per-channel consent (email / SMS / WhatsApp) and an optional `customSource`.

A subscription that's missing identifiers at replay time is dropped with a developer warning rather than re-buffered.

Implementation of BSUID for the whatsapp channel is not yet implemented, waiting on that to be added to the current API revision. 

See API docs: 
https://developers.klaviyo.com/en/reference/create_client_subscription

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Public `Subscription` model + `KlaviyoSDK.create(subscription:)`
- `KlaviyoEndpoint.createSubscription` → `/client/subscriptions` with JSON:API list relationship and nested profile `subscriptions` consent
- Reuses `ProfilePayload` for the embedded profile; channel consent lives in `SubscriptionChannels`
- Validates identifiers against requested channels; buffers requests while initializing (same pattern as events/profiles)
- Warns and drops empty explicit channel configs so they are not collapsed into API default MARKETING consent
- Push marketing via `subscriptions.push` intentionally out of scope (existing `set(pushToken:)` path)

## Test Plan
- [x] `KlaviyoEndpointTests` — URL, revision, wire shape with/without channels (nil `subscriptions` omitted)
- [x] `StateManagementTests` — enqueue happy path, channels, init buffering, missing identifiers, empty channels
- [x] Manual: initialize SDK, set email/phone, call `create(subscription:)`, confirm 202 from `/client/subscriptions` in proxy/logs


## Related Issues/Tickets
Related to MAGE-854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `create(subscription:)` to create list subscription/consent records for email, SMS, and WhatsApp.
  * Supports channel-based consent selection (email marketing + open-tracking; SMS/WhatsApp marketing + transactional) with optional `customSource`.
  * Updated subscription creation to validate required identifiers and only enqueue after initialization.

* **Tests**
  * Added coverage for request URL/body/headers and conditional payload fields, plus state-management enqueueing, replay, and validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->