### PR TITLE
test(KlaviyoForms): de-flake IAF tests; pin CI simulator to iOS 18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ CONFIG = debug
 XCODE = 15.2
 # Pin the simulator runtime. Left unpinned, the macOS-15 runner picks its newest
 # installed simulator (currently iOS 26), where Swift-concurrency code hangs under
-# release optimization. iOS 18 is present on every CI runner image and passes
-# consistently. Bump this as the runner images move forward.
+# release optimization. iOS 18 is installed on both the macOS-14 and macOS-15 CI
+# runner images (independent of the selected Xcode — `xcode-select` does not remove
+# other installed runtimes), so all matrix jobs run on it consistently. Bump this
+# as the runner images move forward; the `test-library` guard below fails loudly if
+# the pinned runtime is ever missing.
 IOS_RUNTIME = iOS 18
-PLATFORM_IOS = iOS Simulator,id=$(call udid_for,$(IOS_RUNTIME),iPhone \d\+ Pro [^M])
+IOS_UDID = $(call udid_for,$(IOS_RUNTIME),iPhone \d\+ Pro [^M])
+PLATFORM_IOS = iOS Simulator,id=$(IOS_UDID)
 
 
 default: test-all
@@ -14,6 +18,11 @@ test-all: $(MAKE) CONFIG=debug test-library
 	$(MAKE) CONFIG=release test-library
 
 test-library:
+	@if [ -z "$(IOS_UDID)" ]; then \
+		echo "ERROR: no '$(IOS_RUNTIME)' iPhone Pro simulator on this runner. Bump IOS_RUNTIME to an installed runtime:"; \
+		xcrun simctl list runtimes; \
+		exit 1; \
+	fi
 	for platform in "$(PLATFORM_IOS)"; do \
 		env TEST_RUNNER_GITHUB_CI=$(GITHUB_CI) \
 		xcodebuild test \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 CONFIG = debug
 XCODE = 15.2
-PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iOS,iPhone \d\+ Pro [^M])
+# Pin the simulator runtime. Left unpinned, the macOS-15 runner picks its newest
+# installed simulator (currently iOS 26), where Swift-concurrency code hangs under
+# release optimization. iOS 18 is present on every CI runner image and passes
+# consistently. Bump this as the runner images move forward.
+IOS_RUNTIME = iOS 18
+PLATFORM_IOS = iOS Simulator,id=$(call udid_for,$(IOS_RUNTIME),iPhone \d\+ Pro [^M])
 
 
 default: test-all
@@ -16,7 +21,10 @@ test-library:
 			-enableCodeCoverage YES \
 			-configuration=$(CONFIG) \
 			-scheme klaviyo-swift-sdk-Package \
