### PR TITLE
fix(KlaviyoSwift): graft swizzle on inherited IMP; honour host willPresent options

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
@@ -193,12 +193,8 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
         return initialClass
     }
 
-    /// Installs the donor IMP on `hostClass` using one of two strategies:
-    /// - **Exchange**: host already implements the method — swap IMPs so the original selector
-    ///   hits our donor first, then the donor forwards to the host's original (now under
-    ///   `swizzledSelector`).
-    /// - **Add**: host has no implementation — install our donor directly under the original
-    ///   selector; no forwarding needed since there is no original to chain to.
+    /// Installs the donor IMP on `hostClass`: exchanges IMPs if the class owns the method,
+    /// grafts (adds) if the class has no own implementation (absent or inherited only).
     @MainActor
     private static func performSwizzle(on hostClass: AnyClass) {
         let originalSelector = #selector(
@@ -227,10 +223,12 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
         // Always add the swizzled selector to the host class so we have a stable forwarding target.
         class_addMethod(hostClass, swizzledSelector, donorIMP, donorTypes)
 
-        if let hostOriginal = class_getInstanceMethod(hostClass, originalSelector),
+        // Only exchange if hostClass owns the method; class_getInstanceMethod walks the
+        // superclass chain and exchanging an inherited IMP mutates the ancestor class.
+        if classOwnsMethod(hostClass, selector: originalSelector),
+           let hostOriginal = class_getInstanceMethod(hostClass, originalSelector),
            let hostSwizzled = class_getInstanceMethod(hostClass, swizzledSelector) {
-            // Host implements the original — exchange so calls to the original selector hit our
-            // IMP, and our forwarding call (swizzled selector) hits the host's original IMP.
+            // Own implementation: exchange originalSelector ↔ swizzledSelector.
             method_exchangeImplementations(hostOriginal, hostSwizzled)
             state.insertSwappedClass(ObjectIdentifier(hostClass))
             if #available(iOS 14.0, *) {
@@ -238,9 +236,20 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
                     "Swizzled didRegisterForRemoteNotificationsWithDeviceToken on \(hostClass)."
                 )
             }
+        } else if let inheritedMethod = class_getInstanceMethod(hostClass, originalSelector),
+                  let swizzledMethod = class_getInstanceMethod(hostClass, swizzledSelector) {
+            // Inherited implementation: graft donorIMP under originalSelector and redirect
+            // swizzledSelector to the inherited IMP so the donor can forward to it.
+            method_setImplementation(swizzledMethod, method_getImplementation(inheritedMethod))
+            class_addMethod(hostClass, originalSelector, donorIMP, donorTypes)
+            state.insertSwappedClass(ObjectIdentifier(hostClass))
+            if #available(iOS 14.0, *) {
+                Logger.notifications.info(
+                    "Grafted (inherited) didRegisterForRemoteNotificationsWithDeviceToken onto \(hostClass)."
+                )
+            }
         } else {
-            // Host does not implement the method — graft our IMP under the original selector
-            // directly. No forwarding required (there is no original to call).
+            // No implementation anywhere — graft donorIMP, no forwarding needed.
             class_addMethod(hostClass, originalSelector, donorIMP, donorTypes)
             if #available(iOS 14.0, *) {
                 Logger.notifications.info(
@@ -248,6 +257,17 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
                 )
             }
         }
+    }
+
+    /// Returns `true` if `cls` declares `selector` in its own IMP table, not via superclass.
+    private static func classOwnsMethod(_ cls: AnyClass, selector: Selector) -> Bool {
+        var count: UInt32 = 0
+        guard let methods = class_copyMethodList(cls, &count) else { return false }
+        defer { free(methods) }
+        for i in 0..<Int(count) {
+            if method_getName(methods[i]) == selector { return true }
+        }
+        return false
     }
 
     /// Donor method installed onto the host AppDelegate class by `performSwizzle(on:)`.

--- a/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
+++ b/Sources/KlaviyoSwift/KlaviyoNotificationDelegate.swift
@@ -194,13 +194,22 @@ extension KlaviyoNotificationDelegate: UNUserNotificationCenterDelegate {
             return
         }
         defer { willPresentGuard.end(requestId) }
+        // Honour the host's options when it responds synchronously. Async hosts that call
+        // back after this method returns will find `once` consumed; that is a known
+        // limitation — a timeout-based fix is deferred to a follow-up.
+        var hostResponded = false
         existingDelegate?.userNotificationCenter?(
-            center, willPresent: notification, withCompletionHandler: { once($0) }
+            center, willPresent: notification, withCompletionHandler: {
+                hostResponded = true
+                once($0)
+            }
         )
