### PR TITLE
refactor(KlaviyoSwift): extract transforms/validation out of the reducer into focused files (MAGE-900)

### DIFF
--- a/Sources/KlaviyoSwift/Models/EventAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/EventAPIExtension.swift
@@ -1,0 +1,39 @@
+//
+//  EventAPIExtension.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/20/26.
+//
+
+import Foundation
+import KlaviyoCore
+
+extension Event {
+    /// Returns a copy of the event stamped with the given profile identifiers.
+    /// For opened-push events, the push token (when present) is added to the
+    /// event properties.
+    func updateEventWithIdentifiers(
+        email: String?,
+        phoneNumber: String?,
+        externalId: String?,
+        pushToken: String?
+    ) -> Event {
+        let identifiers = Identifiers(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId
+        )
+        var properties = properties
+        if metric.name == EventName._openedPush,
+           let pushToken {
+            properties["push_token"] = pushToken
+        }
+        return Event(name: metric.name,
+                     properties: properties,
+                     identifiers: identifiers,
+                     value: value,
+                     time: time,
+                     uniqueId: uniqueId)
+    }
+}

--- a/Sources/KlaviyoSwift/Models/Profile.swift
+++ b/Sources/KlaviyoSwift/Models/Profile.swift
@@ -125,3 +125,86 @@ public struct Profile: Equatable, Codable {
         _properties = AnyCodable(properties ?? [:])
     }
 }
+
+extension Profile {
+    static func updateProfileWithProperties(
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil,
+        dict: [Profile.ProfileKey: AnyEncodable]
+    ) -> Self {
+        var firstName: String?
+        var lastName: String?
+        var address1: String?
+        var address2: String?
+        var title: String?
+        var organization: String?
+        var city: String?
+        var region: String?
+        var country: String?
+        var zip: String?
+        var image: String?
+        var latitude: Double?
+        var longitude: Double?
+        var customProperties: [String: Any] = [:]
+
+        for (key, value) in dict {
+            switch key {
+            case .firstName:
+                firstName = value.value as? String
+            case .lastName:
+                lastName = value.value as? String
+            case .address1:
+                address1 = value.value as? String
+            case .address2:
+                address2 = value.value as? String
+            case .title:
+                title = value.value as? String
+            case .organization:
+                organization = value.value as? String
+            case .city:
+                city = value.value as? String
+            case .region:
+                region = value.value as? String
+            case .country:
+                country = value.value as? String
+            case .zip:
+                zip = value.value as? String
+            case .image:
+                image = value.value as? String
+            case .latitude:
+                latitude = value.value as? Double
+            case .longitude:
+                longitude = value.value as? Double
+            case let .custom(customKey: customKey):
+                customProperties[customKey] = value.value
+            }
+        }
+
+        let location = Profile.Location(
+            address1: address1,
+            address2: address2,
+            city: city,
+            country: country,
+            latitude: latitude,
+            longitude: longitude,
+            region: region,
+            zip: zip
+        )
+
+        let profile = Profile(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            firstName: firstName,
+            lastName: lastName,
+            organization: organization,
+            title: title,
+            image: image,
+            location: location,
+            properties: customProperties
+        )
+
+        return profile
+    }
+}

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -13,6 +13,22 @@ extension String {
         let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedString.isEmpty ? nil : trimmedString
     }
+
+    /// Returns `true` when the trimmed string is non-empty and differs from the
+    /// currently stored value. Emits a developer warning (and returns `false`)
+    /// when the incoming value is empty or unchanged.
+    internal func isNotEmptyOrSame(as state: String?, identifier: String) -> Bool {
+        let incoming = trimmingCharacters(in: .whitespacesAndNewlines)
+        if incoming.isEmpty || incoming == state {
+            environment.emitDeveloperWarning("""
+            \(identifier) is either empty or same as what is already set earlier.
+            The SDK will ignore this change, please use resetProfile for
+            resetting profile identifiers
+            """)
+        }
+
+        return !incoming.isEmpty && incoming != state
+    }
 }
 
 extension Profile {

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -424,14 +424,6 @@ private func removeStateFile(at file: URL) {
     }
 }
 
