### PR TITLE
test: increase timeout for form lifecycle event tests

### DIFF
--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -213,7 +213,7 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
         lifecycleTask.cancel()
     }
 
@@ -249,7 +249,7 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
         lifecycleTask.cancel()
     }
 
@@ -282,7 +282,7 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then - .present should still be yielded
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
         lifecycleTask.cancel()
     }
 
@@ -315,7 +315,7 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then - .dismiss should still be yielded
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
         lifecycleTask.cancel()
     }
 
@@ -351,7 +351,7 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
+        await fulfillment(of: [expectation], timeout: 10.0)
         lifecycleTask.cancel()
     }
 


### PR DESCRIPTION
## Summary
- Bumps the `fulfillment(of:timeout:)` timeout from 5.0s to 10.0s across the five form lifecycle event tests in `IAFWebViewModelTests.swift` (`testFormWillAppearYieldsPresentLifecycleEvent`, `testFormDisappearedYieldsDismissLifecycleEvent`, `testFormWillAppearYieldsPresentEvenWithMissingMetadata`, `testFormDisappearedYieldsDismissEvenWithMissingMetadata`, `testAbortEventYieldsAbortLifecycleEvent`)

## Why
These tests spawn a `Task` that listens on `viewModel.formLifecycleStream`, an `AsyncStream` created via `AsyncStream.makeStream(of:)` with the default `.unbounded` buffering policy. The event is yielded synchronously during `handleScriptMessage`, before the listener `Task` necessarily gets scheduled — but since the stream is unbounded-buffered, the event can't be dropped; the listener will pick it up whenever it's scheduled.

Under this repo's CI matrix (multiple Xcode/iOS version jobs running concurrently), that scheduling can occasionally be delayed past the previous 5s ceiling, causing `testFormDisappearedYieldsDismissLifecycleEvent` (and its `EvenWithMissingMetadata` sibling) to intermittently fail/time out in CI despite no actual regression. This has been observed multiple times on PR #673 with no corresponding change to this test file.

This isn't a logic race (no dropped events possible), so the fix is simply giving the listener task more scheduling headroom under load.

## Test plan
- [x] Ran `IAFWebViewModelTests` locally — all 12 tests pass
- [x] Verified `swiftlint --strict` reports the same pre-existing violations before/after (no new violations introduced)
- [ ] CI green across the Xcode version matrix