### PR TITLE
refactor(KlaviyoSwift): extract tracking-link resolution into TrackingLinkManager (MAGE-902)

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -117,9 +117,6 @@ enum KlaviyoAction: Equatable {
     /// This action makes a call to an engtrack service that will return the destination link *and* log the click.
     case trackingLinkReceived(URL)
 
-    /// when we've successfully resolved the tracking link into a destination link
-    case trackingLinkDestinationResolved(URL)
-
     /// when the attempt to resolve the tracking link into a destination link fails.
     /// This action will enqueue a request that, when delivered, will log the click via the engtrack service.
     case trackingLinkResolutionFailed(trackingLink: URL, clickTime: Date)
@@ -133,7 +130,7 @@ enum KlaviyoAction: Equatable {
         case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
             return true
 
-        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .trackingLinkReceived, .trackingLinkDestinationResolved, .trackingLinkResolutionFailed:
+        case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .trackingLinkReceived, .trackingLinkResolutionFailed:
             return false
         }
     }
@@ -617,6 +614,10 @@ struct KlaviyoReducer: ReducerProtocol {
             return .task { .deQueueCompletedResults(request) }
 
         case let .trackingLinkReceived(trackingLinkURL):
+            // Thin entry point: the resolution work lives in `TrackingLinkManager`.
+            // This case only remains in the reducer to read identity and (on
+            // failure) enqueue; it will fold into the manager once identity and the
+            // queue are canonical in KlaviyoCore. See `TrackingLinkManager`.
             let clickTime = environment.date()
 
             if #available(iOS 14.0, *) {
@@ -631,45 +632,22 @@ struct KlaviyoReducer: ReducerProtocol {
             )
 
             return .run { send in
-                do {
-                    let endpoint = KlaviyoEndpoint.resolveDestinationURL(
-                        trackingLink: trackingLinkURL,
-                        profileInfo: profileInfo
-                    )
-                    let klaviyoRequest = KlaviyoRequest(endpoint: endpoint)
-                    let attemptInfo = try RequestAttemptInfo(attemptNumber: 1, maxAttempts: endpoint.maxRetries)
-                    let result = await environment.klaviyoAPI.send(klaviyoRequest, attemptInfo)
-
-                    switch result {
-                    case let .success(data):
-                        let response: TrackingLinkDestinationResponse = try environment.decoder.decode(data)
-                        let destinationURL = response.destinationLink
-
-                        if #available(iOS 14.0, *) {
-                            Logger.stateLogger.info("Successfully resolved tracking link destination. Destination URL: '\(destinationURL.absoluteString)'")
-                        }
-
-                        await send(.trackingLinkDestinationResolved(destinationURL))
-                    case let .failure(error):
-                        if #available(iOS 14.0, *) {
-                            Logger.stateLogger.warning("Unable to resolve tracking link destination; error:\n'\(error)'")
-                        }
-                        await send(.trackingLinkResolutionFailed(trackingLink: trackingLinkURL, clickTime: clickTime))
-                    }
-                } catch {
-                    if #available(iOS 14.0, *) {
-                        Logger.stateLogger.warning("Unable to resolve tracking link destination; error:\n'\(error)'")
-                    }
+                let outcome = await TrackingLinkManager.resolveDestination(
+                    trackingLink: trackingLinkURL,
+                    profileInfo: profileInfo
+                )
+                switch outcome {
+                case let .resolved(destinationURL):
+                    await DeepLinkManager.openDeepLink(destinationURL)
+                case .failed:
                     await send(.trackingLinkResolutionFailed(trackingLink: trackingLinkURL, clickTime: clickTime))
                 }
             }
 
-        case let .trackingLinkDestinationResolved(url):
-            return .run { _ in
-                await DeepLinkManager.openDeepLink(url)
-            }
-
         case let .trackingLinkResolutionFailed(trackingLink, clickTime):
