### PR TITLE
refactor(push): rename automatic push integration flags (MAGE-931)

### DIFF
--- a/Examples/KlaviyoSwiftExamples/README.md
+++ b/Examples/KlaviyoSwiftExamples/README.md
@@ -18,7 +18,7 @@ This [example](SPMExample) demonstrates how to integrate our SDK using SPM. Foll
 
 ## SPM Example — Automatic Push Tracking
 
-This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts into automatic push integration via two independent Info.plist keys: `klaviyo_automatic_push_tracking` (tracks push opens) and `klaviyo_automatic_token_forwarding` (forwards device tokens). With both keys set, the SDK automatically forwards device tokens and tracks push opens, so no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code is required in your `AppDelegate`.
+This [example](SPMExample/SPMExampleAutomatic) mirrors the SPM Example but opts into automatic push integration via two independent Info.plist keys: `klaviyo_automatic_push_open_tracking` (tracks push opens) and `klaviyo_automatic_push_token_forwarding` (forwards device tokens). With both keys set, the SDK automatically forwards device tokens and tracks push opens, so no `didRegisterForRemoteNotificationsWithDeviceToken` or `UNUserNotificationCenterDelegate` code is required in your `AppDelegate`.
 
 ## Which example should I use?
 

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -3,8 +3,8 @@
 //  SPMExampleAutomatic
 //
 // Automatic push integration: no token-forwarding or notification-delegate code needed.
-// The SDK handles all of that when both `klaviyo_automatic_push_tracking` and
-// `klaviyo_automatic_token_forwarding` are set in Info.plist. The two flags are independent;
+// The SDK handles all of that when both `klaviyo_automatic_push_open_tracking` and
+// `klaviyo_automatic_push_token_forwarding` are set in Info.plist. The two flags are independent;
 // this target opts into both for the fully automatic experience.
 // For the manual integration reference (STEP1–STEP6) see Shared/AppDelegate.swift.
 //

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/Info.plist
@@ -15,9 +15,9 @@
 	</array>
 	<key>klaviyo_app_group</key>
 	<string>group.$(PRODUCT_BUNDLE_IDENTIFIER).shared</string>
-	<key>klaviyo_automatic_push_tracking</key>
+	<key>klaviyo_automatic_push_open_tracking</key>
 	<true/>
