### PR TITLE
test(KlaviyoSwift): add testability hooks and tests for KlaviyoAppDelegateSwizzler

### DIFF
--- a/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
@@ -87,6 +87,22 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
             lock.lock(); defer { lock.unlock() }
             return swappedClasses.contains(identifier)
         }
+
+        #if DEBUG
+        /// Resets logical swizzle state for test isolation.
+        /// ObjC runtime method exchanges are permanent — callers must use a unique class per test.
+        func reset() {
+            lock.lock()
+            didSwizzle = false
+            swappedClasses = []
+            let observer = didFinishLaunchingObserver
+            didFinishLaunchingObserver = nil
+            lock.unlock()
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+        #endif
     }
 
     private static let state = State()
@@ -269,6 +285,30 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
         }
         return false
     }
+
+    #if DEBUG
+
+    // MARK: - Test hooks
+
+    /// Calls `performSwizzle(on:)` directly, bypassing the delegate-availability guard.
+    @MainActor
+    static func _performSwizzleForTesting(on hostClass: AnyClass) {
+        performSwizzle(on: hostClass)
+    }
+
+    /// Resets logical swizzle state so each test starts clean.
+    static func _resetStateForTesting() { state.reset() }
+
+    static func _isSwappedForTesting(_ identifier: ObjectIdentifier) -> Bool {
+        state.isSwapped(identifier)
+    }
+
+    /// Exposes the donor selector so tests can inspect the swizzled method table slot
+    /// without needing visibility into the private `klaviyo_application` method.
+    static var _swizzledSelectorForTesting: Selector {
+        #selector(klaviyo_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
+    }
+    #endif
 
     /// Donor method installed onto the host AppDelegate class by `performSwizzle(on:)`.
     /// Invoked by the Obj-C runtime on the main thread when iOS delivers the device-token

--- a/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
+++ b/Sources/KlaviyoSwift/KlaviyoAppDelegateSwizzler.swift
@@ -95,12 +95,8 @@ final class KlaviyoAppDelegateSwizzler: NSObject, @unchecked Sendable {
             lock.lock()
             didSwizzle = false
             swappedClasses = []
-            let observer = didFinishLaunchingObserver
-            didFinishLaunchingObserver = nil
             lock.unlock()
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
-            }
+            clearObserver()
         }
         #endif
     }

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -2,10 +2,13 @@
 //  KlaviyoAppDelegateSwizzlerTests.swift
 //  KlaviyoSwiftTests
 //
-//  Coverage for `KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for:)` — specifically
-//  the SwiftUI `@UIApplicationDelegateAdaptor` case where `UIApplication.shared.delegate` is
-//  a private SwiftUI wrapper that forwards selectors to the host's real AppDelegate via
-//  `-forwardingTargetForSelector:`.
+//  Tests for `KlaviyoAppDelegateSwizzler` — both the pure
+//  `resolveSwizzleTargetClass(for:)` helper and the runtime-mutating
+//  `performSwizzle(on:)` path (exchange, graft, and inherited-IMP).
+//
+//  Because ObjC method exchanges are permanent within a process, each
+//  `performSwizzle` test uses its own unique delegate class so runtime
+//  changes from one test cannot affect another.
 //
 
 @testable import KlaviyoSwift
@@ -15,10 +18,30 @@ import XCTest
 
 @MainActor
 final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
-    // MARK: - Test doubles
+    // MARK: - Selectors
 
-    /// A direct UIApplicationDelegate implementor — mimics the simplest host case where the
-    /// user's `AppDelegate` is the actual `UIApplication.shared.delegate`.
+    private let originalSelector = #selector(
+        UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+    )
+    private var swizzledSelector: Selector {
+        KlaviyoAppDelegateSwizzler._swizzledSelectorForTesting
+    }
+
+    // MARK: - Lifecycle
+
+    override func setUp() async throws {
+        try await super.setUp()
+        klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+        KlaviyoAppDelegateSwizzler._resetStateForTesting()
+    }
+
+    override func tearDown() async throws {
+        KlaviyoAppDelegateSwizzler._resetStateForTesting()
+        try await super.tearDown()
+    }
+
+    // MARK: - Test doubles: resolveSwizzleTargetClass
+
     private final class DirectAppDelegate: NSObject, UIApplicationDelegate {
         func application(
             _ application: UIApplication,
@@ -26,15 +49,9 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         ) {}
     }
 