-private func logDevWarning(for identifier: String) {
-    environment.emitDeveloperWarning("""
-    \(identifier) is either empty or same as what is already set earlier.
-    The SDK will ignore this change, please use resetProfile for
-    resetting profile identifiers
-    """)
-}
-
 /// Loads SDK state from disk
 /// - Parameter apiKey: the API key that uniquely identiifies the company
 /// - Returns: an instance of the `KlaviyoState`
@@ -466,98 +458,4 @@ private func createAndStoreInitialState(with apiKey: String, at file: URL) -> Kl
     let state = KlaviyoState(apiKey: apiKey, anonymousId: anonymousId, queue: [], requestsInFlight: [])
     storeKlaviyoState(state: state, file: file)
     return state
-}
-
-extension Profile {
-    fileprivate static func updateProfileWithProperties(
-        email: String? = nil,
-        phoneNumber: String? = nil,
-        externalId: String? = nil,
-        dict: [Profile.ProfileKey: AnyEncodable]
-    ) -> Self {
-        var firstName: String?
-        var lastName: String?
-        var address1: String?
-        var address2: String?
-        var title: String?
-        var organization: String?
-        var city: String?
-        var region: String?
-        var country: String?
-        var zip: String?
-        var image: String?
-        var latitude: Double?
-        var longitude: Double?
-        var customProperties: [String: Any] = [:]
-
-        for (key, value) in dict {
-            switch key {
-            case .firstName:
-                firstName = value.value as? String
-            case .lastName:
-                lastName = value.value as? String
-            case .address1:
-                address1 = value.value as? String
-            case .address2:
-                address2 = value.value as? String
-            case .title:
-                title = value.value as? String
-            case .organization:
-                organization = value.value as? String
-            case .city:
-                city = value.value as? String
-            case .region:
-                region = value.value as? String
-            case .country:
-                country = value.value as? String
-            case .zip:
-                zip = value.value as? String
-            case .image:
-                image = value.value as? String
-            case .latitude:
-                latitude = value.value as? Double
-            case .longitude:
-                longitude = value.value as? Double
-            case let .custom(customKey: customKey):
-                customProperties[customKey] = value.value
-            }
-        }
-
-        let location = Profile.Location(
-            address1: address1,
-            address2: address2,
-            city: city,
-            country: country,
-            latitude: latitude,
-            longitude: longitude,
-            region: region,
-            zip: zip
-        )
-
-        let profile = Profile(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
-            firstName: firstName,
-            lastName: lastName,
-            organization: organization,
-            title: title,
-            image: image,
-            location: location,
-            properties: customProperties
-        )
-
-        return profile
-    }
-}
-
-extension String {
-    fileprivate func isNotEmptyOrSame(as state: String?, identifier: String) -> Bool {
-        let incoming = trimmingCharacters(in: .whitespacesAndNewlines)
-        if incoming.isEmpty || incoming == state {
-            logDevWarning(for: identifier)
-        }
-
-        return !incoming.isEmpty && incoming != state
-    }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -468,7 +468,12 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            event = event.updateEventWithState(state: &state)
+            event = event.updateEventWithIdentifiers(
+                email: state.email,
+                phoneNumber: state.phoneNumber,
+                externalId: state.externalId,
+                pushToken: state.pushTokenData?.pushToken
+            )
 
             let payload = CreateEventPayload(
                 data: CreateEventPayload.Event(
@@ -696,25 +701,4 @@ extension Store where State == KlaviyoState, Action == KlaviyoAction {
         initialState: KlaviyoState(queue: [], requestsInFlight: []),
         reducer: KlaviyoReducer()
     )
-}
-
-extension Event {
-    func updateEventWithState(state: inout KlaviyoState) -> Event {
-        let identifiers = Identifiers(
-            email: state.email,
-            phoneNumber: state.phoneNumber,
-            externalId: state.externalId
-        )
-        var properties = properties
-        if metric.name == EventName._openedPush,
-           let pushToken = state.pushTokenData?.pushToken {
-            properties["push_token"] = pushToken
-        }
-        return Event(name: metric.name,
-                     properties: properties,
-                     identifiers: identifiers,
-                     value: value,
-                     time: time,
-                     uniqueId: uniqueId)
-    }
 }

--- a/Tests/KlaviyoSwiftTests/EventAPIExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventAPIExtensionTests.swift
@@ -1,0 +1,68 @@
+//
+//  EventAPIExtensionTests.swift
+//
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+final class EventAPIExtensionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+    }
+
+    func testStampsIdentifiersAndPreservesFields() {
+        let event = Event(
+            name: .customEvent("test"),
+            properties: ["foo": "bar"],
+            value: 42,
+            uniqueId: "unique-id"
+        )
+
+        let updated = event.updateEventWithIdentifiers(
+            email: "test@example.com",
+            phoneNumber: "+15551234567",
+            externalId: "ext-1",
+            pushToken: "token"
+        )
+
+        XCTAssertEqual(updated.identifiers?.email, "test@example.com")
+        XCTAssertEqual(updated.identifiers?.phoneNumber, "+15551234567")
+        XCTAssertEqual(updated.identifiers?.externalId, "ext-1")
+        // Existing fields are preserved.
+        XCTAssertEqual(updated.properties["foo"] as? String, "bar")
+        XCTAssertEqual(updated.value, 42)
+        XCTAssertEqual(updated.uniqueId, "unique-id")
+        XCTAssertEqual(updated.metric.name, .customEvent("test"))
+        // Non-opened-push events never receive a push token.
+        XCTAssertNil(updated.properties["push_token"])
+    }
+
+    func testAddsPushTokenForOpenedPush() {
+        let event = Event(name: ._openedPush)
+
+        let updated = event.updateEventWithIdentifiers(
+            email: nil,
+            phoneNumber: nil,
+            externalId: nil,
+            pushToken: "token"
+        )
+
+        XCTAssertEqual(updated.properties["push_token"] as? String, "token")
+    }
+
+    func testOmitsPushTokenForOpenedPushWhenNil() {
+        let event = Event(name: ._openedPush)
+
+        let updated = event.updateEventWithIdentifiers(
+            email: nil,
+            phoneNumber: nil,
+            externalId: nil,
+            pushToken: nil
+        )
+
+        XCTAssertNil(updated.properties["push_token"])
+    }
+}