-	<key>klaviyo_automatic_token_forwarding</key>
+	<key>klaviyo_automatic_push_token_forwarding</key>
 	<true/>
 	<key>klaviyo_badge_autoclearing</key>
 	<true/>

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ For the fully automatic, no-boilerplate integration, enable both:
 
 ```xml
 <!-- Injects a notification-delegate proxy that tracks push opens automatically -->
-<key>klaviyo_automatic_push_tracking</key>
+<key>klaviyo_automatic_push_open_tracking</key>
 <true/>
 <!-- Forwards the APNs device token to Klaviyo automatically (no didRegister... code needed) -->
-<key>klaviyo_automatic_token_forwarding</key>
+<key>klaviyo_automatic_push_token_forwarding</key>
 <true/>
 ```
 

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -252,10 +252,10 @@ public struct KlaviyoEnvironment {
         },
         sdkFeatures: {
             let autoPushTracking = Bundle.main.object(
-                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
+                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushOpenTracking
             ) as? Bool
             let autoTokenForwarding = Bundle.main.object(
-                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticTokenForwarding
+                forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTokenForwarding
             ) as? Bool
             guard autoPushTracking != nil || autoTokenForwarding != nil else {
                 return nil

--- a/Sources/KlaviyoCore/Models/SdkFeatures.swift
+++ b/Sources/KlaviyoCore/Models/SdkFeatures.swift
@@ -50,10 +50,10 @@ public struct SdkFeatures: Equatable {
     /// Shared so the flag reads stay consistent across modules.
     package enum InfoPlistKey {
         /// When present and `true`, enables proxy delegate injection and automatic push-open tracking.
-        package static let automaticPushTracking = "klaviyo_automatic_push_tracking"
+        package static let automaticPushOpenTracking = "klaviyo_automatic_push_open_tracking"
         /// When present and `true`, enables automatic device-token forwarding (app-delegate swizzling).
-        /// Absent is treated as `false` (opt-in), independent of `automaticPushTracking`.
-        package static let automaticTokenForwarding = "klaviyo_automatic_token_forwarding"
+        /// Absent is treated as `false` (opt-in), independent of `automaticPushOpenTracking`.
+        package static let automaticPushTokenForwarding = "klaviyo_automatic_push_token_forwarding"
     }
 
     /// Configured feature states; only features the host actually configured are present.
@@ -64,9 +64,9 @@ public struct SdkFeatures: Equatable {
     }
 
     /// - Parameters:
-    ///   - autoPushTracking: value of the `klaviyo_automatic_push_tracking` flag, or `nil`
+    ///   - autoPushTracking: value of the `klaviyo_automatic_push_open_tracking` flag, or `nil`
     ///     when that key is absent from Info.plist.
-    ///   - autoTokenForwarding: value of the independent `klaviyo_automatic_token_forwarding`
+    ///   - autoTokenForwarding: value of the independent `klaviyo_automatic_push_token_forwarding`
     ///     flag, or `nil` when that key is absent from Info.plist.
     public init(autoPushTracking: Bool?, autoTokenForwarding: Bool?) {
         var values = [SdkFeatureKey: Bool]()

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -91,8 +91,8 @@ final class KlaviyoNotificationDelegate: NSObject {
 
     /// Reads the two independent opt-in flags and the notification center from
     /// `KlaviyoSwiftEnvironment`, then applies each behavior on its own:
-    /// - `klaviyo_automatic_push_tracking` gates proxy injection (automatic push-open tracking).
-    /// - `klaviyo_automatic_token_forwarding` gates app-delegate swizzling (device-token forwarding).
+    /// - `klaviyo_automatic_push_open_tracking` gates proxy injection (automatic push-open tracking).
+    /// - `klaviyo_automatic_push_token_forwarding` gates app-delegate swizzling (device-token forwarding).
     ///
     /// Neither flag is a prerequisite for the other, so any combination is honored.
     ///
@@ -103,7 +103,7 @@ final class KlaviyoNotificationDelegate: NSObject {
     /// `KlaviyoSwiftEnvironment.injectNotificationDelegate`.
     @MainActor
     static func injectIfEnabled() {
-        if klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled() {
+        if klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled() {
             if #available(iOS 14.0, *) {
                 Logger.notifications.info(
                     "Injecting notification delegate proxy for automatic push tracking."
@@ -114,7 +114,7 @@ final class KlaviyoNotificationDelegate: NSObject {
             Logger.notifications.log("Automatic push tracking is off.")
         }
 
-        if klaviyoSwiftEnvironment.isAutomaticTokenForwardingEnabled() {
+        if klaviyoSwiftEnvironment.isAutomaticPushTokenForwardingEnabled() {
             if #available(iOS 14.0, *) {
                 Logger.notifications.info("Swizzling app delegate for automatic token forwarding.")
             }

--- a/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
+++ b/Sources/KlaviyoSwift/KlaviyoSwiftEnvironment.swift
@@ -26,14 +26,14 @@ struct KlaviyoSwiftEnvironment {
     /// real notification center.
     var injectNotificationDelegate: () -> Void
     /// Returns whether the host has opted in to automatic push open tracking via the
-    /// `klaviyo_automatic_push_tracking` Info.plist key.
+    /// `klaviyo_automatic_push_open_tracking` Info.plist key.
     /// Injected so tests can enable or disable the feature without modifying `Bundle.main`.
-    var isAutomaticPushTrackingEnabled: () -> Bool
+    var isAutomaticPushOpenTrackingEnabled: () -> Bool
     /// Returns whether the host has opted in to automatic device-token forwarding via the
-    /// `klaviyo_automatic_token_forwarding` Info.plist key. Independent of push tracking; absent
+    /// `klaviyo_automatic_push_token_forwarding` Info.plist key. Independent of push tracking; absent
     /// is treated as `false`.
     /// Injected so tests can control the flag without modifying `Bundle.main`.
-    var isAutomaticTokenForwardingEnabled: () -> Bool
+    var isAutomaticPushTokenForwardingEnabled: () -> Bool
     /// Provides the notification center for automatic push tracking injection.
     /// Injected so tests can substitute a mock without the app-bundle context that
     /// `UNUserNotificationCenter.current()` requires.
@@ -75,14 +75,14 @@ struct KlaviyoSwiftEnvironment {
                     KlaviyoNotificationDelegate.injectIfEnabled()
                 }
             },
-            isAutomaticPushTrackingEnabled: {
+            isAutomaticPushOpenTrackingEnabled: {
                 Bundle.main.object(
-                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTracking
+                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushOpenTracking
                 ) as? Bool == true
             },
-            isAutomaticTokenForwardingEnabled: {
+            isAutomaticPushTokenForwardingEnabled: {
                 Bundle.main.object(
-                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticTokenForwarding
+                    forInfoDictionaryKey: SdkFeatures.InfoPlistKey.automaticPushTokenForwarding
                 ) as? Bool == true
             },
             notificationCenter: {

--- a/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoNotificationDelegateTests.swift
@@ -73,8 +73,8 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
     /// Both flags off: `injectIfEnabled()` is a no-op and the proxy delegate is never installed.
     func testInjectIfEnabledIsNoOpWhenBothFlagsDisabled() {
         let mockCenter = MockNotificationCenter()
-        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { false }
-        klaviyoSwiftEnvironment.isAutomaticTokenForwardingEnabled = { false }
+        klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled = { false }
+        klaviyoSwiftEnvironment.isAutomaticPushTokenForwardingEnabled = { false }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
 
         KlaviyoNotificationDelegate.injectIfEnabled()
@@ -87,7 +87,7 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
     /// After injection, the proxy must be the center's active delegate.
     func testInjectSetsDelegateOnCenter() {
         let mockCenter = MockNotificationCenter()
-        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled = { true }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
 
         KlaviyoNotificationDelegate.injectIfEnabled()
@@ -101,7 +101,7 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
         let mockCenter = MockNotificationCenter()
         let priorDelegate = MockUNDelegate()
         mockCenter.delegate = priorDelegate
-        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled = { true }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
 
         KlaviyoNotificationDelegate.injectIfEnabled()
@@ -113,7 +113,7 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
     /// must be a no-op — no duplicate observation tokens, no delegate reassignment.
     func testInjectIsIdempotent() {
         let mockCenter = MockNotificationCenter()
-        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled = { true }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
 
         KlaviyoNotificationDelegate.injectIfEnabled()
@@ -129,7 +129,7 @@ class KlaviyoNotificationDelegateTests: XCTestCase {
     /// new host delegate as `existingDelegate`.
     func testObserverReinstallsProxyAfterHostReassignment() {
         let mockCenter = MockNotificationCenter()
-        klaviyoSwiftEnvironment.isAutomaticPushTrackingEnabled = { true }
+        klaviyoSwiftEnvironment.isAutomaticPushOpenTrackingEnabled = { true }
         klaviyoSwiftEnvironment.notificationCenter = { mockCenter }
         KlaviyoNotificationDelegate.injectIfEnabled()
 

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -228,9 +228,9 @@ extension KlaviyoSwiftEnvironment {
             // no-op: UNUserNotificationCenter.current() is unavailable in test runner
         }, injectNotificationDelegate: {
             // no-op: UNUserNotificationCenter.current() is unavailable in test runner
-        }, isAutomaticPushTrackingEnabled: {
+        }, isAutomaticPushOpenTrackingEnabled: {
             false
-        }, isAutomaticTokenForwardingEnabled: {
+        }, isAutomaticPushTokenForwardingEnabled: {
             false
         }, notificationCenter: {
             MockNotificationCenter()


### PR DESCRIPTION
# Description
Renames the two iOS automatic push integration Info.plist flags for clarity, so the push-open tracking flag reads unambiguously (per feedback that `automatic_push_tracking` was vague about *what* it tracks).

| Old | New |
|-----|-----|
| `klaviyo_automatic_push_tracking` | `klaviyo_automatic_push_open_tracking` |
| `klaviyo_automatic_token_forwarding` | `klaviyo_automatic_push_token_forwarding` |

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Merging to feature branch `feat/auto-push-tracking` so docs only go live on release.
- [x] This is planned work for an upcoming release.

Note: the flags are new on `feat/auto-push-tracking` and not yet released, so this rename is not a breaking change for any shipped API.

## Changelog / Code Overview
- **Production:** renamed `SdkFeatures.InfoPlistKey` constants + string values, and the `KlaviyoSwiftEnvironment` closures (`isAutomaticPushOpenTrackingEnabled`, `isAutomaticPushTokenForwardingEnabled`); updated call sites in `KlaviyoEnvironment.swift` and `KlaviyoNotificationDelegate.swift`.
- **Docs / sample app:** root `README.md`, `Examples/.../README.md`, `SPMExampleAutomatic/Info.plist`, `SPMExampleAutomatic/AppDelegate.swift`.
- **Tests:** `TestData.swift`, `KlaviyoNotificationDelegateTests.swift`.
- **Left unchanged:** the `X-Klaviyo-Sdk-Features` telemetry wire names (`auto_push_tracking`, `auto_push_token_forwarding`) — that header is a backend contract and out of scope.

## Test Plan
1. `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` — BUILD SUCCEEDED.
2. `xcodebuild test ... -only-testing:KlaviyoCoreTests/SdkFeaturesTests -only-testing:KlaviyoSwiftTests/KlaviyoNotificationDelegateTests` — TEST SUCCEEDED.
3. `git grep` confirms no old flag names or symbols remain.
4. SwiftLint + SwiftFormat pre-commit hooks pass.

## Related Issues/Tickets
- [MAGE-931](https://linear.app/klaviyo/issue/MAGE-931/rename-ios-automatic-push-integration-flags)
- Related: MAGE-932 (Android equivalent rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split automatic push behavior into separate opt-in settings for push-open tracking and device-token forwarding.
  * Updated automatic notification handling to respect the new settings independently.

* **Documentation**
  * Updated setup instructions and examples with the revised Info.plist keys.

* **Tests**
  * Updated notification integration tests to validate the new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->