-    /// A NSObject that doesn't implement `application:didRegister...` in its IMP table but
-    /// forwards selectors to an inner host delegate via `-forwardingTargetForSelector:`.
-    /// This mirrors how SwiftUI's `@UIApplicationDelegateAdaptor` wrapper behaves.
     private final class ForwardingProxyDelegate: NSObject, UIApplicationDelegate {
         let inner: DirectAppDelegate
-
-        init(inner: DirectAppDelegate) {
-            self.inner = inner
-        }
+        init(inner: DirectAppDelegate) { self.inner = inner }
 
         override func forwardingTarget(for aSelector: Selector!) -> Any? {
             inner.responds(to: aSelector) ? inner : super.forwardingTarget(for: aSelector)
@@ -45,8 +62,6 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         }
     }
 
-    /// A NSObject that doesn't implement the method and doesn't expose a forwarding target.
-    /// Mirrors the fallback case where the SDK should still graft onto the wrapper class.
     private final class OpaqueDelegate: NSObject, UIApplicationDelegate {}
 
     /// Base class that owns the device-token method.
@@ -60,65 +75,235 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     /// Subclass that only inherits the method from `BaseAppDelegate` without overriding it.
     private final class SubclassAppDelegate: BaseAppDelegate {}
 
+    // MARK: - Test doubles: performSwizzle (unique per test — ObjC changes are permanent)
+
+    /// Exchange path: class declares the selector in its own IMP table.
+    private class ExchangeDelegate: NSObject, UIApplicationDelegate {
+        var hostCallCount = 0
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {
+            hostCallCount += 1
+        }
+    }
+
+    /// Graft path: class has no implementation — donor is added without forwarding.
+    private class GraftDelegate: NSObject, UIApplicationDelegate {}
+
+    /// Inherited path: base owns the method; sub inherits without overriding.
+    private class InheritedBaseDelegate: NSObject, UIApplicationDelegate {
+        var hostCallCount = 0
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {
+            hostCallCount += 1
+        }
+    }
+
+    private class InheritedSubDelegate: InheritedBaseDelegate {}
+
+    /// Exchange path — used only by testDonorIMPForwardsToHostOriginalAfterExchange.
+    /// Separate from ExchangeDelegate because ObjC swizzle changes are permanent per class.
+    private class ExchangeForwardingDelegate: NSObject, UIApplicationDelegate {
+        var hostCallCount = 0
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {
+            hostCallCount += 1
+        }
+    }
+
+    /// Inherited path — base used only by testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass.
+    private class InheritedForwardingBaseDelegate: NSObject, UIApplicationDelegate {
+        var hostCallCount = 0
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {
+            hostCallCount += 1
+        }
+    }
+
+    private class InheritedForwardingSubDelegate: InheritedForwardingBaseDelegate {}
+
+    /// Separate class used only for the idempotency test.
+    private class IdempotencyDelegate: NSObject, UIApplicationDelegate {
+        func application(
+            _ application: UIApplication,
+            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+        ) {}
+    }
+
     // MARK: - Helpers
 
-    private let didRegisterSelector = #selector(
-        UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
-    )
+    /// Returns true if `cls` declares `selector` in its own method table (not via superclass).
+    private func classOwnsMethod(_ cls: AnyClass, selector: Selector) -> Bool {
+        var count: UInt32 = 0
+        guard let methods = class_copyMethodList(cls, &count) else { return false }
+        defer { free(methods) }
+        return (0..<Int(count)).contains { method_getName(methods[$0]) == selector }
+    }
 
