### PR TITLE
feat(push): open web URL support for notifications, push actions and IAF

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,9 @@ let package = Package(
         .testTarget(
             name: "KlaviyoSwiftExtensionTests",
             dependencies: [
-                "KlaviyoSwiftExtension"
+                "KlaviyoSwiftExtension",
+                // Test-only: lets the allowlist parity test compare against the KlaviyoCore copy.
+                "KlaviyoCore"
             ]
         ),
         .target(

--- a/Sources/KlaviyoCore/Models/ActionType.swift
+++ b/Sources/KlaviyoCore/Models/ActionType.swift
@@ -17,11 +17,13 @@ import Foundation
 public enum ActionType: String, Equatable {
     case openApp = "open_app"
     case deepLink = "deep_link"
+    case openUrl = "open_url"
 
     public func displayName() -> String {
         switch self {
         case .openApp: return "Open App"
         case .deepLink: return "Deep Link"
+        case .openUrl: return "Open URL"
         }
     }
 }

--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -55,7 +55,7 @@ public class DeepLinkHandler {
     /// URL in the system browser rather than route into the app.
     package func openExternalURL(_ url: URL) async {
         if #available(iOS 14.0, *) {
-            Logger.navigation.info("Opening external URL: '\(url.absoluteString, privacy: .public)' (bypassing custom deep link handler)")
+            Logger.navigation.info("Opening external URL: '\(url.absoluteString, privacy: .private)' (bypassing custom deep link handler)")
         }
         await Self.openWithUIApplicationAPI(url)
     }

--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -48,11 +48,12 @@ public class DeepLinkHandler {
 
     // MARK: - Handle Link
 
-    /// Opens an external web URL using `UIApplication.shared.open(_:)`, bypassing any
-    /// registered custom deep link handler.
+    /// Opens a supported external/system URL using `UIApplication.shared.open(_:)`,
+    /// bypassing any registered custom deep link handler.
     ///
     /// Used by the `open_url` push action where the customer explicitly chose to open a
-    /// URL in the system browser rather than route into the app.
+    /// URL externally (a browser, dialer, or messaging app, depending on the URL's scheme)
+    /// rather than route into the app.
     package func openExternalURL(_ url: URL) async {
         if #available(iOS 14.0, *) {
             Logger.navigation.info("Opening external URL: '\(url.absoluteString, privacy: .private)' (bypassing custom deep link handler)")

--- a/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
+++ b/Sources/KlaviyoCore/Utils/DeepLinkHandler.swift
@@ -48,6 +48,18 @@ public class DeepLinkHandler {
 
     // MARK: - Handle Link
 
+    /// Opens an external web URL using `UIApplication.shared.open(_:)`, bypassing any
+    /// registered custom deep link handler.
+    ///
+    /// Used by the `open_url` push action where the customer explicitly chose to open a
+    /// URL in the system browser rather than route into the app.
+    package func openExternalURL(_ url: URL) async {
+        if #available(iOS 14.0, *) {
+            Logger.navigation.info("Opening external URL: '\(url.absoluteString, privacy: .public)' (bypassing custom deep link handler)")
+        }
+        await Self.openWithUIApplicationAPI(url)
+    }
+
     /// Attempts to route a Universal Link using the host application's Scene Delegate or App Delegate link handlers
     package func openURL(_ url: URL) async {
         if let customDeepLinkHandler {

--- a/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
@@ -21,3 +21,11 @@ import Foundation
 /// registers `sms:`; `smsto:` has no iOS handler, so `UIApplication.shared.open(_:)` would
 /// no-op. Use `sms:` for SMS on iOS.
 package let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms"]
+
+package extension URL {
+    /// True if this URL's scheme is in ``openUrlAllowedSchemes``. Shared so the `open_url`
+    /// gate on push action buttons and `web_url` can never diverge from each other.
+    var hasAllowedOpenUrlScheme: Bool {
+        scheme.map { openUrlAllowedSchemes.contains($0.lowercased()) } ?? false
+    }
+}

--- a/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift
@@ -1,0 +1,23 @@
+//
+//  URLSchemeAllowlist.swift
+//  klaviyo-swift-sdk
+//
+
+// NOTE: KlaviyoSwiftExtension carries an internal copy of this constant
+// (Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift) because that target cannot
+// depend on KlaviyoCore (NSE/share-extension sandbox restriction). The two
+// copies are intentionally kept in sync. If you change the set here, mirror
+// the change there.
+
+import Foundation
+
+/// URL schemes allowed for the `open_url` push action.
+///
+/// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
+/// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
+/// are silently dropped.
+///
+/// Note: `smsto:` is intentionally excluded (unlike the Android SDK). iOS Messages only
+/// registers `sms:`; `smsto:` has no iOS handler, so `UIApplication.shared.open(_:)` would
+/// no-op. Use `sms:` for SMS on iOS.
+package let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms"]

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -331,49 +331,68 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             }
         case let .trackAggregateEvent(data):
             EventDispatcher.shared.dispatch(.aggregateEvent(data))
-        case let .openDeepLink(url, formId, formName, buttonLabel):
+        case let .openDeepLink(url, formId, formName, buttonLabel, openExternally):
             if #available(iOS 14.0, *) {
-                Logger.webViewLogger.info("Received 'openDeepLink' event from KlaviyoJS with url: \(url?.absoluteString ?? "nil", privacy: .public)")
+                Logger.webViewLogger.info(
+                    """
+                    Received 'openDeepLink' event from KlaviyoJS with url: \
+                    \(url?.absoluteString ?? "nil", privacy: .private), \
+                    openExternally: \(openExternally, privacy: .public)
+                    """
+                )
             }
 
             // 1. Check URL exists and is non-empty — no URL means no navigation and no lifecycle event
             guard let url = url, !url.absoluteString.isEmpty else {
                 if #available(iOS 14.0, *) {
                     Logger.webViewLogger.warning(
-                        "CTA clicked but no deep link URL configured — skipping navigation"
+                        "CTA clicked but no URL configured — skipping navigation"
                     )
                 }
                 return
             }
 
-            // 2. Handle deep link navigation before validating lifecycle metadata
-            if UIApplication.shared.canOpenURL(url) {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
+            // 2. Route by `openExternally`. Deep links and external URLs ride the same
+            //    bridge message (onsite openDeepLink v3); the flag — not the scheme —
+            //    decides how to open, preserving the marketer's chosen action.
+            if openExternally {
+                // External web/system URL: open via the system, bypassing any registered
+                // deep link handler, gated by the on-device scheme allowlist.
+                guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.warning(
+                            "Blocked external URL with disallowed scheme: \(url.scheme ?? "nil", privacy: .public)"
+                        )
+                    }
+                    return
                 }
-                EventDispatcher.shared.dispatch(.deepLink(url))
+                Task {
+                    await environment.linkHandler.openExternalURL(url)
+                }
             } else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
+                // In-app deep link: route to the host app's registered deep link handler.
+                if UIApplication.shared.canOpenURL(url) {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
+                    }
+                    EventDispatcher.shared.dispatch(.deepLink(url))
+                } else {
+                    if #available(iOS 14.0, *) {
+                        Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
+                    }
                 }
             }
 
