### PR TITLE
fix: replace AsyncStream-based handshake wait with a resumed continuation

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -39,16 +39,50 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     /// continuation. Deliberately doesn't require `@MainActor` to touch: the timeout side resumes
     /// it from a plain, non-actor-isolated `Task`, so unblocking on timeout never needs the main
     /// actor to schedule more work onto itself while `establishHandshake` is already suspended on it.
+    ///
+    /// Tracks a generation token so a stale timeout task from a superseded call can never resume
+    /// a newer one's continuation -- it only fires if its own token still matches the box's
+    /// current generation.
     private final class HandshakeContinuationBox: @unchecked Sendable {
         private let lock = NSLock()
         private var continuation: HandshakeContinuation?
+        private var generation = 0
 
-        func exchange(_ newValue: HandshakeContinuation?) -> HandshakeContinuation? {
+        /// Stores `newValue`, returning a token for the timeout task to check back in with.
+        /// Any still-pending prior continuation is resumed with `error` rather than dropped.
+        func store(_ newValue: HandshakeContinuation, supersedingWith error: Error) -> Int {
             lock.lock()
-            defer { lock.unlock() }
             let previous = continuation
             continuation = newValue
-            return previous
+            generation += 1
+            let token = generation
+            lock.unlock()
+            previous?.resume(throwing: error)
+            return token
+        }
+
+        /// Resumes the pending continuation with `error`, but only if `token` still matches the
+        /// most recently stored continuation's generation -- otherwise a newer call has already
+        /// superseded it and this is a no-op.
+        func resumeIfCurrent(token: Int, throwing error: Error) {
+            lock.lock()
+            guard generation == token, let pending = continuation else {
+                lock.unlock()
+                return
+            }
+            continuation = nil
+            lock.unlock()
+            pending.resume(throwing: error)
+        }
+
+        /// Resumes the pending continuation successfully. The `.handShook` bridge event always
+        /// pertains to the most recently stored wait, so no token check is needed here.
+        func resumeSuccess() {
+            lock.lock()
+            let pending = continuation
+            continuation = nil
+            lock.unlock()
+            pending?.resume()
         }
     }
 
@@ -200,13 +234,11 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
         do {
             try await withCheckedThrowingContinuation { [handshakeBox] (cont: HandshakeContinuation) in
-                _ = handshakeBox.exchange(cont)
+                let token = handshakeBox.store(cont, supersedingWith: ObjectStateError.objectDeallocated)
 
                 Task {
                     try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                    if let pending = handshakeBox.exchange(nil) {
-                        pending.resume(throwing: TimeoutError.timeout)
-                    }
+                    handshakeBox.resumeIfCurrent(token: token, throwing: TimeoutError.timeout)
                 }
             }
         } catch let error as TimeoutError {
@@ -410,9 +442,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Successful handshake with JS")
             }
-            if let pending = handshakeBox.exchange(nil) {
-                pending.resume()
-            }
+            handshakeBox.resumeSuccess()
             formLifecycleContinuation.yield(.handShook)
         case .analyticsEvent:
             ()

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -32,7 +32,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private var profileUpdatesCancellable: AnyCancellable?
     let formLifecycleStream: AsyncStream<IAFLifecycleEvent>
     private let formLifecycleContinuation: AsyncStream<IAFLifecycleEvent>.Continuation
-    private let (handshakeStream, handshakeContinuation) = AsyncStream.makeStream(of: Void.self)
+
+    private typealias HandshakeContinuation = CheckedContinuation<Void, Error>
+
+    /// Pending continuation for an in-flight ``establishHandshake(timeout:)`` call. Resumed exactly
+    /// once, either by the `.handShook` bridge event or by the timeout task below — whichever
+    /// happens first clears this so the other is a no-op instead of a double-resume.
+    private var handshakeContinuation: HandshakeContinuation?
 
     // MARK: - Scripts
 
@@ -179,9 +185,20 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         delegate.preloadUrl()
 
         do {
-            try await withTimeout(seconds: timeout) { [weak self] in
-                guard let self else { throw ObjectStateError.objectDeallocated }
-                await self.handshakeStream.first { _ in true }
+            try await withCheckedThrowingContinuation { [weak self] (continuation: HandshakeContinuation) in
+                guard let self else {
+                    continuation.resume(throwing: ObjectStateError.objectDeallocated)
+                    return
+                }
+
+                handshakeContinuation = continuation
+
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    guard let self, let pending = handshakeContinuation else { return }
+                    handshakeContinuation = nil
+                    pending.resume(throwing: TimeoutError.timeout)
+                }
             }
         } catch let error as TimeoutError {
             if #available(iOS 14.0, *) {
@@ -384,8 +401,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Successful handshake with JS")
             }
-            handshakeContinuation.yield()
-            handshakeContinuation.finish()
+            if let pending = handshakeContinuation {
+                handshakeContinuation = nil
+                pending.resume()
+            }
             formLifecycleContinuation.yield(.handShook)
         case .analyticsEvent:
             ()

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -35,10 +35,24 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
     private typealias HandshakeContinuation = CheckedContinuation<Void, Error>
 
-    /// Pending continuation for an in-flight ``establishHandshake(timeout:)`` call. Resumed exactly
-    /// once, either by the `.handShook` bridge event or by the timeout task below — whichever
-    /// happens first clears this so the other is a no-op instead of a double-resume.
-    private var handshakeContinuation: HandshakeContinuation?
+    /// Thread-safe, actor-agnostic holder for the pending ``establishHandshake(timeout:)``
+    /// continuation. Deliberately doesn't require `@MainActor` to touch: the timeout side resumes
+    /// it from a plain, non-actor-isolated `Task`, so unblocking on timeout never needs the main
+    /// actor to schedule more work onto itself while `establishHandshake` is already suspended on it.
+    private final class HandshakeContinuationBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: HandshakeContinuation?
+
+        func exchange(_ newValue: HandshakeContinuation?) -> HandshakeContinuation? {
+            lock.lock()
+            defer { lock.unlock() }
+            let previous = continuation
+            continuation = newValue
+            return previous
+        }
+    }
+
+    private let handshakeBox = HandshakeContinuationBox()
 
     // MARK: - Scripts
 
