### PR TITLE
refactor(forms): consolidate formExternalUrlClicked into formCtaClicked

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -53,10 +53,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     print("🖱️  [Form Lifecycle] Form CTA Clicked: \(event.formId)")
                     print("   Form Name: \(event.formName)")
                     print("   Button: \(buttonLabel) → \(deepLinkUrl)")
-                case let .formExternalUrlClicked(_, _, buttonLabel, url):
-                    print("🌐 [Form Lifecycle] Form External URL Clicked: \(event.formId)")
-                    print("   Form Name: \(event.formName)")
-                    print("   Button: \(buttonLabel) → \(url)")
                 }
             }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -331,46 +331,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
         case let .trackAggregateEvent(data):
             KlaviyoInternal.create(aggregateEvent: data)
-        case let .openDeepLink(url, formId, formName, buttonLabel):
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.info("Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
-            }
-
-            // 1. Check URL exists and is non-empty — no URL means no navigation and no lifecycle event
-            guard let url = url, !url.absoluteString.isEmpty else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning(
-                        "CTA clicked but no deep link URL configured — skipping navigation"
-                    )
-                }
-                return
-            }
-
-            // 2. Handle deep link navigation before validating lifecycle metadata
-            if UIApplication.shared.canOpenURL(url) {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
-                }
-                KlaviyoInternal.handleDeepLink(url: url)
-            } else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
-                }
-            }
-
-            // 3. Invoke lifecycle handler when form identity fields are present
-            invokeCtaLifecycleHandler(eventName: "openDeepLink", formId: formId, formName: formName) {
-                .formCtaClicked(
-                    formId: $0,
-                    formName: $1,
-                    buttonLabel: buttonLabel ?? "",
-                    deepLinkUrl: url
-                )
-            }
-        case let .openExternalUrl(url, formId, formName, buttonLabel):
+        case let .openDeepLink(url, formId, formName, buttonLabel, openExternally):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info(
-                    "Received 'openExternalUrl' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)"
+                    "Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public), openExternally: \(openExternally, privacy: .public)"
                 )
             }
 
@@ -378,31 +342,47 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             guard let url = url, !url.absoluteString.isEmpty else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "CTA clicked but no external URL configured — skipping navigation"
+                        "CTA clicked but no URL configured — skipping navigation"
                     )
                 }
                 return
             }
 
-            // 2. Validate scheme against allowlist
-            guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning(
-                        "Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)"
-                    )
+            // 2. Route by `openExternally`. Deep links and external URLs ride the same
+            //    bridge message (onsite openDeepLink v3); the flag — not the scheme —
+            //    decides how to open, preserving the marketer's chosen action.
+            if openExternally {
+                // External web/system URL: open via the system, bypassing any registered
+                // deep link handler, gated by the on-device scheme allowlist.
+                guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.warning(
+                            "Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)"
+                        )
+                    }
+                    return
                 }
-                return
+                Task {
+                    await environment.linkHandler.openExternalURL(url)
+                }
+            } else {
+                // In-app deep link: route to the host app's registered deep link handler.
+                if UIApplication.shared.canOpenURL(url) {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
+                    }
+                    KlaviyoInternal.handleDeepLink(url: url)
+                } else {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
+                    }
+                }
             }
 