-            // 3. Invoke lifecycle handler when form identity fields are present
-            //    buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click
-            if let formId, !formId.isEmpty,
-               let formName, !formName.isEmpty {
-                IAFPresentationManager.shared.invokeLifecycleHandler(for: .formCtaClicked(
-                    formId: formId,
-                    formName: formName,
+            // 3. Invoke lifecycle handler when form identity fields are present. Both deep
+            //    links and external URLs surface through the same formCtaClicked event; the
+            //    URL rides in the deepLinkUrl field.
+            invokeCtaLifecycleHandler(eventName: "openDeepLink", formId: formId, formName: formName) {
+                .formCtaClicked(
+                    formId: $0,
+                    formName: $1,
                     buttonLabel: buttonLabel ?? "",
                     deepLinkUrl: url
-                ))
-            } else {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning(
-                        "openDeepLink missing metadata — skipping lifecycle callback"
-                    )
-                }
+                )
             }
         case let .abort(reason):
             if #available(iOS 14.0, *) {
@@ -396,5 +415,26 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case .profileMutation:
             ()
         }
+    }
+
+    /// Invokes the form lifecycle handler for a CTA tap when form identity fields are present.
+    /// buttonLabel is allowed to be nil/empty — a CTA with no text is still a valid click.
+    @MainActor
+    private func invokeCtaLifecycleHandler(
+        eventName: String,
+        formId: String?,
+        formName: String?,
+        makeEvent: (_ formId: String, _ formName: String) -> FormLifecycleEvent
+    ) {
+        guard let formId, !formId.isEmpty,
+              let formName, !formName.isEmpty else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning(
+                    "\(eventName, privacy: .public) missing metadata — skipping lifecycle callback"
+                )
+            }
+            return
+        }
+        IAFPresentationManager.shared.invokeLifecycleHandler(for: makeEvent(formId, formName))
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -373,13 +373,16 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 // In-app deep link: route to the host app's registered deep link handler.
                 if UIApplication.shared.canOpenURL(url) {
                     if #available(iOS 14.0, *) {
-                        Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .public)'")
+                        Logger.webViewLogger.info("Attempting to open URL '\(url, privacy: .private)'")
                     }
                     EventDispatcher.shared.dispatch(.deepLink(url))
                 } else {
                     if #available(iOS 14.0, *) {
-                        Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .public)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
+                        Logger.webViewLogger.warning("Unable to open the URL '\(url, privacy: .private)'. This may be because a) the device does not have an installed app registered to handle the URL's scheme, or b) you haven't declared the URL's scheme in your Info.plist file")
                     }
+                    // No navigation occurred — skip the formCtaClicked lifecycle event below,
+                    // consistent with its "fired after the SDK has initiated navigation" contract.
+                    return
                 }
             }
 

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -47,8 +47,8 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     case formDismissed(formId: String, formName: String)
 
     /// Triggered when a user taps a call-to-action (CTA) button in a form
-    /// that has a URL configured — either an in-app deep link or an external
-    /// (web) URL.
+    /// that has a URL configured — either an in-app deep link or a supported
+    /// external/system URL (`http(s)`, `mailto:`, `tel:`, `sms:`).
     ///
     /// Fired after the SDK has initiated navigation (deep link routing, or
     /// opening the URL externally). Not emitted if no URL is configured for
@@ -56,8 +56,8 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     ///
     /// - `buttonLabel`: The label text of the tapped button.
     /// - `deepLinkUrl`: The URL associated with the CTA. For historical reasons
-    ///   this parameter is named `deepLinkUrl`, but it also carries external
-    ///   web URLs.
+    ///   this parameter is named `deepLinkUrl`, but it also carries external/
+    ///   system URLs.
     case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
 
     /// The unique identifier of the form that triggered this event.

--- a/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/FormLifecycleEvent.swift
@@ -47,13 +47,17 @@ public enum FormLifecycleEvent: Equatable, Sendable {
     case formDismissed(formId: String, formName: String)
 
     /// Triggered when a user taps a call-to-action (CTA) button in a form
-    /// that has a deep link URL configured.
+    /// that has a URL configured — either an in-app deep link or an external
+    /// (web) URL.
     ///
-    /// Fired after the SDK has initiated deep link navigation. Not emitted
-    /// if no deep link URL is configured for the CTA.
+    /// Fired after the SDK has initiated navigation (deep link routing, or
+    /// opening the URL externally). Not emitted if no URL is configured for
+    /// the CTA.
     ///
     /// - `buttonLabel`: The label text of the tapped button.
-    /// - `deepLinkUrl`: The deep link URL associated with the CTA.
+    /// - `deepLinkUrl`: The URL associated with the CTA. For historical reasons
+    ///   this parameter is named `deepLinkUrl`, but it also carries external
+    ///   web URLs.
     case formCtaClicked(formId: String, formName: String, buttonLabel: String, deepLinkUrl: URL)
 
     /// The unique identifier of the form that triggered this event.

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -15,7 +15,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case formDisappeared(formId: String?, formName: String?)
     case trackProfileEvent(Data)
     case trackAggregateEvent(Data)
-    case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?)
+    case openDeepLink(url: URL?, formId: String?, formName: String?, buttonLabel: String?, openExternally: Bool)
     case abort(String)
     case handShook
     case analyticsEvent
@@ -67,7 +67,13 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case .openDeepLink:
             let payload = try? container.decode(DeepLinkEventPayload.self, forKey: .data)
             let url = payload?.ios.flatMap { $0.isEmpty ? nil : URL(string: $0) }
-            self = .openDeepLink(url: url, formId: payload?.formId, formName: payload?.formName, buttonLabel: payload?.buttonLabel)
+            self = .openDeepLink(
+                url: url,
+                formId: payload?.formId,
+                formName: payload?.formName,
+                buttonLabel: payload?.buttonLabel,
+                openExternally: payload?.openExternally ?? false
+            )
         case .abort:
             let data = try container.decode(AbortPayload.self, forKey: .data)
             self = .abort(data.reason)
@@ -97,11 +103,16 @@ extension IAFNativeBridgeEvent {
         let formName: String?
     }
 