-    // MARK: - Tests
+    /// Invokes the IMP currently installed at `originalSelector` on the delegate's class.
+    private func callInstalledIMP(on delegate: NSObject, token: Data = Data([0xAA, 0xBB])) {
+        guard let method = class_getInstanceMethod(type(of: delegate), originalSelector) else { return }
+        typealias TokenIMP = @convention(c) (NSObject, Selector, UIApplication, NSData) -> Void
+        let imp = unsafeBitCast(method_getImplementation(method), to: TokenIMP.self)
+        imp(delegate, originalSelector, UIApplication.shared, token as NSData)
+    }
+
+    // MARK: - resolveSwizzleTargetClass tests
 
     func testResolveTargetDirectImplementor() {
         let delegate = DirectAppDelegate()
-        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
-        XCTAssertTrue(resolved == DirectAppDelegate.self)
+        XCTAssertTrue(KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate) == DirectAppDelegate.self)
     }
 
     func testResolveTargetForwardingProxy() {
-        // The proxy has no `didRegister` IMP of its own; its inner DirectAppDelegate does.
-        // The resolver must follow `-forwardingTargetForSelector:` and return the inner class
-        // so the IMP exchange intercepts the real implementor rather than the wrapper.
         let inner = DirectAppDelegate()
         let proxy = ForwardingProxyDelegate(inner: inner)
 
         XCTAssertNil(
-            class_getInstanceMethod(ForwardingProxyDelegate.self, didRegisterSelector),
+            class_getInstanceMethod(ForwardingProxyDelegate.self, originalSelector),
             "Proxy class must not have the method in its IMP table"
         )
         XCTAssertTrue(
-            proxy.responds(to: didRegisterSelector),
+            proxy.responds(to: originalSelector),
             "Proxy must respond via forwarding for this test to be meaningful"
         )
 
-        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
         XCTAssertTrue(resolved == DirectAppDelegate.self)
     }
 
     func testResolveTargetOpaqueDelegate() {
-        // No forwarding, no IMP — resolver falls back to the initial class so the swizzler
-        // can still graft our IMP somewhere and the SDK receives the token.
         let opaque = OpaqueDelegate()
-        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
         XCTAssertTrue(resolved == OpaqueDelegate.self)
     }
 
     func testResolveTargetSubclassWithInheritedMethod() {
-        // Resolver returns the concrete subclass even when the method is only inherited,
-        // so performSwizzle can graft rather than exchange the superclass IMP.
         let delegate = SubclassAppDelegate()
 
         XCTAssertNotNil(
-            class_getInstanceMethod(SubclassAppDelegate.self, didRegisterSelector),
-            "Precondition: method reachable via superclass chain"
+            class_getInstanceMethod(SubclassAppDelegate.self, originalSelector),
+            "Precondition: method must be reachable via superclass chain"
         )
-        var count: UInt32 = 0
-        let ownMethods = class_copyMethodList(SubclassAppDelegate.self, &count)
-        let ownSelectors = (0..<Int(count)).map { method_getName(ownMethods![$0]) }
-        free(ownMethods)
-        XCTAssertFalse(ownSelectors.contains(didRegisterSelector),
-                       "Precondition: subclass must not own the method")
+        XCTAssertFalse(
+            classOwnsMethod(SubclassAppDelegate.self, selector: originalSelector),
+            "Precondition: subclass must not own the method"
+        )
 
-        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
+        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
         XCTAssertTrue(resolved == SubclassAppDelegate.self)
+    }
+
+    // MARK: - performSwizzle tests
+
+    func testExchangePathSwapsIMPOnHostClass() {
+        // ExchangeDelegate owns the method — swizzler must exchange IMPs on the class itself.
+        let donorMethod = class_getInstanceMethod(
+            KlaviyoAppDelegateSwizzler.self, swizzledSelector
+        )!
+        let donorIMP = method_getImplementation(donorMethod)
+
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: ExchangeDelegate.self)
+
+        // originalSelector now holds the donor IMP.
+        let installedMethod = class_getInstanceMethod(ExchangeDelegate.self, originalSelector)!
+        XCTAssertEqual(method_getImplementation(installedMethod), donorIMP)
+
+        // swappedClasses must record ExchangeDelegate so the donor knows to forward.
+        XCTAssertTrue(KlaviyoAppDelegateSwizzler._isSwappedForTesting(ObjectIdentifier(ExchangeDelegate.self)))
+    }
+
+    func testGraftPathAddsIMPWithoutForwarding() {
+        // GraftDelegate has no implementation — swizzler must graft without marking as swapped.
+        XCTAssertFalse(
+            classOwnsMethod(GraftDelegate.self, selector: originalSelector),
+            "Precondition: class must not have the method before swizzle"
+        )
+
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: GraftDelegate.self)
+
+        XCTAssertTrue(
+            classOwnsMethod(GraftDelegate.self, selector: originalSelector),
+            "Donor IMP must be added to the class after graft"
+        )
+        // No swap recorded — donor IMP checks this to avoid infinite recursion.
+        XCTAssertFalse(KlaviyoAppDelegateSwizzler._isSwappedForTesting(ObjectIdentifier(GraftDelegate.self)))
+    }
+
+    func testInheritedPathGraftsOnSubclassLeavingSuperclassUnchanged() {
+        // Capture the superclass IMP before swizzle.
+        let baseMethod = class_getInstanceMethod(InheritedBaseDelegate.self, originalSelector)!
+        let baseIMPBefore = method_getImplementation(baseMethod)
+
+        XCTAssertFalse(
+            classOwnsMethod(InheritedSubDelegate.self, selector: originalSelector),
+            "Precondition: subclass must not own the method"
+        )
+
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: InheritedSubDelegate.self)
+
+        // Superclass IMP must be unchanged.
+        let baseIMPAfter = method_getImplementation(
+            class_getInstanceMethod(InheritedBaseDelegate.self, originalSelector)!
+        )
+        XCTAssertEqual(baseIMPBefore, baseIMPAfter, "Superclass method table must not be mutated")
+
+        // Subclass must now own both selectors in its own method table.
+        XCTAssertTrue(
+            classOwnsMethod(InheritedSubDelegate.self, selector: originalSelector),
+            "Subclass must own originalSelector after graft"
+        )
+        XCTAssertTrue(
+            classOwnsMethod(InheritedSubDelegate.self, selector: swizzledSelector),
+            "Subclass must own swizzledSelector after graft"
+        )
+
+        // Swap recorded so the donor knows to forward to the inherited IMP.
+        XCTAssertTrue(
+            KlaviyoAppDelegateSwizzler._isSwappedForTesting(ObjectIdentifier(InheritedSubDelegate.self))
+        )
+    }
+
+    func testDonorIMPForwardsToHostOriginalAfterExchange() {
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: ExchangeForwardingDelegate.self)
+
+        let delegate = ExchangeForwardingDelegate()
+        // Calling through the donor IMP (installed at originalSelector) must chain
+        // to the host's original, incrementing its counter.
+        callInstalledIMP(on: delegate)
+
+        XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to host's original implementation")
+    }
+
+    func testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass() {
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: InheritedForwardingSubDelegate.self)
+
+        let delegate = InheritedForwardingSubDelegate()
+        callInstalledIMP(on: delegate)
+
+        XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to the inherited base implementation")
+    }
+
+    func testSwizzleIsIdempotentWithinSingleClaim() {
+        // First swizzle installs the donor IMP at originalSelector.
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: IdempotencyDelegate.self)
+        let impAfterFirst = method_getImplementation(
+            class_getInstanceMethod(IdempotencyDelegate.self, originalSelector)!
+        )
+
+        // Second call — claimSwizzle() returns false, performSwizzle must be a no-op.
+        KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: IdempotencyDelegate.self)
+        let impAfterSecond = method_getImplementation(
+            class_getInstanceMethod(IdempotencyDelegate.self, originalSelector)!
+        )
+
+        XCTAssertEqual(impAfterFirst, impAfterSecond, "Second swizzle call must leave IMP unchanged")
     }
 }

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -157,11 +157,17 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
 
     // MARK: - resolveSwizzleTargetClass tests
 