--- a/Tests/KlaviyoSwiftTests/ProfileAPIExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/ProfileAPIExtensionTests.swift
@@ -1,0 +1,50 @@
+//
+//  ProfileAPIExtensionTests.swift
+//
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+final class ProfileAPIExtensionTests: XCTestCase {
+    private var warnings: [String] = []
+
+    override func setUp() {
+        super.setUp()
+        warnings = []
+        environment = KlaviyoEnvironment.test()
+        environment.emitDeveloperWarning = { [weak self] in self?.warnings.append($0) }
+    }
+
+    func testDifferentNonEmptyValueReturnsTrueWithoutWarning() {
+        XCTAssertTrue("new@example.com".isNotEmptyOrSame(as: "old@example.com", identifier: "email"))
+        XCTAssertTrue(warnings.isEmpty)
+    }
+
+    func testValueAgainstNilStateReturnsTrue() {
+        XCTAssertTrue("new@example.com".isNotEmptyOrSame(as: nil, identifier: "email"))
+        XCTAssertTrue(warnings.isEmpty)
+    }
+
+    func testSameValueReturnsFalseAndWarns() {
+        XCTAssertFalse("same@example.com".isNotEmptyOrSame(as: "same@example.com", identifier: "email"))
+        XCTAssertEqual(warnings.count, 1)
+    }
+
+    func testEmptyValueReturnsFalseAndWarns() {
+        XCTAssertFalse("".isNotEmptyOrSame(as: "old@example.com", identifier: "email"))
+        XCTAssertEqual(warnings.count, 1)
+    }
+
+    func testWhitespaceOnlyValueReturnsFalseAndWarns() {
+        XCTAssertFalse("   ".isNotEmptyOrSame(as: "old@example.com", identifier: "email"))
+        XCTAssertEqual(warnings.count, 1)
+    }
+
+    func testValueIsTrimmedBeforeComparison() {
+        // Trimmed value equals the stored value -> treated as unchanged.
+        XCTAssertFalse("  same  ".isNotEmptyOrSame(as: "same", identifier: "email"))
+        XCTAssertEqual(warnings.count, 1)
+    }
+}