+    /// Payload for the `openDeepLink` CTA event. Carries both in-app deep links and external
+    /// web/system URLs, distinguished by `openExternally` (onsite `openDeepLink` v3).
     struct DeepLinkEventPayload: Decodable {
         let ios: String?
         let formId: String?
         let formName: String?
         let buttonLabel: String?
+        /// `true`: open the URL via the system (bypassing any registered deep link handler),
+        /// gated by the on-device scheme allowlist. `false`: route to the deep link handler.
+        let openExternally: Bool?
     }
 
     struct AbortPayload: Decodable {
@@ -143,7 +154,7 @@ extension IAFNativeBridgeEvent {
             .formDisappeared(formId: nil, formName: nil),
             .trackProfileEvent(Data()),
             .trackAggregateEvent(Data()),
-            .openDeepLink(url: nil, formId: nil, formName: nil, buttonLabel: nil),
+            .openDeepLink(url: nil, formId: nil, formName: nil, buttonLabel: nil, openExternally: false),
             .abort(""),
             .lifecycleEvent,
             .profileEvent,
@@ -158,7 +169,7 @@ extension IAFNativeBridgeEvent {
         case .formDisappeared: return 1
         case .trackProfileEvent: return 1
         case .trackAggregateEvent: return 1
-        case .openDeepLink: return 2
+        case .openDeepLink: return 3
         case .abort: return 1
         case .handShook: return 1
         case .analyticsEvent: return 1

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -48,7 +48,8 @@ extension KlaviyoSDKModule {
     /// The handler will be invoked when:
     /// - A form is shown (``FormLifecycleEvent/formShown(formId:formName:)``)
     /// - A form is dismissed (``FormLifecycleEvent/formDismissed(formId:formName:)``)
-    /// - A user taps a CTA in a form (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
+    /// - A user taps a CTA in a form, whether it opens an in-app deep link or an external
+    ///   web URL (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
     ///
     /// Each event case carries contextual data including `formId`, `formName`, and
     /// CTA-specific fields (`buttonLabel`, `deepLinkUrl`) where applicable.
@@ -66,7 +67,8 @@ extension KlaviyoSDKModule {
     ///     case .formCtaClicked(let formId, let formName, let buttonLabel, let deepLinkUrl):
     ///         Analytics.track("Form CTA Clicked", properties: [
     ///             "formId": formId,
-    ///             "buttonLabel": buttonLabel
+    ///             "buttonLabel": buttonLabel,
+    ///             "url": deepLinkUrl.absoluteString
     ///         ])
     ///     }
     /// }

--- a/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
+++ b/Sources/KlaviyoForms/KlaviyoSDK+Forms.swift
@@ -48,8 +48,8 @@ extension KlaviyoSDKModule {
     /// The handler will be invoked when:
     /// - A form is shown (``FormLifecycleEvent/formShown(formId:formName:)``)
     /// - A form is dismissed (``FormLifecycleEvent/formDismissed(formId:formName:)``)
-    /// - A user taps a CTA in a form, whether it opens an in-app deep link or an external
-    ///   web URL (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
+    /// - A user taps a CTA in a form, whether it opens an in-app deep link or an external/system
+    ///   URL (``FormLifecycleEvent/formCtaClicked(formId:formName:buttonLabel:deepLinkUrl:)``)
     ///
     /// Each event case carries contextual data including `formId`, `formName`, and
     /// CTA-specific fields (`buttonLabel`, `deepLinkUrl`) where applicable.

--- a/Sources/KlaviyoSwift/DeepLinkManager.swift
+++ b/Sources/KlaviyoSwift/DeepLinkManager.swift
@@ -41,6 +41,19 @@ enum DeepLinkManager {
         await environment.linkHandler.openURL(url)
         isProcessingDeepLink = false
     }
+
+    /// Opens an external web/system URL via the shared environment link handler,
+    /// bypassing any registered custom deep link handler. Used by the `open_url`
+    /// push action where the customer explicitly chose to open a URL in the
+    /// system browser rather than route into the app. Unlike `openDeepLink`,
+    /// this has no reentrancy guard — concurrent external opens are harmless.
+    static func openExternalURL(_ url: URL) async {
+        if let spy = openExternalURLSpy {
+            spy(url)
+            return
+        }
+        await environment.linkHandler.openExternalURL(url)
+    }
 }
 
 // MARK: - Test-only hooks
@@ -52,10 +65,15 @@ extension DeepLinkManager {
     /// Reset to nil after each test via `resetToProduction()`.
     static var openDeepLinkSpy: ((URL) -> Void)?
 
-    /// Resets the spy and the transient processing flag.
-    /// Call this in `setUp` and `tearDown` of any test that installs the spy.
+    /// When non-nil, called by `openExternalURL(_:)` instead of the production path.
+    /// Reset to nil after each test via `resetToProduction()`.
+    static var openExternalURLSpy: ((URL) -> Void)?
+
+    /// Resets the spies and the transient processing flag.
+    /// Call this in `setUp` and `tearDown` of any test that installs a spy.
     static func resetToProduction() {
         openDeepLinkSpy = nil
+        openExternalURLSpy = nil
         isProcessingDeepLink = false
     }
 }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -263,9 +263,7 @@ public struct KlaviyoSDK {
         } else {
             // Regular notification body tap
             create(event: Event(name: ._openedPush, properties: properties))
-            if let url = notificationResponse.klaviyoDeepLinkURL {
-                Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
-            }
+            resolveOpenAction(for: notificationResponse, deepLinkHandler: nil)
         }
 
         Task { @MainActor in
@@ -279,6 +277,8 @@ public struct KlaviyoSDK {
     ///   - remoteNotification: the remote notification that was opened
     ///   - completionHandler: a completion handler that will be called with a result for Klaviyo notifications
     ///   - deepLinkHandler: a completion handler that will be called when a notification contains a deep link.
+    ///     The handler is invoked only for deep links; external web URLs always route through the
+    ///     SDK's external URL opener and bypass this closure.
     /// - Returns: true if the notification originated from Klaviyo, false otherwise.
     @available(*, deprecated, message: "This will be removed in v6.0; use `handle(notificationResponse:withCompletionHandler:)` instead")
     public func handle(notificationResponse: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void, deepLinkHandler: ((URL) -> Void)? = nil) -> Bool {
@@ -302,15 +302,7 @@ public struct KlaviyoSDK {
             handleActionButtonTap(notificationResponse: notificationResponse, properties: properties)
         } else {
             create(event: Event(name: ._openedPush, properties: properties))
-            if let url = notificationResponse.klaviyoDeepLinkURL {
-                if let deepLinkHandler = deepLinkHandler {
-                    Task { @MainActor in
-                        deepLinkHandler(url)
-                    }
-                } else {
-                    Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
-                }
-            }
+            resolveOpenAction(for: notificationResponse, deepLinkHandler: deepLinkHandler)
         }
         Task { @MainActor in
             completionHandler()
@@ -318,11 +310,42 @@ public struct KlaviyoSDK {
         return true
     }
 
+    /// Resolves the open action for a body tap: deep link, web URL, or neither.
+    ///
+    /// Deep link wins when both are present. The composer enforces a single action
+    /// type at creation, so this only matters for direct-API or test-tooling sends.
+    ///
+    /// When `deepLinkHandler` is non-nil, the deep link is delivered to that closure
+    /// instead of being routed through `DeepLinkManager`. External web URLs always
+    /// route through `DeepLinkManager.openExternalURL` and intentionally bypass the closure.
+    private func resolveOpenAction(
+        for notificationResponse: UNNotificationResponse,
+        deepLinkHandler: ((URL) -> Void)?
+    ) {
+        if let deepLinkURL = notificationResponse.klaviyoDeepLinkURL {
+            if notificationResponse.klaviyoWebUrl != nil, #available(iOS 14.0, *) {
+                Logger.notifications.warning(
+                    "Both url and web_url are present; url (deep link) takes precedence and web_url is ignored."
+                )
+            }
+            if let deepLinkHandler = deepLinkHandler {
+                Task { @MainActor in
+                    deepLinkHandler(deepLinkURL)
+                }
+            } else {
+                Task { @MainActor in await DeepLinkManager.openDeepLink(deepLinkURL) }
+            }
+        } else if let webUrl = notificationResponse.klaviyoWebUrl {
+            Task { @MainActor in await DeepLinkManager.openExternalURL(webUrl) }
+        }
+    }
+
     /// Handles action button tap events.
     ///
     /// This method:
     /// - Tracks a `$opened_push` event with button properties (Button Label, Button Action, Button Link)
-    /// - Handles action-specific deep links (or falls back to default notification URL)
+    /// - Handles action-specific deep links or `open_url` external URLs (or falls back to default
+    ///   notification URL)
     ///
     /// - Parameters:
     ///   - notificationResponse: The notification response containing action info
@@ -345,9 +368,25 @@ public struct KlaviyoSDK {
             actionProperties["Button Action"] = actionType.displayName()
         }
 
-        if let url = notificationResponse.actionButtonURL, notificationResponse.actionButtonType == .deepLink {
-            actionProperties["Button Link"] = url.absoluteString
-            Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
+        if let url = notificationResponse.actionButtonURL {
+            switch notificationResponse.actionButtonType {
+            case .deepLink:
+                actionProperties["Button Link"] = url.absoluteString
+                Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
+            case .openUrl:
+                actionProperties["Button Link"] = url.absoluteString
+                guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+                    if #available(iOS 14.0, *) {
+                        Logger.notifications.warning(
+                            "Action button open_url scheme not in the allowed list; ignoring."
+                        )
+                    }
+                    break
+                }
+                Task { @MainActor in await DeepLinkManager.openExternalURL(url) }
+            case .openApp, .none:
+                break
+            }
         }
 
         // Track action button event

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -375,7 +375,7 @@ public struct KlaviyoSDK {
                 Task { @MainActor in await DeepLinkManager.openDeepLink(url) }
             case .openUrl:
                 actionProperties["Button Link"] = url.absoluteString
-                guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+                guard url.hasAllowedOpenUrlScheme else {
                     if #available(iOS 14.0, *) {
                         Logger.notifications.warning(
                             "Action button open_url scheme not in the allowed list; ignoring."

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -82,6 +82,41 @@ extension UNNotificationResponse {
         return url
     }
 
+    /// Returns the external web URL from a Klaviyo notification payload, if present.
+    ///
+    /// Reads the `web_url` field. The presence of this field indicates the tap should open
+    /// the URL externally rather than route through the app's deep link handler.
+    /// Returns `nil` if the field is absent, the value is not a parseable URL, or the URL's
+    /// scheme is not in ``openUrlAllowedSchemes`` — unlisted schemes are dropped silently to
+    /// prevent dangerous schemes (e.g. `javascript:`, `file:`) from being opened.
+    var klaviyoWebUrl: URL? {
+        guard isKlaviyoNotification else {
+            return nil
+        }
+
+        guard let urlString = klaviyoProperties?["web_url"] as? String, !urlString.isEmpty else {
+            return nil
+        }
+
+        guard let url = URL(string: urlString) else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.warning("Unable to convert web_url string '\(urlString)' to a valid URL.")
+            }
+            return nil
+        }
+
+        guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+            if #available(iOS 14.0, *) {
+                Logger.notifications.warning(
+                    "web_url '\(urlString)' has a scheme not in the allowed list; ignoring."
+                )
+            }
+            return nil
+        }
+
+        return url
+    }
+
     // MARK: - Action Button Support
 
     /// Detects if the user tapped an action button (vs tapping the notification body).

--- a/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Utilities/UNNotificationResponse+Klaviyo.swift
@@ -100,15 +100,18 @@ extension UNNotificationResponse {
 
         guard let url = URL(string: urlString) else {
             if #available(iOS 14.0, *) {
-                Logger.notifications.warning("Unable to convert web_url string '\(urlString)' to a valid URL.")
+                Logger.notifications.warning("Unable to convert web_url string '\(urlString, privacy: .private)' to a valid URL.")
             }
             return nil
         }
 
-        guard let scheme = url.scheme?.lowercased(), openUrlAllowedSchemes.contains(scheme) else {
+        guard url.hasAllowedOpenUrlScheme else {
             if #available(iOS 14.0, *) {
                 Logger.notifications.warning(
-                    "web_url '\(urlString)' has a scheme not in the allowed list; ignoring."
+                    """
+                    web_url '\(urlString, privacy: .private)' has a scheme not in the \
+                    allowed list; ignoring.
+                    """
                 )
             }
             return nil

--- a/Sources/KlaviyoSwiftExtension/ActionType.swift
+++ b/Sources/KlaviyoSwiftExtension/ActionType.swift
@@ -14,4 +14,5 @@ import Foundation
 enum ActionType: String, Equatable {
     case openApp = "open_app"
     case deepLink = "deep_link"
+    case openUrl = "open_url"
 }

--- a/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
@@ -107,7 +107,9 @@ enum KlaviyoActionButtonParser {
     /// Validates that an action type has the correct URL configuration.
     ///
     /// - `.openApp` actions should not have a URL
-    /// - `.deepLink` actions must have a URL
+    /// - `.deepLink` actions must have a parseable URL
+    /// - `.openUrl` actions must have a parseable URL whose scheme is in ``openUrlAllowedSchemes`` —
+    ///   unlisted schemes (e.g. `javascript:`, `file:`, `intent:`) are rejected silently
     ///
     /// - Parameters:
     ///   - action: The action type to validate
@@ -118,8 +120,12 @@ enum KlaviyoActionButtonParser {
         case .openApp:
             return url == nil
         case .deepLink:
-            guard let url else { return false }
-            return URL(string: url) != nil
+            guard let urlString = url else { return false }
+            return URL(string: urlString) != nil
+        case .openUrl:
+            guard let urlString = url, let parsedUrl = URL(string: urlString) else { return false }
+            guard let scheme = parsedUrl.scheme?.lowercased() else { return false }
+            return openUrlAllowedSchemes.contains(scheme)
         }
     }
 

--- a/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
+++ b/Sources/KlaviyoSwiftExtension/URLSchemeAllowlist.swift
@@ -1,0 +1,23 @@
+//
+//  URLSchemeAllowlist.swift
+//  klaviyo-swift-sdk
+//
+
+// NOTE: KlaviyoCore carries the authoritative copy of this constant
+// (Sources/KlaviyoCore/Utils/URLSchemeAllowlist.swift). This internal copy exists
+// because KlaviyoSwiftExtension cannot depend on KlaviyoCore (NSE/share-extension
+// sandbox restriction). The two copies are intentionally kept in sync. If you
+// change the set here, mirror the change there.
+
+import Foundation
+
+/// URL schemes allowed for the `open_url` push action.
+///
+/// These schemes are safe to hand off to `UIApplication.shared.open(_:)` directly.
+/// Schemes **not** on this list (e.g. `intent:`, `javascript:`, `file:`, `geo:`)
+/// are silently dropped.
+///
+/// Note: `smsto:` is intentionally excluded (unlike the Android SDK). iOS Messages only
+/// registers `sms:`; `smsto:` has no iOS handler, so `UIApplication.shared.open(_:)` would
+/// no-op. Use `sms:` for SMS on iOS.
+let openUrlAllowedSchemes: Set<String> = ["http", "https", "mailto", "tel", "sms"]

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -82,7 +82,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -111,7 +111,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -137,7 +137,7 @@ struct IAFNativeBridgeEventTests {
 
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -365,7 +365,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -390,7 +390,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -411,7 +411,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -436,7 +436,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -489,7 +489,7 @@ struct IAFNativeBridgeEventTests {
         """
         let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
-        guard case let .openDeepLink(url, formId, formName, buttonLabel) = event else {
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, _) = event else {
             Issue.record("event type should be .openDeepLink but was '.\(event)'")
             return
         }
@@ -602,6 +602,146 @@ struct IAFNativeBridgeEventTests {
         let associatedValueDataDecoded = try JSONDecoder().decode(AnyCodable.self, from: associatedValueData)
 
         #expect(aggregateEventDataDecoded == associatedValueDataDecoded)
+    }
+
+    @Test
+    func testDecodeExternalUrlWithButtonLabel() async throws {
+        // External web URLs now ride the openDeepLink message with openExternally: true.
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "https://example.com",
+            "android": "https://example.com",
+            "formId": "form123",
+            "formName": "Newsletter",
+            "buttonLabel": "Learn More",
+            "openExternally": true
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == "form123")
+        #expect(formName == "Newsletter")
+        #expect(buttonLabel == "Learn More")
+        #expect(openExternally == true)
+    }
+
+    @Test
+    func testDecodeExternalUrlMissingButtonLabel() async throws {
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "https://example.com",
+            "android": "https://example.com",
+            "formId": "form123",
+            "formName": "Newsletter",
+            "openExternally": true
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == "form123")
+        #expect(formName == "Newsletter")
+        #expect(buttonLabel == nil)
+        #expect(openExternally == true)
+    }
+
+    @Test
+    func testDecodeExternalUrlWithoutFormContext() async throws {
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "https://example.com",
+            "openExternally": true
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(url, formId, formName, buttonLabel, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        let expectedUrl = try #require(URL(string: "https://example.com"))
+        #expect(url == expectedUrl)
+        #expect(formId == nil)
+        #expect(formName == nil)
+        #expect(buttonLabel == nil)
+        #expect(openExternally == true)
+    }
+
+    @Test
+    func testDecodeExternalUrlEmptyUrlNormalized() async throws {
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "",
+            "formId": "form123",
+            "formName": "Newsletter",
+            "openExternally": true
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(url, _, _, _, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        #expect(url == nil)
+        #expect(openExternally == true)
+    }
+
+    @Test
+    func testDecodeOpenDeepLinkDefaultsOpenExternallyFalse() async throws {
+        // A deep link CTA omits `openExternally`; it must default to false so the SDK
+        // routes it through the in-app deep link handler, not the system opener.
+        let json = """
+        {
+          "type": "openDeepLink",
+          "data": {
+            "ios": "klaviyotest://settings",
+            "android": "klaviyotest://settings",
+            "formId": "form456",
+            "formName": "CTA Form"
+          }
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        guard case let .openDeepLink(_, _, _, _, openExternally) = event else {
+            Issue.record("event type should be .openDeepLink but was '.\(event)'")
+            return
+        }
+
+        #expect(openExternally == false)
     }
 }
 #endif

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -155,7 +155,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)
@@ -353,6 +353,113 @@ final class IAFWebViewModelTests: XCTestCase {
         // Then
         await fulfillment(of: [expectation], timeout: 5.0)
         lifecycleTask.cancel()
+    }
+
+    // MARK: - External URL Tests (openDeepLink with openExternally: true)
+
+    private func makeOpenExternalUrlMessage(
+        url: String? = "https://example.com",
+        formId: String? = "form123",
+        formName: String? = "Newsletter",
+        buttonLabel: String? = "Learn More"
+    ) -> MockWKScriptMessage {
+        // External web URLs ride the openDeepLink message with openExternally: true;
+        // the URL is sent in the platform-split `ios`/`android` keys.
+        var data: [String: String] = [:]
+        data["ios"] = url
+        data["android"] = url
+        data["formId"] = formId
+        data["formName"] = formName
+        data["buttonLabel"] = buttonLabel
+        let dataJson = data.map { "\"\($0.key)\": \"\($0.value)\"" }.joined(separator: ", ")
+        let dataBody = dataJson.isEmpty ? "\"openExternally\": true" : "\(dataJson), \"openExternally\": true"
+        return MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: "{ \"type\": \"openDeepLink\", \"data\": { \(dataBody) } }"
+        )
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlFiresLifecycleEvent() async throws {
+        // Given
+        var receivedEvent: FormLifecycleEvent?
+        IAFPresentationManager.shared.registerFormLifecycleHandler { event in
+            receivedEvent = event
+        }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
+
+        // A spurious dispatch through EventDispatcher would mean the deep-link path ran
+        // instead. IAFWebViewModel's deep-link branch calls EventDispatcher.shared.dispatch
+        // synchronously (no Task), so checking immediately after is reliable — no race.
+        let spyDispatcher = SpyDispatcher()
+        EventDispatcher.shared.register(spyDispatcher)
+        defer { EventDispatcher.shared.reset() }
+
+        // When
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage())
+
+        // Then — the handler path is synchronous, so assert immediately.
+        // External URL clicks surface through the same formCtaClicked event as deep links.
+        guard case let .formCtaClicked(formId, formName, buttonLabel, url) = receivedEvent else {
+            XCTFail("Expected formCtaClicked, got \(String(describing: receivedEvent))")
+            return
+        }
+        XCTAssertEqual(formId, "form123")
+        XCTAssertEqual(formName, "Newsletter")
+        XCTAssertEqual(buttonLabel, "Learn More")
+        XCTAssertEqual(url, URL(string: "https://example.com"))
+        XCTAssertTrue(
+            spyDispatcher.received.isEmpty,
+            "openExternally: true must not route through EventDispatcher's deep-link path"
+        )
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithoutFormMetadataSkipsLifecycleEvent() async throws {
+        // Given
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
+
+        // When
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(formId: nil, formName: nil))
+
+        // Then
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not fire without form metadata")
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithMissingUrlSkipsLifecycleEvent() async throws {
+        // Given
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
+
+        // When
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(url: nil))
+
+        // Then
+        XCTAssertFalse(lifecycleEventFired, "Lifecycle event should not fire with nil URL")
+    }
+
+    @MainActor
+    func testHandleOpenExternalUrlWithDisallowedSchemeSkipsLifecycleEvent() async throws {
+        // Given
+        var lifecycleEventFired = false
+        IAFPresentationManager.shared.registerFormLifecycleHandler { _ in
+            lifecycleEventFired = true
+        }
+        defer { IAFPresentationManager.shared.unregisterFormLifecycleHandler() }
+
+        // When
+        viewModel.handleScriptMessage(makeOpenExternalUrlMessage(url: "javascript://alert(1)"))
+
+        // Then
+        XCTAssertFalse(lifecycleEventFired, "Blocked scheme should skip navigation and lifecycle event")
     }
 
     @MainActor

--- a/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
@@ -277,4 +277,230 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertEqual(result?.last?.action, .openApp, "Second button should have correct action")
         XCTAssertNil(result?.last?.url, "Second button (openApp) should not have URL")
     }
+
+    func testParseActionButtons_ParsesValidOpenUrlButton() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.open_url",
+                        "label": "Visit Site",
+                        "action": "open_url",
+                        "url": "https://example.com/sale"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "Should parse valid open_url button")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.action, .openUrl)
+        XCTAssertEqual(result?.first?.url, "https://example.com/sale")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithoutURL() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.openurl_no_url",
+                        "label": "Visit Site",
+                        "action": "open_url"
+                        // Missing URL - open_url must have URL
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid Button",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "Should return valid buttons")
+        XCTAssertEqual(result?.count, 1, "Should skip open_url button without URL")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithBlockedScheme() {
+        // Custom app schemes and other non-allowlisted schemes must be rejected.
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.openurl_custom_scheme",
+                        "label": "Bad",
+                        "action": "open_url",
+                        "url": "klaviyotest://forms"
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "Should return valid buttons")
+        XCTAssertEqual(result?.count, 1, "Should skip open_url buttons with blocked schemes")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    // MARK: - Allowlisted non-web open_url schemes
+
+    func testParseActionButtons_AcceptsOpenUrlWithMailtoScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.mailto",
+                        "label": "Email Us",
+                        "action": "open_url",
+                        "url": "mailto:support@example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "mailto: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.mailto")
+        XCTAssertEqual(result?.first?.url, "mailto:support@example.com")
+    }
+
+    func testParseActionButtons_AcceptsOpenUrlWithTelScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.tel",
+                        "label": "Call Us",
+                        "action": "open_url",
+                        "url": "tel:+15551234567"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "tel: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.tel")
+        XCTAssertEqual(result?.first?.url, "tel:+15551234567")
+    }
+
+    func testParseActionButtons_AcceptsOpenUrlWithSmsScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.sms",
+                        "label": "Text Us",
+                        "action": "open_url",
+                        "url": "sms:+15551234567"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "sms: should be accepted by open_url")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.sms")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithIntentScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.intent",
+                        "label": "Bad",
+                        "action": "open_url",
+                        "url": "intent://example"
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertEqual(result?.count, 1, "intent: should be blocked")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    func testParseActionButtons_SkipsOpenUrlWithJavascriptScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.js",
+                        "label": "Bad",
+                        "action": "open_url",
+                        "url": "javascript:alert(1)"
+                    ],
+                    [
+                        "id": "com.klaviyo.test.valid",
+                        "label": "Valid",
+                        "action": "open_url",
+                        "url": "https://example.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertEqual(result?.count, 1, "javascript: should be blocked")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+    }
+
+    func testParseActionButtons_AllowsDeepLinkWithHttpScheme() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.deeplink_http",
+                        "label": "Deep link with http",
+                        "action": "deep_link",
+                        "url": "https://www.google.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertNotNil(result, "Deep link should accept any URL scheme — customer handler decides")
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.action, .deepLink)
+    }
 }