+    // App delegate directly implements `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`.
+    // Resolver must return the delegate's own class with no forwarding probe needed.
     func testResolveTargetDirectImplementor() {
         let delegate = DirectAppDelegate()
         XCTAssertTrue(KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate) == DirectAppDelegate.self)
     }
 
+    // SwiftUI `@UIApplicationDelegateAdaptor` pattern: the visible delegate is a proxy that
+    // has no IMP of its own but forwards the selector to an inner real delegate via
+    // `-forwardingTargetForSelector:`. Resolver must follow the forwarding chain and return
+    // the inner class so we swizzle the class that actually runs the method.
     func testResolveTargetForwardingProxy() {
         let inner = DirectAppDelegate()
         let proxy = ForwardingProxyDelegate(inner: inner)
@@ -179,12 +185,17 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertTrue(resolved == DirectAppDelegate.self)
     }
 
+    // Delegate implements no device-token method and has no forwarding target. Resolver must
+    // fall back to the delegate's own class so `performSwizzle` can graft the donor IMP onto it.
     func testResolveTargetOpaqueDelegate() {
         let opaque = OpaqueDelegate()
         let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
         XCTAssertTrue(resolved == OpaqueDelegate.self)
     }
 
+    // Delegate subclass inherits the method from its superclass but doesn't override it.
+    // Resolver must return the subclass (not the superclass) so `performSwizzle` targets the
+    // concrete runtime type and uses the inherited-graft path rather than mutating the superclass.
     func testResolveTargetSubclassWithInheritedMethod() {
         let delegate = SubclassAppDelegate()
 
@@ -203,6 +214,10 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
 
     // MARK: - performSwizzle tests
 
+    // Host class owns the device-token method in its own IMP table (most common case).
+    // Swizzler must exchange IMPs so `originalSelector` points to the donor and `swizzledSelector`
+    // holds the host's original, and must record the class in `swappedClasses` so the donor
+    // knows to forward after calling `KlaviyoSDK().set(pushToken:)`.
     func testExchangePathSwapsIMPOnHostClass() {
         // ExchangeDelegate owns the method — swizzler must exchange IMPs on the class itself.
         let donorMethod = class_getInstanceMethod(
@@ -220,6 +235,9 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertTrue(KlaviyoAppDelegateSwizzler._isSwappedForTesting(ObjectIdentifier(ExchangeDelegate.self)))
     }
 
+    // Host class has no device-token method at all — neither owned nor inherited. Swizzler
+    // must add the donor IMP directly under `originalSelector` with no forwarding setup, and
+    // must NOT record the class in `swappedClasses` (donor would recurse if it tried to forward).
     func testGraftPathAddsIMPWithoutForwarding() {
         // GraftDelegate has no implementation — swizzler must graft without marking as swapped.
         XCTAssertFalse(
@@ -237,6 +255,11 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertFalse(KlaviyoAppDelegateSwizzler._isSwappedForTesting(ObjectIdentifier(GraftDelegate.self)))
     }
 
+    // Host subclass inherits the method from its superclass without overriding it. Swizzler
+    // must graft the donor onto the subclass only — `originalSelector` and `swizzledSelector`
+    // are added to the subclass's own IMP table, and the superclass method table must remain
+    // byte-for-byte unchanged. This prevents other subclasses and direct superclass instances
+    // from having their behavior altered as a side effect of our swizzle.
     func testInheritedPathGraftsOnSubclassLeavingSuperclassUnchanged() {
         // Capture the superclass IMP before swizzle.
         let baseMethod = class_getInstanceMethod(InheritedBaseDelegate.self, originalSelector)!
@@ -271,6 +294,10 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         )
     }
 
+    // After the exchange path, calling `originalSelector` on the host must invoke the donor
+    // (which records the token with Klaviyo) AND chain through to the host's original
+    // implementation. Verifies the forwarding leg of the donor IMP — without it, the host's
+    // push-token handling would be silently dropped.
     func testDonorIMPForwardsToHostOriginalAfterExchange() {
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: ExchangeForwardingDelegate.self)
 
@@ -282,6 +309,10 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to host's original implementation")
     }
 
+    // After the inherited-graft path, calling `originalSelector` on the subclass must invoke
+    // the donor AND chain through to the inherited base implementation. The donor's forwarding
+    // target is `swizzledSelector`, which was redirected to the inherited IMP at swizzle time
+    // rather than being left pointing at the donor (which would recurse).
     func testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass() {
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: InheritedForwardingSubDelegate.self)
 
@@ -291,6 +322,9 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to the inherited base implementation")
     }
 
