### PR TITLE
refactor(KlaviyoSwift): extract deep-link processing into DeepLinkManager (MAGE-899)

### DIFF
--- a/Sources/KlaviyoSwift/DeepLinkManager.swift
+++ b/Sources/KlaviyoSwift/DeepLinkManager.swift
@@ -1,0 +1,61 @@
+//
+//  DeepLinkManager.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/16/26.
+//
+
+import Foundation
+import KlaviyoCore
+import OSLog
+
+@MainActor
+enum DeepLinkManager {
+    /// Transient reentrancy guard — `true` while a deep link is being opened.
+    /// Not persisted; reconstructed on launch.
+    static var isProcessingDeepLink = false
+
+    /// Opens `url` via the shared environment link handler, guarding against
+    /// overlapping opens. If a deep link is already being processed this is a
+    /// no-op (matching the reducer's "already processing" guard).
+    ///
+    /// The guard and its `true` assignment run synchronously before the
+    /// `await`, so on the main actor overlapping calls are reliably skipped.
+    ///
+    /// The guard is process-wide: an open triggered from any entry point (push
+    /// body tap, action button, tracking-link resolution, or the event
+    /// dispatcher) suppresses a concurrent open from another.
+    static func openDeepLink(_ url: URL) async {
+        if let spy = openDeepLinkSpy {
+            spy(url)
+            return
+        }
+        guard !isProcessingDeepLink else {
+            if #available(iOS 14.0, *) {
+                Logger.navigation.log("Already processing a deep link; skipping.")
+            }
+            return
+        }
+        isProcessingDeepLink = true
+        await environment.linkHandler.openURL(url)
+        isProcessingDeepLink = false
+    }
+}
+
+// MARK: - Test-only hooks
+
+// TEST-ONLY. The members below exist solely so the reducer / facade test suites
+// can observe deep-link invocations and restore state between tests.
+extension DeepLinkManager {
+    /// When non-nil, called by `openDeepLink(_:)` instead of the production path.
+    /// Reset to nil after each test via `resetToProduction()`.
+    static var openDeepLinkSpy: ((URL) -> Void)?
+
+    /// Resets the spy and the transient processing flag.
+    /// Call this in `setUp` and `tearDown` of any test that installs the spy.
+    static func resetToProduction() {
+        openDeepLinkSpy = nil
+        isProcessingDeepLink = false
+    }
+}

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -239,7 +239,7 @@ public struct KlaviyoSDK {
             // Regular notification body tap
             create(event: Event(name: ._openedPush, properties: properties))
             if let url = notificationResponse.klaviyoDeepLinkURL {
-                dispatchOnMainThread(action: .openDeepLink(url))
+                Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
             }
         }
 
@@ -283,7 +283,7 @@ public struct KlaviyoSDK {
                         deepLinkHandler(url)
                     }
                 } else {
-                    dispatchOnMainThread(action: .openDeepLink(url))
+                    Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
                 }
             }
         }