-			-destination platform="$$platform" || exit 1; \
+			-destination platform="$$platform" \
+			-test-timeouts-enabled YES \
+			-default-test-execution-time-allowance 120 \
+			-maximum-test-execution-time-allowance 300 || exit 1; \
 	done;
 
 define udid_for

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelPreloadingTests.swift
@@ -57,42 +57,36 @@ final class IAFWebViewModelPreloadingTests: XCTestCase {
     /// Tests scenario in which the timeout is reached before the `formWillAppear` event is emitted.
     @MainActor
     func testPreloadWebsiteTimeout() async {
-        // Given
+        // Given - the handshake arrives later than the timeout allows
         delegate.handshakeResult = .handshakeEstablished(delay: 1.0)
-        let expectation = XCTestExpectation(description: "Preloading website times out")
 
-        // When
+        // When / Then - establishHandshake must surface a timeout. The throw is
+        // awaited directly, so no separate expectation/fulfillment is needed.
         do {
             try await viewModel.establishHandshake(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch TimeoutError.timeout {
-            expectation.fulfill()
+            // expected
         } catch {
             XCTFail("Expected timeout error, but got: \(error)")
         }
-
-        // Then
-        await fulfillment(of: [expectation], timeout: 10.0)
     }
 
     /// Tests scenario in which the delegate does nothing and emits no events after `preloadUrl()` is called.
     @MainActor
     func testPreloadWebsiteNoActionTimeout() async {
-        // Given
+        // Given - the delegate emits no events after preloadUrl()
         delegate.handshakeResult = MockIAFWebViewDelegate.HandshakeResult.none
-        let expectation = XCTestExpectation(description: "Preloading website times out")
 
-        // When
+        // When / Then - establishHandshake must surface a timeout rather than hang.
+        // The throw is awaited directly, so no separate expectation/fulfillment is needed.
         do {
             try await viewModel.establishHandshake(timeout: 0.1)
             XCTFail("Expected timeout error, but succeeded")
         } catch TimeoutError.timeout {
-            expectation.fulfill()
+            // expected
         } catch {
             XCTFail("Expected timeout error, but got: \(error)")
         }
-
-        // Then
-        await fulfillment(of: [expectation], timeout: 2.0)
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -183,19 +183,6 @@ final class IAFWebViewModelTests: XCTestCase {
 
     @MainActor
     func testFormWillAppearYieldsPresentLifecycleEvent() async throws {
-        // Given
-        let expectation = XCTestExpectation(description: "Form will appear should yield present lifecycle event")
-
-        // Create a task to listen for lifecycle events
-        let lifecycleTask = Task {
-            for await event in viewModel.formLifecycleStream {
-                if case .present = event {
-                    expectation.fulfill()
-                    break
-                }
-            }
-        }
-
         // When - simulate a form will appear script message
         let scriptMessage = MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
@@ -213,25 +200,14 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
-        lifecycleTask.cancel()
+        await assertLifecycleEvent("present", from: viewModel.formLifecycleStream) { event in
+            if case .present = event { return true }
+            return false
+        }
     }
 
     @MainActor
     func testFormDisappearedYieldsDismissLifecycleEvent() async throws {
-        // Given
-        let expectation = XCTestExpectation(description: "Form disappeared should yield dismiss lifecycle event")
-
-        // Create a task to listen for lifecycle events
-        let lifecycleTask = Task {
-            for await event in viewModel.formLifecycleStream {
-                if case .dismiss = event {
-                    expectation.fulfill()
-                    break
-                }
-            }
-        }
-
         // When - simulate a form disappeared script message with formId and formName
         let scriptMessage = MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
@@ -249,25 +225,14 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
-        lifecycleTask.cancel()
+        await assertLifecycleEvent("dismiss", from: viewModel.formLifecycleStream) { event in
+            if case .dismiss = event { return true }
+            return false
+        }
     }
 
     @MainActor
     func testFormWillAppearYieldsPresentEvenWithMissingMetadata() async throws {
-        // Given
-        let expectation = XCTestExpectation(
-            description: "formWillAppear with missing metadata should still yield .present")
-
-        let lifecycleTask = Task {
-            for await event in viewModel.formLifecycleStream {
-                if case .present = event {
-                    expectation.fulfill()
-                    break
-                }
-            }
-        }
-
         // When - simulate a formWillAppear with empty data (no formId/formName)
         let scriptMessage = MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
@@ -282,25 +247,14 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then - .present should still be yielded
-        await fulfillment(of: [expectation], timeout: 5.0)
-        lifecycleTask.cancel()
+        await assertLifecycleEvent("present", from: viewModel.formLifecycleStream) { event in
+            if case .present = event { return true }
+            return false
+        }
     }
 
     @MainActor
     func testFormDisappearedYieldsDismissEvenWithMissingMetadata() async throws {
-        // Given
-        let expectation = XCTestExpectation(
-            description: "formDisappeared with missing metadata should still yield .dismiss")
-
-        let lifecycleTask = Task {
-            for await event in viewModel.formLifecycleStream {
-                if case .dismiss = event {
-                    expectation.fulfill()
-                    break
-                }
-            }
-        }
-
         // When - simulate a formDisappeared with empty data
         let scriptMessage = MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
@@ -315,25 +269,16 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then - .dismiss should still be yielded
-        await fulfillment(of: [expectation], timeout: 5.0)
-        lifecycleTask.cancel()
+        await assertLifecycleEvent("dismiss", from: viewModel.formLifecycleStream) { event in
+            if case .dismiss = event { return true }
+            return false
+        }
     }
 
     @MainActor
     func testAbortEventYieldsAbortLifecycleEvent() async throws {
         // Given
-        let expectation = XCTestExpectation(description: "Abort event should yield abort lifecycle event")
         let abortReason = "test abort reason"
-
-        // Create a task to listen for lifecycle events
-        let lifecycleTask = Task {
-            for await event in viewModel.formLifecycleStream {
-                if case .abort = event {
-                    expectation.fulfill()
-                    break
-                }
-            }
-        }
 
         // When - simulate an abort script message
         let scriptMessage = MockWKScriptMessage(
@@ -351,8 +296,10 @@ final class IAFWebViewModelTests: XCTestCase {
         viewModel.handleScriptMessage(scriptMessage)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 5.0)
-        lifecycleTask.cancel()
+        await assertLifecycleEvent("abort", from: viewModel.formLifecycleStream) { event in
+            if case .abort = event { return true }
+            return false
+        }
     }
 
     // MARK: - External URL Tests (openDeepLink with openExternally: true)

--- a/Tests/KlaviyoFormsTests/LifecycleEventTestSupport.swift
+++ b/Tests/KlaviyoFormsTests/LifecycleEventTestSupport.swift
@@ -1,0 +1,72 @@
+//
+//  LifecycleEventTestSupport.swift
+//  klaviyo-swift-sdk
+//
+//  Shared helpers for asserting on `IAFWebViewModel.formLifecycleStream` without
+//  the listener-startup race + wall-clock `fulfillment` that made these tests flaky.
+//
+
+@testable import KlaviyoForms
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    /// Asserts that `stream` emits a lifecycle event matching `predicate`.
+    ///
+    /// `IAFWebViewModel.handleScriptMessage(_:)` yields synchronously into the
+    /// unbounded-buffered `formLifecycleStream`, so once the triggering message has
+    /// been handled the event is already buffered. Consuming the stream inline —
+    /// rather than spawning a listener `Task` and then waiting on a wall-clock
+    /// `fulfillment(of:timeout:)` — removes the "did the listener subscribe before
+    /// the event was yielded?" race and the executor-timing sensitivity that made
+    /// these tests flaky (and, under load, hang) in CI.
+    ///
+    /// Bounded by `timeout` so a genuinely missing event fails fast instead of
+    /// hanging the whole test run.
+    ///
+    /// - Parameter description: Human-readable name of the expected event, used in
+    ///   the failure message (e.g. `"present"`).
+    func assertLifecycleEvent(
+        _ description: String,
+        from stream: AsyncStream<IAFLifecycleEvent>,
+        timeout: TimeInterval = 2.0,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        matching predicate: @escaping @Sendable (IAFLifecycleEvent) -> Bool
+    ) async {
+        let observed = await firstResult(within: timeout) {
+            for await event in stream where predicate(event) {
+                return true
+            }
+            return false
+        }
+
+        XCTAssertEqual(
+            observed,
+            true,
+            "Expected lifecycle event '\(description)' within \(timeout)s",
+            file: file,
+            line: line
+        )
+    }
+}
+
+/// Runs `operation`, returning `nil` if it does not finish within `seconds`.
+///
+/// The losing child task is cancelled, which lets a suspended `AsyncStream`
+/// iterator unwind rather than leak.
+private func firstResult<T: Sendable>(
+    within seconds: TimeInterval,
+    _ operation: @Sendable @escaping () async -> T
+) async -> T? {
+    await withThrowingTaskGroup(of: T?.self) { group in
+        group.addTask { await operation() }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return nil
+        }
+        let result = try? await group.next()
+        group.cancelAll()
+        return result ?? nil
+    }
+}


### PR DESCRIPTION
## Summary
Fixes flaky/hanging `KlaviyoFormsTests` in CI and makes the IAF lifecycle tests deterministic. Test + CI-config only — no production code changes.

## Root cause
The Xcode 16.4 CI job selected the runner's newest simulator — **iOS 26** — where Swift-concurrency code (`AsyncStream`/task-group timeouts, `WKWebView` callbacks) hangs under **release** optimization, stalling the job for hours. 16.4 *debug* passed on that same sim; only *release* hung. The Xcode 15.x jobs run on iOS 18 and always passed.

## Changes
- **`ci`: pin the test simulator to iOS 18** across all jobs — the fix. iOS 18 is installed on both runner images and passes consistently. `test-library` now **fails loudly** if the pinned runtime is ever missing (instead of an opaque empty `-destination`), and enables XCTest test-timeouts (120s/300s) as a stall backstop.
- **`test(KlaviyoForms)`: deterministic lifecycle tests.** The IAF lifecycle tests raced a listener `Task` against a wall-clock `fulfillment(5s)` — a real flake (`testFormDisappearedYieldsDismissLifecycleEvent` failed this way on iOS 18). They now consume the already-buffered `formLifecycleStream` inline via a shared `assertLifecycleEvent` helper (~0.001s). Redundant `fulfillment` also dropped from the preloading timeout tests.

## Release
`Patch` — internal test/CI change, backwards compatible.

## Test plan
- Debug, iOS 18 simulator, affected classes → all pass, no hangs (WKWebView 7 + 27, lifecycle/preloading 16 + 3).
- Full CI matrix (Xcode 15.2 / 15.4 / 16.4 × debug/release) green — 255 tests, 0 failures per job.

## Follow-up
**MAGE-992** — determine whether the iOS 26 + release hang is a real device concern (production `withTimeout`/`establishHandshake`) or a simulator/toolchain artifact, and restore newest-OS coverage in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of iOS simulator test execution by targeting a specific runtime and reporting available runtimes when it is unavailable.
  * Simplified timeout and lifecycle event testing with shared asynchronous assertions.
  * Added safeguards to prevent tests from hanging when expected events or responses do not occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->