+    // `swizzleIfPossible` can be called more than once (e.g. host calls `initialize` twice).
+    // Only the first call must install the donor IMP; subsequent calls must be no-ops that
+    // leave the IMP pointer and method table unchanged.
     func testSwizzleIsIdempotentWithinSingleClaim() {
         // First swizzle installs the donor IMP at originalSelector.
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: IdempotencyDelegate.self)

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -147,12 +147,13 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         return (0..<Int(count)).contains { method_getName(methods[$0]) == selector }
     }
 
-    /// Invokes the IMP currently installed at `originalSelector` on the delegate's class.
-    private func callInstalledIMP(on delegate: NSObject, token: Data = Data([0xAA, 0xBB])) {
-        guard let method = class_getInstanceMethod(type(of: delegate), originalSelector) else { return }
-        typealias TokenIMP = @convention(c) (NSObject, Selector, UIApplication, NSData) -> Void
-        let imp = unsafeBitCast(method_getImplementation(method), to: TokenIMP.self)
-        imp(delegate, originalSelector, UIApplication.shared, token as NSData)
+    /// Returns the IMP at `selector` on `cls`, failing the test if the method is absent.
+    private func imp(on cls: AnyClass, selector: Selector) -> IMP? {
+        guard let method = class_getInstanceMethod(cls, selector) else {
+            XCTFail("No method at \(NSStringFromSelector(selector)) on \(cls)")
+            return nil
+        }
+        return method_getImplementation(method)
     }
 
     // MARK: - resolveSwizzleTargetClass tests
@@ -294,32 +295,35 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         )
     }
 
