### PR TITLE
fix(forms): redact logged CTA URL, verify openExternally skips deep-link path

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -334,7 +334,11 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case let .openDeepLink(url, formId, formName, buttonLabel, openExternally):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info(
-                    "Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .private), openExternally: \(openExternally, privacy: .public)"
+                    """
+                    Received 'openDeepLink' event from KlaviyoJS with url: \
+                    \(url?.absoluteString ?? "nil", privacy: .private), \
+                    openExternally: \(openExternally, privacy: .public)
+                    """
                 )
             }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -334,7 +334,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case let .openDeepLink(url, formId, formName, buttonLabel, openExternally):
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info(
-                    "Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public), openExternally: \(openExternally, privacy: .public)"
+                    "Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .private), openExternally: \(openExternally, privacy: .public)"
                 )
             }
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -19,6 +19,19 @@ private class TestKlaviyoWebViewController: KlaviyoWebViewController {
     }
 }
 
+/// Installs a `klaviyoSwiftEnvironment.send` that fulfills `expectation` on `.openDeepLink`
+/// and passes every other action through to the original closure. Returns a closure that
+/// restores the original `send`, which callers must invoke (e.g. via `defer`).
+private func interceptDeepLinkDispatch(failing expectation: XCTestExpectation) -> () -> Void {
+    let originalSend = klaviyoSwiftEnvironment.send
+    klaviyoSwiftEnvironment.send = { action in
+        guard case .openDeepLink = action else { return originalSend(action) }
+        expectation.fulfill()
+        return nil
+    }
+    return { klaviyoSwiftEnvironment.send = originalSend }
+}
+
 final class IAFWebViewModelTests: XCTestCase {
     // MARK: - Properties
 
@@ -383,13 +396,11 @@ final class IAFWebViewModelTests: XCTestCase {
         }
         defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
-        // A spurious .openDeepLink dispatch (via dispatchOnMainThread's own Task) would
-        // mean the deep-link path ran instead — fulfilling this would be the regression.
+        // A spurious .openDeepLink dispatch would mean the deep-link path ran instead.
         let noDeepLink = XCTestExpectation(description: "no .openDeepLink dispatched")
         noDeepLink.isInverted = true
-        let originalSend = klaviyoSwiftEnvironment.send
-        klaviyoSwiftEnvironment.send = { if case .openDeepLink = $0 { noDeepLink.fulfill() }; return nil }
-        defer { klaviyoSwiftEnvironment.send = originalSend }
+        let restoreSend = interceptDeepLinkDispatch(failing: noDeepLink)
+        defer { restoreSend() }
 
         // When
         viewModel.handleScriptMessage(makeOpenExternalUrlMessage())

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -383,6 +383,10 @@ final class IAFWebViewModelTests: XCTestCase {
         }
         defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
+        // A spurious .openDeepLink dispatch would mean the deep-link path ran instead.
+        var capturedActions: [KlaviyoAction] = []
+        klaviyoSwiftEnvironment.send = { action in capturedActions.append(action); return nil }
+
         // When
         viewModel.handleScriptMessage(makeOpenExternalUrlMessage())
 
@@ -396,6 +400,10 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertEqual(formName, "Newsletter")
         XCTAssertEqual(buttonLabel, "Learn More")
         XCTAssertEqual(url, URL(string: "https://example.com"))
+        XCTAssertFalse(
+            capturedActions.contains { if case .openDeepLink = $0 { return true }; return false },
+            "openExternally: true must not route through the deep-link path"
+        )
     }
 
     @MainActor

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -383,9 +383,13 @@ final class IAFWebViewModelTests: XCTestCase {
         }
         defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
 
-        // A spurious .openDeepLink dispatch would mean the deep-link path ran instead.
-        var capturedActions: [KlaviyoAction] = []
-        klaviyoSwiftEnvironment.send = { action in capturedActions.append(action); return nil }
+        // A spurious .openDeepLink dispatch (via dispatchOnMainThread's own Task) would
+        // mean the deep-link path ran instead — fulfilling this would be the regression.
+        let noDeepLink = XCTestExpectation(description: "no .openDeepLink dispatched")
+        noDeepLink.isInverted = true
+        let originalSend = klaviyoSwiftEnvironment.send
+        klaviyoSwiftEnvironment.send = { if case .openDeepLink = $0 { noDeepLink.fulfill() }; return nil }
+        defer { klaviyoSwiftEnvironment.send = originalSend }
 
         // When
         viewModel.handleScriptMessage(makeOpenExternalUrlMessage())
@@ -400,10 +404,9 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertEqual(formName, "Newsletter")
         XCTAssertEqual(buttonLabel, "Learn More")
         XCTAssertEqual(url, URL(string: "https://example.com"))
-        XCTAssertFalse(
-            capturedActions.contains { if case .openDeepLink = $0 { return true }; return false },
-            "openExternally: true must not route through the deep-link path"
-        )
+
+        // Give the deep-link path's Task a real window to run before concluding absence.
+        await fulfillment(of: [noDeepLink], timeout: 0.3)
     }
 
     @MainActor


### PR DESCRIPTION
# Description
Addresses two CodeRabbit findings from PR #666: a PII logging issue and a test-coverage gap on the IAF external-URL bridge.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
- `IAFWebViewModel.swift` — the `openDeepLink` case logged the externally-supplied CTA URL as `.public` in an `os_log` call. CTA URLs can carry emails, phone numbers, or signed query parameters, so mark that interpolation `.private` (the `openExternally` flag stays `.public`, it's just a bool).
- `IAFWebViewModelTests.swift` — `testHandleOpenExternalUrlFiresLifecycleEvent` only asserted the `formCtaClicked` lifecycle event fired, not that `openExternally: true` actually skips the deep-link path (`KlaviyoInternal.handleDeepLink` → `dispatchOnMainThread(.openDeepLink)`). Added an assertion that no `.openDeepLink` action is dispatched, using the same `klaviyoSwiftEnvironment.send` capture pattern already established in `KlaviyoSDKTests.swift`. (`environment.linkHandler.openExternalURL` itself isn't mockable — it's a concrete class wrapping `UIApplication.shared.open` — so this verifies the negative: the deep-link path wasn't taken, which is the actual regression risk.)

Skipped the remaining CodeRabbit nitpicks (line-length on unrelated pre-existing lines, and several "extract a shared test helper" DRY suggestions across 4 test files) as out of scope for a pre-release-branch-merge fix — logged as optional follow-up, not blocking.

## Test Plan
`make CONFIG=release test-library` — full suite (251 tests) passes. `swiftlint --strict` on both changed files shows only pre-existing violations (confirmed via diff against `git stash`), nothing newly introduced.

## Related Issues/Tickets
PUSH-638 — part of the "open web URL" project. Findings surfaced by CodeRabbit on #666.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy handling for deep-link URLs in diagnostic logging.
  * Prevented unintended deep-link events when opening external URLs.

* **Tests**
  * Added regression coverage to verify external URL handling does not trigger deep-link navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->