### PR TITLE
refactor(KlaviyoCore): extract request construction into RequestFactory (MAGE-903)

### DIFF
--- a/Sources/KlaviyoCore/Models/Event+Identifiers.swift
+++ b/Sources/KlaviyoCore/Models/Event+Identifiers.swift
@@ -1,5 +1,5 @@
 //
-//  EventAPIExtension.swift
+//  Event+Identifiers.swift
 //
 //  Klaviyo Swift SDK
 //
@@ -7,13 +7,12 @@
 //
 
 import Foundation
-import KlaviyoCore
 
 extension Event {
     /// Returns a copy of the event stamped with the given profile identifiers.
     /// For opened-push events, the push token (when present) is added to the
     /// event properties.
-    func updateEventWithIdentifiers(
+    package func updateEventWithIdentifiers(
         email: String?,
         phoneNumber: String?,
         externalId: String?,

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -84,7 +84,7 @@ public enum RequestFactory {
                 uniqueId: stamped.uniqueId,
                 pushToken: pushToken
             ))
-        return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload))
+        return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload), priority: stamped.priority)
     }
 
     public static func unregisterRequest(

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -33,9 +33,6 @@ public struct RequestIdentity: Equatable {
 }
 
 /// Pure construction of `KlaviyoRequest` values from domain inputs.
-///
-/// Reads no store and does not touch `environment`. Byte-identical to the
-/// construction previously inlined in `KlaviyoState` / the reducer.
 public enum RequestFactory {
     public static func profileRequest(
         identity: RequestIdentity,

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -1,0 +1,119 @@
+//
+//  RequestFactory.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/23/26.
+//
+
+import AnyCodable
+import Foundation
+
+/// Identity inputs required to construct a Klaviyo API request.
+///
+/// Supplied by the caller (today: the reducer / `KlaviyoState`; later: `IdentityStore`).
+public struct RequestIdentity: Equatable {
+    public let apiKey: String
+    public let anonymousId: String
+    public let email: String?
+    public let phoneNumber: String?
+    public let externalId: String?
+
+    public init(apiKey: String,
+                anonymousId: String,
+                email: String? = nil,
+                phoneNumber: String? = nil,
+                externalId: String? = nil) {
+        self.apiKey = apiKey
+        self.anonymousId = anonymousId
+        self.email = email
+        self.phoneNumber = phoneNumber
+        self.externalId = externalId
+    }
+}
+
+/// Pure construction of `KlaviyoRequest` values from domain inputs.
+///
+/// Reads no store and does not touch `environment`. Byte-identical to the
+/// construction previously inlined in `KlaviyoState` / the reducer.
+public enum RequestFactory {
+    public static func profileRequest(
+        identity: RequestIdentity,
+        properties: [String: Any] = [:]
+    ) -> KlaviyoRequest {
+        let payload = ProfilePayload(
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
+            properties: properties,
+            anonymousId: identity.anonymousId
+        )
+        return profileRequest(apiKey: identity.apiKey,
+                              payload: CreateProfilePayload(data: payload))
+    }
+
+    /// Wraps an already-resolved `CreateProfilePayload` (e.g. after a pending-profile merge).
+    public static func profileRequest(
+        apiKey: String,
+        payload: CreateProfilePayload
+    ) -> KlaviyoRequest {
+        KlaviyoRequest(endpoint: .createProfile(apiKey, payload))
+    }
+
+    public static func eventRequest(
+        identity: RequestIdentity,
+        event: Event,
+        pushToken: String?
+    ) -> KlaviyoRequest {
+        let stamped = event.updateEventWithIdentifiers(
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
+            pushToken: pushToken
+        )
+        let payload = CreateEventPayload(
+            data: CreateEventPayload.Event(
+                name: stamped.metric.name.value,
+                properties: stamped.properties,
+                email: stamped.identifiers?.email,
+                phoneNumber: stamped.identifiers?.phoneNumber,
+                externalId: stamped.identifiers?.externalId,
+                anonymousId: identity.anonymousId,
+                value: stamped.value,
+                time: stamped.time,
+                uniqueId: stamped.uniqueId,
+                pushToken: pushToken
+            ))
+        return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload))
+    }
+
+    public static func unregisterRequest(
+        identity: RequestIdentity,
+        pushToken: String
+    ) -> KlaviyoRequest {
+        let payload = UnregisterPushTokenPayload(
+            pushToken: pushToken,
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
+            anonymousId: identity.anonymousId
+        )
+        return KlaviyoRequest(endpoint: .unregisterPushToken(identity.apiKey, payload))
+    }
+
+    public static func tokenRequest(
+        apiKey: String,
+        pushToken: String,
+        enablement: PushEnablement,
+        background: String,
+        profile: ProfilePayload
+    ) -> KlaviyoRequest {
+        let payload = PushTokenPayload(
+            pushToken: pushToken,
+            enablement: enablement.rawValue,
+            background: background,
+            profile: profile
+        )
+        return KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload))
+    }
+}

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -19,11 +19,13 @@ public struct RequestIdentity: Equatable {
     public let phoneNumber: String?
     public let externalId: String?
 
-    public init(apiKey: String,
-                anonymousId: String,
-                email: String? = nil,
-                phoneNumber: String? = nil,
-                externalId: String? = nil) {
+    public init(
+        apiKey: String,
+        anonymousId: String,
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil
+    ) {
         self.apiKey = apiKey
         self.anonymousId = anonymousId
         self.email = email
@@ -38,8 +40,10 @@ public enum RequestFactory {
         identity: RequestIdentity,
         properties: [String: Any] = [:]
     ) -> KlaviyoRequest {
-        profileRequest(apiKey: identity.apiKey,
-                       payload: profilePayload(identity: identity, properties: properties))
+        profileRequest(
+            apiKey: identity.apiKey,
+            payload: profilePayload(identity: identity, properties: properties)
+        )
     }
 
     /// Builds a `CreateProfilePayload` from identity + properties without wrapping it in a request,

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -41,15 +41,24 @@ public enum RequestFactory {
         identity: RequestIdentity,
         properties: [String: Any] = [:]
     ) -> KlaviyoRequest {
-        let payload = ProfilePayload(
+        profileRequest(apiKey: identity.apiKey,
+                       payload: profilePayload(identity: identity, properties: properties))
+    }
+
+    /// Builds a `CreateProfilePayload` from identity + properties without wrapping it in a request,
+    /// so callers can resolve/merge it (e.g. a pending-profile merge) before turning it into a
+    /// request via ``profileRequest(apiKey:payload:)``.
+    public static func profilePayload(
+        identity: RequestIdentity,
+        properties: [String: Any] = [:]
+    ) -> CreateProfilePayload {
+        CreateProfilePayload(data: ProfilePayload(
             email: identity.email,
             phoneNumber: identity.phoneNumber,
             externalId: identity.externalId,
             properties: properties,
             anonymousId: identity.anonymousId
-        )
-        return profileRequest(apiKey: identity.apiKey,
-                              payload: CreateProfilePayload(data: payload))
+        ))
     }
 
     /// Wraps an already-resolved `CreateProfilePayload` (e.g. after a pending-profile merge).

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -216,13 +216,16 @@ struct KlaviyoState: Equatable, Codable {
     }
 
     /// Resolves the profile for a token request, folding in and consuming any pending profile.
-    mutating func resolveProfileConsumingPending() -> Profile {
-        let profile = pendingProfile.map {
-            Profile.updateProfileWithProperties(
-                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: $0
+    private mutating func resolveProfileConsumingPending() -> Profile {
+        let profile: Profile
+        if let pendingProfile {
+            profile = Profile.updateProfileWithProperties(
+                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
             )
-        } ?? Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
-        pendingProfile = nil
+            self.pendingProfile = nil
+        } else {
+            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
+        }
         return profile
     }
 

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -251,12 +251,9 @@ struct KlaviyoState: Equatable, Codable {
     }
 
     mutating func enqueueProfileRequest(apiKey: String, anonymousId: String) {
-        let identity = requestIdentity(apiKey: apiKey, anonymousId: anonymousId)
-        let baseRequest = RequestFactory.profileRequest(identity: identity)
-        guard case let .createProfile(_, payload) = baseRequest.endpoint else {
-            environment.raiseFatalError("Unexpected request type. \(baseRequest.endpoint)")
-            return
-        }
+        let payload = RequestFactory.profilePayload(
+            identity: requestIdentity(apiKey: apiKey, anonymousId: anonymousId)
+        )
         let updatedPayload = updateRequestAndStateWithPendingProfile(profile: payload)
         enqueueRequest(request: RequestFactory.profileRequest(apiKey: apiKey, payload: updatedPayload))
     }
@@ -383,57 +380,6 @@ struct KlaviyoState: Equatable, Codable {
         )
 
         return pushTokenData != newPushTokenData
-    }
-
-    func buildProfileRequest(apiKey: String, anonymousId: String, properties: [String: Any] = [:]) -> KlaviyoRequest {
-        let payload = ProfilePayload(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
-            properties: properties,
-            anonymousId: anonymousId
-        )
-
-        let endpoint = KlaviyoEndpoint.createProfile(apiKey, CreateProfilePayload(data: payload))
-
-        return KlaviyoRequest(endpoint: endpoint)
-    }
-
-    mutating func buildTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
-        var profile: Profile
-
-        if let pendingProfile = pendingProfile {
-            profile = Profile.updateProfileWithProperties(
-                email: email,
-                phoneNumber: phoneNumber,
-                externalId: externalId,
-                dict: pendingProfile
-            )
-            self.pendingProfile = nil
-        } else {
-            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
-        }
-
-        let payload = PushTokenPayload(
-            pushToken: pushToken,
-            enablement: enablement.rawValue,
-            background: environment.getBackgroundSetting().rawValue,
-            profile: profile.toAPIModel(anonymousId: anonymousId)
-        )
-        let endpoint = KlaviyoEndpoint.registerPushToken(apiKey, payload)
-        return KlaviyoRequest(endpoint: endpoint)
-    }
-
-    func buildUnregisterRequest(apiKey: String, anonymousId: String, pushToken: String) -> KlaviyoRequest {
-        let payload = UnregisterPushTokenPayload(
-            pushToken: pushToken,
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
-            anonymousId: anonymousId
-        )
-        let endpoint = KlaviyoEndpoint.unregisterPushToken(apiKey, payload)
-        return KlaviyoRequest(endpoint: endpoint)
     }
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -230,7 +230,8 @@ struct KlaviyoState: Equatable, Codable {
     }
 
     /// Builds a push-token registration request, resolving (and consuming) any pending profile.
-    mutating func tokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
+    /// The `resolved` prefix marks the state-sourcing layer over the pure `RequestFactory.tokenRequest`.
+    mutating func resolvedTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
         RequestFactory.tokenRequest(
             apiKey: apiKey,
             pushToken: pushToken,
@@ -250,7 +251,7 @@ struct KlaviyoState: Equatable, Codable {
         // we want to associate the token with the new email.
         if let pushTokenData = pushTokenData {
             self.pushTokenData = nil
-            let request = tokenRequest(
+            let request = resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,
                 pushToken: pushTokenData.pushToken,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -215,6 +215,28 @@ struct KlaviyoState: Equatable, Codable {
         )
     }
 
+    /// Resolves the profile for a token request, folding in and consuming any pending profile.
+    mutating func resolveProfileConsumingPending() -> Profile {
+        let profile = pendingProfile.map {
+            Profile.updateProfileWithProperties(
+                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: $0
+            )
+        } ?? Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
+        pendingProfile = nil
+        return profile
+    }
+
+    /// Builds a push-token registration request, resolving (and consuming) any pending profile.
+    mutating func tokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
+        RequestFactory.tokenRequest(
+            apiKey: apiKey,
+            pushToken: pushToken,
+            enablement: enablement,
+            background: environment.getBackgroundSetting().rawValue,
+            profile: resolveProfileConsumingPending().toAPIModel(anonymousId: anonymousId)
+        )
+    }
+
     mutating func enqueueProfileOrTokenRequest() {
         guard let apiKey = apiKey,
               let anonymousId = anonymousId else {
@@ -225,28 +247,15 @@ struct KlaviyoState: Equatable, Codable {
         // we want to associate the token with the new email.
         if let pushTokenData = pushTokenData {
             self.pushTokenData = nil
-            let profile: Profile
-            if let pendingProfile {
-                profile = Profile.updateProfileWithProperties(
-                    email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
-                )
-                self.pendingProfile = nil
-            } else {
-                profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
-            }
-            let request = RequestFactory.tokenRequest(
+            let request = tokenRequest(
                 apiKey: apiKey,
+                anonymousId: anonymousId,
                 pushToken: pushTokenData.pushToken,
-                enablement: pushTokenData.pushEnablement,
-                background: environment.getBackgroundSetting().rawValue,
-                profile: profile.toAPIModel(anonymousId: anonymousId)
+                enablement: pushTokenData.pushEnablement
             )
             enqueueRequest(request: request)
         } else {
-            enqueueProfileRequest(
-                apiKey: apiKey,
-                anonymousId: anonymousId
-            )
+            enqueueProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
         }
     }
 

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -231,7 +231,12 @@ struct KlaviyoState: Equatable, Codable {
 
     /// Builds a push-token registration request, resolving (and consuming) any pending profile.
     /// The `resolved` prefix marks the state-sourcing layer over the pure `RequestFactory.tokenRequest`.
-    mutating func resolvedTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
+    mutating func resolvedTokenRequest(
+        apiKey: String,
+        anonymousId: String,
+        pushToken: String,
+        enablement: PushEnablement
+    ) -> KlaviyoRequest {
         RequestFactory.tokenRequest(
             apiKey: apiKey,
             pushToken: pushToken,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -205,6 +205,16 @@ struct KlaviyoState: Equatable, Codable {
         }
     }
 
+    func requestIdentity(apiKey: String, anonymousId: String) -> RequestIdentity {
+        RequestIdentity(
+            apiKey: apiKey,
+            anonymousId: anonymousId,
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId
+        )
+    }
+
     mutating func enqueueProfileOrTokenRequest() {
         guard let apiKey = apiKey,
               let anonymousId = anonymousId else {
@@ -215,11 +225,21 @@ struct KlaviyoState: Equatable, Codable {
         // we want to associate the token with the new email.
         if let pushTokenData = pushTokenData {
             self.pushTokenData = nil
-            let request = buildTokenRequest(
+            let profile: Profile
+            if let pendingProfile {
+                profile = Profile.updateProfileWithProperties(
+                    email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
+                )
+                self.pendingProfile = nil
+            } else {
+                profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
+            }
+            let request = RequestFactory.tokenRequest(
                 apiKey: apiKey,
-                anonymousId: anonymousId,
                 pushToken: pushTokenData.pushToken,
-                enablement: pushTokenData.pushEnablement
+                enablement: pushTokenData.pushEnablement,
+                background: environment.getBackgroundSetting().rawValue,
+                profile: profile.toAPIModel(anonymousId: anonymousId)
             )
             enqueueRequest(request: request)
         } else {
@@ -231,15 +251,14 @@ struct KlaviyoState: Equatable, Codable {
     }
 
     mutating func enqueueProfileRequest(apiKey: String, anonymousId: String) {
-        let request = buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
-        switch request.endpoint {
-        case let .createProfile(_, payload):
-            let updatedPayload = updateRequestAndStateWithPendingProfile(profile: payload)
-            let request = KlaviyoRequest(endpoint: .createProfile(apiKey, updatedPayload))
-            enqueueRequest(request: request)
-        default:
-            environment.raiseFatalError("Unexpected request type. \(request.endpoint)")
+        let identity = requestIdentity(apiKey: apiKey, anonymousId: anonymousId)
+        let baseRequest = RequestFactory.profileRequest(identity: identity)
+        guard case let .createProfile(_, payload) = baseRequest.endpoint else {
+            environment.raiseFatalError("Unexpected request type. \(baseRequest.endpoint)")
+            return
         }
+        let updatedPayload = updateRequestAndStateWithPendingProfile(profile: payload)
+        enqueueRequest(request: RequestFactory.profileRequest(apiKey: apiKey, payload: updatedPayload))
     }
 
     mutating func updateStateWithProfile(profile: Profile) {
@@ -338,17 +357,14 @@ struct KlaviyoState: Equatable, Codable {
             if let apiKey = apiKey,
                let anonymousId = anonymousId,
                let tokenData = previousPushTokenData {
-                let payload = PushTokenPayload(
+                let profile = Profile().toAPIModel(anonymousId: anonymousId)
+                let request = RequestFactory.tokenRequest(
+                    apiKey: apiKey,
                     pushToken: tokenData.pushToken,
-                    enablement: tokenData.pushEnablement.rawValue,
+                    enablement: tokenData.pushEnablement,
                     background: tokenData.pushBackground.rawValue,
-                    profile: Profile().toAPIModel(anonymousId: anonymousId)
+                    profile: profile
                 )
-
-                let request = KlaviyoRequest(
-                    endpoint: KlaviyoEndpoint.registerPushToken(apiKey, payload)
-                )
-
                 enqueueRequest(request: request)
             }
         }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -559,8 +559,6 @@ struct KlaviyoReducer: ReducerProtocol {
             else {
                 return .none
             }
-            let request: KlaviyoRequest!
-
             let profilePayload = profile.toAPIModel(
                 email: state.email,
                 phoneNumber: state.phoneNumber,
@@ -568,19 +566,19 @@ struct KlaviyoReducer: ReducerProtocol {
                 anonymousId: anonymousId
             )
 
+            let request: KlaviyoRequest
             if let tokenData = pushTokenData {
-                let payload = PushTokenPayload(
+                request = RequestFactory.tokenRequest(
+                    apiKey: apiKey,
                     pushToken: tokenData.pushToken,
-                    enablement: tokenData.pushEnablement.rawValue,
+                    enablement: tokenData.pushEnablement,
                     background: tokenData.pushBackground.rawValue,
                     profile: profilePayload
                 )
-                request = KlaviyoRequest(
-                    endpoint: KlaviyoEndpoint.registerPushToken(apiKey, payload)
-                )
             } else {
-                request = KlaviyoRequest(
-                    endpoint: KlaviyoEndpoint.createProfile(apiKey, CreateProfilePayload(data: profilePayload))
+                request = RequestFactory.profileRequest(
+                    apiKey: apiKey,
+                    payload: CreateProfilePayload(data: profilePayload)
                 )
             }
             state.enqueueRequest(request: request)

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -264,7 +264,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            let request = state.tokenRequest(
+            let request = state.resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,
                 pushToken: pushToken,

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -165,9 +165,8 @@ struct KlaviyoReducer: ReducerProtocol {
                 if let apiKey = state.apiKey,
                    let anonymousId = state.anonymousId,
                    let tokenData = state.pushTokenData {
-                    let request = state.buildUnregisterRequest(
-                        apiKey: apiKey,
-                        anonymousId: anonymousId,
+                    let request = RequestFactory.unregisterRequest(
+                        identity: state.requestIdentity(apiKey: apiKey, anonymousId: anonymousId),
                         pushToken: tokenData.pushToken
                     )
                     state.enqueueRequest(request: request)
@@ -265,7 +264,23 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            let request = state.buildTokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement)
+            let profile: Profile
+            if let pendingProfile = state.pendingProfile {
+                profile = Profile.updateProfileWithProperties(
+                    email: state.email, phoneNumber: state.phoneNumber,
+                    externalId: state.externalId, dict: pendingProfile
+                )
+                state.pendingProfile = nil
+            } else {
+                profile = Profile(email: state.email, phoneNumber: state.phoneNumber, externalId: state.externalId)
+            }
+            let request = RequestFactory.tokenRequest(
+                apiKey: apiKey,
+                pushToken: pushToken,
+                enablement: enablement,
+                background: environment.getBackgroundSetting().rawValue,
+                profile: profile.toAPIModel(anonymousId: anonymousId)
+            )
             state.enqueueRequest(request: request)
             return .none
 
@@ -477,22 +492,11 @@ struct KlaviyoReducer: ReducerProtocol {
                 pushToken: state.pushTokenData?.pushToken
             )
 
-            let payload = CreateEventPayload(
-                data: CreateEventPayload.Event(
-                    name: event.metric.name.value,
-                    properties: event.properties,
-                    email: event.identifiers?.email,
-                    phoneNumber: event.identifiers?.phoneNumber,
-                    externalId: event.identifiers?.externalId,
-                    anonymousId: anonymousId,
-                    value: event.value,
-                    time: event.time,
-                    uniqueId: event.uniqueId,
-                    pushToken: state.pushTokenData?.pushToken
-                ))
-
-            let endpoint = KlaviyoEndpoint.createEvent(apiKey, payload)
-            let request = KlaviyoRequest(endpoint: endpoint, priority: event.priority)
+            let request = RequestFactory.eventRequest(
+                identity: state.requestIdentity(apiKey: apiKey, anonymousId: anonymousId),
+                event: event,
+                pushToken: state.pushTokenData?.pushToken
+            )
 
             /*
              High-priority requests (e.g. opened-push, geofence events) are front-inserted and

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -264,22 +264,11 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
 
-            let profile: Profile
-            if let pendingProfile = state.pendingProfile {
-                profile = Profile.updateProfileWithProperties(
-                    email: state.email, phoneNumber: state.phoneNumber,
-                    externalId: state.externalId, dict: pendingProfile
-                )
-                state.pendingProfile = nil
-            } else {
-                profile = Profile(email: state.email, phoneNumber: state.phoneNumber, externalId: state.externalId)
-            }
-            let request = RequestFactory.tokenRequest(
+            let request = state.tokenRequest(
                 apiKey: apiKey,
+                anonymousId: anonymousId,
                 pushToken: pushToken,
-                enablement: enablement,
-                background: environment.getBackgroundSetting().rawValue,
-                profile: profile.toAPIModel(anonymousId: anonymousId)
+                enablement: enablement
             )
             state.enqueueRequest(request: request)
             return .none

--- a/Tests/KlaviyoCoreTests/EventIdentifiersTests.swift
+++ b/Tests/KlaviyoCoreTests/EventIdentifiersTests.swift
@@ -1,0 +1,31 @@
+//
+//  EventIdentifiersTests.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/23/26.
+//
+
+@testable import KlaviyoCore
+import XCTest
+
+final class EventIdentifiersTests: XCTestCase {
+    func testStampsIdentifiers() {
+        let event = Event(name: .customEvent("Test"), properties: ["k": "v"])
+        let stamped = event.updateEventWithIdentifiers(
+            email: "a@b.com", phoneNumber: "+15551234567", externalId: "ext-1", pushToken: nil
+        )
+        XCTAssertEqual(stamped.identifiers?.email, "a@b.com")
+        XCTAssertEqual(stamped.identifiers?.phoneNumber, "+15551234567")
+        XCTAssertEqual(stamped.identifiers?.externalId, "ext-1")
+        XCTAssertNil(stamped.properties["push_token"])
+    }
+
+    func testOpenedPushInjectsPushTokenProperty() {
+        let event = Event(name: ._openedPush, properties: [:])
+        let stamped = event.updateEventWithIdentifiers(
+            email: nil, phoneNumber: nil, externalId: nil, pushToken: "tok-123"
+        )
+        XCTAssertEqual(stamped.properties["push_token"] as? String, "tok-123")
+    }
+}

--- a/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
@@ -63,6 +63,7 @@ final class RequestFactoryTests: XCTestCase {
         XCTAssertEqual(apiKey, "key")
         XCTAssertEqual(payload.data.attributes.profile.data.attributes.email, "a@b.com")
         XCTAssertEqual(payload.data.attributes.profile.data.attributes.anonymousId, "anon")
-        XCTAssertEqual(payload.data.attributes.properties.value as? [String: Any] != nil, true)
+        let props = payload.data.attributes.properties.value as? [String: Any]
+        XCTAssertEqual(props?["Push Token"] as? String, "tok")
     }
 }

--- a/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
@@ -1,0 +1,68 @@
+//
+//  RequestFactoryTests.swift
+//
+//  Klaviyo Swift SDK
+//
+//  Created by Belle Lim on 7/23/26.
+//
+
+@testable import KlaviyoCore
+import AnyCodable
+import XCTest
+
+final class RequestFactoryTests: XCTestCase {
+    private let identity = RequestIdentity(
+        apiKey: "key", anonymousId: "anon",
+        email: "a@b.com", phoneNumber: "+15551234567", externalId: "ext-1"
+    )
+
+    func testProfileRequestBuildsCreateProfileEndpoint() {
+        let request = RequestFactory.profileRequest(identity: identity, properties: ["k": "v"])
+        guard case let .createProfile(apiKey, payload) = request.endpoint else {
+            return XCTFail("expected createProfile")
+        }
+        XCTAssertEqual(apiKey, "key")
+        XCTAssertEqual(payload.data.attributes.email, "a@b.com")
+        XCTAssertEqual(payload.data.attributes.phoneNumber, "+15551234567")
+        XCTAssertEqual(payload.data.attributes.externalId, "ext-1")
+        XCTAssertEqual(payload.data.attributes.anonymousId, "anon")
+    }
+
+    func testUnregisterRequestBuildsEndpoint() {
+        let request = RequestFactory.unregisterRequest(identity: identity, pushToken: "tok")
+        guard case let .unregisterPushToken(apiKey, payload) = request.endpoint else {
+            return XCTFail("expected unregisterPushToken")
+        }
+        XCTAssertEqual(apiKey, "key")
+        XCTAssertEqual(payload.data.attributes.profile.data.attributes.anonymousId, "anon")
+        XCTAssertEqual(payload.data.attributes.token, "tok")
+    }
+
+    func testTokenRequestBuildsEndpoint() {
+        let profile = ProfilePayload(anonymousId: "anon")
+        let request = RequestFactory.tokenRequest(
+            apiKey: "key", pushToken: "tok",
+            enablement: .authorized, background: PushBackground.available.rawValue,
+            profile: profile
+        )
+        guard case let .registerPushToken(apiKey, payload) = request.endpoint else {
+            return XCTFail("expected registerPushToken")
+        }
+        XCTAssertEqual(apiKey, "key")
+        XCTAssertEqual(payload.data.attributes.token, "tok")
+        XCTAssertEqual(payload.data.attributes.enablementStatus, PushEnablement.authorized.rawValue)
+        XCTAssertEqual(payload.data.attributes.backgroundStatus, PushBackground.available.rawValue)
+    }
+
+    func testEventRequestStampsIdentifiers() {
+        let event = Event(name: ._openedPush)
+        let request = RequestFactory.eventRequest(identity: identity, event: event, pushToken: "tok")
+        guard case let .createEvent(apiKey, payload) = request.endpoint else {
+            return XCTFail("expected createEvent")
+        }
+        XCTAssertEqual(apiKey, "key")
+        XCTAssertEqual(payload.data.attributes.profile.data.attributes.email, "a@b.com")
+        XCTAssertEqual(payload.data.attributes.profile.data.attributes.anonymousId, "anon")
+        XCTAssertEqual(payload.data.attributes.properties.value as? [String: Any] != nil, true)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -158,7 +158,7 @@ extension KlaviyoState {
     }
 
     mutating func buildTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
-        tokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement)
+        resolvedTokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement)
     }
 
     func buildUnregisterRequest(apiKey: String, anonymousId: String, pushToken: String) -> KlaviyoRequest {

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -144,6 +144,44 @@ extension KlaviyoState {
                                    requestsInFlight: [],
                                    initalizationState: .initialized,
                                    flushing: true)
+
+    // MARK: - Request fixtures
+
+    // Build expected requests through `RequestFactory` (the single production construction path)
+    // so test expectations can't silently diverge from what the SDK actually sends.
+
+    func buildProfileRequest(apiKey: String, anonymousId: String, properties: [String: Any] = [:]) -> KlaviyoRequest {
+        RequestFactory.profileRequest(
+            identity: requestIdentity(apiKey: apiKey, anonymousId: anonymousId),
+            properties: properties
+        )
+    }
+
+    mutating func buildTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
+        let profile: Profile
+        if let pendingProfile {
+            profile = Profile.updateProfileWithProperties(
+                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
+            )
+            self.pendingProfile = nil
+        } else {
+            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
+        }
+        return RequestFactory.tokenRequest(
+            apiKey: apiKey,
+            pushToken: pushToken,
+            enablement: enablement,
+            background: environment.getBackgroundSetting().rawValue,
+            profile: profile.toAPIModel(anonymousId: anonymousId)
+        )
+    }
+
+    func buildUnregisterRequest(apiKey: String, anonymousId: String, pushToken: String) -> KlaviyoRequest {
+        RequestFactory.unregisterRequest(
+            identity: requestIdentity(apiKey: apiKey, anonymousId: anonymousId),
+            pushToken: pushToken
+        )
+    }
 }
 
 let SAMPLE_DATA: NSMutableArray = [

--- a/Tests/KlaviyoSwiftTests/TestData.swift
+++ b/Tests/KlaviyoSwiftTests/TestData.swift
@@ -158,22 +158,7 @@ extension KlaviyoState {
     }
 
     mutating func buildTokenRequest(apiKey: String, anonymousId: String, pushToken: String, enablement: PushEnablement) -> KlaviyoRequest {
-        let profile: Profile
-        if let pendingProfile {
-            profile = Profile.updateProfileWithProperties(
-                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
-            )
-            self.pendingProfile = nil
-        } else {
-            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
-        }
-        return RequestFactory.tokenRequest(
-            apiKey: apiKey,
-            pushToken: pushToken,
-            enablement: enablement,
-            background: environment.getBackgroundSetting().rawValue,
-            profile: profile.toAPIModel(anonymousId: anonymousId)
-        )
+        tokenRequest(apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement)
     }
 
     func buildUnregisterRequest(apiKey: String, anonymousId: String, pushToken: String) -> KlaviyoRequest {


### PR DESCRIPTION
# Description
Extract request/payload construction out of the reducer into a `RequestFactory` in `KlaviyoCore`, decoupling *what request is built* from *how it is queued/flushed* (MAGE-903).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Part of the Phase 4 modularization chain (MAGE-956); targets `feat/modularization-2`.

## Changelog / Code Overview
- **`KlaviyoCore`**: add `RequestFactory` (pure `KlaviyoRequest` construction for event / profile / token / unregister) + `RequestIdentity` value type.
- **`KlaviyoCore`**: move `Event.updateEventWithIdentifiers` into Core (`Event+Identifiers.swift`); preserves MAGE-895 `priority`.
- **`KlaviyoSwift`**: reducer now builds requests via `RequestFactory` instead of inlining payload construction; adds `KlaviyoState.requestIdentity(apiKey:anonymousId:)` as the identity source.
- **Priority**: `RequestFactory.eventRequest` threads `event.priority` onto the request, so the front-insert + immediate-flush path (MAGE-895) is preserved through the factory.
- Reads no store and does not touch `environment`; construction is byte-identical to what was previously inlined.

## Test Plan
- `xcodebuild test` (iPhone 17 Pro sim):
  - `KlaviyoCoreTests`: `RequestFactoryTests` (4), `EventIdentifiersTests` (2), `EncodableTests` (5) — all pass.
  - `KlaviyoSwiftTests`: `GeofenceEventDispatchTests` (4), `StateManagementTests` (32) — all pass, confirming high-priority (opened-push/geofence) requests still front-insert + flush immediately through the factory.
- Build: `xcodebuild build -scheme klaviyo-swift-sdk-Package` — **BUILD SUCCEEDED**.

## Related Issues/Tickets
- [MAGE-903](https://linear.app/klaviyo/issue/MAGE-903) — Extract request construction into a RequestFactory (Core)
- Parent: [MAGE-956](https://linear.app/klaviyo/issue/MAGE-956) — Phase 4: Retire TCA reducer
- Builds on MAGE-895 (priority as a request property), merged into `feat/modularization-2` as #671.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved consistency when creating profile, event, and push-token requests.
  * Event requests now include available profile identifiers and relevant push-token information.

* **Bug Fixes**
  * Pending profile details are retained when registering push tokens.
  * Push-token registration data is preserved during state resets.

* **Tests**
  * Added coverage for event identifiers, push-token properties, and request payload generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->