@@ -322,7 +322,7 @@ public struct KlaviyoSDK {
 
         if let url = notificationResponse.actionButtonURL, notificationResponse.actionButtonType == .deepLink {
             actionProperties["Button Link"] = url.absoluteString
-            dispatchOnMainThread(action: .openDeepLink(url))
+            Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
         }
 
         // Track action button event

--- a/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
+++ b/Sources/KlaviyoSwift/KlaviyoEventDispatcher.swift
@@ -15,7 +15,7 @@ struct KlaviyoEventDispatcher: EventDispatching {
         case let .aggregateEvent(payload):
             dispatchOnMainThread(action: .enqueueAggregateEvent(payload))
         case let .deepLink(deepLinkURL):
-            dispatchOnMainThread(action: .openDeepLink(deepLinkURL))
+            Task { @MainActor in await DeepLinkManager.openDeepLink(deepLinkURL) }
         }
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -79,7 +79,6 @@ struct KlaviyoState: Equatable, Codable {
     var retryState = RetryState.retry(StateManagementConstants.initialAttempt)
     var pendingRequests: [PendingRequest] = []
     var pendingProfile: [Profile.ProfileKey: AnyEncodable]?
-    var isProcessingDeepLink = false
 
     enum CodingKeys: CodingKey {
         case apiKey
@@ -128,8 +127,7 @@ struct KlaviyoState: Equatable, Codable {
         flushInterval: Double = StateManagementConstants.wifiFlushInterval,
         retryState: RetryState = .retry(StateManagementConstants.initialAttempt),
         pendingRequests: [PendingRequest] = [],
-        pendingProfile: [Profile.ProfileKey: AnyEncodable]? = nil,
-        isProcessingDeepLink: Bool = false
+        pendingProfile: [Profile.ProfileKey: AnyEncodable]? = nil
     ) {
         self.apiKey = apiKey
         identity = ProfileData(
@@ -147,7 +145,6 @@ struct KlaviyoState: Equatable, Codable {
         self.retryState = retryState
         self.pendingRequests = pendingRequests
         self.pendingProfile = pendingProfile
-        self.isProcessingDeepLink = isProcessingDeepLink
     }
 
     mutating func enqueueRequest(request: KlaviyoRequest) {

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -124,12 +124,6 @@ enum KlaviyoAction: Equatable {
     /// This action will enqueue a request that, when delivered, will log the click via the engtrack service.
     case trackingLinkResolutionFailed(trackingLink: URL, clickTime: Date)
 
-    /// open a deep link URL originating from a Klaviyo notification
-    case openDeepLink(URL)
-
-    /// indicates that deep link processing has completed
-    case deepLinkProcessingCompleted
-
     var requiresInitialization: Bool {
         switch self {
         // if event metric is opened push or geofence events we DON'T require initialization
@@ -139,7 +133,7 @@ enum KlaviyoAction: Equatable {
         case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
             return true
 
-        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .trackingLinkReceived, .trackingLinkDestinationResolved, .trackingLinkResolutionFailed, .openDeepLink, .deepLinkProcessingCompleted:
+        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .trackingLinkReceived, .trackingLinkDestinationResolved, .trackingLinkResolutionFailed:
             return false
         }
     }
@@ -671,8 +665,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
         case let .trackingLinkDestinationResolved(url):
-            return .run { send in
-                await send(.openDeepLink(url))
+            return .run { _ in
+                await DeepLinkManager.openDeepLink(url)
             }
 
         case let .trackingLinkResolutionFailed(trackingLink, clickTime):
@@ -692,25 +686,6 @@ struct KlaviyoReducer: ReducerProtocol {
             )
             state.enqueueRequest(request: request)
 
-            return .none
-
-        case let .openDeepLink(url):
-            guard !state.isProcessingDeepLink else {
-                if #available(iOS 14.0, *) {
-                    Logger.navigation.log("Already processing a deep link; skipping.")
-                }
-                return .none
-            }
-
-            state.isProcessingDeepLink = true
-
-            return .run { send in
-                await environment.linkHandler.openURL(url)
-                await send(.deepLinkProcessingCompleted)
-            }
-
-        case .deepLinkProcessingCompleted:
-            state.isProcessingDeepLink = false
             return .none
         }
     }

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -16,80 +16,23 @@ final class DeepLinkHandlingTests: XCTestCase {
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
 
-        // Ensure clean deep link handler state for each test
+        // Ensure clean deep link handler + coordinator state for each test.
         environment.linkHandler.unregisterCustomHandler()
-
-        // Reset TCA state to ensure clean slate for each test
-        // This is crucial because previous tests might leave isProcessingDeepLink = true
-        klaviyoSwiftEnvironment.state = {
-            KlaviyoState(queue: [], requestsInFlight: [])
-        }
+        DeepLinkManager.resetToProduction()
     }
 
     @MainActor
     override func tearDown() async throws {
-        // Ensure each test cleans up after itself
         environment.linkHandler.unregisterCustomHandler()
+        DeepLinkManager.resetToProduction()
 
-        // Reset TCA state to clean slate after each test
-        klaviyoSwiftEnvironment.state = {
-            KlaviyoState(queue: [], requestsInFlight: [])
-        }
-
-        // Reset environments to ensure clean state
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
 
         try await super.tearDown()
     }
 
-    @MainActor
-    func testOpenDeepLinkActionCallsLinkHandler() async throws {
-        let expectedURL = URL(string: "https://example.com/path")!
-        let called = expectation(description: "linkHandler.openURL called")
-        var handlerCalled = false
-
-        environment.linkHandler.registerCustomHandler { url in
-            XCTAssertEqual(url, expectedURL)
-            handlerCalled = true
-            called.fulfill()
-        }
-
-        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
-
-        await store.send(.openDeepLink(expectedURL)) {
-            $0.isProcessingDeepLink = true
-        }
-
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-
-        await fulfillment(of: [called], timeout: 1.0)
-        XCTAssertTrue(handlerCalled)
-    }
-
-    @MainActor
-    func testRegisterDeepLinkHandlerOverridesEnvironmentFallback() async throws {
-        let expectedURL = URL(string: "https://example.com/override")!
-
-        let customCalled = expectation(description: "custom handler called")
-        KlaviyoSDK().registerDeepLinkHandler { url in
-            XCTAssertEqual(url, expectedURL)
-            customCalled.fulfill()
-        }
-
-        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
-        await store.send(.openDeepLink(expectedURL)) {
-            $0.isProcessingDeepLink = true
-        }
-
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-
-        await fulfillment(of: [customCalled], timeout: 1.0)
-    }
+    // MARK: - handle(notificationResponse:) → DeepLinkManager
 
     @MainActor
     func testHandleNotificationResponseUsesRegisteredDeepLinkHandler() async throws {
@@ -104,17 +47,12 @@ final class DeepLinkHandlingTests: XCTestCase {
         let completionCalled = expectation(description: "completion handler called")
 
         let sdk = KlaviyoSDK()
-
-        // Verify clean starting state
         XCTAssertFalse(sdk.isDeepLinkHandlerRegistered, "Should start with no handler registered")
 
-        // Use the modern approach: register the handler first
         _ = sdk.registerDeepLinkHandler { url in
             XCTAssertEqual(url.absoluteString, urlString)
             handlerCalled.fulfill()
         }
-
-        // Verify the handler was registered
         XCTAssertTrue(sdk.isDeepLinkHandlerRegistered, "Handler should be registered")
 
         let result = sdk.handle(notificationResponse: response, withCompletionHandler: {
@@ -126,7 +64,7 @@ final class DeepLinkHandlingTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleNotificationResponseDispatchesOpenDeepLinkWhenNoHandler() async throws {
+    func testHandleNotificationResponseInvokesDeepLinkManagerWhenNoHandler() async throws {
         let urlString = "https://example.com/deeplink2"
         let expectedURL = try XCTUnwrap(URL(string: urlString))
         let userInfo: [AnyHashable: Any] = [
@@ -135,25 +73,14 @@ final class DeepLinkHandlingTests: XCTestCase {
         ]
         let response = try UNNotificationResponse.with(userInfo: userInfo)
 
-        // Ensure no custom handler is registered (testing the "no handler" scenario)
+        // No custom handler registered — the facade should route the URL to DeepLinkManager.
         environment.linkHandler.unregisterCustomHandler()
-        XCTAssertFalse(environment.linkHandler.hasCustomHandler, "Should have no custom handler registered")
 
         let completionCalled = expectation(description: "completion handler called")
-
-        // Set up action tracking through the test environment
-        let actionReceived = expectation(description: "openDeepLink action received")
-        let originalSend = klaviyoSwiftEnvironment.send
-        klaviyoSwiftEnvironment.send = { action in
-            if case let .openDeepLink(url) = action {
-                XCTAssertEqual(url, expectedURL, "Should dispatch openDeepLink with correct URL")
-                actionReceived.fulfill()
-
-                // Return nil to prevent the actual async processing that could interfere
-                // This test is only verifying that the action is dispatched, not the full processing
-                return nil
-            }
-            return originalSend(action)
+        let deepLinkInvoked = expectation(description: "DeepLinkManager.openDeepLink invoked")
+        DeepLinkManager.openDeepLinkSpy = { url in
+            XCTAssertEqual(url, expectedURL, "Should invoke openDeepLink with the notification's URL")
+            deepLinkInvoked.fulfill()
         }
 
         let sdk = KlaviyoSDK()
@@ -161,85 +88,8 @@ final class DeepLinkHandlingTests: XCTestCase {
             completionCalled.fulfill()
         })
 
-        // Verify the notification was processed successfully
         XCTAssertTrue(result, "SDK should return true for Klaviyo notifications with deep links")
-
-        // Verify that both the completion handler was called AND the deep link action was dispatched
-        await fulfillment(of: [completionCalled, actionReceived], timeout: 1.0)
-
-        // Restore original send function
-        klaviyoSwiftEnvironment.send = originalSend
-    }
-
-    // MARK: - TCA State Management Tests
-
-    @MainActor
-    func testOpenDeepLinkActionSetsProcessingState() async throws {
-        let url = URL(string: "https://example.com/test")!
-        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
-
-        environment.linkHandler.registerCustomHandler { _ in }
-
-        await store.send(.openDeepLink(url)) {
-            $0.isProcessingDeepLink = true
-        }
-
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-    }
-
-    @MainActor
-    func testOpenDeepLinkActionIgnoredWhenAlreadyProcessing() async throws {
-        let url = URL(string: "https://example.com/test")!
-        var initialState = KlaviyoState(queue: [], requestsInFlight: [])
-        initialState.isProcessingDeepLink = true
-
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-
-        await store.send(.openDeepLink(url))
-    }
-
-    @MainActor
-    func testDeepLinkProcessingCompletedResetsState() async throws {
-        var initialState = KlaviyoState(queue: [], requestsInFlight: [])
-        initialState.isProcessingDeepLink = true
-
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-
-        await store.send(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-    }
-
-    @MainActor
-    func testSequentialDeepLinkProcessing() async throws {
-        let url1 = URL(string: "https://example.com/test1")!
-        let url2 = URL(string: "https://example.com/test2")!
-
-        let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
-
-        // Register a simple handler
-        environment.linkHandler.registerCustomHandler { _ in }
-
-        // Send first action - should be processed
-        await store.send(.openDeepLink(url1)) {
-            $0.isProcessingDeepLink = true
-        }
-
-        // Complete first processing
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-
-        // Now that processing is complete, a new action should work
-        await store.send(.openDeepLink(url2)) {
-            $0.isProcessingDeepLink = true
-        }
-
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
+        await fulfillment(of: [completionCalled, deepLinkInvoked], timeout: 1.0)
     }
 
     // MARK: - isDeepLinkHandlerRegistered Property Tests
@@ -248,14 +98,11 @@ final class DeepLinkHandlingTests: XCTestCase {
     func testIsDeepLinkHandlerRegisteredProperty() {
         let sdk = KlaviyoSDK()
 
-        // Initial state should be false
         XCTAssertFalse(sdk.isDeepLinkHandlerRegistered)
 
-        // After registering a handler
         sdk.registerDeepLinkHandler { _ in }
         XCTAssertTrue(sdk.isDeepLinkHandlerRegistered)
 
-        // After unregistering the handler
         sdk.unregisterDeepLinkHandler()
         XCTAssertFalse(sdk.isDeepLinkHandlerRegistered)
     }
@@ -265,14 +112,12 @@ final class DeepLinkHandlingTests: XCTestCase {
         let sdk1 = KlaviyoSDK()
         let sdk2 = KlaviyoSDK()
 
-        // Both should start as false
         XCTAssertFalse(sdk1.isDeepLinkHandlerRegistered)
         XCTAssertFalse(sdk2.isDeepLinkHandlerRegistered)
 
-        // Register handler on first instance
         _ = sdk1.registerDeepLinkHandler { _ in }
 
-        // Both should reflect the same underlying state (shared environment)
+        // Both should reflect the same underlying state (shared environment).
         XCTAssertTrue(sdk1.isDeepLinkHandlerRegistered)
         XCTAssertTrue(sdk2.isDeepLinkHandlerRegistered)
     }
@@ -281,14 +126,11 @@ final class DeepLinkHandlingTests: XCTestCase {
     func testIsDeepLinkHandlerRegisteredAfterEnvironmentReset() {
         let sdk = KlaviyoSDK()
 
-        // Register a handler
         _ = sdk.registerDeepLinkHandler { _ in }
         XCTAssertTrue(sdk.isDeepLinkHandlerRegistered)
 
-        // Reset the environment (simulating what happens in test tearDown)
         environment.linkHandler.unregisterCustomHandler()
 
-        // SDK should reflect the new state
         XCTAssertFalse(sdk.isDeepLinkHandlerRegistered)
     }
 
@@ -296,15 +138,12 @@ final class DeepLinkHandlingTests: XCTestCase {
     func testIsDeepLinkHandlerRegisteredConsistencyWithEnvironment() {
         let sdk = KlaviyoSDK()
 
-        // Should match environment state
         XCTAssertEqual(sdk.isDeepLinkHandlerRegistered, environment.linkHandler.hasCustomHandler)
 
-        // Register through SDK
         _ = sdk.registerDeepLinkHandler { _ in }
         XCTAssertEqual(sdk.isDeepLinkHandlerRegistered, environment.linkHandler.hasCustomHandler)
         XCTAssertTrue(sdk.isDeepLinkHandlerRegistered)
 
-        // Unregister through environment directly
         environment.linkHandler.unregisterCustomHandler()
         XCTAssertEqual(sdk.isDeepLinkHandlerRegistered, environment.linkHandler.hasCustomHandler)
         XCTAssertFalse(sdk.isDeepLinkHandlerRegistered)

--- a/Tests/KlaviyoSwiftTests/DeepLinkManagerTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkManagerTests.swift
@@ -1,0 +1,89 @@
+//
+//  DeepLinkManagerTests.swift
+//
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import Foundation
+import XCTest
+
+@MainActor
+final class DeepLinkManagerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+        environment.linkHandler.unregisterCustomHandler()
+        DeepLinkManager.resetToProduction()
+    }
+
+    override func tearDown() {
+        DeepLinkManager.resetToProduction()
+        environment.linkHandler.unregisterCustomHandler()
+        super.tearDown()
+    }
+
+    // MARK: - openDeepLink
+
+    func testOpenDeepLink_routesThroughLinkHandler() async {
+        let expectedURL = URL(string: "https://example.com/path")!
+        let called = expectation(description: "linkHandler.openURL called")
+        environment.linkHandler.registerCustomHandler { url in
+            XCTAssertEqual(url, expectedURL)
+            called.fulfill()
+        }
+
+        await DeepLinkManager.openDeepLink(expectedURL)
+
+        await fulfillment(of: [called], timeout: 1.0)
+        XCTAssertFalse(DeepLinkManager.isProcessingDeepLink, "processing flag should reset after opening")
+    }
+
+    func testOpenDeepLink_skippedWhenAlreadyProcessing() async {
+        DeepLinkManager.isProcessingDeepLink = true
+        var handlerCalled = false
+        environment.linkHandler.registerCustomHandler { _ in handlerCalled = true }
+
+        await DeepLinkManager.openDeepLink(URL(string: "https://example.com")!)
+
+        XCTAssertFalse(handlerCalled, "openURL must not run while a deep link is already processing")
+        XCTAssertTrue(DeepLinkManager.isProcessingDeepLink, "the in-flight processing state must be left untouched")
+    }
+
+    func testOpenDeepLink_sequentialCallsBothProcessed() async {
+        var opened: [URL] = []
+        environment.linkHandler.registerCustomHandler { opened.append($0) }
+        let url1 = URL(string: "https://example.com/1")!
+        let url2 = URL(string: "https://example.com/2")!
+
+        await DeepLinkManager.openDeepLink(url1)
+        await DeepLinkManager.openDeepLink(url2)
+
+        XCTAssertEqual(opened, [url1, url2], "each open should proceed once the previous finished")
+        XCTAssertFalse(DeepLinkManager.isProcessingDeepLink)
+    }
+
+    func testOpenDeepLink_withSpy_bypassesProductionPath() async {
+        var spiedURL: URL?
+        DeepLinkManager.openDeepLinkSpy = { spiedURL = $0 }
+        var handlerCalled = false
+        environment.linkHandler.registerCustomHandler { _ in handlerCalled = true }
+
+        await DeepLinkManager.openDeepLink(URL(string: "https://example.com/x")!)
+
+        XCTAssertEqual(spiedURL?.absoluteString, "https://example.com/x", "spy should receive the URL")
+        XCTAssertFalse(handlerCalled, "production path must be bypassed when a spy is installed")
+    }
+
+    // MARK: - resetToProduction
+
+    func testResetToProduction_clearsSpyAndFlag() {
+        DeepLinkManager.openDeepLinkSpy = { _ in }
+        DeepLinkManager.isProcessingDeepLink = true
+
+        DeepLinkManager.resetToProduction()
+
+        XCTAssertNil(DeepLinkManager.openDeepLinkSpy)
+        XCTAssertFalse(DeepLinkManager.isProcessingDeepLink)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -25,11 +25,13 @@ class KlaviyoSDKTests: XCTestCase {
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
         BadgeManager.resetToProduction()
+        DeepLinkManager.resetToProduction()
     }
 
     override func tearDown() async throws {
         environment = KlaviyoEnvironment.test()
         BadgeManager.resetToProduction()
+        DeepLinkManager.resetToProduction()
     }
 
     func setupActionAssertion(expectedAction: KlaviyoAction, file: StaticString = #filePath, line: UInt = #line) -> XCTestExpectation {
@@ -294,12 +296,16 @@ class KlaviyoSDKTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testKlaviyoSDKInitRegistersDeepLinkDispatch() {
+    func testKlaviyoSDKInitRegistersDeepLinkDispatch() async {
         _ = KlaviyoSDK()
         let url = URL(string: "https://example.com")!
-        let expectation = setupActionAssertion(expectedAction: .openDeepLink(url))
+        let opened = expectation(description: "openDeepLink invoked with URL")
+        DeepLinkManager.openDeepLinkSpy = { dispatchedURL in
+            XCTAssertEqual(dispatchedURL, url)
+            opened.fulfill()
+        }
         EventDispatcher.shared.dispatch(.deepLink(url))
-        wait(for: [expectation], timeout: 1.0)
+        await fulfillment(of: [opened], timeout: 1.0)
     }
 
     // MARK: - Deep Link Handler Registration Tests

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -15,6 +15,13 @@ final class ResolveTrackingLinkTests: XCTestCase {
     override func setUpWithError() throws {
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+        DeepLinkManager.resetToProduction()
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        DeepLinkManager.resetToProduction()
+        try await super.tearDown()
     }
 
     @MainActor
@@ -49,19 +56,18 @@ final class ResolveTrackingLinkTests: XCTestCase {
             return .success(responseData)
         }
 
-        // Register a mock handler to prevent fallback execution in test environment
-        environment.linkHandler.registerCustomHandler { _ in }
+        // Observe the deep-link open that trackingLinkDestinationResolved triggers.
+        let opened = expectation(description: "openDeepLink invoked with destination")
+        DeepLinkManager.openDeepLinkSpy = { url in
+            XCTAssertEqual(url, destinationURL)
+            opened.fulfill()
+        }
 
         // When
         await store.send(.trackingLinkReceived(trackingLinkURL))
         // Then
         await store.receive(.trackingLinkDestinationResolved(destinationURL))
-        await store.receive(.openDeepLink(destinationURL)) {
-            $0.isProcessingDeepLink = true
-        }
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
+        await fulfillment(of: [opened], timeout: 1.0)
         await store.finish()
     }
 
@@ -98,19 +104,18 @@ final class ResolveTrackingLinkTests: XCTestCase {
             return .success(responseData)
         }
 
-        // Register a mock handler to prevent fallback execution in test environment
-        environment.linkHandler.registerCustomHandler { _ in }
+        // Observe the deep-link open that trackingLinkDestinationResolved triggers.
+        let opened = expectation(description: "openDeepLink invoked with destination")
+        DeepLinkManager.openDeepLinkSpy = { url in
+            XCTAssertEqual(url, destinationURL)
+            opened.fulfill()
+        }
 
         // When
         await store.send(.trackingLinkReceived(trackingLinkURL))
         // Then
         await store.receive(.trackingLinkDestinationResolved(destinationURL))
-        await store.receive(.openDeepLink(destinationURL)) {
-            $0.isProcessingDeepLink = true
-        }
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
+        await fulfillment(of: [opened], timeout: 1.0)
         await store.finish()
     }
 
@@ -195,22 +200,17 @@ final class ResolveTrackingLinkTests: XCTestCase {
         let destinationURL = try XCTUnwrap(URL(string: "https://example.com/destination"))
         let store = TestStore(initialState: INITIALIZED_TEST_STATE(), reducer: KlaviyoReducer())
 
-        let openCalled = expectation(description: "linkHandler.openURL called with destination")
-        environment.linkHandler.registerCustomHandler { url in
+        let opened = expectation(description: "openDeepLink invoked with destination")
+        DeepLinkManager.openDeepLinkSpy = { url in
             XCTAssertEqual(url, destinationURL)
-            openCalled.fulfill()
+            opened.fulfill()
         }
 
         // When
         await store.send(.trackingLinkDestinationResolved(destinationURL))
 
-        // Then the reducer should emit .openDeepLink and call linkHandler.openURL
-        await store.receive(.openDeepLink(destinationURL)) {
-            $0.isProcessingDeepLink = true
-        }
-        await store.receive(.deepLinkProcessingCompleted) {
-            $0.isProcessingDeepLink = false
-        }
-        await fulfillment(of: [openCalled], timeout: 1.0)
+        // Then the reducer should route the destination through DeepLinkManager.
+        await fulfillment(of: [opened], timeout: 1.0)
+        await store.finish()
     }
 }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -10,7 +10,6 @@
     - externalId: Optional<String>.none
     - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
-  - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - pushTokenData: Optional<PushTokenData>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -10,7 +10,6 @@
     - externalId: Optional<String>.none
     - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
-  - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - pushTokenData: Optional<PushTokenData>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -10,7 +10,6 @@
     - externalId: Optional<String>.none
     - phoneNumber: Optional<String>.none
   - initalizationState: InitializationState.uninitialized
-  - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   - pushTokenData: Optional<PushTokenData>.none

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -13,7 +13,6 @@
     ▿ phoneNumber: Optional<String>
       - some: "phoneNumber"
   - initalizationState: InitializationState.initialized
-  - isProcessingDeepLink: false
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
   ▿ pushTokenData: Optional<PushTokenData>


### PR DESCRIPTION
# Description

Second strangler chip (MAGE-899) toward retiring the vendored TCA engine. Moves deep-link handling out of `KlaviyoAction` / `KlaviyoState` into a self-contained, `@MainActor` `DeepLinkManager`, mirroring the `BadgeManager` extraction (#652).

## Due Diligence

- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.

No public API changes. `registerDeepLinkHandler` / `unregisterDeepLinkHandler` / `isDeepLinkHandlerRegistered` keep their signatures and behavior (they still delegate to `environment.linkHandler`). Deep-link resolution behavior is preserved, including the "already processing" guard.

## Changelog / Code Overview

**Deleted:**
- `KlaviyoAction.openDeepLink(URL)` / `.deepLinkProcessingCompleted` cases + reducer bodies
- Both actions' entries in the `requiresInitialization` switch arm
- Transient `KlaviyoState.isProcessingDeepLink` field (never persisted — not in `CodingKeys`)

**Added:**
- `Sources/KlaviyoSwift/DeepLinkManager.swift` — `@MainActor` enum owning:
  - the transient `isProcessingDeepLink` reentrancy guard (rebuilt on launch)
  - `openDeepLink(_:) async` — guards against overlapping opens, then routes through the shared `environment.linkHandler.openURL`. The guard + its `true`-assignment run synchronously before the `await`, so overlapping calls are reliably skipped.
  - a clearly marked, internal **test-only** extension (`openDeepLinkSpy` + `resetToProduction()`) at the bottom of the file
- `Tests/KlaviyoSwiftTests/DeepLinkManagerTests.swift` — guard, routing, sequential, spy-bypass, reset

**Updated:**
- All five `.openDeepLink` dispatch sites now call `DeepLinkManager.openDeepLink` directly: 3 in `Klaviyo.swift` (push body tap, custom-handler fallback, action-button deep link), 1 in `KlaviyoEventDispatcher` (Forms/EventBus `.deepLink`), and the reducer's `trackingLinkDestinationResolved` follow-up
- Migrated the reducer/action assertions in `DeepLinkHandlingTests` and `ResolveTrackingLinkTests`, and the facade dispatch test in `KlaviyoSDKTests`, to observe the coordinator via its spy
- Regenerated the 4 `KlaviyoState` value-dump snapshots

**Design notes:**
- `environment.linkHandler` is intentionally **kept on the environment** — it backs the public `registerDeepLinkHandler` API, holds the customer's registered-handler state, and does the real routing (SceneDelegate → AppDelegate → `UIApplication.open`). It is not a test-only seam, so `DeepLinkManager` reuses it rather than owning its own.
- Not init-gated (unchanged); the flag was never persisted, so no migration exposure.
- The `KlaviyoForms` `IAFNativeBridgeEvent.openDeepLink` is a *different* type and is untouched.
- swiftlint/swiftformat are not installed locally — CI runs them.

## Test Plan

```
xcodebuild test -scheme klaviyo-swift-sdk-Package \
  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
  -only-testing:KlaviyoSwiftTests
```

Result: **208 tests, 0 failures**. Full package build succeeds. New `DeepLinkManagerTests`: 5 tests.

A manual regression plan (push body/action-button deep links, tracking-link resolution, custom-handler vs fallback routing, the reentrancy guard) is drafted for QA.

## Related Issues/Tickets

Related to MAGE-899
Parent: MAGE-892 (iOS modularization — retire vendored TCA engine)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
