### PR TITLE
test(push): fix racy web_url/deep_link precedence tests

### DIFF
--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -487,6 +487,11 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleBodyTap_WebUrlDispatchesOpenWebUrl() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        // Each dispatched action (event track + openWebUrl) is scheduled on its own
+        // Task by `dispatchOnMainThread`, independently of the completion handler's Task,
+        // so waiting on `callback` alone races with those dispatches landing.
+        let dispatched = XCTestExpectation(description: "actions dispatched")
+        dispatched.expectedFulfillmentCount = 2
         let webURL = try XCTUnwrap(URL(string: "https://example.com/sale"))
 
         let userInfo: [AnyHashable: Any] = [
@@ -497,6 +502,7 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            dispatched.fulfill()
             return nil
         }
 
@@ -505,7 +511,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, dispatched], timeout: 1.0)
         XCTAssertTrue(handled)
 
         let webUrlDispatched = capturedActions.contains { action in
@@ -523,6 +529,9 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleBodyTap_DeepLinkUnchangedWhenWebUrlAbsent() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        // See testHandleBodyTap_WebUrlDispatchesOpenWebUrl re: why we wait for both.
+        let dispatched = XCTestExpectation(description: "actions dispatched")
+        dispatched.expectedFulfillmentCount = 2
         let deepURL = try XCTUnwrap(URL(string: "myapp://path"))
 
         let userInfo: [AnyHashable: Any] = [
@@ -533,6 +542,7 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            dispatched.fulfill()
             return nil
         }
 
@@ -541,7 +551,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, dispatched], timeout: 1.0)
 
         let deepLinkDispatched = capturedActions.contains { action in
             if case let .openDeepLink(url) = action { return url == deepURL }
@@ -555,6 +565,9 @@ class KlaviyoSDKTests: XCTestCase {
         // the user stays in the host app. The composer UI enforces a single action type
         // at creation, so this only fires via direct-API or test-tooling sends.
         let callback = XCTestExpectation(description: "callback is made")
+        // See testHandleBodyTap_WebUrlDispatchesOpenWebUrl re: why we wait for both.
+        let dispatched = XCTestExpectation(description: "actions dispatched")
+        dispatched.expectedFulfillmentCount = 2
         let webURL = try XCTUnwrap(URL(string: "https://example.com/sale"))
         let deepURL = try XCTUnwrap(URL(string: "myapp://path"))
 
@@ -567,6 +580,7 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            dispatched.fulfill()
             return nil
         }
 
@@ -575,7 +589,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, dispatched], timeout: 1.0)
 
         let deepLinkDispatched = capturedActions.contains { action in
             if case let .openDeepLink(dispatchedUrl) = action { return dispatchedUrl == deepURL }
@@ -592,6 +606,9 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleActionButtonTap_OpenUrlButton() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        // See testHandleBodyTap_WebUrlDispatchesOpenWebUrl re: why we wait for both.
+        let dispatched = XCTestExpectation(description: "actions dispatched")
+        dispatched.expectedFulfillmentCount = 2
         let actionURL = try XCTUnwrap(URL(string: "https://example.com/promo"))
         let actionId = "com.klaviyo.test.web"
         let buttonLabel = "Visit Site"
@@ -613,6 +630,7 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            dispatched.fulfill()
             return nil
         }
 
@@ -625,7 +643,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, dispatched], timeout: 1.0)
         XCTAssertTrue(handled)
 
         let webUrlDispatched = capturedActions.contains { action in
@@ -649,6 +667,11 @@ class KlaviyoSDKTests: XCTestCase {
 
     func testHandleActionButtonTap_OpenUrlButtonWithBlockedSchemeDoesNotDispatch() throws {
         let callback = XCTestExpectation(description: "callback is made")
+        // Only the event track dispatches here (the blocked scheme short-circuits before
+        // dispatchOnMainThread(.openWebUrl)) — see testHandleBodyTap_WebUrlDispatchesOpenWebUrl
+        // re: why we wait for dispatch count rather than just the completion callback.
+        let dispatched = XCTestExpectation(description: "actions dispatched")
+        dispatched.expectedFulfillmentCount = 1
         let actionURL = try XCTUnwrap(URL(string: "javascript:alert(1)"))
         let actionId = "com.klaviyo.test.blocked"
         let buttonLabel = "Bad Button"
@@ -670,6 +693,7 @@ class KlaviyoSDKTests: XCTestCase {
         var capturedActions: [KlaviyoAction] = []
         klaviyoSwiftEnvironment.send = { action in
             capturedActions.append(action)
+            dispatched.fulfill()
             return nil
         }
 
@@ -682,7 +706,7 @@ class KlaviyoSDKTests: XCTestCase {
             callback.fulfill()
         }
 
-        wait(for: [callback], timeout: 1.0)
+        wait(for: [callback, dispatched], timeout: 1.0)
         XCTAssertTrue(handled)
 
         let webUrlDispatched = capturedActions.contains { action in


### PR DESCRIPTION
# Description
Fixes an intermittent CI failure on the `web_url`/`deep_link` precedence tests, caused by a race between two independently-scheduled Tasks in the test, not a bug in the SDK's dispatch behavior.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
PR #666 (`feat/push-638-open-url` → `rel/5.4.0`) hit a real but intermittent CI failure on `16.4, release`: `testHandleBodyTap_DeepLinkUnchangedWhenWebUrlAbsent` and `testHandleBodyTap_WebUrlDispatchesOpenWebUrl` failed on two separate reruns (once with 1 test failing, once with 2).

Root cause: `dispatchOnMainThread()` schedules the actual action dispatch (`klaviyoSwiftEnvironment.send(action)`) in its own `Task { await MainActor.run { ... } }`, while `handle(notificationResponse:withCompletionHandler:)` schedules the completion callback in a *separate* `Task { @MainActor in completionHandler() }`. Swift Concurrency gives no ordering guarantee between independently-created Tasks, so `wait(for: [callback], timeout: 1.0)` can return before the actual dispatch(es) have landed — especially under CI load, which is exactly what surfaced this.

Fix (test-only, no production code changed): each affected test now also waits on an `XCTestExpectation` with `expectedFulfillmentCount` set to the number of `send()` calls the scenario actually produces (verified against `handleActionButtonTap`/`resolveOpenAction` in `Klaviyo.swift`), fulfilled from inside the `send` closure itself. This makes the test wait for the actual side effects it asserts on, rather than an unrelated callback.

Affected tests: `testHandleBodyTap_WebUrlDispatchesOpenWebUrl`, `testHandleBodyTap_DeepLinkUnchangedWhenWebUrlAbsent`, `testHandleBodyTap_DeepLinkTakesPrecedenceOverWebUrl`, `testHandleActionButtonTap_OpenUrlButton`, `testHandleActionButtonTap_OpenUrlButtonWithBlockedSchemeDoesNotDispatch`.

## Test Plan
`make CONFIG=release test-library` — full suite (251 tests) passes, including all five updated tests. `swiftlint --strict` on the changed file shows only pre-existing violations (identical before/after this diff, confirmed via `git stash`), nothing newly introduced.

## Related Issues/Tickets
PUSH-638 — part of the "open web URL" project. Surfaced via flaky CI on #666.