-            // 3. Open URL externally (bypasses any registered deep link handler)
-            Task {
-                await environment.linkHandler.openExternalURL(url)
-            }
-
-            // 4. Invoke lifecycle handler when form identity fields are present.
-            //    External URL clicks are surfaced through the same formCtaClicked
-            //    event as deep link clicks; the URL rides in the deepLinkUrl field.
-            invokeCtaLifecycleHandler(eventName: "openExternalUrl", formId: formId, formName: formName) {
+            // 3. Invoke lifecycle handler when form identity fields are present. Both deep
+            //    links and external URLs surface through the same formCtaClicked event; the
+            //    URL rides in the deepLinkUrl field.
+            invokeCtaLifecycleHandler(eventName: "openDeepLink", formId: formId, formName: formName) {
                 .formCtaClicked(
                     formId: $0,
                     formName: $1,

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -399,13 +399,15 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 await environment.linkHandler.openExternalURL(url)
             }
 
-            // 4. Invoke lifecycle handler when form identity fields are present
+            // 4. Invoke lifecycle handler when form identity fields are present.
+            //    External URL clicks are surfaced through the same formCtaClicked
+            //    event as deep link clicks; the URL rides in the deepLinkUrl field.
             invokeCtaLifecycleHandler(eventName: "openExternalUrl", formId: formId, formName: formName) {
-                .formExternalUrlClicked(
+                .formCtaClicked(
                     formId: $0,
                     formName: $1,
                     buttonLabel: buttonLabel ?? "",
-                    url: url
+                    deepLinkUrl: url
                 )
             }
         case let .abort(reason):

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -47,32 +47,25 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     case formDismissed(formId: String, formName: String)
 
     /// Triggered when a user taps a call-to-action (CTA) button in a form
-    /// that has a deep link URL configured.
+    /// that has a URL configured — either an in-app deep link or an external
+    /// (web) URL.
     ///
-    /// Fired after the SDK has initiated deep link navigation. Not emitted
-    /// if no deep link URL is configured for the CTA.
+    /// Fired after the SDK has initiated navigation (deep link routing, or
+    /// opening the URL externally). Not emitted if no URL is configured for
+    /// the CTA.
     ///
     /// - `buttonLabel`: The label text of the tapped button.
-    /// - `deepLinkUrl`: The deep link URL associated with the CTA.
+    /// - `deepLinkUrl`: The URL associated with the CTA. For historical reasons
+    ///   this parameter is named `deepLinkUrl`, but it also carries external
+    ///   web URLs.
     case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
-
-    /// Triggered when a user taps a call-to-action (CTA) button in a form
-    /// that has an external (web) URL configured.
-    ///
-    /// Fired after the SDK has initiated opening the URL in Safari. Not emitted
-    /// if no external URL is configured for the CTA.
-    ///
-    /// - `buttonLabel`: The label text of the tapped button.
-    /// - `url`: The external URL associated with the CTA.
-    case formExternalUrlClicked(formId: String, formName: String, buttonLabel: String, url: URL)
 
     /// The unique identifier of the form that triggered this event.
     public var formId: String {
         switch self {
         case let .formShown(formId, _),
              let .formDismissed(formId, _),
-             let .formCtaClicked(formId, _, _, _),
-             let .formExternalUrlClicked(formId, _, _, _):
+             let .formCtaClicked(formId, _, _, _):
             return formId
         }
     }
@@ -82,8 +75,7 @@ public enum FormLifecycleEvent: Equatable, Sendable {
         switch self {
         case let .formShown(_, formName),
              let .formDismissed(_, formName),
-             let .formCtaClicked(_, formName, _, _),
-             let .formExternalUrlClicked(_, formName, _, _):
+             let .formCtaClicked(_, formName, _, _):
             return formName
         }
     }
@@ -94,7 +86,6 @@ public enum FormLifecycleEvent: Equatable, Sendable {
         case .formShown: return "formShown"
         case .formDismissed: return "formDismissed"
         case .formCtaClicked: return "formCtaClicked"
-        case .formExternalUrlClicked: return "formExternalUrlClicked"
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -15,8 +15,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formDisappeared(formId: String?, formName: String?)
     case trackProfileEvent(Data)
     case trackAggregateEvent(Data)
-    case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
-    case openExternalUrl(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
+    case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?, openExternally: Bool)
     case abort(String)
     case handShook
     case analyticsEvent
@@ -36,7 +35,6 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case trackProfileEvent
         case trackAggregateEvent
         case openDeepLink
-        case openExternalUrl
         case abort
         case handShook
         case analyticsEvent
@@ -69,17 +67,12 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case .openDeepLink:
             let payload = try? container.decode(DeepLinkEventPayload.self, forKey: .data)
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
-            self = .openDeepLink(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
-        case .openExternalUrl:
-            // Unlike `openDeepLink` (which carries platform-split `ios`/`android` keys),
-            // the external web URL is sent as a single flat `url` field by onsite.
-            let payload = try? container.decode(ExternalUrlEventPayload.self, forKey: .data)
-            let url = payload?.url.flatMap { $0.isEmpty ? nil : URL(string: $0) }
-            self = .openExternalUrl(
+            self = .openDeepLink(
                 url: url,
                 formId: payload?.formId,
                 formName: payload?.formName,
-                buttonLabel: payload?.buttonLabel
+                buttonLabel: payload?.buttonLabel,
+                openExternally: payload?.openExternally ?? false
             )
         case .abort:
             let data = try container.decode(AbortPayload.self, forKey: .data)
@@ -110,21 +103,18 @@ extension IAFNativeBridgeEvent {
         let formName: String?
     }
 
-    /// Payload for the `openDeepLink` CTA event, which carries platform-split deep link URLs.
+    /// Payload for the `openDeepLink` CTA event. Carries both in-app deep links and external
+    /// web/system URLs; `openExternally` distinguishes them (onsite `openDeepLink` v3). The URL
+    /// rides in the platform-split `ios`/`android` keys — for external URLs both hold the same
+    /// value, so reading `ios` suffices.
     struct DeepLinkEventPayload: Decodable {
         let ios: String?
         let formId: String?
         let formName: String?
         let buttonLabel: String?
-    }
-
-    /// Payload for the `openExternalUrl` CTA event. The external web URL is platform-agnostic,
-    /// so onsite sends it as a single flat `url` field (not the `ios`/`android` split used by deep links).
-    struct ExternalUrlEventPayload: Decodable {
-        let url: String?
-        let formId: String?
-        let formName: String?
-        let buttonLabel: String?
+        /// `true`: open the URL via the system (bypassing any registered deep link handler),
+        /// gated by the on-device scheme allowlist. `false`: route to the deep link handler.
+        let openExternally: Bool?
     }
 
     struct AbortPayload: Decodable {
@@ -166,8 +156,7 @@ extension IAFNativeBridgeEvent {
             .formDisappeared(formId: nil, formName: nil),
             .trackProfileEvent(Data()),
             .trackAggregateEvent(Data()),
-            .openDeepLink(url: nil, formId: nil, formName: nil, buttonLabel: nil),
-            .openExternalUrl(url: nil, formId: nil, formName: nil, buttonLabel: nil),
+            .openDeepLink(url: nil, formId: nil, formName: nil, buttonLabel: nil, openExternally: false),
             .abort(""),
             .lifecycleEvent,
             .profileEvent,
@@ -182,8 +171,7 @@ extension IAFNativeBridgeEvent {
         case .formDisappeared: return 1
         case .trackProfileEvent: return 1
         case .trackAggregateEvent: return 1
-        case .openDeepLink: return 2
-        case .openExternalUrl: return 1
+        case .openDeepLink: return 3
         case .abort: return 1
         case .handShook: return 1
         case .analyticsEvent: return 1
@@ -201,7 +189,6 @@ extension IAFNativeBridgeEvent {
         case .trackProfileEvent: return "trackProfileEvent"
         case .trackAggregateEvent: return "trackAggregateEvent"
         case .openDeepLink: return "openDeepLink"
-        case .openExternalUrl: return "openExternalUrl"
         case .abort: return "abort"
         case .handShook: return "handShook"
         case .analyticsEvent: return "analyticsEvent"

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -104,9 +104,7 @@ extension IAFNativeBridgeEvent {
     }
 
     /// Payload for the `openDeepLink` CTA event. Carries both in-app deep links and external
-    /// web/system URLs; `openExternally` distinguishes them (onsite `openDeepLink` v3). The URL
-    /// rides in the platform-split `ios`/`android` keys — for external URLs both hold the same
-    /// value, so reading `ios` suffices.
+    /// web/system URLs, distinguished by `openExternally` (onsite `openDeepLink` v3).
     struct DeepLinkEventPayload: Decodable {
         let ios: String?
         let formId: String?

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -48,11 +48,11 @@ extension KlaviyoSDK {
     /// The handler will be invoked when:
     /// - A form is shown (``FormLifecycleEvent/formShown(formId:formName:)``)
     /// - A form is dismissed (``FormLifecycleEvent/formDismissed(formId:formName:)``)
-    /// - A user taps a deep link CTA (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
-    /// - A user taps an external URL CTA (``FormLifecycleEvent/formExternalUrlClicked(formId:formName:buttonLabel:url:)``)
+    /// - A user taps a CTA in a form, whether it opens an in-app deep link or an external
+    ///   web URL (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
     ///
     /// Each event case carries contextual data including `formId`, `formName`, and
-    /// CTA-specific fields (`buttonLabel`, `deepLinkUrl` or `url`) where applicable.
+    /// CTA-specific fields (`buttonLabel`, `deepLinkUrl`) where applicable.
     ///
     /// The handler is called on the main thread.
     ///
@@ -65,16 +65,10 @@ extension KlaviyoSDK {
     ///     case .formDismissed(let formId, let formName):
     ///         Analytics.track("Form Dismissed", properties: ["formId": formId])
     ///     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
-    ///         Analytics.track("Form CTA Clicked - Deep Link", properties: [
+    ///         Analytics.track("Form CTA Clicked", properties: [
     ///             "formId": formId,
     ///             "buttonLabel": buttonLabel,
     ///             "url": deepLinkUrl.absoluteString
-    ///         ])
-    ///     case .formExternalUrlClicked(let formId, let formName, let buttonLabel, let url):
-    ///         Analytics.track("Form CTA Clicked - External URL", properties: [
-    ///             "formId": formId,
-    ///             "buttonLabel": buttonLabel,
-    ///             "url": url.absoluteString
     ///         ])
     ///     }
     /// }

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -405,47 +405,4 @@ final class FormLifecycleHandlerTests: XCTestCase {
         )
         XCTAssertEqual(ctaForEventName.eventName, "formCtaClicked")
     }
-
-    @MainActor
-    func testHandlerCalledForFormExternalUrlClicked() {
-        // Given
-        let expectation = expectation(description: "Handler called for formExternalUrlClicked")
-        var receivedEvent: FormLifecycleEvent?
-
-        presentationManager.registerFormLifecycleHandler { event in
-            if case .formExternalUrlClicked = event {
-                receivedEvent = event
-                expectation.fulfill()
-            }
-        }
-
-        let externalUrl = URL(string: "https://example.com")!
-
-        // When
-        presentationManager.invokeLifecycleHandler(
-            for: .formExternalUrlClicked(formId: "form123", formName: "Newsletter", buttonLabel: "Learn More", url: externalUrl)
-        )
-
-        // Then
-        wait(for: [expectation], timeout: 1.0)
-        guard case let .formExternalUrlClicked(formId, formName, buttonLabel, url) = receivedEvent else {
-            XCTFail("Handler should receive formExternalUrlClicked event")
-            return
-        }
-        XCTAssertEqual(formId, "form123")
-        XCTAssertEqual(formName, "Newsletter")
-        XCTAssertEqual(buttonLabel, "Learn More")
-        XCTAssertEqual(url, externalUrl)
-    }
-
-    func testFormExternalUrlClickedComputedProperties() {
-        let externalUrl = URL(string: "https://example.com")!
-        let event = FormLifecycleEvent.formExternalUrlClicked(
-            formId: "form456", formName: "Promo", buttonLabel: "Shop", url: externalUrl
-        )
-
-        XCTAssertEqual(event.formId, "form456")
-        XCTAssertEqual(event.formName, "Promo")
-        XCTAssertEqual(event.eventName, "formExternalUrlClicked")
-    }
 }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"openExternalUrl","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -82,7 +82,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -111,7 +111,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -137,7 +137,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -365,7 +365,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -390,7 +390,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -411,7 +411,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -436,7 +436,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -489,7 +489,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -605,23 +605,26 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenExternalUrlWithButtonLabel() async throws {
+    func testDecodeExternalUrlWithButtonLabel() async throws {
+        // External web URLs now ride the openDeepLink message with openExternally: true.
         let json = """
         {
-          "type": "openExternalUrl",
+          "type": "openDeepLink",
           "data": {
-            "url": "https://example.com",
+            "ios": "https://example.com",
+            "android": "https://example.com",
             "formId": "form123",
             "formName": "Newsletter",
-            "buttonLabel": "Learn More"
+            "buttonLabel": "Learn More",
+            "openExternally": true
           }
         }
         """
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
-            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
 
@@ -630,25 +633,28 @@ struct IAFNativeBridgeEventTests {
         #expect(formId == "form123")
         #expect(formName == "Newsletter")
         #expect(buttonLabel == "Learn More")
+        #expect(openExternally == true)
     }
 
     @Test
-    func testDecodeOpenExternalUrlMissingButtonLabel() async throws {
+    func testDecodeExternalUrlMissingButtonLabel() async throws {
         let json = """
         {
-          "type": "openExternalUrl",
+          "type": "openDeepLink",
           "data": {
-            "url": "https://example.com",
+            "ios": "https://example.com",
+            "android": "https://example.com",
             "formId": "form123",
-            "formName": "Newsletter"
+            "formName": "Newsletter",
+            "openExternally": true
           }
         }
         """
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
-            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
 
@@ -657,23 +663,25 @@ struct IAFNativeBridgeEventTests {
         #expect(formId == "form123")
         #expect(formName == "Newsletter")
         #expect(buttonLabel == nil)
+        #expect(openExternally == true)
     }
 
     @Test
-    func testDecodeOpenExternalUrlWithoutFormContext() async throws {
+    func testDecodeExternalUrlWithoutFormContext() async throws {
         let json = """
         {
-          "type": "openExternalUrl",
+          "type": "openDeepLink",
           "data": {
-            "url": "https://example.com"
+            "ios": "https://example.com",
+            "openExternally": true
           }
         }
         """
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openExternalUrl(url, formId, formName, buttonLabel) = event else {
-            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
 
@@ -682,29 +690,58 @@ struct IAFNativeBridgeEventTests {
         #expect(formId == nil)
         #expect(formName == nil)
         #expect(buttonLabel == nil)
+        #expect(openExternally == true)
     }
 
     @Test
-    func testDecodeOpenExternalUrlEmptyUrlNormalized() async throws {
+    func testDecodeExternalUrlEmptyUrlNormalized() async throws {
         let json = """
         {
-          "type": "openExternalUrl",
+          "type": "openDeepLink",
           "data": {
-            "url": "",
+            "ios": "",
             "formId": "form123",
-            "formName": "Newsletter"
+            "formName": "Newsletter",
+            "openExternally": true
           }
         }
         """
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openExternalUrl(url, _, _, _) = event else {
-            Issue.record("event type should be .openExternalUrl but was '.\(event)'")
+        guard case let .openDeepLink(url, _, _, _, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
 
         #expect(url == nil)
+        #expect(openExternally == true)
+    }
+
+    @Test
+    func testDecodeOpenDeepLinkDefaultsOpenExternallyFalse() async throws {
+        // A deep link CTA omits `openExternally`; it must default to false so the SDK
+        // routes it through the in-app deep link handler, not the system opener.
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "klaviyotest://settings",
+            "android": "klaviyotest://settings",
+            "formId": "form456",
+            "formName": "CTA Form"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(_, _, _, _, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        #expect(openExternally == false)
     }
 }
 #endif

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"openExternalUrl","version":1},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -350,7 +350,7 @@ final class IAFWebViewModelTests: XCTestCase {
         lifecycleTask.cancel()
     }
 
-    // MARK: - openExternalUrl Tests
+    // MARK: - External URL Tests (openDeepLink with openExternally: true)
 
     private func makeOpenExternalUrlMessage(
         url: String? = "https://example.com",
@@ -358,15 +358,19 @@ final class IAFWebViewModelTests: XCTestCase {
         formName: String? = "Newsletter",
         buttonLabel: String? = "Learn More"
     ) -> MockWKScriptMessage {
+        // External web URLs ride the openDeepLink message with openExternally: true;
+        // the URL is sent in the platform-split `ios`/`android` keys.
         var data: [String: String] = [:]
-        data["url"] = url
+        data["ios"] = url
+        data["android"] = url
         data["formId"] = formId
         data["formName"] = formName
         data["buttonLabel"] = buttonLabel
         let dataJson = data.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ", ")
+        let dataBody = dataJson.isEmpty ? "\"openExternally\": true" : "\(dataJson), \"openExternally\": true"
         return MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
-            body: "{ \"type\": \"openExternalUrl\", \"data\": { \(dataJson) } }"
+            body: "{ \"type\": \"openDeepLink\", \"data\": { \(dataBody) } }"
         )
     }
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -382,9 +382,10 @@ final class IAFWebViewModelTests: XCTestCase {
         // When
         viewModel.handleScriptMessage(makeOpenExternalUrlMessage())
 
-        // Then — the handler path is synchronous, so assert immediately
-        guard case let .formExternalUrlClicked(formId, formName, buttonLabel, url) = receivedEvent else {
-            XCTFail("Expected formExternalUrlClicked, got \(String(describing: receivedEvent))")
+        // Then — the handler path is synchronous, so assert immediately.
+        // External URL clicks surface through the same formCtaClicked event as deep links.
+        guard case let .formCtaClicked(formId, formName, buttonLabel, url) = receivedEvent else {
+            XCTFail("Expected formCtaClicked, got \(String(describing: receivedEvent))")
             return
         }
         XCTAssertEqual(formId, "form123")


### PR DESCRIPTION
# Description
Consolidates the newly-added `FormLifecycleEvent.formExternalUrlClicked` case into the existing `formCtaClicked` case so external-URL CTA taps reuse the already-released event, avoiding a source-breaking change to the public enum.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Removing `formExternalUrlClicked` before it ships keeps the public `FormLifecycleEvent` enum identical to the released 5.3.1 surface, so integrators with exhaustive `switch` statements are not broken.

## Changelog / Code Overview
- **Removed** the unreleased `FormLifecycleEvent.formExternalUrlClicked` case.
- **`IAFWebViewModel`**: the `openExternalUrl` bridge event now emits `.formCtaClicked` instead of `.formExternalUrlClicked`. Scheme-allowlist validation and external-open behavior are unchanged; the external web URL is carried in the existing `deepLinkUrl` associated value.
- **Docs**: `formCtaClicked` / `registerFormLifecycleHandler` doc comments updated to note the event now covers both in-app deep links and external web URLs.
- **Example app** and **tests** updated to match; the two tests that exercised the deleted case were removed, and the `openExternalUrl` view-model test now asserts `.formCtaClicked`.

**Known tradeoffs** (inherent to the consolidation decision):
- The external URL travels in a parameter literally named `deepLinkUrl` — documented in the case's doc comment. Renaming it would itself break the released 5.3.1 signature, so it's deferred to a future major.
- Consumers can no longer distinguish a deep-link CTA from an external-URL CTA from the event alone; both are `formCtaClicked`.

## Test Plan
- `xcodebuild build -scheme KlaviyoForms -destination "platform=iOS Simulator,name=iPhone 17 Pro"` → **BUILD SUCCEEDED**
- `xcodebuild test` for `KlaviyoFormsTests/IAFWebViewModelTests` and `KlaviyoFormsTests/FormLifecycleHandlerTests` → **33 tests, 0 failures**
  - `testHandleOpenExternalUrlFiresLifecycleEvent` verifies external-URL taps now fire `formCtaClicked` with the URL in `deepLinkUrl`.

## Related Issues/Tickets
PUSH-638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified CTA interactions for in-app deep links and external web URLs.
  - External navigation now opens through the system browser when specified.
  - CTA lifecycle events now surface the button label along with the destination URL.

- **Updates**
  - Removed the separate external-URL CTA lifecycle event and consolidated behavior under the unified CTA event.
  - Updated in-app form integration documentation/examples to reflect the unified CTA tracking and payload shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->