+            // Kept in the reducer only for the enqueue below (a state mutation).
+            // Folds into `TrackingLinkManager` once the queue is canonical in
+            // KlaviyoCore.
             let profileInfo = ProfilePayload(
                 email: state.email,
                 phoneNumber: state.phoneNumber,

--- a/Sources/KlaviyoSwift/TrackingLinkManager.swift
+++ b/Sources/KlaviyoSwift/TrackingLinkManager.swift
@@ -1,0 +1,72 @@
+//
+//  TrackingLinkManager.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/20/26.
+//
+
+import Foundation
+import KlaviyoCore
+import OSLog
+
+/// Owns the tracking-link (click-tracking) resolution flow.
+///
+/// Today this manager holds only the state-free work — the network resolve,
+/// decode, logging, and navigation. The reducer keeps two thin cases
+/// (`trackingLinkReceived`, `trackingLinkResolutionFailed`) solely
+/// because they touch reducer-owned state: reading identity to build the
+/// `ProfilePayload`, and enqueuing the click-log request on failure.
+///
+/// Once identity and the request queue become canonical in `KlaviyoCore` (an
+/// `IdentityStore` that is the source of truth and a queue that can be enqueued
+/// into from anywhere), both of those reducer cases can be folded into this
+/// manager: it will read identity from `IdentityStore`, enqueue the failure
+/// request directly, and be invoked straight from the SDK entry point — at which
+/// point the two reducer cases are deleted.
+enum TrackingLinkManager {
+    /// The result of resolving a Klaviyo tracking link to its destination.
+    enum Outcome: Equatable {
+        case resolved(URL)
+        case failed
+    }
+
+    /// Resolves a Klaviyo tracking link to its destination URL via the engtrack
+    /// service. Returns `.resolved` with the destination on success, or `.failed`
+    /// if the request or decode fails (the caller logs the click via the failure
+    /// path).
+    static func resolveDestination(
+        trackingLink: URL,
+        profileInfo: ProfilePayload
+    ) async -> Outcome {
+        do {
+            let endpoint = KlaviyoEndpoint.resolveDestinationURL(
+                trackingLink: trackingLink,
+                profileInfo: profileInfo
+            )
+            let klaviyoRequest = KlaviyoRequest(endpoint: endpoint)
+            let attemptInfo = try RequestAttemptInfo(attemptNumber: 1, maxAttempts: endpoint.maxRetries)
+            let result = await environment.klaviyoAPI.send(klaviyoRequest, attemptInfo)
+
+            switch result {
+            case let .success(data):
+                let response: TrackingLinkDestinationResponse = try environment.decoder.decode(data)
+                let destinationURL = response.destinationLink
+                if #available(iOS 14.0, *) {
+                    Logger.stateLogger.info("Successfully resolved tracking link destination. Destination URL: '\(destinationURL.absoluteString)'")
+                }
+                return .resolved(destinationURL)
+            case let .failure(error):
+                if #available(iOS 14.0, *) {
+                    Logger.stateLogger.warning("Unable to resolve tracking link destination; error:\n'\(error)'")
+                }
+                return .failed
+            }
+        } catch {
+            if #available(iOS 14.0, *) {
+                Logger.stateLogger.warning("Unable to resolve tracking link destination; error:\n'\(error)'")
+            }
+            return .failed
+        }
+    }
+}

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -56,7 +56,7 @@ final class ResolveTrackingLinkTests: XCTestCase {
             return .success(responseData)
         }
 