--- a/Tests/KlaviyoSwiftExtensionTests/URLSchemeAllowlistParityTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/URLSchemeAllowlistParityTests.swift
@@ -1,0 +1,16 @@
+@testable import KlaviyoSwiftExtension
+import KlaviyoCore
+import XCTest
+
+/// `openUrlAllowedSchemes` is intentionally duplicated in KlaviyoCore and KlaviyoSwiftExtension
+/// because the extension target cannot depend on KlaviyoCore. This test fails if the two copies
+/// drift, which would let the NSE and the main app disagree on which `open_url` schemes are allowed.
+final class URLSchemeAllowlistParityTests: XCTestCase {
+    func testExtensionAllowlistMatchesCoreAllowlist() {
+        XCTAssertEqual(
+            KlaviyoSwiftExtension.openUrlAllowedSchemes,
+            KlaviyoCore.openUrlAllowedSchemes,
+            "openUrlAllowedSchemes copies in KlaviyoCore and KlaviyoSwiftExtension must stay in sync."
+        )
+    }
+}

--- a/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DeepLinkHandlingTests.swift
@@ -92,6 +92,85 @@ final class DeepLinkHandlingTests: XCTestCase {
         await fulfillment(of: [completionCalled, deepLinkInvoked], timeout: 1.0)
     }
 
