### PR TITLE
ci: bump pinned SwiftFormat 0.51.2 → 0.59.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: swiftlint
         entry: swiftlint --fix --strict
 -   repo: https://github.com/nicklockwood/SwiftFormat
-    rev: 0.51.2
+    rev: 0.59.1
     hooks:
     -   id: swiftformat
         entry: swiftformat

--- a/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/CocoapodsExample/NotificationServiceExtension/NotificationService.swift
@@ -46,8 +46,8 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
-        /// Called just before the extension will be terminated by the system.
-        /// Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+        // Called just before the extension will be terminated by the system.
+        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
         if let contentHandler = contentHandler,
            let bestAttemptContent = bestAttemptContent {
             KlaviyoExtensionSDK.handleNotificationServiceExtensionTimeWillExpireRequest(

--- a/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/NotificationServiceExtension/NotificationService.swift
@@ -56,8 +56,8 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
-        /// Called just before the extension will be terminated by the system.
-        /// Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+        // Called just before the extension will be terminated by the system.
+        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
         if let contentHandler = contentHandler,
            let bestAttemptContent = bestAttemptContent {
             KlaviyoExtensionSDK.handleNotificationServiceExtensionTimeWillExpireRequest(

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import KlaviyoForms
 import KlaviyoLocation
+
 // STEP1: Importing klaviyo SDK modules into your app code
 // `KlaviyoSwift` is for analytics and push notifications and `KlaviyoForms` is for presenting marketing in app forms/messages
 import KlaviyoSwift
@@ -70,7 +71,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    // example of registering for forms to display on the applicationDidBecomeActive lifecycle event (every foreground event)
+    /// example of registering for forms to display on the applicationDidBecomeActive lifecycle event (every foreground event)
     func applicationDidBecomeActive(_ application: UIApplication) {
         KlaviyoSDK().registerForInAppForms()
     }
@@ -193,7 +194,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 // STEP6: Add this extension on AppDelegate for additional push notifications handling
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    // below method will be called when the user interacts with the push notification
+    /// below method will be called when the user interacts with the push notification
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
@@ -207,7 +208,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 
-    // below method is called when the app receives push notifications when the app is the foreground
+    /// below method is called when the app receives push notifications when the app is the foreground
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,

--- a/Examples/KlaviyoSwiftExamples/Shared/Cart.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/Cart.swift
@@ -15,7 +15,7 @@ class Cart {
         initializeCart()
     }
 
-    /*
+    /**
      Returns the quantity of a given item in the cart
      */
     func numberOfItemsInBasket(_ menuItem: MenuItem) -> Int {
@@ -26,7 +26,7 @@ class Cart {
             }
     }
 
-    // Check standard defaults to see what is in the cart
+    /// Check standard defaults to see what is in the cart
     func initializeCart() {
         guard let items = UserDefaults.standard.object(forKey: "cartItems") as? [String]
         else {

--- a/Examples/KlaviyoSwiftExamples/Shared/DeepLinking.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/DeepLinking.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// This should be an exhaustive list of deep linking paths that are handled by the app
+/// This should be an exhaustive list of deep linking paths that are handled by the app
 enum DeepLinking: String {
     case home
     case menu

--- a/Sources/KlaviyoCore/KlaviyoEnvironment.swift
+++ b/Sources/KlaviyoCore/KlaviyoEnvironment.swift
@@ -166,7 +166,7 @@ public struct KlaviyoEnvironment {
             .eraseToAnyPublisher()
     }
 
-    // Known wrapper SDK CocoaPods pod names. Add new entries here when a new wrapper is released.
+    /// Known wrapper SDK CocoaPods pod names. Add new entries here when a new wrapper is released.
     package static let knownWrapperBundleNames = ["klaviyo-react-native-sdk", "klaviyo_flutter_sdk"]
 
     private static let wrapperSDKConfig: [String: AnyObject] = {

--- a/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoAPI.swift
@@ -74,6 +74,6 @@ public struct KlaviyoAPI {
         self.send = send
     }
 
-    // For internal testing use only
+    /// For internal testing use only
     public static var requestHandler: (KlaviyoRequest, URLRequest?, RequestStatus) -> Void = { _, _, _ in }
 }

--- a/Sources/KlaviyoCore/Networking/NetworkSession.swift
+++ b/Sources/KlaviyoCore/Networking/NetworkSession.swift
@@ -52,7 +52,7 @@ public struct NetworkSession {
 
     public static var defaultUserAgent: String = defaultUserAgent(bundle: .main)
 
-    internal static func defaultUserAgent(bundle: Bundle) -> String {
+    static func defaultUserAgent(bundle: Bundle) -> String {
         let appContext = environment.appContextInfo()
         let klaivyoSDKVersion = "klaviyo-\(environment.sdkName())/\(environment.sdkVersion())"
         var userAgent = "\(appContext.executable)/\(appContext.appVersion) (\(appContext.bundleId); build:\(appContext.appBuild); \(appContext.osVersionName)) \(klaivyoSDKVersion)"
@@ -68,7 +68,6 @@ public struct NetworkSession {
         let session = createEmphemeralSession()
 
         return NetworkSession(data: { request async throws -> (Data, URLResponse) in
-
             session.configuration.protocolClasses = URLProtocolOverrides.protocolClasses
             if #available(iOS 15, *) {
                 return try await session.data(for: request)

--- a/Sources/KlaviyoCore/Utils/FileUtils.swift
+++ b/Sources/KlaviyoCore/Utils/FileUtils.swift
@@ -47,8 +47,7 @@ public struct FileClient {
 public func filePathForData(apiKey: String, data: String) -> URL {
     let fileName = "klaviyo-\(apiKey)-\(data).plist"
     let directory = environment.fileClient.libraryDirectory()
-    let filePath = directory.appendingPathComponent(fileName, isDirectory: false)
-    return filePath
+    return directory.appendingPathComponent(fileName, isDirectory: false)
 }
 
 /**

--- a/Sources/KlaviyoCore/Utils/UInt64+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/UInt64+Ext.swift
@@ -7,9 +7,20 @@
 
 import Foundation
 
-package extension UInt64 {
-    var seconds: TimeInterval { Double(self) / 1_000_000_000 }
-    var milliseconds: TimeInterval { Double(self) / 1_000_000 }
-    var microseconds: TimeInterval { Double(self) / 1000 }
-    var nanoseconds: TimeInterval { Double(self) }
+extension UInt64 {
+    package var seconds: TimeInterval {
+        Double(self) / 1_000_000_000
+    }
+
+    package var milliseconds: TimeInterval {
+        Double(self) / 1_000_000
+    }
+
+    package var microseconds: TimeInterval {
+        Double(self) / 1000
+    }
+
+    package var nanoseconds: TimeInterval {
+        Double(self)
+    }
 }

--- a/Sources/KlaviyoCore/Vendor/ReachabilitySwift.swift
+++ b/Sources/KlaviyoCore/Vendor/ReachabilitySwift.swift
@@ -93,7 +93,7 @@ public class Reachability {
     var whenUnreachable: NetworkUnreachable?
     var reachableOnWWAN: Bool
 
-    // The notification center on which "reachability changed" events are being posted
+    /// The notification center on which "reachability changed" events are being posted
     var notificationCenter: NotificationCenter = .default
 
     var currentReachabilityString: String {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -219,8 +219,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     @MainActor
     private func createProfileAttributesScript(from profileData: ProfileData) -> String? {
         guard let profileDataString = try? profileData.toHtmlString() else { return nil }
-        let profileAttributesScript = "document.head.setAttribute('data-klaviyo-profile', '\(profileDataString)');"
-        return profileAttributesScript
+        return "document.head.setAttribute('data-klaviyo-profile', '\(profileDataString)');"
     }
 
     @MainActor
@@ -302,11 +301,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if let formId, !formId.isEmpty,
                let formName, !formName.isEmpty {
                 IAFPresentationManager.shared.invokeLifecycleHandler(
-                    for: .formShown(formId: formId, formName: formName))
+                    for: .formShown(formId: formId, formName: formName)
+                )
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "formWillAppear missing metadata — skipping lifecycle callback")
+                        "formWillAppear missing metadata — skipping lifecycle callback"
+                    )
                 }
             }
         case let .formDisappeared(formId, formName):
@@ -317,11 +318,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if let formId, !formId.isEmpty,
                let formName, !formName.isEmpty {
                 IAFPresentationManager.shared.invokeLifecycleHandler(
-                    for: .formDismissed(formId: formId, formName: formName))
+                    for: .formDismissed(formId: formId, formName: formName)
+                )
             } else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "formDisappeared missing metadata — skipping lifecycle callback")
+                        "formDisappeared missing metadata — skipping lifecycle callback"
+                    )
                 }
             }
         case let .trackProfileEvent(data):

--- a/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/InAppWindowManager.swift
@@ -19,7 +19,9 @@ class InAppWindowManager {
     /// Exposes the form's overlay window so callers that enumerate scene windows can
     /// filter it out — e.g. `DeviceInfo.current()` must not read bounds/insets from
     /// our own overlay (which becomes key while the user interacts with the form).
-    var currentFormWindow: UIWindow? { window }
+    var currentFormWindow: UIWindow? {
+        window
+    }
 
     /// Tracks the most-recently-reported keyboard end frame so that layout
     /// is keyboard-aware even when a form is presented while the keyboard is

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -110,7 +110,7 @@ extension IAFNativeBridgeEvent {
 }
 
 extension IAFNativeBridgeEvent {
-    public static var handshake: String {
+    static var handshake: String {
         struct HandshakeData: Codable {
             var type: String
             var version: Int

--- a/Sources/KlaviyoForms/InAppForms/Observers/CompanyObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/CompanyObserver.swift
@@ -22,7 +22,9 @@ class CompanyObserver {
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let stream: AsyncStream<Event>
 
-    var eventsStream: AsyncStream<Event> { stream }
+    var eventsStream: AsyncStream<Event> {
+        stream
+    }
 
     init() {
         (stream, eventsContinuation) = AsyncStream.makeStream(of: Event.self)

--- a/Sources/KlaviyoForms/InAppForms/Observers/LifecycleObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/LifecycleObserver.swift
@@ -21,7 +21,9 @@ class LifecycleObserver {
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let stream: AsyncStream<Event>
 
-    var eventsStream: AsyncStream<Event> { stream }
+    var eventsStream: AsyncStream<Event> {
+        stream
+    }
 
     init() {
         (stream, eventsContinuation) = AsyncStream.makeStream(of: Event.self)

--- a/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
+++ b/Sources/KlaviyoForms/InAppForms/Observers/ProfileEventObserver.swift
@@ -16,7 +16,9 @@ class ProfileEventObserver {
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let stream: AsyncStream<Event>
 
-    var eventsStream: AsyncStream<Event> { stream }
+    var eventsStream: AsyncStream<Event> {
+        stream
+    }
 
     init() {
         (stream, eventsContinuation) = AsyncStream.makeStream(of: Event.self)

--- a/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
+++ b/Sources/KlaviyoForms/KlaviyoWebView/Development Assets/PreviewWebViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
 import KlaviyoCore
 import WebKit
 
-// ViewModel for testing the KlaviyoWebViewController & KlaviyoWebViewModeling protocol in Xcode previews only.
+/// ViewModel for testing the KlaviyoWebViewController & KlaviyoWebViewModeling protocol in Xcode previews only.
 class PreviewWebViewModel: KlaviyoWebViewModeling {
     private enum MessageHandler: String, CaseIterable {
         case toggleMessageHandler
@@ -55,7 +55,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
     ///
     /// The caller of this method should `await` completion of this method, then present the ViewController.
     /// - Parameter timeout: the amount of time, in milliseconds, to wait before throwing a `timeout` error.
-    public func preloadWebsite(timeout: TimeInterval) async throws {
+    func preloadWebsite(timeout: TimeInterval) async throws {
         guard let delegate else { return }
 
         await delegate.preloadUrl()
@@ -90,7 +90,7 @@ class PreviewWebViewModel: KlaviyoWebViewModeling {
 
     // MARK: handle WKWebView events
 
-    public func handleNavigationEvent(_ event: WKNavigationEvent) {
+    func handleNavigationEvent(_ event: WKNavigationEvent) {
         navEventContinuation.yield(event)
     }
 

--- a/Sources/KlaviyoForms/Utilities/ResourceLoader.swift
+++ b/Sources/KlaviyoForms/Utilities/ResourceLoader.swift
@@ -41,8 +41,7 @@ enum ResourceLoader {
         }
 
         do {
-            let contents = try String(contentsOfFile: resourcePath, encoding: .utf8)
-            return contents
+            return try String(contentsOfFile: resourcePath, encoding: .utf8)
         } catch {
             if #available(iOS 14.0, *) {
                 Logger.filesystem.warning("Unable to cast file contents for resource '\(path).\(type)' to type String")
@@ -51,7 +50,7 @@ enum ResourceLoader {
         }
     }
 
-    // Determines the appropriate bundle based on the build system
+    /// Determines the appropriate bundle based on the build system
     private static func resourceBundle() throws -> Bundle {
         #if SWIFT_PACKAGE
         return Bundle.module
@@ -65,7 +64,7 @@ enum ResourceLoader {
     }
 }
 
-// Helper class for locating the resource bundle (CocoaPods)
+/// Helper class for locating the resource bundle (CocoaPods)
 private class BundleLocator {}
 
 extension Bundle {

--- a/Sources/KlaviyoLocation/KlaviyoLocationManager+CLLocationManagerDelegate.swift
+++ b/Sources/KlaviyoLocation/KlaviyoLocationManager+CLLocationManagerDelegate.swift
@@ -48,6 +48,7 @@ extension KlaviyoLocationManager: CLLocationManagerDelegate {
             Task {
                 await stopGeofenceMonitoring()
             }
+
         @unknown default:
             return
         }

--- a/Sources/KlaviyoLocation/Models/Geofence.swift
+++ b/Sources/KlaviyoLocation/Models/Geofence.swift
@@ -63,12 +63,11 @@ extension Geofence {
     /// Converts this geofence to a Core Location circular region
     /// - Returns: A CLCircularRegion instance
     func toCLCircularRegion() -> CLCircularRegion {
-        let region = CLCircularRegion(
+        CLCircularRegion(
             center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
             radius: radius,
             identifier: id
         )
-        return region
     }
 }
 

--- a/Sources/KlaviyoLocation/Utilities/CLLocationManager+LocationManagerProtocol.swift
+++ b/Sources/KlaviyoLocation/Utilities/CLLocationManager+LocationManagerProtocol.swift
@@ -31,7 +31,7 @@ protocol LocationManagerProtocol {
 extension CLLocationManager: LocationManagerProtocol {
     var currentAuthorizationStatus: CLAuthorizationStatus {
         if #available(iOS 14.0, *) {
-            return self.authorizationStatus
+            return authorizationStatus
         } else {
             return CLLocationManager.authorizationStatus()
         }

--- a/Sources/KlaviyoLocation/Utilities/GeofenceDistanceCalculator.swift
+++ b/Sources/KlaviyoLocation/Utilities/GeofenceDistanceCalculator.swift
@@ -38,9 +38,7 @@ enum GeofenceDistanceCalculator {
             sin(deltaLonRad / 2.0) * sin(deltaLonRad / 2.0)
 
         let angularDistanceRadians = 2.0 * atan2(sqrt(haversineValue), sqrt(1.0 - haversineValue))
-        let distance = earthRadiusMeters * angularDistanceRadians
-
-        return distance
+        return earthRadiusMeters * angularDistanceRadians
     }
 
     /// Calculates the distance from a coordinate to a geofence center in meters.

--- a/Sources/KlaviyoSwift/KlaviyoInternal.swift
+++ b/Sources/KlaviyoSwift/KlaviyoInternal.swift
@@ -1,5 +1,5 @@
 //
-//  KlaviyoSDK.swift
+//  KlaviyoInternal.swift
 //  klaviyo-swift-sdk
 //
 //  Created by Andrew Balmer on 2/4/25.
@@ -35,7 +35,7 @@ package enum KlaviyoInternal {
 
     // MARK: - API Key methods
 
-    // Setup the profile data subject to receive updates from the state publisher
+    /// Setup the profile data subject to receive updates from the state publisher
     private static func setupAPIKeySubject() {
         // Only set up the subscription if it hasn't already been set up
         guard apiKeyCancellable == nil else { return }
@@ -59,7 +59,7 @@ package enum KlaviyoInternal {
     /// A publisher that monitors the API key (aka Company ID) and emits valid API keys.
     ///
     /// - Returns: A publisher that emits valid API keys (non-nil, non-empty strings),
-    //             or a failure if the API is not initialized or the API key is empty or nil
+    ///             or a failure if the API is not initialized or the API key is empty or nil
     package static func apiKeyPublisher() -> AnyPublisher<APIKeyResult, Never> {
         // Set up the subject if it hasn't been set up yet
         setupAPIKeySubject()
@@ -98,7 +98,7 @@ package enum KlaviyoInternal {
 
     // MARK: - Profile Data methods
 
-    // Setup the profile data subject to receive updates from the state publisher
+    /// Setup the profile data subject to receive updates from the state publisher
     private static func setupProfileDataSubject() {
         // Only set up the subscription if it hasn't already been set up
         guard profileDataCancellable == nil else { return }
@@ -161,7 +161,7 @@ package enum KlaviyoInternal {
     /// Publishes an event to subscribers and also buffers it for replay to future subscribers.
     ///
     /// - Parameter event: the profile event to publish
-    internal static func publishEvent(_ event: Event) {
+    static func publishEvent(_ event: Event) {
         let enrichedEvent = enrichEventWithMetadata(event)
         eventBuffer.buffer(enrichedEvent)
         profileEventSubject.send(enrichedEvent)

--- a/Sources/KlaviyoSwift/Models/Event.swift
+++ b/Sources/KlaviyoSwift/Models/Event.swift
@@ -18,7 +18,7 @@ public struct Event: Equatable {
         case locationEvent(LocationEvent)
         case customEvent(String)
 
-        internal static var _openedPush: EventName {
+        static var _openedPush: EventName {
             EventName.customEvent("_openedPush")
         }
 
@@ -43,12 +43,12 @@ public struct Event: Equatable {
     }
 
     struct Identifiers: Equatable {
-        public let email: String?
-        public let phoneNumber: String?
-        public let externalId: String?
-        public init(email: String? = nil,
-                    phoneNumber: String? = nil,
-                    externalId: String? = nil) {
+        let email: String?
+        let phoneNumber: String?
+        let externalId: String?
+        init(email: String? = nil,
+             phoneNumber: String? = nil,
+             externalId: String? = nil) {
             self.email = email
             self.phoneNumber = phoneNumber
             self.externalId = externalId

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -9,7 +9,7 @@ import Foundation
 import KlaviyoCore
 
 extension String {
-    internal func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
+    func trimWhiteSpaceOrReturnNilIfEmpty() -> String? {
         let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedString.isEmpty ? nil : trimmedString
     }

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -459,7 +459,7 @@ extension Profile {
             zip: zip
         )
 
-        let profile = Profile(
+        return Profile(
             email: email,
             phoneNumber: phoneNumber,
             externalId: externalId,
@@ -471,8 +471,6 @@ extension Profile {
             location: location,
             properties: customProperties
         )
-
-        return profile
     }
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/StateChangePublisher.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateChangePublisher.swift
@@ -24,8 +24,8 @@ public struct StateChangePublisher {
             .eraseToAnyPublisher()
     }
 
-    // publisher to listen for state and persist them on an interval.
-    // does not emit action but mapped that way so it can be used in the store.
+    /// publisher to listen for state and persist them on an interval.
+    /// does not emit action but mapped that way so it can be used in the store.
     var publisher: () -> AnyPublisher<KlaviyoAction, Never> = {
         debouncedPublisher(createStatePublisher())
             .flatMap { state -> Empty<KlaviyoAction, Never> in

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -496,7 +496,8 @@ struct KlaviyoReducer: ReducerProtocol {
                     time: event.time,
                     uniqueId: event.uniqueId,
                     pushToken: state.pushTokenData?.pushToken
-                ))
+                )
+            )
 
             let endpoint = KlaviyoEndpoint.createEvent(apiKey, payload)
             let request = KlaviyoRequest(endpoint: endpoint)
@@ -518,6 +519,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 baseEffect,
                 .fireAndForget { KlaviyoInternal.publishEvent(event) }
             ])
+
         case let .enqueueAggregateEvent(payload):
             guard case .initialized = state.initalizationState,
                   let apiKey = state.apiKey

--- a/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/ArchivalUtilsTests.swift
@@ -32,14 +32,14 @@ class ArchivalUtilsTests: XCTestCase {
         removedFile = false
     }
 
-    func testArchiveUnarchive() throws {
+    func testArchiveUnarchive() {
         archiveQueue(queue: SAMPLE_DATA, to: TEST_URL)
 
         XCTAssert(wroteToFile)
         XCTAssertEqual(ARCHIVED_RETURNED_DATA, dataToWrite)
     }
 
-    func testArchiveFails() throws {
+    func testArchiveFails() {
         environment.archiverClient.archivedData = { _, _ in throw FakeFileError.fake }
         archiveQueue(queue: SAMPLE_DATA, to: TEST_URL)
 
@@ -47,7 +47,7 @@ class ArchivalUtilsTests: XCTestCase {
         XCTAssertNil(dataToWrite)
     }
 
-    func testArchiveWriteFails() throws {
+    func testArchiveWriteFails() {
         environment.fileClient.write = { _, _ in throw FakeFileError.fake }
         archiveQueue(queue: SAMPLE_DATA, to: TEST_URL)
 
@@ -55,14 +55,14 @@ class ArchivalUtilsTests: XCTestCase {
         XCTAssertNil(dataToWrite)
     }
 
-    func testUnarchive() throws {
+    func testUnarchive() {
         let archiveResult = unarchiveFromFile(fileURL: TEST_URL)
 
         XCTAssertEqual(SAMPLE_DATA, archiveResult)
         XCTAssertTrue(removedFile)
     }
 
-    func testUnarchiveInvalidData() throws {
+    func testUnarchiveInvalidData() {
         environment.dataFromUrl = { _ in throw FakeFileError.fake }
 
         let archiveResult = unarchiveFromFile(fileURL: TEST_URL)
@@ -70,7 +70,7 @@ class ArchivalUtilsTests: XCTestCase {
         XCTAssertNil(archiveResult)
     }
 
-    func testUnarchiveUnarchiveFails() throws {
+    func testUnarchiveUnarchiveFails() {
         environment.archiverClient.unarchivedMutableArray = { _ in throw FakeFileError.fake }
 
         let archiveResult = unarchiveFromFile(fileURL: TEST_URL)
@@ -78,7 +78,7 @@ class ArchivalUtilsTests: XCTestCase {
         XCTAssertNil(archiveResult)
     }
 
-    func testUnarchiveUnableToRemoveFile() throws {
+    func testUnarchiveUnableToRemoveFile() {
         var firstCall = true
         environment.fileClient.fileExists = { _ in
             if firstCall {
@@ -93,7 +93,7 @@ class ArchivalUtilsTests: XCTestCase {
         XCTAssertFalse(removedFile)
     }
 
-    func testUnarchiveWhereFileDoesNotExist() throws {
+    func testUnarchiveWhereFileDoesNotExist() {
         environment.fileClient.fileExists = { _ in false }
         let archiveResult = unarchiveFromFile(fileURL: TEST_URL)
 
@@ -110,7 +110,7 @@ class ArchivalSystemTest: XCTestCase {
         try? FileManager.default.removeItem(atPath: TEST_URL.path)
     }
 
-    /* This will attempt to actually archive and unarchive a queue. */
+    /** This will attempt to actually archive and unarchive a queue. */
     func testArchiveUnarchive() {
         archiveQueue(queue: SAMPLE_DATA, to: TEST_URL)
         let result = unarchiveFromFile(fileURL: filePathForData(apiKey: "foo", data: "people"))

--- a/Tests/KlaviyoCoreTests/DeepLinkHandlerTests.swift
+++ b/Tests/KlaviyoCoreTests/DeepLinkHandlerTests.swift
@@ -53,8 +53,8 @@ final class DeepLinkHandlerTests: XCTestCase {
     // MARK: - Custom Handler Execution Tests
 
     @MainActor
-    func testOpenURLUsesCustomHandlerWhenRegistered() async {
-        let expectedURL = URL(string: "https://example.com/custom")!
+    func testOpenURLUsesCustomHandlerWhenRegistered() async throws {
+        let expectedURL = try XCTUnwrap(URL(string: "https://example.com/custom"))
         let handlerCalled = expectation(description: "custom handler called")
 
         deepLinkHandler.registerCustomHandler { url in
@@ -69,8 +69,8 @@ final class DeepLinkHandlerTests: XCTestCase {
     // MARK: - Handler Replacement Tests
 
     @MainActor
-    func testRegisteringNewHandlerReplacesOld() async {
-        let url = URL(string: "https://example.com/test")!
+    func testRegisteringNewHandlerReplacesOld() async throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/test"))
         let firstHandlerCalled = expectation(description: "first handler called")
         let secondHandlerCalled = expectation(description: "second handler called")
         firstHandlerCalled.isInverted = true
@@ -94,8 +94,8 @@ final class DeepLinkHandlerTests: XCTestCase {
     // MARK: - Thread Safety Tests
 
     @MainActor
-    func testCustomHandlerCalledOnMainActor() async {
-        let url = URL(string: "https://example.com/main-actor")!
+    func testCustomHandlerCalledOnMainActor() async throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/main-actor"))
         let handlerCalled = expectation(description: "handler called on main actor")
 
         deepLinkHandler.registerCustomHandler { _ in

--- a/Tests/KlaviyoCoreTests/EncodableTests.swift
+++ b/Tests/KlaviyoCoreTests/EncodableTests.swift
@@ -17,18 +17,18 @@ final class EncodableTests: XCTestCase {
         testEncoder.outputFormatting = .prettyPrinted.union(.sortedKeys)
     }
 
-    func testProfilePayload() throws {
+    func testProfilePayload() {
         let payload = CreateProfilePayload(data: .test)
         assertSnapshot(matching: payload, as: .json(KlaviyoEnvironment.encoder))
     }
 
-    func testEventPayload() throws {
+    func testEventPayload() {
         let payloadData = CreateEventPayload.Event(name: "test", properties: SAMPLE_PROPERTIES, anonymousId: "anon-id")
         let createEventPayload = CreateEventPayload(data: payloadData)
         assertSnapshot(matching: createEventPayload, as: .json(KlaviyoEnvironment.encoder))
     }
 
-    func testTokenPayload() throws {
+    func testTokenPayload() {
         let tokenPayload = PushTokenPayload(
             pushToken: "foo",
             enablement: "AUTHORIZED",
@@ -38,7 +38,7 @@ final class EncodableTests: XCTestCase {
         assertSnapshot(matching: tokenPayload, as: .json(KlaviyoEnvironment.encoder))
     }
 
-    func testUnregisterTokenPayload() throws {
+    func testUnregisterTokenPayload() {
         let tokenPayload = UnregisterPushTokenPayload(
             pushToken: "foo",
             email: "foo",
@@ -48,7 +48,7 @@ final class EncodableTests: XCTestCase {
         assertSnapshot(matching: tokenPayload, as: .json)
     }
 
-    func testKlaviyoRequest() throws {
+    func testKlaviyoRequest() {
         let tokenPayload = PushTokenPayload(
             pushToken: "foo",
             enablement: "AUTHORIZED",

--- a/Tests/KlaviyoCoreTests/FileUtilsTests.swift
+++ b/Tests/KlaviyoCoreTests/FileUtilsTests.swift
@@ -30,12 +30,12 @@ class FileUtilsTests: XCTestCase {
         removedFile = false
     }
 
-    func testFilePathForData() throws {
+    func testFilePathForData() {
         let eventsResult = filePathForData(apiKey: "mykey", data: "events")
-        XCTAssertEqual(URL(string: "fake_url/klaviyo-mykey-events.plist")!, eventsResult)
+        XCTAssertEqual(URL(string: "fake_url/klaviyo-mykey-events.plist"), eventsResult)
 
         let peopleResult = filePathForData(apiKey: "mykey", data: "people")
-        XCTAssertEqual(URL(string: "fake_url/klaviyo-mykey-people.plist")!, peopleResult)
+        XCTAssertEqual(URL(string: "fake_url/klaviyo-mykey-people.plist"), peopleResult)
     }
 
     func testRemoveItemWithError() {

--- a/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoAPITests.swift
@@ -20,8 +20,7 @@ final class KlaviyoAPITests: XCTestCase {
 
         try await sendAndAssert(with: KlaviyoRequest(
             endpoint: .createProfile("foo", CreateProfilePayload(data: .test))
-        )
-        ) { result in
+        )) { result in
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .description)
@@ -36,7 +35,6 @@ final class KlaviyoAPITests: XCTestCase {
         }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -52,7 +50,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -68,7 +65,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .failure(error):
                 assertSnapshot(matching: error, as: .dump)
@@ -87,7 +83,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .createProfile("foo", CreateProfilePayload(data: .test)))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .success(data):
                 XCTAssertEqual(data.count, 0)
@@ -124,7 +119,6 @@ final class KlaviyoAPITests: XCTestCase {
         }) }
         let request = KlaviyoRequest(endpoint: .registerPushToken("foo", .test))
         try await sendAndAssert(with: request) { result in
-
             switch result {
             case let .success(data):
                 XCTAssertEqual(data.count, 0)

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -92,7 +92,7 @@ final class KlaviyoEndpointTests: XCTestCase {
 
     func testResolveDestinationURLEndpointUrlRequest() throws {
         // Given
-        let trackingLink = URL(string: "https://email.klaviyo.com/tracking/link")!
+        let trackingLink = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
         let profileInfo = ProfilePayload(email: "test@example.com", phoneNumber: "+15551234567", externalId: "user-123", anonymousId: "anon-456")
         let endpoint = KlaviyoEndpoint.resolveDestinationURL(trackingLink: trackingLink, profileInfo: profileInfo)
 
@@ -117,15 +117,15 @@ final class KlaviyoEndpointTests: XCTestCase {
             }
 
             // Compare JSON objects instead of string representations to avoid order issues
-            let profileJson = try JSONSerialization.jsonObject(with: Data(profileDataString.utf8), options: []) as! [String: Any]
-            let headerJson = try JSONSerialization.jsonObject(with: Data(decodedJsonString.utf8), options: []) as! [String: Any]
+            let profileJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(profileDataString.utf8), options: []) as? [String: Any])
+            let headerJson = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(decodedJsonString.utf8), options: []) as? [String: Any])
 
             // Compare the type
             XCTAssertEqual(profileJson["type"] as? String, headerJson["type"] as? String)
 
             // Compare attributes as dictionaries
-            let profileAttrs = profileJson["attributes"] as! [String: Any]
-            let headerAttrs = headerJson["attributes"] as! [String: Any]
+            let profileAttrs = try XCTUnwrap(profileJson["attributes"] as? [String: Any])
+            let headerAttrs = try XCTUnwrap(headerJson["attributes"] as? [String: Any])
 
             XCTAssertEqual(profileAttrs["email"] as? String, headerAttrs["email"] as? String)
             XCTAssertEqual(profileAttrs["phone_number"] as? String, headerAttrs["phone_number"] as? String)

--- a/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
+++ b/Tests/KlaviyoCoreTests/NetworkSessionTests.swift
@@ -107,7 +107,7 @@ class NetworkSessionTests: XCTestCase {
     }
 }
 
-// Mock Bundle class for testing
+/// Mock Bundle class for testing
 private class MockBundle: Bundle {
     private let mockPlistURL: URL?
 

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -151,7 +151,7 @@ extension NetworkSession {
 }
 
 class TestJSONDecoder: JSONDecoder, @unchecked Sendable {
-    override func decode<T>(_: T.Type, from _: Data) throws -> T where T: Decodable {
+    override func decode<T: Decodable>(_: T.Type, from _: Data) throws -> T {
         AppLifeCycleEvents.test as! T
     }
 }

--- a/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
+++ b/Tests/KlaviyoFormsTests/FormLifecycleHandlerTests.swift
@@ -165,7 +165,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
     }
 
     @MainActor
-    func testHandlerCalledForFormCtaClicked() {
+    func testHandlerCalledForFormCtaClicked() throws {
         // Given
         let expectation = expectation(description: "Handler called for formCtaClicked")
         var receivedEvent: FormLifecycleEvent?
@@ -176,11 +176,11 @@ final class FormLifecycleHandlerTests: XCTestCase {
         }
 
         // When
-        presentationManager.invokeLifecycleHandler(for: .formCtaClicked(
+        try presentationManager.invokeLifecycleHandler(for: .formCtaClicked(
             formId: "",
             formName: "",
             buttonLabel: "",
-            deepLinkUrl: URL(string: "myapp://test")!
+            deepLinkUrl: XCTUnwrap(URL(string: "myapp://test"))
         ))
 
         // Then
@@ -193,11 +193,11 @@ final class FormLifecycleHandlerTests: XCTestCase {
     }
 
     @MainActor
-    func testCtaEventCarriesButtonLabelAndUrl() {
+    func testCtaEventCarriesButtonLabelAndUrl() throws {
         // Given
         let expectation = expectation(description: "formCtaClicked carries buttonLabel and deepLinkUrl")
         var receivedEvent: FormLifecycleEvent?
-        let deepLink = URL(string: "myapp://checkout")!
+        let deepLink = try XCTUnwrap(URL(string: "myapp://checkout"))
 
         presentationManager.registerFormLifecycleHandler { event in
             receivedEvent = event
@@ -225,7 +225,7 @@ final class FormLifecycleHandlerTests: XCTestCase {
     }
 
     @MainActor
-    func testMultipleEventsInSequence() {
+    func testMultipleEventsInSequence() throws {
         // Given
         let expectation = expectation(description: "Handler called for all events")
         expectation.expectedFulfillmentCount = 3
@@ -238,8 +238,8 @@ final class FormLifecycleHandlerTests: XCTestCase {
 
         // When
         presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
-        presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!)
+        try presentationManager.invokeLifecycleHandler(
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test")))
         )
         presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
 
@@ -260,14 +260,14 @@ final class FormLifecycleHandlerTests: XCTestCase {
     // MARK: - Edge Case Tests
 
     @MainActor
-    func testInvokeWithoutHandler() {
+    func testInvokeWithoutHandler() throws {
         // Given - No handler registered
 
         // When/Then - Should not crash
         presentationManager.invokeLifecycleHandler(for: .formShown(formId: "", formName: ""))
         presentationManager.invokeLifecycleHandler(for: .formDismissed(formId: "", formName: ""))
-        presentationManager.invokeLifecycleHandler(
-            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!)
+        try presentationManager.invokeLifecycleHandler(
+            for: .formCtaClicked(formId: "", formName: "", buttonLabel: "", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test")))
         )
 
         // Test passes if no crash occurs
@@ -352,27 +352,27 @@ final class FormLifecycleHandlerTests: XCTestCase {
 
     // MARK: - FormLifecycleEvent Computed Property Tests
 
-    func testFormIdComputedProperty() {
+    func testFormIdComputedProperty() throws {
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "abc", formName: "").formId, "abc")
         XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "def", formName: "").formId, "def")
-        let ctaEvent = FormLifecycleEvent.formCtaClicked(
-            formId: "ghi", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
+        let ctaEvent = try FormLifecycleEvent.formCtaClicked(
+            formId: "ghi", formName: "", buttonLabel: "", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test"))
         )
         XCTAssertEqual(ctaEvent.formId, "ghi")
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formId, "")
     }
 
-    func testFormNameComputedProperty() {
+    func testFormNameComputedProperty() throws {
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "Form A").formName, "Form A")
         XCTAssertEqual(FormLifecycleEvent.formDismissed(formId: "", formName: "Form B").formName, "Form B")
-        let ctaEventC = FormLifecycleEvent.formCtaClicked(
-            formId: "", formName: "Form C", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
+        let ctaEventC = try FormLifecycleEvent.formCtaClicked(
+            formId: "", formName: "Form C", buttonLabel: "", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test"))
         )
         XCTAssertEqual(ctaEventC.formName, "Form C")
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").formName, "")
     }
 
-    func testFormLifecycleEventEquality() {
+    func testFormLifecycleEventEquality() throws {
         XCTAssertEqual(
             FormLifecycleEvent.formShown(formId: "abc", formName: "Test"),
             FormLifecycleEvent.formShown(formId: "abc", formName: "Test")
@@ -381,8 +381,8 @@ final class FormLifecycleHandlerTests: XCTestCase {
             FormLifecycleEvent.formDismissed(formId: "", formName: ""),
             FormLifecycleEvent.formDismissed(formId: "", formName: "")
         )
-        let ctaBuy = FormLifecycleEvent.formCtaClicked(
-            formId: "x", formName: "y", buttonLabel: "Buy", deepLinkUrl: URL(string: "myapp://test")!
+        let ctaBuy = try FormLifecycleEvent.formCtaClicked(
+            formId: "x", formName: "y", buttonLabel: "Buy", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test"))
         )
         XCTAssertEqual(ctaBuy, ctaBuy)
         XCTAssertNotEqual(
@@ -395,13 +395,13 @@ final class FormLifecycleHandlerTests: XCTestCase {
         )
     }
 
-    func testEventNameProperty() {
+    func testEventNameProperty() throws {
         XCTAssertEqual(FormLifecycleEvent.formShown(formId: "", formName: "").eventName, "formShown")
         XCTAssertEqual(
             FormLifecycleEvent.formDismissed(formId: "", formName: "").eventName, "formDismissed"
         )
-        let ctaForEventName = FormLifecycleEvent.formCtaClicked(
-            formId: "", formName: "", buttonLabel: "", deepLinkUrl: URL(string: "myapp://test")!
+        let ctaForEventName = try FormLifecycleEvent.formCtaClicked(
+            formId: "", formName: "", buttonLabel: "", deepLinkUrl: XCTUnwrap(URL(string: "myapp://test"))
         )
         XCTAssertEqual(ctaForEventName.eventName, "formCtaClicked")
     }

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 struct IAFNativeBridgeEventTests {
     @Test
-    func testHandshakeCreated() async throws {
+    func handshakeCreated() throws {
         struct TestableHandshakeData: Codable, Equatable {
             var type: String
             var version: Int
@@ -32,7 +32,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testHandShook() async throws {
+    func testHandShook() throws {
         let json = """
         {
           "type": "handShook",
@@ -46,7 +46,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testAbort() async throws {
+    func testAbort() throws {
         let json = """
         {
           "type": "abort",
@@ -67,7 +67,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingButtonLabel() async throws {
+    func decodeOpenDeepLinkMissingButtonLabel() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -95,7 +95,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithButtonLabel() async throws {
+    func decodeOpenDeepLinkWithButtonLabel() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -124,7 +124,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithoutFormContext() async throws {
+    func decodeOpenDeepLinkWithoutFormContext() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -150,7 +150,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppear() async throws {
+    func decodeFormWillAppear() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -161,7 +161,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -172,7 +172,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearMissingFormName() async throws {
+    func decodeFormWillAppearMissingFormName() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -182,7 +182,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -193,7 +193,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappeared() async throws {
+    func decodeFormDisappeared() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -204,7 +204,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -215,7 +215,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedWithoutPayload() async throws {
+    func decodeFormDisappearedWithoutPayload() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -223,7 +223,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -234,7 +234,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeTrackProfileEvent() async throws {
+    func decodeTrackProfileEvent() throws {
         let json = """
         {
           "type": "trackProfileEvent",
@@ -274,7 +274,7 @@ struct IAFNativeBridgeEventTests {
     // MARK: - Missing Metadata Fields (parsing is permissive, nil for missing/empty)
 
     @Test
-    func testDecodeFormWillAppearMissingFormId() async throws {
+    func decodeFormWillAppearMissingFormId() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -283,7 +283,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -294,14 +294,14 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearEmptyData() async throws {
+    func decodeFormWillAppearEmptyData() throws {
         let json = """
         {
           "type": "formWillAppear",
           "data": {}
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -312,7 +312,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingFormId() async throws {
+    func decodeFormDisappearedMissingFormId() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -321,7 +321,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -332,7 +332,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingFormName() async throws {
+    func decodeFormDisappearedMissingFormName() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -341,7 +341,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -352,7 +352,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingFormId() async throws {
+    func decodeOpenDeepLinkMissingFormId() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -377,7 +377,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingFormName() async throws {
+    func decodeOpenDeepLinkMissingFormName() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -402,7 +402,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkEmptyData() async throws {
+    func decodeOpenDeepLinkEmptyData() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -422,7 +422,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithoutIosUrl() async throws {
+    func decodeOpenDeepLinkWithoutIosUrl() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -447,13 +447,13 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearMissingDataKey() async throws {
+    func decodeFormWillAppearMissingDataKey() throws {
         let json = """
         {
           "type": "formWillAppear"
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -464,13 +464,13 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingDataKey() async throws {
+    func decodeFormDisappearedMissingDataKey() throws {
         let json = """
         {
           "type": "formDisappeared"
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -481,7 +481,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingDataKey() async throws {
+    func decodeOpenDeepLinkMissingDataKey() throws {
         let json = """
         {
           "type": "openDeepLink"
@@ -500,7 +500,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeAggregateEvent() async throws {
+    func decodeAggregateEvent() throws {
         let json = """
         {
           "type": "trackAggregateEvent",

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -1,5 +1,5 @@
 //
-//  IAFWebViewModelTests.swift
+//  IAFWebViewModelPreloadingTests.swift
 //  klaviyo-swift-sdk
 //
 //  Created by Andrew Balmer on 2/6/25.

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -11,8 +11,8 @@ import KlaviyoCore
 import WebKit
 import XCTest
 
-// Test-specific subclass that overrides navigation policy to allow all navigation
-// This is required to get these unit tests to pass
+/// Test-specific subclass that overrides navigation policy to allow all navigation
+/// This is required to get these unit tests to pass
 private class TestKlaviyoWebViewController: KlaviyoWebViewController {
     override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
         .allow
@@ -73,7 +73,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - SDK Attribute Tests
 
     @MainActor
-    func testInjectSdkNameAttribute() async throws {
+    func testInjectSdkNameAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let sdkNameScript = viewModel.findScript(containing: ["data-sdk-name", "swift"])
@@ -83,7 +83,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testInjectSdkVersionAttribute() async throws {
+    func testInjectSdkVersionAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let sdkVersionScript = viewModel.findScript(containing: ["data-sdk-version", "0.0.1"])
@@ -95,7 +95,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Environment Tests
 
     @MainActor
-    func testInjectFormsDataEnvironmentAttribute() async throws {
+    func testInjectFormsDataEnvironmentAttribute() {
         // When
         viewModel.initializeLoadScripts()
         let environmentScript = viewModel.findScript(containing: "data-forms-data-environment")
@@ -125,7 +125,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Handshake Tests
 
     @MainActor
-    func testInjectHandshakeAttribute() async throws {
+    func testInjectHandshakeAttribute() throws {
         // When
         viewModel.initializeLoadScripts()
         let handshakeScript = viewModel.findScript(containing: "data-native-bridge-handshake")
@@ -163,7 +163,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Klaviyo JS Tests
 
     @MainActor
-    func testInjectKlaviyoJsScript() async throws {
+    func testInjectKlaviyoJsScript() {
         // When
         viewModel.initializeLoadScripts()
         let klaviyoJsScript = viewModel.findScript(containing: ["klaviyoJS", "static.klaviyo.com/onsite/js/klaviyo.js"])
@@ -177,7 +177,7 @@ final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Event Handling Tests
 
     @MainActor
-    func testFormWillAppearYieldsPresentLifecycleEvent() async throws {
+    func testFormWillAppearYieldsPresentLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Form will appear should yield present lifecycle event")
 
@@ -213,7 +213,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormDisappearedYieldsDismissLifecycleEvent() async throws {
+    func testFormDisappearedYieldsDismissLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Form disappeared should yield dismiss lifecycle event")
 
@@ -249,10 +249,11 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormWillAppearYieldsPresentEvenWithMissingMetadata() async throws {
+    func testFormWillAppearYieldsPresentEvenWithMissingMetadata() async {
         // Given
         let expectation = XCTestExpectation(
-            description: "formWillAppear with missing metadata should still yield .present")
+            description: "formWillAppear with missing metadata should still yield .present"
+        )
 
         let lifecycleTask = Task {
             for await event in viewModel.formLifecycleStream {
@@ -282,10 +283,11 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testFormDisappearedYieldsDismissEvenWithMissingMetadata() async throws {
+    func testFormDisappearedYieldsDismissEvenWithMissingMetadata() async {
         // Given
         let expectation = XCTestExpectation(
-            description: "formDisappeared with missing metadata should still yield .dismiss")
+            description: "formDisappeared with missing metadata should still yield .dismiss"
+        )
 
         let lifecycleTask = Task {
             for await event in viewModel.formLifecycleStream {
@@ -315,7 +317,7 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testAbortEventYieldsAbortLifecycleEvent() async throws {
+    func testAbortEventYieldsAbortLifecycleEvent() async {
         // Given
         let expectation = XCTestExpectation(description: "Abort event should yield abort lifecycle event")
         let abortReason = "test abort reason"

--- a/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoFormsTestUtils.swift
@@ -152,7 +152,7 @@ extension NetworkSession {
 }
 
 class TestJSONDecoder: JSONDecoder, @unchecked Sendable {
-    override func decode<T>(_: T.Type, from _: Data) throws -> T where T: Decodable {
+    override func decode<T: Decodable>(_: T.Type, from _: Data) throws -> T {
         KlaviyoState.test as! T
     }
 }

--- a/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
+++ b/Tests/KlaviyoFormsTests/KlaviyoWebViewControllerTests.swift
@@ -49,13 +49,13 @@ final class KlaviyoWebViewControllerTests: XCTestCase {
     /// Test to validate that the ``KlaviyoWebViewController`` removes any script message handlers
     /// from its ``WKWebView``'s ``WKUserContentController`` when it gets deallocated.
     @MainActor
-    func testScriptMessageHandlersAreRemovedOnDeallocation() async throws {
+    func testScriptMessageHandlersAreRemovedOnDeallocation() throws {
         // Given
         let config = WKWebViewConfiguration()
         let mockController = MockWKUserContentController()
         config.userContentController = mockController
 
-        let url = URL(string: "https://www.google.com")!
+        let url = try XCTUnwrap(URL(string: "https://www.google.com"))
         let viewModel = MockIAFWebViewModel(url: url)
         let messageHandlers = Set(["handler1", "handler2"])
         viewModel.messageHandlers = messageHandlers
@@ -135,7 +135,7 @@ final class IAFWebViewModelScriptTests: XCTestCase {
     // MARK: - Tests
 
     @MainActor
-    func testKlaviyoJsScriptIsAddedToWebView() async throws {
+    func testKlaviyoJsScriptIsAddedToWebView() {
         // When
         _ = createWebViewController()
         let userScripts = config.userContentController.userScripts
@@ -145,7 +145,7 @@ final class IAFWebViewModelScriptTests: XCTestCase {
     }
 
     @MainActor
-    func testSdkNameScriptIsAddedToWebView() async throws {
+    func testSdkNameScriptIsAddedToWebView() {
         // When
         _ = createWebViewController()
         let userScripts = config.userContentController.userScripts
@@ -179,7 +179,7 @@ final class IAFWebViewModelScriptTests: XCTestCase {
     }
 
     @MainActor
-    func testHandshakeScriptIsAddedToWebView() async throws {
+    func testHandshakeScriptIsAddedToWebView() {
         // When
         _ = createWebViewController()
         let userScripts = config.userContentController.userScripts
@@ -227,7 +227,7 @@ final class IAFWebViewModelScriptTests: XCTestCase {
     }
 
     @MainActor
-    func testScriptMessageHandlerDeduplication() async throws {
+    func testScriptMessageHandlerDeduplication() {
         // Given
         let viewController = createWebViewController()
 

--- a/Tests/KlaviyoLocationTests/GeofenceTests.swift
+++ b/Tests/KlaviyoLocationTests/GeofenceTests.swift
@@ -111,14 +111,14 @@ final class GeofenceTests: XCTestCase {
 
         // Then
         XCTAssertEqual(geofences.count, 2)
-        let firstGeofence = geofences.first { $0.locationId == "8db4effa-44f1-45e6-a88d-8e7d50516a0f" }!
+        let firstGeofence = try XCTUnwrap(geofences.first { $0.locationId == "8db4effa-44f1-45e6-a88d-8e7d50516a0f" })
         XCTAssertEqual(firstGeofence.id, "_k:ABC123:8db4effa-44f1-45e6-a88d-8e7d50516a0f")
         XCTAssertEqual(firstGeofence.companyId, "ABC123")
         XCTAssertEqual(firstGeofence.latitude, 40.7128)
         XCTAssertEqual(firstGeofence.longitude, -74.006)
         XCTAssertEqual(firstGeofence.radius, 100)
 
-        let secondGeofence = geofences.first { $0.locationId == "a84011cf-93ef-4e78-b047-c0ce4ea258e4" }!
+        let secondGeofence = try XCTUnwrap(geofences.first { $0.locationId == "a84011cf-93ef-4e78-b047-c0ce4ea258e4" })
         XCTAssertEqual(secondGeofence.id, "_k:ABC123:a84011cf-93ef-4e78-b047-c0ce4ea258e4")
         XCTAssertEqual(secondGeofence.companyId, "ABC123")
         XCTAssertEqual(secondGeofence.latitude, 40.6892)

--- a/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
+++ b/Tests/KlaviyoLocationTests/KlaviyoLocationManagerTests.swift
@@ -141,7 +141,7 @@ final class KlaviyoLocationManagerTests: XCTestCase {
 
     // MARK: - Klaviyo Geofence Isolation Tests
 
-    func test_syncGeofences_only_removes_klaviyo_geofences() async throws {
+    func test_syncGeofences_only_removes_klaviyo_geofences() async {
         // GIVEN - Set up test environment with API key
         let apiKey = "ABC123"
         KlaviyoLocationTestUtils.setupTestEnvironment(apiKey: apiKey)
@@ -198,14 +198,14 @@ final class KlaviyoLocationManagerTests: XCTestCase {
 
         // Mock GeofenceService to return new Klaviyo geofences
         let mockGeofenceService = MockGeofenceService()
-        mockGeofenceService.mockGeofences = [
-            try! Geofence(
+        mockGeofenceService.mockGeofences = try [
+            Geofence(
                 id: "_k:\(apiKey):new-uuid-1",
                 longitude: 1.0,
                 latitude: 1.0,
                 radius: 100.0
             ),
-            try! Geofence(
+            Geofence(
                 id: "_k:\(apiKey):new-uuid-2",
                 longitude: 2.0,
                 latitude: 2.0,
@@ -233,7 +233,7 @@ final class KlaviyoLocationManagerTests: XCTestCase {
         XCTAssertTrue(addedIds.contains("_k:\(apiKey):new-uuid-2"))
     }
 
-    func test_syncGeofences_does_not_affect_non_klaviyo_regions_when_exceeding_limit() async throws {
+    func test_syncGeofences_does_not_affect_non_klaviyo_regions_when_exceeding_limit() async {
         // GIVEN - Set up test environment with API key
         let apiKey = "ABC123"
         KlaviyoLocationTestUtils.setupTestEnvironment(apiKey: apiKey)
@@ -280,7 +280,7 @@ final class KlaviyoLocationManagerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(klaviyoRegions.count, 0, "Should attempt to add Klaviyo geofences")
     }
 
-    func test_getActiveGeofences_only_returns_klaviyo_geofences() async throws {
+    func test_getActiveGeofences_only_returns_klaviyo_geofences() async {
         // GIVEN - Set up test environment with API key
         let apiKey = "ABC123"
         KlaviyoLocationTestUtils.setupTestEnvironment(apiKey: apiKey)

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -23,7 +23,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestHttpFailureDequesRequest() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -41,7 +41,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestHttpFailureForPhoneNumberResetsStateAndDequesRequest() async throws {
         var initialState = INITIALIZED_TEST_STATE_INVALID_PHONE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -64,7 +64,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestHttpFailureForEmailResetsStateAndDequesRequest() async throws {
         var initialState = INITIALIZED_TEST_STATE_INVALID_EMAIL()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -87,7 +87,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestHttpFailureForPhoneNumberForDifferentErrorPathResetsStateAndDequesRequest() async throws {
         var initialState = INITIALIZED_TEST_STATE_INVALID_PHONE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -114,7 +114,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
         // in the case of state loaded from old sdk where email was stored with whitespaces
         initialState.email = "foo@blob.com      "
 
-        let request = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: initialState.pushTokenData?.pushToken ?? "", enablement: .authorized)
+        let request = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: initialState.pushTokenData?.pushToken ?? "", enablement: .authorized)
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -135,8 +135,8 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestFailureIncrementsRetryCount() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "new_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "new_token", enablement: .authorized)
         initialState.requestsInFlight = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -156,8 +156,8 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testSendRequestFailureWithBackoff() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 1)
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "new_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "new_token", enablement: .authorized)
         initialState.requestsInFlight = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -176,11 +176,11 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestMaxRetries() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         let maxRetries = request.endpoint.maxRetries
         initialState.retryState = .retry(maxRetries)
 
-        var request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "new_token", enablement: .authorized)
+        var request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "new_token", enablement: .authorized)
         request2 = KlaviyoRequest(id: "foo", endpoint: request2.endpoint)
         initialState.requestsInFlight = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -204,7 +204,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
         // NOTE: should really happen but putting this in for possible future cases and test coverage
         var initialState = INITIALIZED_TEST_STATE()
 
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -226,7 +226,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testSendRequestInternalRequestError() async throws {
         var initialState = INITIALIZED_TEST_STATE()
 
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -248,7 +248,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testSendRequestUnknownError() async throws {
         var initialState = INITIALIZED_TEST_STATE()
 
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -269,7 +269,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestDataEncodingError() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -290,7 +290,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testSendRequestInvalidData() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -311,7 +311,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testRateLimitErrorWithExistingRetry() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -331,7 +331,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testRateLimitErrorWithExistingBackoffRetry() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -351,7 +351,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testRetryWithRetryAfter() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 4)
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -373,7 +373,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testMissingOrInvalidResponse() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -394,7 +394,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testRetryOn500InternalServerError() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -413,7 +413,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testRetryOn502BadGateway() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -432,7 +432,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testRetryOn503ServiceUnavailable() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -451,7 +451,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testRetryOn504GatewayTimeout() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -470,7 +470,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testNoRetryOn501NotImplemented() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -489,7 +489,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     func testRetryOn5XXWithExistingBackoff() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 1, totalRetryCount: 1, currentBackoff: 1)
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -508,7 +508,7 @@ class APIRequestErrorHandlingTests: XCTestCase {
     @MainActor
     func testNoRetryOn4XXClientErrors() async throws {
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
         initialState.requestsInFlight = [request]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 

--- a/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
+++ b/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class AttemptNumberTests: XCTestCase {
-    func testFirstRequestStartsAtOne() async throws {
+    func testFirstRequestStartsAtOne() async {
         var capturedAttempt: Int?
         environment.klaviyoAPI.send = { _, attemptInfo in
             capturedAttempt = attemptInfo.attemptNumber

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -45,7 +45,7 @@ final class DeepLinkHandlingTests: XCTestCase {
 
     @MainActor
     func testOpenDeepLinkActionCallsLinkHandler() async throws {
-        let expectedURL = URL(string: "https://example.com/path")!
+        let expectedURL = try XCTUnwrap(URL(string: "https://example.com/path"))
         let called = expectation(description: "linkHandler.openURL called")
         var handlerCalled = false
 
@@ -71,7 +71,7 @@ final class DeepLinkHandlingTests: XCTestCase {
 
     @MainActor
     func testRegisterDeepLinkHandlerOverridesEnvironmentFallback() async throws {
-        let expectedURL = URL(string: "https://example.com/override")!
+        let expectedURL = try XCTUnwrap(URL(string: "https://example.com/override"))
 
         let customCalled = expectation(description: "custom handler called")
         KlaviyoSDK().registerDeepLinkHandler { url in
@@ -175,7 +175,7 @@ final class DeepLinkHandlingTests: XCTestCase {
 
     @MainActor
     func testOpenDeepLinkActionSetsProcessingState() async throws {
-        let url = URL(string: "https://example.com/test")!
+        let url = try XCTUnwrap(URL(string: "https://example.com/test"))
         let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
 
         environment.linkHandler.registerCustomHandler { _ in }
@@ -191,7 +191,7 @@ final class DeepLinkHandlingTests: XCTestCase {
 
     @MainActor
     func testOpenDeepLinkActionIgnoredWhenAlreadyProcessing() async throws {
-        let url = URL(string: "https://example.com/test")!
+        let url = try XCTUnwrap(URL(string: "https://example.com/test"))
         var initialState = KlaviyoState(queue: [], requestsInFlight: [])
         initialState.isProcessingDeepLink = true
 
@@ -201,7 +201,7 @@ final class DeepLinkHandlingTests: XCTestCase {
     }
 
     @MainActor
-    func testDeepLinkProcessingCompletedResetsState() async throws {
+    func testDeepLinkProcessingCompletedResetsState() async {
         var initialState = KlaviyoState(queue: [], requestsInFlight: [])
         initialState.isProcessingDeepLink = true
 
@@ -214,8 +214,8 @@ final class DeepLinkHandlingTests: XCTestCase {
 
     @MainActor
     func testSequentialDeepLinkProcessing() async throws {
-        let url1 = URL(string: "https://example.com/test1")!
-        let url2 = URL(string: "https://example.com/test2")!
+        let url1 = try XCTUnwrap(URL(string: "https://example.com/test1"))
+        let url2 = try XCTUnwrap(URL(string: "https://example.com/test2"))
 
         let store = TestStore(initialState: KlaviyoState(queue: [], requestsInFlight: []), reducer: KlaviyoReducer())
 

--- a/Tests/KlaviyoSwiftTests/EncodableTests.swift
+++ b/Tests/KlaviyoSwiftTests/EncodableTests.swift
@@ -5,10 +5,9 @@
 //  Created by Ajay Subramanya on 8/15/24.
 //
 
-import Foundation
-
 @testable import KlaviyoCore
 @testable import KlaviyoSwift
+import Foundation
 import SnapshotTesting
 import XCTest
 
@@ -20,7 +19,7 @@ final class EncodableTests: XCTestCase {
         testEncoder.outputFormatting = .prettyPrinted.union(.sortedKeys)
     }
 
-    func testKlaviyoState() throws {
+    func testKlaviyoState() {
         let tokenPayload = PushTokenPayload(
             pushToken: "foo",
             enablement: "AUTHORIZED",

--- a/Tests/KlaviyoSwiftTests/EventBufferTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventBufferTests.swift
@@ -167,7 +167,7 @@ class EventBufferTests: XCTestCase {
 
     // MARK: - Thread Safety Tests
 
-    func testConcurrentBuffering() async throws {
+    func testConcurrentBuffering() async {
         // Given
         let expectation = XCTestExpectation(description: "All events buffered")
         expectation.expectedFulfillmentCount = 100
@@ -186,7 +186,7 @@ class EventBufferTests: XCTestCase {
         XCTAssertLessThanOrEqual(events.count, 5, "Should respect max buffer size")
     }
 
-    func testConcurrentReadingAndWriting() async throws {
+    func testConcurrentReadingAndWriting() async {
         // Given
         let writeExpectation = XCTestExpectation(description: "Writing complete")
         let readExpectation = XCTestExpectation(description: "Reading complete")
@@ -282,7 +282,7 @@ class EventBufferTests: XCTestCase {
 
         // Then
         XCTAssertEqual(retrievedEvents.count, 1)
-        let retrievedEvent = retrievedEvents.first!
+        let retrievedEvent = try XCTUnwrap(retrievedEvents.first)
         XCTAssertEqual(retrievedEvent.metric.name.value, "test")
         XCTAssertEqual(retrievedEvent.properties["key1"] as? String, "value1")
         XCTAssertEqual(retrievedEvent.properties["key2"] as? Int, 123)

--- a/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoInternalTests.swift
@@ -31,7 +31,7 @@ final class KlaviyoInternalTests: XCTestCase {
     // MARK: - Profile Data Tests
 
     @MainActor
-    func testProfileChangePublisherEmitsCorrectData() throws {
+    func testProfileChangePublisherEmitsCorrectData() {
         let expectation = XCTestExpectation(description: "Profile data is emitted")
         var receivedResult: KlaviyoInternal.ProfileDataResult?
 
@@ -428,7 +428,7 @@ final class KlaviyoInternalTests: XCTestCase {
     // MARK: - Event Publishing Tests
 
     @MainActor
-    func testEventPublisher_emitsEventWithProperties() throws {
+    func testEventPublisher_emitsEventWithProperties() {
         // Given: Set up a mock to capture published events
         var publishedEvents: [Event] = []
         let initialState = KlaviyoState(
@@ -462,7 +462,7 @@ final class KlaviyoInternalTests: XCTestCase {
     // MARK: - Integration Tests
 
     @MainActor
-    func testBothPublishersWorkIndependently() async throws {
+    func testBothPublishersWorkIndependently() async {
         // Set up test environment
         let testStore = Store(initialState: .test, reducer: KlaviyoReducer())
         klaviyoSwiftEnvironment.statePublisher = { testStore.state.eraseToAnyPublisher() }
@@ -749,8 +749,8 @@ final class KlaviyoInternalTests: XCTestCase {
         initialState.flushing = false
 
         // Add some existing requests to the queue
-        let existingRequest1 = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let existingRequest2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "token1", enablement: .authorized)
+        let existingRequest1 = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let existingRequest2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "token1", enablement: .authorized)
         initialState.queue = [existingRequest1, existingRequest2]
 
         let testStore = Store(initialState: initialState, reducer: KlaviyoReducer())
@@ -767,7 +767,7 @@ final class KlaviyoInternalTests: XCTestCase {
             name: .locationEvent(.geofenceEnter),
             properties: ["$geofence_id": "test-location-id"]
         )
-        let apiKey = initialState.apiKey!
+        let apiKey = try XCTUnwrap(initialState.apiKey)
         await KlaviyoInternal.createGeofenceEvent(event: geofenceEvent, for: apiKey)
         try await Task.sleep(nanoseconds: 500_000_000)
 
@@ -814,8 +814,8 @@ final class KlaviyoInternalTests: XCTestCase {
         initialState.flushing = false
 
         // Add some existing requests to the queue
-        let existingRequest1 = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let existingRequest2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "token1", enablement: .authorized)
+        let existingRequest1 = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let existingRequest2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "token1", enablement: .authorized)
         initialState.queue = [existingRequest1, existingRequest2]
 
         let testStore = Store(initialState: initialState, reducer: KlaviyoReducer())

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -10,7 +10,7 @@ import Foundation
 import XCTest
 
 class KlaviyoModelsTest: XCTestCase {
-    func testProfileModelConvertsToAPIModel() {
+    func testProfileModelConvertsToAPIModel() throws {
         let profile = Profile(
             email: "walter.white@breakingbad.com",
             phoneNumber: "1800-better-call-saul",
@@ -46,10 +46,10 @@ class KlaviyoModelsTest: XCTestCase {
         XCTAssertEqual(apiProfile.attributes.location?.zip, profile.location?.zip)
         XCTAssertEqual(apiProfile.attributes.location?.timezone, profile.location?.timezone)
 
-        let apiProps = apiProfile.attributes.properties.value as! [String: Any]
-        let orderAmount = apiProps["order amount"] as! String
+        let apiProps = try XCTUnwrap(apiProfile.attributes.properties.value as? [String: Any])
+        let orderAmount = try XCTUnwrap(apiProps["order amount"] as? String)
 
-        XCTAssertEqual(orderAmount, profile.properties["order amount"] as! String)
+        XCTAssertEqual(orderAmount, profile.properties["order amount"] as? String)
         XCTAssertEqual(apiProfile.attributes.anonymousId, anonymousId)
     }
 
@@ -86,7 +86,8 @@ class KlaviyoModelsTest: XCTestCase {
         )
         let anonymousId = "C10H15N"
         let apiProfile = profile.toAPIModel(
-            anonymousId: anonymousId)
+            anonymousId: anonymousId
+        )
 
         XCTAssertNil(apiProfile.attributes.email)
         XCTAssertNil(apiProfile.attributes.phoneNumber)

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -70,14 +70,14 @@ final class KlaviyoStateTests: XCTestCase {
         environment = KlaviyoEnvironment.test()
     }
 
-    func testLoadNewKlaviyoState() throws {
+    func testLoadNewKlaviyoState() {
         environment.fileClient.fileExists = { _ in false }
         environment.archiverClient.unarchivedMutableArray = { _ in [] }
         let state = loadKlaviyoStateFromDisk(apiKey: "foo")
         assertSnapshot(matching: state, as: .dump)
     }
 
-    func testStateFileExistsInvalidData() throws {
+    func testStateFileExistsInvalidData() {
         environment.fileClient.fileExists = { _ in
             true
         }
@@ -93,7 +93,7 @@ final class KlaviyoStateTests: XCTestCase {
         assertSnapshot(matching: state, as: .dump)
     }
 
-    func testStateFileExistsInvalidJSON() throws {
+    func testStateFileExistsInvalidJSON() {
         environment.fileClient.fileExists = { _ in
             true
         }
@@ -108,7 +108,7 @@ final class KlaviyoStateTests: XCTestCase {
         assertSnapshot(matching: state, as: .dump)
     }
 
-    func testValidStateFileExists() throws {
+    func testValidStateFileExists() {
         environment.fileClient.fileExists = { _ in
             true
         }
@@ -161,7 +161,7 @@ final class KlaviyoStateTests: XCTestCase {
 
     // MARK: test background and authorization states
 
-    func testBackgroundStates() {
+    func testBackgroundStates() throws {
         let backgroundStates = [
             UIBackgroundRefreshStatus.available: PushBackground.available,
             .denied: .denied,
@@ -173,11 +173,11 @@ final class KlaviyoStateTests: XCTestCase {
         }
 
         // Fake value to test availability
-        XCTAssertEqual(PushBackground.create(from: UIBackgroundRefreshStatus(rawValue: 20)!), .available)
+        XCTAssertEqual(try PushBackground.create(from: XCTUnwrap(UIBackgroundRefreshStatus(rawValue: 20))), .available)
     }
 
     @available(iOS 14.0, *)
-    func testPushEnablementStates() {
+    func testPushEnablementStates() throws {
         let enablementStates = [
             UNAuthorizationStatus.authorized: PushEnablement.authorized,
             .denied: .denied,
@@ -191,6 +191,6 @@ final class KlaviyoStateTests: XCTestCase {
         }
 
         // Fake value to test availability
-        XCTAssertEqual(PushEnablement.create(from: UNAuthorizationStatus(rawValue: 50)!), .notDetermined)
+        XCTAssertEqual(try PushEnablement.create(from: XCTUnwrap(UNAuthorizationStatus(rawValue: 50))), .notDetermined)
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -65,13 +65,13 @@ extension KlaviyoEnvironment {
 }
 
 class TestJSONDecoder: JSONDecoder, @unchecked Sendable {
-    override func decode<T>(_: T.Type, from _: Data) throws -> T where T: Decodable {
+    override func decode<T: Decodable>(_: T.Type, from _: Data) throws -> T {
         KlaviyoState.test as! T
     }
 }
 
 class InvalidJSONDecoder: JSONDecoder, @unchecked Sendable {
-    override func decode<T>(_: T.Type, from _: Data) throws -> T where T: Decodable {
+    override func decode<T: Decodable>(_: T.Type, from _: Data) throws -> T {
         throw KlaviyoDecodingError.invalidType
     }
 }
@@ -148,8 +148,13 @@ extension StateChangePublisher {
 }
 
 private final class KeyedArchiver: NSKeyedArchiver {
-    override func decodeObject(forKey _: String) -> Any { "" }
-    override func decodeInt64(forKey _: String) -> Int64 { 0 }
+    override func decodeObject(forKey _: String) -> Any {
+        ""
+    }
+
+    override func decodeInt64(forKey _: String) -> Int64 {
+        0
+    }
 }
 
 extension UNNotificationResponse {

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -124,7 +124,7 @@ final class ResolveTrackingLinkTests: XCTestCase {
             clickTime
         }
 
-        let trackingLinkURL = URL(string: "https://email.klaviyo.com/tracking/link")!
+        let trackingLinkURL = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
 
         // Mock API failure
         environment.klaviyoAPI.send = { _, _ in

--- a/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateChangePublisherTests.swift
@@ -19,7 +19,7 @@ final class StateChangePublisherTests: XCTestCase {
     }
 
     @MainActor
-    func testStateChangePublisher() throws {
+    func testStateChangePublisher() {
         let savedCalledExpectation = XCTestExpectation(description: "Save called on initialization")
         // Third call set email should trigger again
         let setEmailSaveExpectation = XCTestExpectation(description: "Set email should be saved.")
@@ -80,7 +80,7 @@ final class StateChangePublisherTests: XCTestCase {
     }
 
     @MainActor
-    func testStateChangeDuplicateAreRemoved() throws {
+    func testStateChangeDuplicateAreRemoved() {
         let savedCalledExpectation = XCTestExpectation(description: "Save called on initialization")
         savedCalledExpectation.assertForOverFulfill = true
 
@@ -121,7 +121,7 @@ final class StateChangePublisherTests: XCTestCase {
         wait(for: [savedCalledExpectation], timeout: 1.0)
     }
 
-    func testQuickStateUpdatesTriggerOnlyOneSaves() throws {
+    func testQuickStateUpdatesTriggerOnlyOneSaves() {
         let savedCalledExpectation = XCTestExpectation(description: "Save called on initialization")
         var count = 0
         environment.fileClient.write = { _, _ in

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -20,7 +20,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - initialization
 
     @MainActor
-    func testInitializeWhileInitializing() async throws {
+    func testInitializeWhileInitializing() async {
         let initialState = KlaviyoState(queue: [], requestsInFlight: [])
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -48,7 +48,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         // Using the same key shouldn't do much
-        _ = await store.send(.initialize(initialState.apiKey!))
+        _ = try await store.send(.initialize(XCTUnwrap(initialState.apiKey)))
 
         let newApiKey = "new-api-key"
         // Using a new key should update the key and generate two requests
@@ -62,7 +62,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Send Request
 
     @MainActor
-    func testSendRequestBeforeInitialization() async throws {
+    func testSendRequestBeforeInitialization() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -77,7 +77,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Complete Initialization
 
     @MainActor
-    func testCompleteInitializationWhileAlreadyInitialized() async throws {
+    func testCompleteInitializationWhileAlreadyInitialized() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -94,7 +94,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testCompleteInitializationWithExistingIdentifiers() async throws {
+    func testCompleteInitializationWithExistingIdentifiers() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         anonymousId: "foo", queue: [],
@@ -120,7 +120,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Set Email
 
     @MainActor
-    func testSetEmailUninitializedDoesNotAddToPendingRequest() async throws {
+    func testSetEmailUninitializedDoesNotAddToPendingRequest() async {
         let expection = XCTestExpectation(description: "fatal error expected")
         environment.emitDeveloperWarning = { _ in
             // Would really fatalError - not happening because we can't do that in tests so we fake it.
@@ -141,7 +141,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmailMissingAnonymousIdStillSetsEmail() async throws {
+    func testSetEmailMissingAnonymousIdStillSetsEmail() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -156,7 +156,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmptyEmail() async throws {
+    func testSetEmptyEmail() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -164,7 +164,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmailWithWhiteSpace() async throws {
+    func testSetEmailWithWhiteSpace() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -172,7 +172,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmailWithTrailingWhiteSpace() async throws {
+    func testSetEmailWithTrailingWhiteSpace() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -188,7 +188,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Set External Id
 
     @MainActor
-    func testSetExternalIdUninitializedDoesNotAddToPendingRequest() async throws {
+    func testSetExternalIdUninitializedDoesNotAddToPendingRequest() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         anonymousId: environment.uuid().uuidString,
@@ -202,7 +202,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetExternalIdMissingAnonymousIdStillSetsExternalId() async throws {
+    func testSetExternalIdMissingAnonymousIdStillSetsExternalId() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -217,7 +217,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmptyExternalId() async throws {
+    func testSetEmptyExternalId() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -225,7 +225,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetExternalIdWithWhiteSpaces() async throws {
+    func testSetExternalIdWithWhiteSpaces() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -233,7 +233,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetExternalIdWithTrailingWhiteSpace() async throws {
+    func testSetExternalIdWithTrailingWhiteSpace() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -249,7 +249,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Set Phone number
 
     @MainActor
-    func testSetPhoneNumberUninitializedDoesNotAddToPendingRequest() async throws {
+    func testSetPhoneNumberUninitializedDoesNotAddToPendingRequest() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         anonymousId: environment.uuid().uuidString,
@@ -263,7 +263,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetPhoneNumberMissingApiKeyStillSetsPhoneNumber() async throws {
+    func testSetPhoneNumberMissingApiKeyStillSetsPhoneNumber() async {
         let initialState = KlaviyoState(anonymousId: environment.uuid().uuidString,
                                         queue: [],
                                         requestsInFlight: [],
@@ -277,7 +277,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetEmptyPhoneNumber() async throws {
+    func testSetEmptyPhoneNumber() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -285,7 +285,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetPhoneNumberWithWhiteSpaces() async throws {
+    func testSetPhoneNumberWithWhiteSpaces() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -293,7 +293,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetPhoneNumberWithTrailingWhiteSpace() async throws {
+    func testSetPhoneNumberWithTrailingWhiteSpace() async {
         let initialState = KlaviyoState(anonymousId: environment.uuid().uuidString,
                                         queue: [],
                                         requestsInFlight: [],
@@ -309,7 +309,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Set Push Token
 
     @MainActor
-    func testSetPushTokenUninitializedDoesNotAddToPendingRequest() async throws {
+    func testSetPushTokenUninitializedDoesNotAddToPendingRequest() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         anonymousId: environment.uuid().uuidString,
@@ -323,7 +323,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetPushTokenWithMissingAnonymousId() async throws {
+    func testSetPushTokenWithMissingAnonymousId() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -387,7 +387,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - Default Badge Clearing
 
     @MainActor
-    func testDefaultBadgeClearingOn() async throws {
+    func testDefaultBadgeClearingOn() async {
         let apiKey = "fake-key"
         environment.getBadgeAutoClearingSetting = { true }
         let expectation = XCTestExpectation(description: "Should set badge to 0")
@@ -489,7 +489,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - set enqueue event uninitialized
 
     @MainActor
-    func testOpenedPushEventUninitializedAddsToPendingRequests() async throws {
+    func testOpenedPushEventUninitializedAddsToPendingRequests() async {
         let store = TestStore(initialState: .init(queue: []), reducer: KlaviyoReducer())
         let event = Event(name: ._openedPush)
         _ = await store.send(.enqueueEvent(event)) {
@@ -498,7 +498,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testEnqueueNonOpenedPushEventUninitializedDoesNotAddToPendingRequest() async throws {
+    func testEnqueueNonOpenedPushEventUninitializedDoesNotAddToPendingRequest() async {
         let expection = XCTestExpectation(description: "fatal error expected")
         environment.emitDeveloperWarning = { _ in
             // Would really runTimeWarn - not happening because we can't do that in tests so we fake it.
@@ -519,7 +519,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - set profile uninitialized
 
     @MainActor
-    func testSetProfileUnitialized() async throws {
+    func testSetProfileUnitialized() async {
         let expection = XCTestExpectation(description: "fatal error expected")
         environment.emitDeveloperWarning = { _ in
             // Would really runTimeWarn - not happening because we can't do that in tests so we fake it.
@@ -532,7 +532,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfileWithEmptyStringIdentifiers() async throws {
+    func testSetProfileWithEmptyStringIdentifiers() async {
         let initialState = KlaviyoState(
             apiKey: TEST_API_KEY,
             email: "foo@bar.com",
@@ -563,7 +563,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     // MARK: - enqueueProfile: conditional reset (push-token storm fix)
 
     @MainActor
-    func testSetProfileSameIdentifiersDoesNotReset() async throws {
+    func testSetProfileSameIdentifiersDoesNotReset() async {
         // When setProfile is called with the same identifiers that are already on state,
         // reset() should NOT fire — anonymousId stays the same, no spurious push-token request.
         let initialState = KlaviyoState(
@@ -591,7 +591,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfileDifferentIdentifiersResetsState() async throws {
+    func testSetProfileDifferentIdentifiersResetsState() async {
         // When setProfile is called with different identifiers, reset() SHOULD fire,
         // regenerating the anonymousId and clearing pushTokenData.
         let initialState = KlaviyoState(
@@ -637,7 +637,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfileSameIdentifiersDifferentAttributesStillUpdates() async throws {
+    func testSetProfileSameIdentifiersDifferentAttributesStillUpdates() async {
         // Same identifiers but different non-identifier attributes (e.g. firstName) —
         // should NOT reset, but attributes should still be sent in the profile request.
         let initialState = KlaviyoState(
@@ -671,7 +671,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfilePartialIdentifierMatchStillResets() async throws {
+    func testSetProfilePartialIdentifierMatchStillResets() async {
         // If only one identifier changes (e.g. email changes, phone stays same),
         // reset should still fire.
         let initialState = KlaviyoState(
@@ -714,7 +714,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfileNilIdentifiersTriggersResetWhenStateHasIdentifiers() async throws {
+    func testSetProfileNilIdentifiersTriggersResetWhenStateHasIdentifiers() async {
         // All-nil incoming identifiers differ from non-nil state identifiers,
         // so reset fires — preserving the old "clobbering" setProfile behavior.
         let initialState = KlaviyoState(
@@ -760,7 +760,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
     }
 
     @MainActor
-    func testResetProfileStillClobbersAllState() async throws {
+    func testResetProfileStillClobbersAllState() async {
         // resetProfile() should always clobber all state, regardless of identifiers.
         let initialState = KlaviyoState(
             apiKey: TEST_API_KEY,

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -22,7 +22,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Initialization
 
     @MainActor
-    func testInitialize() async throws {
+    func testInitialize() async {
         let initialState = KlaviyoState(queue: [], requestsInFlight: [])
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -47,7 +47,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testInitializeSubscribesToAppropriatePublishers() async throws {
+    func testInitializeSubscribesToAppropriatePublishers() async {
         let lifecycleExpectation = XCTestExpectation(description: "lifecycle is subscribed")
         let stateChangeIsSubscribed = XCTestExpectation(description: "state change is subscribed")
         let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
@@ -80,7 +80,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Set Email
 
     @MainActor
-    func testSetEmail() async throws {
+    func testSetEmail() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -95,7 +95,7 @@ class StateManagementTests: XCTestCase {
     // MARK: Set Phone Number
 
     @MainActor
-    func testSetPhoneNumber() async throws {
+    func testSetPhoneNumber() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -110,7 +110,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Set External Id.
 
     @MainActor
-    func testSetExternalId() async throws {
+    func testSetExternalId() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -131,7 +131,7 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let pushTokenRequest = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blobtoken", enablement: .authorized)
+        let pushTokenRequest = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blobtoken", enablement: .authorized)
         _ = await store.send(.setPushToken("blobtoken", .authorized)) {
             $0.queue = [pushTokenRequest]
         }
@@ -158,14 +158,14 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let pushTokenRequest = initialState.buildTokenRequest(
-            apiKey: initialState.apiKey!,
-            anonymousId: initialState.anonymousId!,
-            pushToken: initialState.pushTokenData!.pushToken,
+        let pushTokenRequest = try initialState.buildTokenRequest(
+            apiKey: XCTUnwrap(initialState.apiKey),
+            anonymousId: XCTUnwrap(initialState.anonymousId),
+            pushToken: XCTUnwrap(initialState.pushTokenData?.pushToken),
             enablement: .authorized
         )
 
-        _ = await store.send(.setPushToken(initialState.pushTokenData!.pushToken, .authorized)) {
+        _ = try await store.send(.setPushToken(XCTUnwrap(initialState.pushTokenData?.pushToken), .authorized)) {
             $0.queue = [pushTokenRequest]
         }
 
@@ -196,7 +196,7 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let pushTokenRequest = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blobtoken", enablement: .authorized)
+        let pushTokenRequest = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blobtoken", enablement: .authorized)
 
         _ = await store.send(.setPushToken("blobtoken", .authorized)) {
             $0.queue = [pushTokenRequest]
@@ -221,7 +221,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Set Push Enablement
 
     @MainActor
-    func testSetPushEnablementPushTokenIsNil() async throws {
+    func testSetPushEnablementPushTokenIsNil() async {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData = nil
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -235,16 +235,16 @@ class StateManagementTests: XCTestCase {
         initialState.pushTokenData?.pushEnablement = .denied
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let pushTokenRequest = initialState.buildTokenRequest(
-            apiKey: initialState.apiKey!,
-            anonymousId: initialState.anonymousId!,
-            pushToken: initialState.pushTokenData!.pushToken,
+        let pushTokenRequest = try initialState.buildTokenRequest(
+            apiKey: XCTUnwrap(initialState.apiKey),
+            anonymousId: XCTUnwrap(initialState.anonymousId),
+            pushToken: XCTUnwrap(initialState.pushTokenData?.pushToken),
             enablement: .authorized
         )
 
         _ = await store.send(.setPushEnablement(.authorized))
 
-        await store.receive(.setPushToken(initialState.pushTokenData!.pushToken, .authorized)) {
+        try await store.receive(.setPushToken(XCTUnwrap(initialState.pushTokenData?.pushToken), .authorized)) {
             $0.queue = [pushTokenRequest]
         }
     }
@@ -252,7 +252,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - flush
 
     @MainActor
-    func testFlushUninitializedQueueDoesNotFlush() async throws {
+    func testFlushUninitializedQueueDoesNotFlush() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -264,7 +264,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testQueueThatIsFlushingDoesNotFlush() async throws {
+    func testQueueThatIsFlushingDoesNotFlush() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -276,7 +276,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testEmptyQueueDoesNotFlush() async throws {
+    func testEmptyQueueDoesNotFlush() async {
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         queue: [],
@@ -304,8 +304,8 @@ class StateManagementTests: XCTestCase {
         }
         var initialState = INITIALIZED_TEST_STATE()
         initialState.flushing = false
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blob_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blob_token", enablement: .authorized)
         initialState.queue = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -335,8 +335,8 @@ class StateManagementTests: XCTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 23, totalRetryCount: 23, currentBackoff: 200)
         initialState.flushing = false
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blob_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blob_token", enablement: .authorized)
         initialState.queue = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -350,8 +350,8 @@ class StateManagementTests: XCTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(requestCount: 23, totalRetryCount: 23, currentBackoff: Int(initialState.flushInterval) - 2)
         initialState.flushing = false
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blob_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blob_token", enablement: .authorized)
         initialState.queue = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -373,7 +373,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testSendRequestWhenNotFlushing() async throws {
+    func testSendRequestWhenNotFlushing() async {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -384,7 +384,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - send request
 
     @MainActor
-    func testSendRequestWithNoRequestsInFlight() async throws {
+    func testSendRequestWithNoRequestsInFlight() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         // Shouldn't really happen but getting more coverage...
@@ -396,7 +396,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Network Connectivity Changed
 
     @MainActor
-    func testNetworkConnectivityChanges() async throws {
+    func testNetworkConnectivityChanges() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         // Shouldn't really happen but getting more coverage...
@@ -424,8 +424,8 @@ class StateManagementTests: XCTestCase {
         // This test is a little convoluted but essentially want to make when we stop
         // that we save our state.
         var initialState = INITIALIZED_TEST_STATE()
-        let request = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let request2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blob_token", enablement: .authorized)
+        let request = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let request2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "blob_token", enablement: .authorized)
         initialState.requestsInFlight = [request, request2]
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -447,20 +447,20 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
-        let profileAttributes: [(Profile.ProfileKey, Any)] = [
-            (.city, Profile.test.location!.city!),
-            (.region, Profile.test.location!.region!),
-            (.address1, Profile.test.location!.address1!),
-            (.address2, Profile.test.location!.address2!),
-            (.zip, Profile.test.location!.zip!),
-            (.country, Profile.test.location!.country!),
-            (.latitude, Profile.test.location!.latitude!),
-            (.longitude, Profile.test.location!.longitude!),
-            (.title, Profile.test.title!),
-            (.organization, Profile.test.organization!),
-            (.firstName, Profile.test.firstName!),
-            (.lastName, Profile.test.lastName!),
-            (.image, Profile.test.image!),
+        let profileAttributes: [(Profile.ProfileKey, Any)] = try [
+            (.city, XCTUnwrap(Profile.test.location?.city)),
+            (.region, XCTUnwrap(Profile.test.location?.region)),
+            (.address1, XCTUnwrap(Profile.test.location?.address1)),
+            (.address2, XCTUnwrap(Profile.test.location?.address2)),
+            (.zip, XCTUnwrap(Profile.test.location?.zip)),
+            (.country, XCTUnwrap(Profile.test.location?.country)),
+            (.latitude, XCTUnwrap(Profile.test.location?.latitude)),
+            (.longitude, XCTUnwrap(Profile.test.location?.longitude)),
+            (.title, XCTUnwrap(Profile.test.title)),
+            (.organization, XCTUnwrap(Profile.test.organization)),
+            (.firstName, XCTUnwrap(Profile.test.firstName)),
+            (.lastName, XCTUnwrap(Profile.test.lastName)),
+            (.image, XCTUnwrap(Profile.test.image)),
             (.custom(customKey: "foo"), 20)
         ]
 
@@ -508,7 +508,7 @@ class StateManagementTests: XCTestCase {
         }
 
         await store.receive(.sendRequest)
-        await store.receive(.deQueueCompletedResults(request!)) {
+        try await store.receive(.deQueueCompletedResults(XCTUnwrap(request))) {
             $0.requestsInFlight = $0.queue
             $0.flushing = false
             $0.pendingProfile = nil
@@ -519,7 +519,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Test set profile
 
     @MainActor
-    func testSetProfileWithExistingProperties() async throws {
+    func testSetProfileWithExistingProperties() async {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "555BLOB"
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -533,7 +533,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testSetProfileWithAllProfileIdentifiersAndProperties() async throws {
+    func testSetProfileWithAllProfileIdentifiersAndProperties() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -562,7 +562,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testCreateProfileWithTrailingWhitespaceProperties() async throws {
+    func testCreateProfileWithTrailingWhitespaceProperties() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         _ = await store.send(.enqueueProfile(Profile(email: "foo@blob.com ", phoneNumber: "+19999999999     ", externalId: "abcdefg    "))) {
@@ -597,7 +597,7 @@ class StateManagementTests: XCTestCase {
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         for eventName in Event.EventName.allCases {
-            let event = Event(name: eventName, properties: ["push_token": initialState.pushTokenData!.pushToken])
+            let event = try Event(name: eventName, properties: ["push_token": XCTUnwrap(initialState.pushTokenData?.pushToken)])
             await store.send(.enqueueEvent(event)) {
                 try $0.enqueueRequest(
                     request: KlaviyoRequest(
@@ -626,7 +626,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testEnqueueEventWhenInitilizingSendsEvent() async throws {
+    func testEnqueueEventWhenInitilizingSendsEvent() async {
         let initialState = INITILIZING_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -668,7 +668,7 @@ class StateManagementTests: XCTestCase {
     // MARK: - Test enqueue aggregate event
 
     @MainActor
-    func testEnqueueAggregateEvent() async throws {
+    func testEnqueueAggregateEvent() async {
         let initialState = INITIALIZED_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -686,7 +686,7 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
-    func testEnqueueAggregateEventWhenInitilizingSendsEvent() async throws {
+    func testEnqueueAggregateEventWhenInitilizingSendsEvent() async {
         let initialState = INITILIZING_TEST_STATE()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -723,8 +723,8 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
 
         // Add some existing requests to the queue
-        let existingRequest1 = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
-        let existingRequest2 = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "token1", enablement: .authorized)
+        let existingRequest1 = try initialState.buildProfileRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId))
+        let existingRequest2 = try initialState.buildTokenRequest(apiKey: XCTUnwrap(initialState.apiKey), anonymousId: XCTUnwrap(initialState.anonymousId), pushToken: "token1", enablement: .authorized)
         initialState.queue = [existingRequest1, existingRequest2]
 
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
@@ -772,7 +772,7 @@ class StateManagementTests: XCTestCase {
             XCTAssertEqual($0.requestsInFlight[2].id, existingRequest2.id, "Third request should be existing request 2")
         }
         await store.receive(.sendRequest)
-        await store.receive(.deQueueCompletedResults(actualGeofenceRequest!)) {
+        try await store.receive(.deQueueCompletedResults(XCTUnwrap(actualGeofenceRequest))) {
             $0.requestsInFlight.removeAll { $0.id == actualGeofenceRequest!.id }
             $0.retryState = .retry(1)
             $0.flushing = false

--- a/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
+++ b/Tests/KlaviyoSwiftTests/TrackingLinkDestinationResponseTests.swift
@@ -37,7 +37,7 @@ final class TrackingLinkDestinationResponseTests: XCTestCase {
             "original_destination": ""
         }
         """
-        let jsonData = json.data(using: .utf8)!
+        let jsonData = try XCTUnwrap(json.data(using: .utf8))
 
         // When/Then
         XCTAssertThrowsError(try JSONDecoder().decode(TrackingLinkDestinationResponse.self, from: jsonData)) { error in
@@ -59,7 +59,7 @@ final class TrackingLinkDestinationResponseTests: XCTestCase {
     func testDecodingMissingField() throws {
         // Given
         let json = "{}"
-        let jsonData = json.data(using: .utf8)!
+        let jsonData = try XCTUnwrap(json.data(using: .utf8))
 
         // When/Then
         XCTAssertThrowsError(try JSONDecoder().decode(TrackingLinkDestinationResponse.self, from: jsonData)) { error in


### PR DESCRIPTION
## Summary

Clean re-do of #591, which was reverted in #663 because its squash merge dragged unrelated master-only changes into `rel/5.4.0`.

This branch is cut **directly off `rel/5.4.0`**, so it contains **only** the intended change:
- bump the pinned SwiftFormat hook `0.51.2 → 0.59.1` (`.pre-commit-config.yaml`)
- the resulting `swiftformat .` reformat across `Sources/`, `Examples/`, `Tests/`

No `PUSH_NOTIFICATION_DATA_GUIDE.md`, `PushLog*`, `CODEOWNERS`, or `Gemfile.lock` changes (those were the #647/#651 pollution).

## ⚠️ Blocked on #663

Kept as a **draft** until the revert (#663) merges. Once `rel/5.4.0` is restored, this branch's merge base and target line up and it can be marked ready. (The diff already shows clean because the merge base is the pre-merge commit `3b5fd16c`.)

## Notes

- The reformat includes force-unwrap → `try XCTUnwrap(...)` rewrites in tests — this is legitimate SwiftFormat 0.59.1 output, not hand edits.
- CodeRabbit will likely re-flag line-length/DRY on those expanded test lines; these are advisory (repo SwiftLint runs `--fix`, where `--strict` is a no-op, and SwiftFormat has no `--maxwidth`), so they are non-blocking.

## Test plan

- CI green (pre-commit, all test matrix cells) once rebuilt on the reverted `rel/5.4.0`
- Confirm diff is formatter-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)