### PR TITLE
test(KlaviyoCore): de-flake EventBuffer concurrency test

### DIFF
--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -202,10 +202,11 @@ class EventBufferTests: XCTestCase {
             }
         }
 
-        // Concurrent access is safe and the size limit still holds. This final read is
-        // a barrier-flushing `queue.sync`, so it observes every enqueued write.
+        // The 50 writes all landed and the size limit held. This final read is a
+        // barrier-flushing `queue.sync`, so it observes every enqueued write; with a
+        // frozen clock (nothing ages out) the buffer settles at exactly maxBufferSize.
         let events = eventBuffer.getRecentEvents()
-        XCTAssertLessThanOrEqual(events.count, 5, "Should respect max buffer size under concurrent access")
+        XCTAssertEqual(events.count, 5, "50 concurrent writes should fill the buffer to its max size")
     }
 
     // MARK: - Edge Cases

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -190,29 +190,22 @@ class EventBufferTests: XCTestCase {
         XCTAssertLessThanOrEqual(events.count, 5, "Should respect max buffer size")
     }
 
-    func testConcurrentReadingAndWriting() async throws {
-        // Given
-        let writeExpectation = XCTestExpectation(description: "Writing complete")
-        let readExpectation = XCTestExpectation(description: "Reading complete")
-
-        // When - write and read concurrently
-        DispatchQueue.global().async {
-            for iter in 0..<50 {
-                self.eventBuffer.buffer(Event(name: .customEvent("event_\(iter)")))
+    func testConcurrentReadingAndWriting() {
+        // Stress the reader/writer lock from many real threads: even iterations issue
+        // barrier writes, odd iterations issue reads. `concurrentPerform` fully joins
+        // all iterations before returning, so no work outlives the test.
+        DispatchQueue.concurrentPerform(iterations: 100) { index in
+            if index.isMultiple(of: 2) {
+                eventBuffer.buffer(Event(name: .customEvent("event_\(index)")))
+            } else {
+                _ = eventBuffer.getRecentEvents()
             }
-            writeExpectation.fulfill()
         }
 
-        DispatchQueue.global().async {
-            for _ in 0..<50 {
-                _ = self.eventBuffer.getRecentEvents()
-            }
-            readExpectation.fulfill()
-        }
-
-        // Then - should not crash
-        await fulfillment(of: [writeExpectation, readExpectation], timeout: 10.0)
-        XCTAssertNoThrow(eventBuffer.getRecentEvents())
+        // Concurrent access is safe and the size limit still holds. This final read is
+        // a barrier-flushing `queue.sync`, so it observes every enqueued write.
+        let events = eventBuffer.getRecentEvents()
+        XCTAssertLessThanOrEqual(events.count, 5, "Should respect max buffer size under concurrent access")
     }
 
     // MARK: - Edge Cases


### PR DESCRIPTION
# Description
De-flakes `EventBufferTests.testConcurrentReadingAndWriting`, whose intermittent hang under release optimization was stalling and failing the `iOS SDK CI` job on `rel/5.4.0` (e.g. the merge commit for #677).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

Test-only change; no production code touched.

## Changelog / Code Overview
Rewrote `testConcurrentReadingAndWriting` to remove a flaky-under-load concurrency pattern.

**Before:** the test fired two detached `DispatchQueue.global().async` closures (50 writes / 50 reads) and then waited on `await fulfillment(of:timeout: 10.0)`. Under release optimization on a loaded CI runner:
1. the 10s wall-clock wait would time out → the test **fails** (observed: `testConcurrentReadingAndWriting` failed at 15.6s), and
2. the detached closures were **never joined**, so they kept issuing blocking `queue.sync` reads / barrier writes into GCD's shared worker pool after the test returned — starving the *next* test's `queue.sync` and hanging it (observed: `testGetRecentEventsMultipleTimes` started and never completed, killed by the execution-time allowance added in #677).

That combination is what stalled and then failed the `iOS SDK CI` / macOS-15 / Xcode 16.4 / release job on the #677 merge commit, even though the same commit passed on its PR branch (the tests are flaky, not deterministically broken).

**After:** a single `DispatchQueue.concurrentPerform(iterations: 100)` (even iterations write, odd iterations read) exercises the same reader/writer contention but **fully joins** all iterations before the test method returns — no work outlives the test, no wall-clock `fulfillment` race. This mirrors the existing `testConcurrentBuffering` pattern. `EventBuffer`'s public API is unchanged.

Note: this is a separate root cause from the iOS-18 simulator pin in #677. That pin works correctly (jobs build against the iOS 18.5 SDK); this flaky test is unrelated to the runtime version.

## Test Plan
- `EventBufferTests` (all 15, run in order so `testGetRecentEventsMultipleTimes` follows `testConcurrentReadingAndWriting`) — **debug**, iOS 18.5 simulator, Xcode 26 locally: passed 4/4 consecutive runs. `testConcurrentReadingAndWriting` now completes in ~0.025s (was failing at 15.6s); `testGetRecentEventsMultipleTimes` in ~0.001s (was hanging).
- Release-config verification is left to CI (Xcode 15.2/15.4/16.4), which is the environment where the original stall occurred; local release builds aren't possible on Xcode 26 due to a `swift-custom-dump` toolchain incompatibility.

## Related Issues/Tickets
Follow-up to #677.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrency stress testing for event buffering by switching to a deterministic parallel execution approach.
  * Added stronger validation under concurrent reads and barrier writes, confirming the buffer reaches exactly the configured maximum size after the stress run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->