+    // MARK: - open_url with allowlisted non-web schemes
+
+    @MainActor
+    func testHandleNotificationResponseDispatchesOpenWebUrlForMailtoWebUrl() async throws {
+        let urlString = "mailto:support@example.com"
+        let expectedURL = try XCTUnwrap(URL(string: urlString))
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        let completionCalled = expectation(description: "completion handler called")
+        let externalUrlInvoked = expectation(description: "DeepLinkManager.openExternalURL invoked for mailto:")
+        DeepLinkManager.openExternalURLSpy = { url in
+            XCTAssertEqual(url, expectedURL, "Should invoke openExternalURL with mailto: URL")
+            externalUrlInvoked.fulfill()
+        }
+
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        })
+
+        XCTAssertTrue(result, "SDK should return true for Klaviyo notifications with web_url")
+        await fulfillment(of: [completionCalled, externalUrlInvoked], timeout: 1.0)
+    }
+
+    @MainActor
+    func testHandleNotificationResponseDispatchesOpenWebUrlForTelWebUrl() async throws {
+        let urlString = "tel:+15551234567"
+        let expectedURL = try XCTUnwrap(URL(string: urlString))
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": urlString
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        let completionCalled = expectation(description: "completion handler called")
+        let externalUrlInvoked = expectation(description: "DeepLinkManager.openExternalURL invoked for tel:")
+        DeepLinkManager.openExternalURLSpy = { url in
+            XCTAssertEqual(url, expectedURL, "Should invoke openExternalURL with tel: URL")
+            externalUrlInvoked.fulfill()
+        }
+
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {
+            completionCalled.fulfill()
+        })
+
+        XCTAssertTrue(result, "SDK should return true for Klaviyo notifications with web_url")
+        await fulfillment(of: [completionCalled, externalUrlInvoked], timeout: 1.0)
+    }
+
+    @MainActor
+    func testHandleNotificationResponseDropsBlockedSchemeWebUrl() throws {
+        // javascript: is a blocked scheme — the gate is the synchronous klaviyoWebUrl
+        // property, and resolveOpenAction only calls openExternalURL when it is non-nil
+        // (positive dispatch coverage in the mailto:/tel: tests above). handle still
+        // returns true: it is a valid Klaviyo notification, it just takes no open action.
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "1"],
+            "web_url": "javascript:alert(1)"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+
+        environment.linkHandler.unregisterCustomHandler()
+
+        XCTAssertNil(response.klaviyoWebUrl, "Blocked scheme must not produce a web URL")
+
+        let klaviyoSDK = KlaviyoSDK()
+        let result = klaviyoSDK.handle(notificationResponse: response, withCompletionHandler: {})
+        XCTAssertTrue(result, "Klaviyo notification is still handled; it just takes no open action")
+    }
+
     // MARK: - isDeepLinkHandlerRegistered Property Tests
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -562,4 +562,210 @@ class KlaviyoSDKTests: XCTestCase {
             XCTAssertNil(event.properties["Button Link"], "Should NOT include Button Link for body tap")
         }
     }