### PR DESCRIPTION
# Description
Extracts pure transform/validation logic out of the `KlaviyoSwift` reducer files into focused, well-homed files — **all kept in KlaviyoSwift**. No behavior change.

## Why this matters for Phase 3
Phase 3 ([MAGE-892](https://linear.app/klaviyo/issue/MAGE-892/phase-3-migrate-more-off-klaviyoswift-to-klaviyocore)) progressively shrinks the TCA reducer down to just the flush lifecycle. `KlaviyoState.swift` and `StateManagement.swift` are the largest, most-churned files in that effort and the ones every later ticket touches. This peels off logic with **no** reducer-state dependency so those files get smaller and clearer ahead of the heavier extractions (queue → `QueueStore`, identity/config → canonical Core stores):

- The two reducer files shed **~116 lines** of pure logic (`KlaviyoState.swift` −102, `StateManagement.swift` net −~14).
- Each helper is re-homed next to the type it belongs to, making the reducer's responsibilities clearer.

**Deliberately kept in KlaviyoSwift, not moved to Core.** These are business logic (SDK-specific identity-change rules, analytics event enrichment) used only within KlaviyoSwift. Core should hold shared types + generic infrastructure, not feature-module business rules — moving them down would pollute the shared layer and mislabel rules as utilities. The reducer-shrinking win comes from extraction into focused files, which doesn't require crossing the module boundary.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

No public API changes and no changes to KlaviyoCore.

## Changelog / Code Overview
- **`Profile.updateProfileWithProperties`** moved out of `KlaviyoState.swift` onto the `Profile` model (`Profile.swift`) — profile construction belongs on the model, not the state file. `fileprivate static` → `static`.
- **`Event.updateEventWithIdentifiers`** (was `updateEventWithState`) moved into a new `EventAPIExtension.swift`. It took `inout KlaviyoState` but never mutated it — only read `email/phoneNumber/externalId/pushToken` — so it now takes those identity primitives, decoupling it from `KlaviyoState`. Single reducer call site updated. Output byte-for-byte identical.
- **`String.isNotEmptyOrSame`** moved next to its sibling `trimWhiteSpaceOrReturnNilIfEmpty` in `ProfileAPIExtension.swift` (both are used together in the identity setters). The now-orphaned `logDevWarning` was removed and its (unchanged) warning inlined.
- **Added KlaviyoSwiftTests** for the Event and String helpers (`EventAPIExtensionTests`, `ProfileAPIExtensionTests`).

## Test Plan
- `xcodebuild build -scheme klaviyo-swift-sdk-Package` → **BUILD SUCCEEDED** (all modules).
- `KlaviyoSwiftTests`: 217 passed, 0 failures (was 208; +9 new: 3 Event + 6 String).
- `KlaviyoCoreTests`: 121 passed, 0 failures (Core unchanged by this PR).

## Related Issues/Tickets
[MAGE-900](https://linear.app/klaviyo/issue/MAGE-900/move-pure-transformsvalidation-into-core-helpers) · parent [MAGE-892](https://linear.app/klaviyo/issue/MAGE-892/phase-3-migrate-more-off-klaviyoswift-to-klaviyocore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for updating events with email, phone number, external ID, and push token identifiers.
  - Added profile creation and updates using standard and custom properties.
  - Push tokens are automatically included for push-opened events when available.

- **Bug Fixes**
  - Improved handling of empty, whitespace-only, or unchanged profile identifiers.
  - Preserved existing event details when identifiers are updated.

- **Tests**
  - Added coverage for event identifier updates, push-token behavior, and profile identifier validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->