### PR TITLE
refactor: use failable/conversion initializers instead of toAPIModel

### DIFF
--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -15,41 +15,45 @@ extension String {
     }
 }
 
-extension Profile {
-    func toAPIModel(
+extension ProfilePayload {
+    /// Builds the API profile payload from a ``Profile``, letting the caller override the identifiers
+    /// (email, phone number, external ID) that are tracked separately on state.
+    init(
+        _ profile: Profile,
         email: String? = nil,
         phoneNumber: String? = nil,
         externalId: String? = nil,
         anonymousId: String
-    ) -> ProfilePayload {
-        ProfilePayload(
-            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            firstName: firstName,
-            lastName: lastName,
-            organization: organization,
-            title: title,
-            image: image,
-            location: location?.toAPILocation,
-            properties: properties,
+    ) {
+        self.init(
+            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+            organization: profile.organization,
+            title: profile.title,
+            image: profile.image,
+            location: profile.location.map { Attributes.Location($0) },
+            properties: profile.properties,
             anonymousId: anonymousId
         )
     }
 }
 
-extension Profile.Location {
-    var toAPILocation: ProfilePayload.Attributes.Location {
-        ProfilePayload.Attributes.Location(
-            address1: address1,
-            address2: address2,
-            city: city,
-            country: country,
-            latitude: latitude,
-            longitude: longitude,
-            region: region,
-            zip: zip,
-            timezone: timezone
+extension ProfilePayload.Attributes.Location {
+    /// Maps a ``Profile/Location`` to the API location object.
+    init(_ location: Profile.Location) {
+        self.init(
+            address1: location.address1,
+            address2: location.address2,
+            city: location.city,
+            country: location.country,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            region: location.region,
+            zip: location.zip,
+            timezone: location.timezone
         )
     }
 }

--- a/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
@@ -18,29 +18,38 @@ extension Subscription.Channels {
     var needsPhone: Bool {
         sms?.isEmpty == false || whatsapp?.isEmpty == false
     }
+}
 
+extension EmailConsent {
+    /// Maps the requested EMAIL sub-types to the API consent object, or `nil` when none were named.
+    init?(_ options: Subscription.Channels.Email) {
+        guard !options.isEmpty else { return nil }
+        self.init(
+            marketing: options.contains(.marketing) ? .subscribed : nil,
+            openTracking: options.contains(.openTracking) ? .subscribed : nil
+        )
+    }
+}
+
+extension MarketingTransactionalConsent {
+    /// Maps the requested SMS/WhatsApp sub-types to the API consent object, or `nil` when none were named.
+    init?(_ options: Subscription.Channels.Messaging) {
+        guard !options.isEmpty else { return nil }
+        self.init(
+            marketing: options.contains(.marketing) ? .subscribed : nil,
+            transactional: options.contains(.transactional) ? .subscribed : nil
+        )
+    }
+}
+
+extension SubscriptionChannels {
     /// Maps the requested channels to the API's `subscriptions` object, or `nil` when no sub-types
     /// were named (nothing to send).
-    var toAPIModel: SubscriptionChannels? {
-        let emailConsent = email.flatMap { set -> EmailConsent? in
-            guard !set.isEmpty else { return nil }
-            return EmailConsent(
-                marketing: set.contains(.marketing) ? .subscribed : nil,
-                openTracking: set.contains(.openTracking) ? .subscribed : nil
-            )
-        }
-        let smsConsent = messagingConsent(sms)
-        let whatsappConsent = messagingConsent(whatsapp)
-
-        guard emailConsent != nil || smsConsent != nil || whatsappConsent != nil else { return nil }
-        return SubscriptionChannels(email: emailConsent, sms: smsConsent, whatsapp: whatsappConsent)
-    }
-
-    private func messagingConsent(_ set: Messaging?) -> MarketingTransactionalConsent? {
-        guard let set, !set.isEmpty else { return nil }
-        return MarketingTransactionalConsent(
-            marketing: set.contains(.marketing) ? .subscribed : nil,
-            transactional: set.contains(.transactional) ? .subscribed : nil
-        )
+    init?(_ channels: Subscription.Channels) {
+        let email = channels.email.flatMap(EmailConsent.init)
+        let sms = channels.sms.flatMap(MarketingTransactionalConsent.init)
+        let whatsapp = channels.whatsapp.flatMap(MarketingTransactionalConsent.init)
+        guard email != nil || sms != nil || whatsapp != nil else { return nil }
+        self.init(email: email, sms: sms, whatsapp: whatsapp)
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -238,7 +238,7 @@ struct KlaviyoState: Equatable, Codable {
                     pushToken: tokenData.pushToken,
                     enablement: tokenData.pushEnablement.rawValue,
                     background: tokenData.pushBackground.rawValue,
-                    profile: Profile().toAPIModel(anonymousId: anonymousId)
+                    profile: ProfilePayload(Profile(), anonymousId: anonymousId)
                 )
 
                 let request = KlaviyoRequest(
@@ -298,7 +298,7 @@ struct KlaviyoState: Equatable, Codable {
             pushToken: pushToken,
             enablement: enablement.rawValue,
             background: environment.getBackgroundSetting().rawValue,
-            profile: profile.toAPIModel(anonymousId: anonymousId)
+            profile: ProfilePayload(profile, anonymousId: anonymousId)
         )
         let endpoint = KlaviyoEndpoint.registerPushToken(apiKey, payload)
         return KlaviyoRequest(endpoint: endpoint)
@@ -335,7 +335,7 @@ struct KlaviyoState: Equatable, Codable {
                 return nil
             }
 
-            guard let mappedChannels = requestedChannels.toAPIModel else {
+            guard let mappedChannels = SubscriptionChannels(requestedChannels) else {
                 environment.emitDeveloperWarning(
                     "Subscription channels were provided but none were enabled; request was not enqueued."
                 )

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -608,7 +608,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
             let request: KlaviyoRequest!
 
-            let profilePayload = profile.toAPIModel(
+            let profilePayload = ProfilePayload(
+                profile,
                 email: state.email,
                 phoneNumber: state.phoneNumber,
                 externalId: state.externalId,

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -30,7 +30,7 @@ class KlaviyoModelsTest: XCTestCase {
             properties: ["order amount": "a lot of money"]
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(anonymousId: anonymousId)
+        let apiProfile = ProfilePayload(profile, anonymousId: anonymousId)
 
         XCTAssertEqual(apiProfile.attributes.email, profile.email)
         XCTAssertEqual(apiProfile.attributes.phoneNumber, profile.phoneNumber)
@@ -59,7 +59,8 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
+        let apiProfile = ProfilePayload(
+            profile,
             email: "walter.white@breakingbad.com",
             phoneNumber: "1800-better-call-saul",
             externalId: "999",
@@ -85,7 +86,8 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
+        let apiProfile = ProfilePayload(
+            profile,
             anonymousId: anonymousId)
 
         XCTAssertNil(apiProfile.attributes.email)
@@ -105,7 +107,8 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
+        let apiProfile = ProfilePayload(
+            profile,
             email: "test@blob.com    ",
             phoneNumber: "+12345678901    ",
             externalId: "a       ",

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -7,6 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
+import KlaviyoCore
 import XCTest
 
 class KlaviyoModelsTest: XCTestCase {
@@ -88,7 +89,8 @@ class KlaviyoModelsTest: XCTestCase {
         let anonymousId = "C10H15N"
         let apiProfile = ProfilePayload(
             profile,
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
 
         XCTAssertNil(apiProfile.attributes.email)
         XCTAssertNil(apiProfile.attributes.phoneNumber)

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -131,7 +131,7 @@ final class KlaviyoStateTests: XCTestCase {
         let eventRequest = KlaviyoRequest(endpoint: .createEvent("foo", createEventPayload))
 
         let profile = Profile.test
-        let payload = CreateProfilePayload(data: profile.toAPIModel(anonymousId: "foo"))
+        let payload = CreateProfilePayload(data: ProfilePayload(profile, anonymousId: "foo"))
 
         let profileRequest = KlaviyoRequest(endpoint: .createProfile("foo", payload))
         let tokenPayload = PushTokenPayload(

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -627,8 +627,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )
@@ -657,7 +659,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.enqueueProfile(profile)) {
             // No reset (same email), so anonymousId unchanged
             // A createProfile request should be enqueued with the updated attributes
-            let profilePayload = profile.toAPIModel(
+            let profilePayload = ProfilePayload(
+                profile,
                 email: $0.email,
                 phoneNumber: $0.phoneNumber,
                 externalId: $0.externalId,
@@ -704,8 +707,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "different@email.com", phoneNumber: "+15555555555")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "different@email.com", phoneNumber: "+15555555555"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )
@@ -751,7 +756,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: profile.toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(profile, anonymousId: $0.anonymousId!)
                     )
                 )
             )
@@ -796,8 +801,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile()
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(Profile(), anonymousId: $0.anonymousId!)
                     )
                 )
             )

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -551,7 +551,8 @@ class StateManagementTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile.test.toAPIModel(
+                        profile: ProfilePayload(
+                            Profile.test,
                             anonymousId: initialState.anonymousId!
                         )
                     )
@@ -579,8 +580,10 @@ class StateManagementTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )


### PR DESCRIPTION
# Description
Replaces the `toAPIModel` conversion convention with "failable" optional / conversion initializers on the API model types themselves, as discussed in the review of #648. Behavior is unchanged — this is an internal refactor only.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
Follow-up to the `toAPIModel` discussion on #648. Moves the model-mapping helpers onto the destination types as initializers:

- **`SubscriptionAPIExtension.swift`** — `Subscription.Channels.toAPIModel` is replaced by failable inits on the API types:
  - `EmailConsent.init?(_ options: Subscription.Channels.Email)`
  - `MarketingTransactionalConsent.init?(_ options: Subscription.Channels.Messaging)`
  - `SubscriptionChannels.init?(_ channels: Subscription.Channels)`
  - `needsEmail` / `needsPhone` remain on `Subscription.Channels`.
- **`ProfileAPIExtension.swift`** — `Profile.toAPIModel(...)` and `Profile.Location.toAPILocation` become conversion inits:
  - `ProfilePayload.init(_ profile: Profile, email:phoneNumber:externalId:anonymousId:)`
  - `ProfilePayload.Attributes.Location.init(_ location: Profile.Location)`
- Call sites in `KlaviyoState.swift` and `StateManagement.swift` now read e.g. `SubscriptionChannels(requestedChannels)` and `ProfilePayload(profile, anonymousId:)`.
- Tests updated to the new initializer call style.

## Test Plan
Existing reducer/state tests exercise these conversions (profile payload building, push token registration, subscription request building). No new behavior — all prior assertions hold with the new initializer syntax.

## Related Issues/Tickets
Follow-up to review feedback on #648 (create client subscription API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkV8p27SaLMvGgZkeHFY6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkV8p27SaLMvGgZkeHFY6d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Refreshed API payload construction for profile registration and push-token flows, including whitespace trimming and handling optional identifiers.
  - Updated location mapping to safely translate all location fields (including address/coordinates and timezone) into the API payload.
  - Improved subscription consent mapping by converting requested email, SMS, and WhatsApp channels into the correct API consent structure.
- **Bug Fixes**
  - Prevented unsupported/empty consent combinations from being included in API requests.
- **Tests**
  - Updated unit tests to validate the revised profile and subscription request payload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->