+
+    // MARK: - web_url tests
+
+    // Deep link / web URL resolution now routes through `DeepLinkManager`
+    // (`openDeepLinkSpy`/`openExternalURLSpy`), not a dispatched `KlaviyoAction` — only
+    // the `$opened_push` event track still goes through `klaviyoSwiftEnvironment.send`.
+
+    func testHandleBodyTap_WebUrlDispatchesOpenWebUrl() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let eventDispatched = XCTestExpectation(description: "event action dispatched")
+        let webURL = try XCTUnwrap(URL(string: "https://example.com/sale"))
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "test_web_url"],
+            "web_url": webURL.absoluteString
+        ]
+
+        klaviyoSwiftEnvironment.send = { action in
+            if case .enqueueEvent = action { eventDispatched.fulfill() }
+            return nil
+        }
+        let externalUrlInvoked = XCTestExpectation(description: "openExternalURL invoked")
+        DeepLinkManager.openExternalURLSpy = { dispatchedUrl in
+            XCTAssertEqual(dispatchedUrl, webURL)
+            externalUrlInvoked.fulfill()
+        }
+
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        let handled = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, eventDispatched, externalUrlInvoked], timeout: 1.0)
+        XCTAssertTrue(handled)
+    }
+
+    func testHandleBodyTap_DeepLinkUnchangedWhenWebUrlAbsent() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let eventDispatched = XCTestExpectation(description: "event action dispatched")
+        let deepURL = try XCTUnwrap(URL(string: "myapp://path"))
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "test_deep_link_regression"],
+            "url": deepURL.absoluteString
+        ]
+
+        klaviyoSwiftEnvironment.send = { action in
+            if case .enqueueEvent = action { eventDispatched.fulfill() }
+            return nil
+        }
+        let deepLinkInvoked = XCTestExpectation(description: "openDeepLink invoked")
+        DeepLinkManager.openDeepLinkSpy = { dispatchedUrl in
+            XCTAssertEqual(dispatchedUrl, deepURL)
+            deepLinkInvoked.fulfill()
+        }
+
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        _ = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, eventDispatched, deepLinkInvoked], timeout: 1.0)
+    }
+
+    func testHandleBodyTap_DeepLinkTakesPrecedenceOverWebUrl() throws {
+        // Defensive: if backend ever ships both web_url and url, the deep link wins so
+        // the user stays in the host app. The composer UI enforces a single action type
+        // at creation, so this only fires via direct-API or test-tooling sends.
+        let callback = XCTestExpectation(description: "callback is made")
+        let webURL = try XCTUnwrap(URL(string: "https://example.com/sale"))
+        let deepURL = try XCTUnwrap(URL(string: "myapp://path"))
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": ["_k": "test_both_present"],
+            "web_url": webURL.absoluteString,
+            "url": deepURL.absoluteString
+        ]
+
+        let deepLinkInvoked = XCTestExpectation(description: "openDeepLink invoked")
+        DeepLinkManager.openDeepLinkSpy = { dispatchedUrl in
+            XCTAssertEqual(dispatchedUrl, deepURL)
+            deepLinkInvoked.fulfill()
+        }
+        let externalUrlNotInvoked = XCTestExpectation(description: "openExternalURL must not be invoked")
+        externalUrlNotInvoked.isInverted = true
+        DeepLinkManager.openExternalURLSpy = { _ in externalUrlNotInvoked.fulfill() }
+
+        let response = try UNNotificationResponse.with(userInfo: userInfo)
+        _ = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, deepLinkInvoked], timeout: 1.0)
+        wait(for: [externalUrlNotInvoked], timeout: 0.3)
+    }
+
+    func testHandleActionButtonTap_OpenUrlButton() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let actionURL = try XCTUnwrap(URL(string: "https://example.com/promo"))
+        let actionId = "com.klaviyo.test.web"
+        let buttonLabel = "Visit Site"
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": "test_open_url_button",
+                "action_buttons": [
+                    [
+                        "id": actionId,
+                        "label": buttonLabel,
+                        "action": "open_url",
+                        "url": actionURL.absoluteString
+                    ]
+                ]
+            ]
+        ]
+
+        var capturedActions: [KlaviyoAction] = []
+        let eventDispatched = XCTestExpectation(description: "event action dispatched")
+        klaviyoSwiftEnvironment.send = { action in
+            capturedActions.append(action)
+            if case .enqueueEvent = action { eventDispatched.fulfill() }
+            return nil
+        }
+        let externalUrlInvoked = XCTestExpectation(description: "openExternalURL invoked")
+        DeepLinkManager.openExternalURLSpy = { dispatchedUrl in
+            XCTAssertEqual(dispatchedUrl, actionURL)
+            externalUrlInvoked.fulfill()
+        }
+
+        let response = try UNNotificationResponse.with(
+            userInfo: userInfo,
+            actionIdentifier: actionId
+        )
+
+        let handled = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, eventDispatched, externalUrlInvoked], timeout: 1.0)
+        XCTAssertTrue(handled)
+
+        let eventAction = capturedActions.first { action in
+            if case let .enqueueEvent(event) = action {
+                return event.metric.name == ._openedPush
+            }
+            return false
+        }
+        XCTAssertNotNil(eventAction)
+        if case let .enqueueEvent(event) = eventAction! {
+            XCTAssertEqual(event.properties["Button Action"] as? String, "Open URL")
+            XCTAssertEqual(event.properties["Button Link"] as? String, actionURL.absoluteString)
+        }
+    }
+
+    func testHandleActionButtonTap_OpenUrlButtonWithBlockedSchemeDoesNotDispatch() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let actionURL = try XCTUnwrap(URL(string: "javascript:alert(1)"))
+        let actionId = "com.klaviyo.test.blocked"
+        let buttonLabel = "Bad Button"
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": "test_open_url_blocked",
+                "action_buttons": [
+                    [
+                        "id": actionId,
+                        "label": buttonLabel,
+                        "action": "open_url",
+                        "url": actionURL.absoluteString
+                    ]
+                ]
+            ]
+        ]
+
+        var capturedActions: [KlaviyoAction] = []
+        let eventDispatched = XCTestExpectation(description: "event action dispatched")
+        klaviyoSwiftEnvironment.send = { action in
+            capturedActions.append(action)
+            if case .enqueueEvent = action { eventDispatched.fulfill() }
+            return nil
+        }
+        let externalUrlNotInvoked = XCTestExpectation(description: "openExternalURL must not be invoked for blocked scheme")
+        externalUrlNotInvoked.isInverted = true
+        DeepLinkManager.openExternalURLSpy = { _ in externalUrlNotInvoked.fulfill() }
+
+        let response = try UNNotificationResponse.with(
+            userInfo: userInfo,
+            actionIdentifier: actionId
+        )
+
+        let handled = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, eventDispatched], timeout: 1.0)
+        wait(for: [externalUrlNotInvoked], timeout: 0.3)
+        XCTAssertTrue(handled)
+
+        let eventAction = capturedActions.first { action in
+            if case let .enqueueEvent(event) = action {
+                return event.metric.name == ._openedPush
+            }
+            return false
+        }
+        XCTAssertNotNil(eventAction, "Tap should still be tracked even when the scheme is blocked")
+    }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -710,7 +710,7 @@ class KlaviyoSDKTests: XCTestCase {
             return false
         }
         XCTAssertNotNil(eventAction)