-        // Observe the deep-link open that trackingLinkDestinationResolved triggers.
+        // On success the reducer routes the destination straight to DeepLinkManager.
         let opened = expectation(description: "openDeepLink invoked with destination")
         DeepLinkManager.openDeepLinkSpy = { url in
             XCTAssertEqual(url, destinationURL)
@@ -66,7 +66,6 @@ final class ResolveTrackingLinkTests: XCTestCase {
         // When
         await store.send(.trackingLinkReceived(trackingLinkURL))
         // Then
-        await store.receive(.trackingLinkDestinationResolved(destinationURL))
         await fulfillment(of: [opened], timeout: 1.0)
         await store.finish()
     }
@@ -104,7 +103,7 @@ final class ResolveTrackingLinkTests: XCTestCase {
             return .success(responseData)
         }
 
-        // Observe the deep-link open that trackingLinkDestinationResolved triggers.
+        // Tracking-link resolution is not init-gated, so it still resolves and navigates.
         let opened = expectation(description: "openDeepLink invoked with destination")
         DeepLinkManager.openDeepLinkSpy = { url in
             XCTAssertEqual(url, destinationURL)
@@ -114,7 +113,6 @@ final class ResolveTrackingLinkTests: XCTestCase {
         // When
         await store.send(.trackingLinkReceived(trackingLinkURL))
         // Then
-        await store.receive(.trackingLinkDestinationResolved(destinationURL))
         await fulfillment(of: [opened], timeout: 1.0)
         await store.finish()
     }
@@ -192,25 +190,5 @@ final class ResolveTrackingLinkTests: XCTestCase {
 
             $0.queue = [request]
         }
-    }
-
-    @MainActor
-    func testTrackingLinkDestinationResolvedTriggersOpenDeepLink() async throws {
-        // Given
-        let destinationURL = try XCTUnwrap(URL(string: "https://example.com/destination"))
-        let store = TestStore(initialState: INITIALIZED_TEST_STATE(), reducer: KlaviyoReducer())
-
-        let opened = expectation(description: "openDeepLink invoked with destination")
-        DeepLinkManager.openDeepLinkSpy = { url in
-            XCTAssertEqual(url, destinationURL)
-            opened.fulfill()
-        }
-
-        // When
-        await store.send(.trackingLinkDestinationResolved(destinationURL))
-
-        // Then the reducer should route the destination through DeepLinkManager.
-        await fulfillment(of: [opened], timeout: 1.0)
-        await store.finish()
     }
 }

--- a/Tests/KlaviyoSwiftTests/TrackingLinkManagerTests.swift
+++ b/Tests/KlaviyoSwiftTests/TrackingLinkManagerTests.swift
@@ -1,0 +1,75 @@
+//
+//  TrackingLinkManagerTests.swift
+//
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+final class TrackingLinkManagerTests: XCTestCase {
+    private let trackingLink = URL(string: "https://email.klaviyo.com/tracking/link")!
+    private let profileInfo = ProfilePayload(
+        email: "test@example.com",
+        phoneNumber: nil,
+        externalId: nil,
+        anonymousId: "anon-1"
+    )
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+    }
+
+    func testResolveDestinationReturnsResolvedOnSuccess() async throws {
+        let destinationURL = try XCTUnwrap(URL(string: "https://example.com/destination"))
+        let responseData = try XCTUnwrap("""
+        {
+            "original_destination": "\(destinationURL.absoluteString)"
+        }
+        """.data(using: .utf8))
+
+        environment.decoder = DataDecoder(jsonDecoder: JSONDecoder())
+        environment.klaviyoAPI.send = { request, _ in
+            XCTAssertEqual(request.endpoint, KlaviyoEndpoint.resolveDestinationURL(
+                trackingLink: self.trackingLink,
+                profileInfo: self.profileInfo
+            ))
+            return .success(responseData)
+        }
+
+        let outcome = await TrackingLinkManager.resolveDestination(
+            trackingLink: trackingLink,
+            profileInfo: profileInfo
+        )
+
+        XCTAssertEqual(outcome, .resolved(destinationURL))
+    }
+
+    func testResolveDestinationReturnsFailedOnAPIError() async {
+        environment.klaviyoAPI.send = { _, _ in
+            .failure(.networkError(NSError(domain: "foo", code: NSURLErrorCancelled)))
+        }
+
+        let outcome = await TrackingLinkManager.resolveDestination(
+            trackingLink: trackingLink,
+            profileInfo: profileInfo
+        )
+
+        XCTAssertEqual(outcome, .failed)
+    }
+
+    func testResolveDestinationReturnsFailedOnDecodeError() async throws {
+        let responseData = try XCTUnwrap("{}".data(using: .utf8))
+        environment.decoder = DataDecoder(jsonDecoder: InvalidJSONDecoder())
+        environment.klaviyoAPI.send = { _, _ in .success(responseData) }
+
+        let outcome = await TrackingLinkManager.resolveDestination(
+            trackingLink: trackingLink,
+            profileInfo: profileInfo
+        )
+
+        XCTAssertEqual(outcome, .failed)
+    }
+}