-        if #available(iOS 14.0, *) {
-            once([.list, .banner, .badge, .sound])
-        } else {
-            once([.alert, .badge, .sound])
+        if !hostResponded {
+            if #available(iOS 14.0, *) {
+                once([.list, .banner, .badge, .sound])
+            } else {
+                once([.alert, .badge, .sound])
+            }
         }
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -83,7 +83,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
 
         XCTAssertNil(
             class_getInstanceMethod(ForwardingProxyDelegate.self, didRegisterSelector),
-            "Proxy class must not have the method in its IMP table; otherwise we're not testing the forwarding path"
+            "Proxy class must not have the method in its IMP table"
         )
         XCTAssertTrue(
             proxy.responds(to: didRegisterSelector),
@@ -105,7 +105,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     func testResolveTargetSubclassWithInheritedMethod() {
         // Resolver returns the concrete subclass even when the method is only inherited,
         // so performSwizzle can graft rather than exchange the superclass IMP.
-        let sub = SubclassAppDelegate()
+        let delegate = SubclassAppDelegate()
 
         XCTAssertNotNil(
             class_getInstanceMethod(SubclassAppDelegate.self, didRegisterSelector),
@@ -118,7 +118,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertFalse(ownSelectors.contains(didRegisterSelector),
                        "Precondition: subclass must not own the method")
 
-        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: sub)
+        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
         XCTAssertTrue(resolved == SubclassAppDelegate.self)
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -49,6 +49,17 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     /// Mirrors the fallback case where the SDK should still graft onto the wrapper class.
     private final class OpaqueDelegate: NSObject, UIApplicationDelegate {}
 
+    /// Base class that owns the device-token method.
+    private class BaseAppDelegate: NSObject, UIApplicationDelegate {
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {}
+    }
+
+    /// Subclass that only inherits the method from `BaseAppDelegate` without overriding it.
+    private final class SubclassAppDelegate: BaseAppDelegate {}
+
     // MARK: - Helpers
 
     private let didRegisterSelector = #selector(
@@ -89,5 +100,25 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         let opaque = OpaqueDelegate()
         let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
         XCTAssertTrue(resolved == OpaqueDelegate.self)
+    }
+
+    func testResolveTargetSubclassWithInheritedMethod() {
+        // Resolver returns the concrete subclass even when the method is only inherited,
+        // so performSwizzle can graft rather than exchange the superclass IMP.
+        let sub = SubclassAppDelegate()
+
+        XCTAssertNotNil(
+            class_getInstanceMethod(SubclassAppDelegate.self, didRegisterSelector),
+            "Precondition: method reachable via superclass chain"
+        )
+        var count: UInt32 = 0
+        let ownMethods = class_copyMethodList(SubclassAppDelegate.self, &count)
+        let ownSelectors = (0..<Int(count)).map { method_getName(ownMethods![$0]) }
+        free(ownMethods)
+        XCTAssertFalse(ownSelectors.contains(didRegisterSelector),
+                       "Precondition: subclass must not own the method")
+
+        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: sub)
+        XCTAssertTrue(resolved == SubclassAppDelegate.self)
     }
 }


### PR DESCRIPTION
## Summary

- **Swizzler (MAGE-994)**: `class_getInstanceMethod` walks the superclass chain, so calling `method_exchangeImplementations` on an inherited method mutates the ancestor IMP and breaks all sibling subclasses. Now uses `class_copyMethodList` to verify the host class owns the method before exchanging. Three cases handled:
  - **Owns method**: exchange (existing behaviour)
  - **Inherits only**: graft `donorIMP` under `originalSelector`, redirect `swizzledSelector` to the inherited IMP so the donor forwards correctly, mark as swapped
  - **No implementation**: graft only, no forwarding
- **willPresent race (MAGE-993)**: proxy was calling `once([.list,.banner,.badge,.sound])` unconditionally after forwarding, so a host that responds synchronously with suppress-options (e.g. `[]`) would lose the race. Now tracks `hostResponded` and only applies defaults if the host did not respond synchronously. Async hosts remain a known limitation (documented in code; timeout-based fix deferred).

## Test plan

- [ ] Build succeeds: `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6"`
- [ ] All 276 tests pass: `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6"`
- [ ] New test `testResolveTargetSubclassWithInheritedMethod` verifies resolver returns concrete subclass for the inherited-method case
- [ ] Manual: app with a base `AppDelegate` that implements `didRegisterForRemoteNotificationsWithDeviceToken` and a subclass as the actual delegate — token forwarding fires and base class method still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of inherited app delegate methods to ensure remote notification callbacks are forwarded correctly.
  - Updated notification presentation forwarding so host-provided options are respected when returned synchronously.
  - Applied reliable default presentation options only when the host does not respond during the delegate callback.

- **Tests**
  - Added coverage for app delegate method inheritance and verified correct swizzle targeting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->