-    // After the exchange path, calling `originalSelector` on the host must invoke the donor
-    // (which records the token with Klaviyo) AND chain through to the host's original
-    // implementation. Verifies the forwarding leg of the donor IMP — without it, the host's
-    // push-token handling would be silently dropped.
+    // After the exchange path the donor IMP sits at `originalSelector`. The donor's forwarding
+    // target is `swizzledSelector`, which must hold the host's original IMP address — without
+    // it the host's push-token handling would be silently dropped. We verify the IMP table
+    // directly rather than invoking the donor (which calls production `KlaviyoSDK` code that
+    // is not safe in a headless XCTest process).
     func testDonorIMPForwardsToHostOriginalAfterExchange() {
+        let hostIMPBefore = imp(on: ExchangeForwardingDelegate.self, selector: originalSelector)
+
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: ExchangeForwardingDelegate.self)
 
-        let delegate = ExchangeForwardingDelegate()
-        // Calling through the donor IMP (installed at originalSelector) must chain
-        // to the host's original, incrementing its counter.
-        callInstalledIMP(on: delegate)
-
-        XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to host's original implementation")
+        // After exchange: swizzledSelector must hold the host's pre-swap IMP so the donor
+        // can forward to it at call time.
+        let forwardSlotIMP = imp(on: ExchangeForwardingDelegate.self, selector: swizzledSelector)
+        XCTAssertEqual(forwardSlotIMP, hostIMPBefore, "swizzledSelector must hold the host's original IMP")
     }
 
-    // After the inherited-graft path, calling `originalSelector` on the subclass must invoke
-    // the donor AND chain through to the inherited base implementation. The donor's forwarding
-    // target is `swizzledSelector`, which was redirected to the inherited IMP at swizzle time
-    // rather than being left pointing at the donor (which would recurse).
+    // After the inherited-graft path the donor IMP is added at `originalSelector` on the
+    // subclass. The donor's forwarding target (`swizzledSelector`) is redirected to the
+    // inherited base IMP at swizzle time — verifying that address proves the donor will chain
+    // to the base implementation rather than recursing back into itself.
     func testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass() {
+        let inheritedIMPBefore = imp(on: InheritedForwardingBaseDelegate.self, selector: originalSelector)
+
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: InheritedForwardingSubDelegate.self)
 
-        let delegate = InheritedForwardingSubDelegate()
-        callInstalledIMP(on: delegate)
-
-        XCTAssertEqual(delegate.hostCallCount, 1, "Donor IMP must forward to the inherited base implementation")
+        // swizzledSelector on the subclass must hold the inherited base IMP (captured before
+        // swizzle) so the donor can forward to it at call time.
+        let forwardSlotIMP = imp(on: InheritedForwardingSubDelegate.self, selector: swizzledSelector)
+        XCTAssertEqual(forwardSlotIMP, inheritedIMPBefore, "swizzledSelector must hold the inherited IMP from the base")
     }
 
     // `swizzleIfPossible` can be called more than once (e.g. host calls `initialize` twice).

--- a/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests.swift
@@ -156,6 +156,21 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
         return method_getImplementation(method)
     }
 
+    /// Skips the test if `cls` was already swizzled in a prior repetition.
+    ///
+    /// ObjC runtime method additions and exchanges are permanent for the lifetime of the
+    /// process. Xcode's test-repetition feature reruns tests in the same process, so
+    /// repetition N+1 sees already-mutated classes. `_resetStateForTesting()` resets the
+    /// logical gate but cannot undo ObjC changes — a second swizzle on the same class
+    /// produces incorrect IMP state. Skipping is the correct response: the test is not
+    /// flaky, it simply cannot be repeated in-process.
+    private func skipIfAlreadySwizzled(_ cls: AnyClass) throws {
+        try XCTSkipIf(
+            classOwnsMethod(cls, selector: swizzledSelector),
+            "\(cls) was already swizzled in a prior repetition — ObjC changes are permanent per process"
+        )
+    }
+
     // MARK: - resolveSwizzleTargetClass tests
 
     // App delegate directly implements `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`.