### PR DESCRIPTION
# Description
Extracts the tracking-link (click-tracking) resolution async flow out of the `KlaviyoSwift` reducer into a new `TrackingLinkManager`, mirroring the `DeepLinkManager` (MAGE-899) / `BadgeManager` (MAGE-898) pattern. No behavior change.

## Why this matters for Phase 3
Phase 3 ([MAGE-892](https://linear.app/klaviyo/issue/MAGE-892/phase-3-migrate-more-off-klaviyoswift-to-klaviyocore)) progressively shrinks the TCA reducer toward just the flush lifecycle. `StateManagement.swift` is the largest, most-churned file in that effort. This peels the resolve → decode → log flow into a focused manager and drops a dead intermediate action:

- The reducer's `.trackingLinkReceived` shrinks to a thin delegate; the network/decode/log logic moves to `TrackingLinkManager`.
- One action is deleted (`.trackingLinkDestinationResolved`), matching how MAGE-899 dropped its intermediate `.openDeepLink` / `.deepLinkProcessingCompleted` actions.

## Approach (thin reducer cases delegating to the manager)
The reducer keeps thin cases only for the two things it must own; the work moves to the manager:

- **`.trackingLinkReceived(url)` — kept** (real entry point, dispatched from `Klaviyo.swift:184`). Reads identity to build `ProfilePayload`, then delegates resolution to `TrackingLinkManager.resolveDestination(...)`. On `.resolved(dest)` → `DeepLinkManager.openDeepLink(dest)`; on `.failed` → dispatch `.trackingLinkResolutionFailed`.
- **`.trackingLinkResolutionFailed` — kept** (owns a state mutation: `state.enqueueRequest(...)`). A reducer effect can't mutate state after an `await`, so the failure path returns as an action.
- **`.trackingLinkDestinationResolved` — dropped** (internal-only; its whole body was `DeepLinkManager.openDeepLink`, now reached directly from the run block).

## Follow-up (documented in code)
Both remaining reducer cases are anchored to reducer-owned state — the identity **read** and the queue **write**. Once identity and the request queue become canonical in `KlaviyoCore` (canonical `IdentityStore` + a queue enqueue-able from anywhere), both cases fold into `TrackingLinkManager` and `Klaviyo.swift` calls it directly. This is documented on the manager type and at each reducer case (no ticket ids in source, per repo convention).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

No public API changes and no KlaviyoCore changes.

## Changelog / Code Overview
- **New `TrackingLinkManager.swift`** — `resolveDestination(trackingLink:profileInfo:) async -> Outcome` (`.resolved(URL)` / `.failed`) owning the endpoint build, `klaviyoAPI.send`, decode, and logging; plus a doc comment describing the future full collapse.
- **`StateManagement.swift`** — thin `.trackingLinkReceived`; removed `.trackingLinkDestinationResolved` (declaration, `requiresInitialization` entry, case body); brief pointer comments on the two remaining cases.
- **Tests** — new `TrackingLinkManagerTests` (resolve success / API failure / decode failure); `ResolveTrackingLinkTests` updated for the dropped intermediate action.

## Test Plan
- `xcodebuild build -scheme klaviyo-swift-sdk-Package` → **BUILD SUCCEEDED** (all modules).
- `KlaviyoSwiftTests`: 210 passed, 0 failures — incl. `ResolveTrackingLinkTests` (4: resolve→navigate, uninitialized, failure→enqueue, decode-error→enqueue) and `TrackingLinkManagerTests` (3).

## Related Issues/Tickets
[MAGE-902](https://linear.app/klaviyo/issue/MAGE-902/extract-tracking-link-resolution-into-trackinglinkmanager) · parent [MAGE-892](https://linear.app/klaviyo/issue/MAGE-892/phase-3-migrate-more-off-klaviyoswift-to-klaviyocore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tracking links now resolve destinations through a dedicated flow before opening the resulting deep link.
  * Failed tracking-link resolution is handled gracefully while still recording the interaction.

* **Bug Fixes**
  * Improved handling of network and response errors during tracking-link resolution.

* **Tests**
  * Added coverage for successful resolution, network failures, and invalid responses.
  * Updated deep-link tests to verify the resolved destination is opened correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->