-        if case let .enqueueEvent(event) = eventAction! {
+        if case let .enqueueEvent(event) = try XCTUnwrap(eventAction) {
             XCTAssertEqual(event.properties["Button Action"] as? String, "Open URL")
             XCTAssertEqual(event.properties["Button Link"] as? String, actionURL.absoluteString)
         }

--- a/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/UNNotificationResponseExtensionTests.swift
@@ -197,4 +197,145 @@ class UNNotificationResponseExtensionTests: XCTestCase {
         // Assert
         XCTAssertNil(response.klaviyoDeepLinkURL)
     }
+
+    // MARK: - klaviyoWebUrl Tests
+
+    func testKlaviyoWebUrl_WithValidURL_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "https://example.com/sale"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "https://example.com/sale")
+    }
+
+    func testKlaviyoWebUrl_WithInvalidURLString_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "ht tp://invalid-url"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithEmptyString_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": ""
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WhenAbsent_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"]
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithNonKlaviyoNotification_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "web_url": "https://example.com"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithNonStringValue_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": 12_345
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithDeepLinkScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "klaviyotest://forms"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithHttpScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "http://example.com"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "http://example.com")
+    }
+
+    // MARK: - Allowlisted non-web schemes
+
+    func testKlaviyoWebUrl_WithMailtoScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "mailto:test@example.com"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "mailto:test@example.com")
+    }
+
+    func testKlaviyoWebUrl_WithTelScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "tel:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "tel:+15551234567")
+    }
+
+    func testKlaviyoWebUrl_WithSmsScheme_ReturnsURL() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "sms:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertEqual(response.klaviyoWebUrl?.absoluteString, "sms:+15551234567")
+    }
+
+    // MARK: - Blocked schemes
+
+    func testKlaviyoWebUrl_WithSmstoScheme_ReturnsNil() throws {
+        // smsto: is Android-only; iOS Messages registers sms: but not smsto:, so it is
+        // deliberately absent from the iOS allowlist and dropped here.
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "smsto:+15551234567"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithIntentScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "intent://scan/#Intent;scheme=zxing;package=com.example;end"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithJavascriptScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "javascript:alert(1)"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
+
+    func testKlaviyoWebUrl_WithFileScheme_ReturnsNil() throws {
+        let payload: [AnyHashable: Any] = [
+            "body": ["_k": "some-value"],
+            "web_url": "file:///etc/passwd"
+        ]
+        let response = try UNNotificationResponse.with(userInfo: payload)
+        XCTAssertNil(response.klaviyoWebUrl)
+    }
 }