@@ -185,19 +199,14 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         delegate.preloadUrl()
 
         do {
-            try await withCheckedThrowingContinuation { [weak self] (continuation: HandshakeContinuation) in
-                guard let self else {
-                    continuation.resume(throwing: ObjectStateError.objectDeallocated)
-                    return
-                }
+            try await withCheckedThrowingContinuation { [handshakeBox] (cont: HandshakeContinuation) in
+                _ = handshakeBox.exchange(cont)
 
-                handshakeContinuation = continuation
-
-                Task { @MainActor [weak self] in
+                Task {
                     try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                    guard let self, let pending = handshakeContinuation else { return }
-                    handshakeContinuation = nil
-                    pending.resume(throwing: TimeoutError.timeout)
+                    if let pending = handshakeBox.exchange(nil) {
+                        pending.resume(throwing: TimeoutError.timeout)
+                    }
                 }
             }
         } catch let error as TimeoutError {
@@ -401,8 +410,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.info("Successful handshake with JS")
             }
-            if let pending = handshakeContinuation {
-                handshakeContinuation = nil
+            if let pending = handshakeBox.exchange(nil) {
                 pending.resume()
             }
             formLifecycleContinuation.yield(.handShook)


### PR DESCRIPTION
## Summary
- Fixes a real hang in `IAFWebViewModel.establishHandshake(timeout:)`, which is what's been causing the "16.4, release" CI job to hang for 1-2 hours (twice, on both PR #673 and PR #674) instead of failing fast.
- Replaces the `AsyncStream<Void>`-backed handshake signal with a single one-shot `CheckedContinuation<Void, Error>`.

## Why
`establishHandshake` raced two tasks inside `withThrowingTaskGroup`: the real wait (`handshakeStream.first { _ in true }`) against a `Task.sleep`-based timeout. Structured concurrency guarantees a task group can't return until *every* child task finishes — including a "losing", cancelled one. Cancelling the operation task only requests cancellation; it never actually caused the suspended `AsyncStream.first(where:)` call to resolve, since nothing ever yielded into or finished that stream. Once the timeout fired with no handshake having happened, the whole call — and the test/host process running it — hung forever instead of throwing `TimeoutError.timeout`.

This is exactly the scenario `IAFWebViewModelPreloadingTests.testPreloadWebsiteNoActionTimeout` exercises (a mock delegate that never fires a handshake event), and it's what's been intermittently hanging CI:
- Confirmed via direct log inspection of the cancelled CI job: the last thing printed before the ~1h50m stall was `Test Case '...testPreloadWebsiteNoActionTimeout' started.`
- Confirmed this is pre-existing/untouched by any in-flight PR: `git diff origin/rel/5.4.0 -- Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift` is empty against the base this branches from.
- Reproduced the underlying mechanism standalone (plain Swift script + a `@MainActor`-isolated variant) with an unyielded `AsyncStream` raced the same way — cancellation resolved it fine on the local/current Swift runtime, meaning this is likely a runtime-version-specific gap in how reliably an in-flight `AsyncStream.next()` responds to cancellation (matches the observed pattern of only `16.4` ever hanging, never `15.2`/`15.4`). Rather than depend on that behavior at all, the fix removes the dependency entirely.

## Fix
Both the success path (`.handShook` bridge event) and the timeout path now explicitly resume the *same* stored continuation, whichever happens first; the loser is a guarded no-op. No cancellation propagation is required for either side to unblock the other.

## Test plan
- [x] `IAFWebViewModelPreloadingTests` (all 3) and the full `KlaviyoFormsTests` suite (61 tests) pass locally
- [x] Ran `testPreloadWebsiteNoActionTimeout` 11 times back-to-back — consistently resolves in ~0.1-0.4s, no hangs
- [x] `swiftlint --strict` violation count/set on the changed file matches base exactly (no new violations)
- [ ] CI green (this is what should stop the "16.4, release" job from hanging)