### PR TITLE
feat: add list subscription demo to sample app

### DIFF
--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -15,6 +15,10 @@ import SwiftUI
 import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    // [OPTIONAL] To demo list subscriptions, set a list ID from your account.
+    // Leave `nil` to hide the subscribe toggle entirely.
+    static let subscriptionListId: String? = nil
+
     // MARK: - Private members
 
     private var email: String? {

--- a/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
@@ -83,6 +83,14 @@ class AppState: ObservableObject {
         KlaviyoSDK().create(event: .init(name: .addedToCartMetric, properties: propertiesDictionary))
     }
 
+    /// Grants marketing consent on every channel the tracked profile has an identifier for.
+    func subscribeToList(listId: String) {
+        KlaviyoSDK().create(subscription: .allAvailableMarketing(
+            listId: listId,
+            customSource: "KLMunchery Sample App"
+        ))
+    }
+
     func removeFromCart(_ item: MenuItem) {
         if let index = cartItems.firstIndex(where: { $0.id == item.id }) {
             cartItems.remove(at: index)

--- a/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
@@ -85,10 +85,11 @@ class AppState: ObservableObject {
 
     /// Grants marketing consent on every channel the tracked profile has an identifier for.
     func subscribeToList(listId: String) {
-        KlaviyoSDK().create(subscription: .allAvailableMarketing(
-            listId: listId,
-            customSource: "KLMunchery Sample App"
-        ))
+        KlaviyoSDK().create(
+            subscription: .allAvailableMarketing(
+                listId: listId
+            )
+        )
     }
 
     func removeFromCart(_ item: MenuItem) {

--- a/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
@@ -5,6 +5,7 @@ struct LoginView: View {
     @State private var email: String = ""
     @State private var zipcode: String = ""
     @State private var rememberMe: Bool = true
+    @State private var subscribeToMarketing: Bool = false
 
     var body: some View {
         ScrollView {
@@ -69,6 +70,20 @@ struct LoginView: View {
                             .toggleStyle(SwitchToggleStyle(tint: .blue))
                     }
 
+                    // Collect marketing consent at signup, shown only when a list ID is configured
+                    if AppDelegate.subscriptionListId != nil {
+                        HStack {
+                            Text("Subscribe to email marketing")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+
+                            Spacer()
+
+                            Toggle("", isOn: $subscribeToMarketing)
+                                .toggleStyle(SwitchToggleStyle(tint: .blue))
+                        }
+                    }
+
                     Button(action: login) {
                         Text("Get Started")
                             .font(.headline)
@@ -96,6 +111,11 @@ struct LoginView: View {
 
     private func login() {
         appState.login(email: email, zipcode: zipcode)
+
+        // Subscribe after login so the profile already has the email set
+        if subscribeToMarketing, let listId = AppDelegate.subscriptionListId {
+            appState.subscribeToList(listId: listId)
+        }
     }
 
     private var isFormInvalid: Bool {

--- a/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
@@ -72,16 +72,12 @@ struct LoginView: View {
 
                     // Collect marketing consent at signup, shown only when a list ID is configured
                     if AppDelegate.subscriptionListId != nil {
-                        HStack {
+                        Toggle(isOn: $subscribeToMarketing) {
                             Text("Subscribe to email marketing")
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
-
-                            Spacer()
-
-                            Toggle("", isOn: $subscribeToMarketing)
-                                .toggleStyle(SwitchToggleStyle(tint: .blue))
                         }
+                        .toggleStyle(SwitchToggleStyle(tint: .blue))
                     }
 
                     Button(action: login) {


### PR DESCRIPTION
# Description
Adds an optional "Subscribe to email marketing" demo to the public sample app (KLMunchery), exercising the `create(subscription:)` API shipped in MAGE-854.

For UI, see [slack discussion](https://klaviyo.slack.com/archives/C0BFHP24WFL/p1785174737333699)

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
  - Sample-app-only change; `Examples/` has no test target.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No SDK source changes — `Examples/` is not shipped to customers via SPM/CocoaPods.

## Changelog / Code Overview
- `Shared/AppDelegate.swift` — new `static let subscriptionListId: String?`, `nil` by default, placed next to the hardcoded `initialize(with: "YOUR_PUBLIC_API_KEY")` so both opt-in values live in one spot.
- `Shared/LoginView.swift` — a "Subscribe to email marketing" toggle in the same block as Remember Me, rendered only when `subscriptionListId != nil`. On tapping Get Started, subscribes after `appState.login(...)` so the profile already has an email set.
- `Shared/ContentView.swift` — `AppState.subscribeToList(listId:)` calls `KlaviyoSDK().create(subscription: .allAvailableMarketing(listId:customSource:))`, routed through `AppState` like `login` / `addToCart`.

Consent is collected at signup rather than behind a standalone button, which is the pattern a third-party developer is most likely to copy. With `subscriptionListId` left at `nil` the sample app is visually unchanged.

## Test Plan
1. In `Shared/AppDelegate.swift`, set `subscriptionListId` to a list ID from your account and replace `YOUR_PUBLIC_API_KEY` with that account's public API key.
2. Build and run the SPM example on a simulator (`Examples/KlaviyoSwiftExamples/SPMExample`).
3. On the login screen, confirm the "Subscribe to email marketing" row appears below Remember Me.
4. Enter an email and zipcode, leave the toggle **off**, tap Get Started — no subscription is created.
5. Log out, repeat with the toggle **on** — the profile appears on the list in-account with `$source` set to "KLMunchery Sample App".
6. Revert `subscriptionListId` to `nil` and relaunch — the toggle is gone and the login screen matches `master`.

Verified on iPhone 17 simulator (Xcode 26.2): builds clean, toggle shows/hides with the list ID as expected. Step 5's in-account confirmation still needs a run against a real account.

<img width="1444" height="295" alt="2026-07-27_15-22-50" src="https://github.com/user-attachments/assets/d13680d8-2d05-4950-8aaf-2cbb0edae9db" />
^^ note the user agent string


<img width="369" height="742" alt="image" src="https://github.com/user-attachments/assets/28a1aaaf-b7b0-4237-9581-c0a31faf6708" />



## Related Issues/Tickets
Closes MAGE-944
Part of MAGE-854


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional marketing consent toggle to the login form.
  * When enabled (and a marketing list is configured), signing in can create a subscription for that list.
  * The consent toggle is shown only when marketing list subscription is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->