### PR DESCRIPTION
# Description
Ships the "open web URL" push/IAF work for the 5.4.0 release: `open_url` support for push body taps and action buttons, non-web scheme allowlisting, `deep_link`-over-`web_url` precedence, and the in-app form `openExternalUrl` bridge event — rebuilt on top of the `DeepLinkManager`/`EventDispatcher` architecture introduced by "feat: iOS modularization" (#657).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Note: adds public `FormLifecycleEvent.formExternalUrlClicked` case — source-breaking for any exhaustive switch over `FormLifecycleEvent`; call out in changelog.

## Changelog / Code Overview
Supersedes #666, which was built from the `feat/push-638-open-url` integration branch and hit a real merge conflict against `rel/5.4.0` once #657 ("feat: iOS modularization") landed — that PR removed `KlaviyoAction.openDeepLink`/`.setBadgeCount`/`.syncBadgeCount` from the TCA reducer entirely in favor of direct `DeepLinkManager`/`BadgeManager` calls, which our `.openDeepLink`/`.openWebUrl`-based dispatch depended on. Rather than carry a merge commit (which would've pulled in ~5 weeks of unrelated `rel/5.4.0` CI/tooling/example churn into the PR diff), this branch is a clean, single-commit port of the same feature onto the current `rel/5.4.0` tip, verified byte-identical to the fully-resolved and tested merge.

**Feature work** (from the original `feat/push-638-open-url` chain — #580, #615, #623, #633, #654):
- `open_url` push action support (body tap + action buttons), scheme-allowlisted to `http`/`https`/`mailto`/`tel`/`sms` (`URLSchemeAllowlist.swift`, duplicated in `KlaviyoSwiftExtension` for the NSE sandbox, kept in sync via a parity test).
- `deep_link` takes precedence over `web_url` when both are present on a body tap.
- IAF `openExternalUrl` bridge event, consolidated onto the shared `openDeepLink` v3 bridge message with an `openExternally` flag.

**Modularization port** (new in this branch, replacing the merge commit from #672):
- `resolveOpenAction`/`handleActionButtonTap` in `Klaviyo.swift` now call `DeepLinkManager.openDeepLink`/`openExternalURL` directly instead of dispatching the now-removed `.openDeepLink`/`.openWebUrl` `KlaviyoAction` cases.
- Added `DeepLinkManager.openExternalURL(_:)` as a sibling to the existing `openDeepLink(_:)`, with its own `openExternalURLSpy` test hook — matching the production-dependency/spy/`resetToProduction()` pattern already established for `DeepLinkManager`/`BadgeManager`.
- `IAFWebViewModel`'s deep-link branch dispatches via `EventDispatcher.shared.dispatch(.deepLink(url))` instead of the removed `KlaviyoInternal.handleDeepLink`.
- Rewrote the open_url precedence/allowlist tests to assert via `DeepLinkManager`'s spies / the `EventDispatcher` `SpyDispatcher` instead of capturing `KlaviyoAction` off `klaviyoSwiftEnvironment.send`.

## Test Plan
`make CONFIG=release test-library` — full suite passes. Manually verified end-to-end on a physical iPhone (push body tap + action buttons for open_url/deep_link/web_url precedence, IAF external URL CTA).

## Related Issues/Tickets
PUSH-637, PUSH-638, PUSH-732, PUSH-834 — part of the "open web URL" project. Supersedes #666, #672.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening external URLs from push notifications, action buttons, and in-app form CTAs.
  * Added support for `open_url` actions with approved schemes including web, email, phone, and SMS links.
  * Deep links continue to take precedence when both deep-link and external URL data are provided.

* **Bug Fixes**
  * Unsafe or unsupported URL schemes are now rejected without opening.

* **Documentation**
  * Clarified CTA and URL behavior for external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->