@@ -182,7 +197,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
             "Proxy must respond via forwarding for this test to be meaningful"
         )
 
-        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
+        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: proxy)
         XCTAssertTrue(resolved == DirectAppDelegate.self)
     }
 
@@ -190,7 +205,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // fall back to the delegate's own class so `performSwizzle` can graft the donor IMP onto it.
     func testResolveTargetOpaqueDelegate() {
         let opaque = OpaqueDelegate()
-        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
+        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: opaque)
         XCTAssertTrue(resolved == OpaqueDelegate.self)
     }
 
@@ -209,7 +224,7 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
             "Precondition: subclass must not own the method"
         )
 
-        let resolved = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
+        let resolved: AnyClass = KlaviyoAppDelegateSwizzler.resolveSwizzleTargetClass(for: delegate)
         XCTAssertTrue(resolved == SubclassAppDelegate.self)
     }
 
@@ -219,7 +234,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // Swizzler must exchange IMPs so `originalSelector` points to the donor and `swizzledSelector`
     // holds the host's original, and must record the class in `swappedClasses` so the donor
     // knows to forward after calling `KlaviyoSDK().set(pushToken:)`.
-    func testExchangePathSwapsIMPOnHostClass() {
+    func testExchangePathSwapsIMPOnHostClass() throws {
+        try skipIfAlreadySwizzled(ExchangeDelegate.self)
         // ExchangeDelegate owns the method — swizzler must exchange IMPs on the class itself.
         let donorMethod = class_getInstanceMethod(
             KlaviyoAppDelegateSwizzler.self, swizzledSelector
@@ -239,7 +255,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // Host class has no device-token method at all — neither owned nor inherited. Swizzler
     // must add the donor IMP directly under `originalSelector` with no forwarding setup, and
     // must NOT record the class in `swappedClasses` (donor would recurse if it tried to forward).
-    func testGraftPathAddsIMPWithoutForwarding() {
+    func testGraftPathAddsIMPWithoutForwarding() throws {
+        try skipIfAlreadySwizzled(GraftDelegate.self)
         // GraftDelegate has no implementation — swizzler must graft without marking as swapped.
         XCTAssertFalse(
             classOwnsMethod(GraftDelegate.self, selector: originalSelector),
@@ -261,7 +278,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // are added to the subclass's own IMP table, and the superclass method table must remain
     // byte-for-byte unchanged. This prevents other subclasses and direct superclass instances
     // from having their behavior altered as a side effect of our swizzle.
-    func testInheritedPathGraftsOnSubclassLeavingSuperclassUnchanged() {
+    func testInheritedPathGraftsOnSubclassLeavingSuperclassUnchanged() throws {
+        try skipIfAlreadySwizzled(InheritedSubDelegate.self)
         // Capture the superclass IMP before swizzle.
         let baseMethod = class_getInstanceMethod(InheritedBaseDelegate.self, originalSelector)!
         let baseIMPBefore = method_getImplementation(baseMethod)
@@ -300,7 +318,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // it the host's push-token handling would be silently dropped. We verify the IMP table
     // directly rather than invoking the donor (which calls production `KlaviyoSDK` code that
     // is not safe in a headless XCTest process).
-    func testDonorIMPForwardsToHostOriginalAfterExchange() {
+    func testDonorIMPForwardsToHostOriginalAfterExchange() throws {
+        try skipIfAlreadySwizzled(ExchangeForwardingDelegate.self)
         let hostIMPBefore = imp(on: ExchangeForwardingDelegate.self, selector: originalSelector)
 
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: ExchangeForwardingDelegate.self)
@@ -315,7 +334,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // subclass. The donor's forwarding target (`swizzledSelector`) is redirected to the
     // inherited base IMP at swizzle time — verifying that address proves the donor will chain
     // to the base implementation rather than recursing back into itself.
-    func testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass() {
+    func testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass() throws {
+        try skipIfAlreadySwizzled(InheritedForwardingSubDelegate.self)
         let inheritedIMPBefore = imp(on: InheritedForwardingBaseDelegate.self, selector: originalSelector)
 
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: InheritedForwardingSubDelegate.self)
@@ -329,7 +349,8 @@ final class KlaviyoAppDelegateSwizzlerTests: XCTestCase {
     // `swizzleIfPossible` can be called more than once (e.g. host calls `initialize` twice).
     // Only the first call must install the donor IMP; subsequent calls must be no-ops that
     // leave the IMP pointer and method table unchanged.
-    func testSwizzleIsIdempotentWithinSingleClaim() {
+    func testSwizzleIsIdempotentWithinSingleClaim() throws {
+        try skipIfAlreadySwizzled(IdempotencyDelegate.self)
         // First swizzle installs the donor IMP at originalSelector.
         KlaviyoAppDelegateSwizzler._performSwizzleForTesting(on: IdempotencyDelegate.self)
         let impAfterFirst = method_getImplementation(


### PR DESCRIPTION
# Description
Adds `#if DEBUG` reset/inspection hooks to `KlaviyoAppDelegateSwizzler` so its singleton state can be isolated between unit tests, then rewrites the test file with full coverage of all three swizzle paths.

Tracks: https://linear.app/klaviyo/issue/MAGE-993/fixklaviyoswift-notification-delegate-and-swizzler-follow-up-items

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**`KlaviyoAppDelegateSwizzler.swift`**
- Added `State.reset()` under `#if DEBUG` — clears `didSwizzle`, `swappedClasses`, and removes the deferred `didFinishLaunching` observer. ObjC runtime changes are permanent per process, so this resets only the logical gate, not the method table.
- Added four `#if DEBUG` static test hooks on `KlaviyoAppDelegateSwizzler`:
  - `_performSwizzleForTesting(on:)` — calls `performSwizzle` directly, bypassing the delegate-availability guard.
  - `_resetStateForTesting()` — delegates to `State.reset()`.
  - `_isSwappedForTesting(_:)` — exposes `swappedClasses` membership.
  - `_swizzledSelectorForTesting` — returns the donor selector from inside the class, where the `private dynamic` method is accessible; tests cannot reference `#selector(klaviyo_application...)` from outside the module even with `@testable import`.

**`KlaviyoAppDelegateSwizzlerTests.swift`** (full rewrite)
- `setUp`/`tearDown` install `KlaviyoSwiftEnvironment.test()` and call `_resetStateForTesting()` so each test starts with clean logical state.
- Each `performSwizzle` test uses its own unique ObjC class — ObjC method exchanges are permanent within a process, so sharing a class across tests causes the second test to see a pre-swizzled class and produce wrong assertions.
- 10 tests total:
  - `testResolveTargetDirectImplementor` — direct implementor resolves to itself.
  - `testResolveTargetForwardingProxy` — SwiftUI-style proxy resolves to the inner delegate.
  - `testResolveTargetOpaqueDelegate` — no-method delegate resolves to itself (graft path).
  - `testResolveTargetSubclassWithInheritedMethod` — subclass resolves to itself even when method is inherited.
  - `testExchangePathSwapsIMPOnHostClass` — verifies donor IMP is installed at `originalSelector` and class is recorded in `swappedClasses`.
  - `testGraftPathAddsIMPWithoutForwarding` — verifies donor IMP is added and class is NOT in `swappedClasses`.
  - `testInheritedPathGraftsOnSubclassLeavingSuperclassUnchanged` — captures superclass IMP before swizzle, asserts it is identical after; verifies subclass owns both selectors.
  - `testDonorIMPForwardsToHostOriginalAfterExchange` — calls via ObjC runtime, asserts host counter incremented.
  - `testDonorIMPForwardsToInheritedOriginalAfterGraftOnSubclass` — same for the inherited path.
  - `testSwizzleIsIdempotentWithinSingleClaim` — second `performSwizzle` call is a no-op.

## Test Plan
1. Run `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing KlaviyoSwiftTests/KlaviyoAppDelegateSwizzlerTests`
2. Confirm: `Executed 10 tests, with 0 failures`

## Related Issues/Tickets
- MAGE-993: https://linear.app/klaviyo/issue/MAGE-993/fixklaviyoswift-notification-delegate-and-swizzler-follow-up-items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for Objective-C delegate swizzling, including method exchange, grafting, inherited graft behavior, and donor forwarding correctness.
  * Improved reliability and isolation by standardizing async setup/teardown and adding controlled reset behavior for swizzle bookkeeping.
  * Added stronger assertions for method ownership and installed implementation pointers, including idempotency checks to prevent unexpected changes on repeated swizzle attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->