### PR TITLE
feat(KlaviyoForms): add explicit BadJWT native bridge handler (MAGE-847)

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -451,6 +451,10 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
             ()
         case .jwtMutation:
             ()
+        case .badJWT:
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("KlaviyoJS rejected the injected auth token (BadJWT)")
+            }
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -23,6 +23,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
     case profileEvent
     case profileMutation
     case jwtMutation
+    case badJWT
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -43,6 +44,7 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
         case profileEvent
         case profileMutation
         case jwtMutation
+        case badJWT
     }
 
     init(from decoder: Decoder) throws {
@@ -85,6 +87,8 @@ enum IAFNativeBridgeEvent: Decodable, Equatable {
             self = .profileMutation
         case .jwtMutation:
             self = .jwtMutation
+        case .badJWT:
+            self = .badJWT
         }
     }
 }
@@ -171,6 +175,7 @@ extension IAFNativeBridgeEvent {
         case .profileEvent: return 1
         case .profileMutation: return 1
         case .jwtMutation: return 1
+        case .badJWT: return 1
         }
     }
 
@@ -189,6 +194,7 @@ extension IAFNativeBridgeEvent {
         case .profileEvent: return "profileEvent"
         case .profileMutation: return "profileMutation"
         case .jwtMutation: return "jwtMutation"
+        case .badJWT: return "badJWT"
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -156,7 +156,8 @@ extension IAFNativeBridgeEvent {
             .lifecycleEvent,
             .profileEvent,
             .profileMutation,
-            .jwtMutation
+            .jwtMutation,
+            .badJWT
         ]
     }
 

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1},{"type":"badJWT","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -46,6 +46,20 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
+    func testBadJWT() async throws {
+        let json = """
+        {
+          "type": "badJWT",
+          "data": {}
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
+        #expect(event == .badJWT)
+    }
+
+    @Test
     func testAbort() async throws {
         let json = """
         {

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,19 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1},{"type":"badJWT","version":1}]
+        [
+            {"type":"formWillAppear","version":2},
+            {"type":"formDisappeared","version":1},
+            {"type":"trackProfileEvent","version":1},
+            {"type":"trackAggregateEvent","version":1},
+            {"type":"openDeepLink","version":2},
+            {"type":"abort","version":1},
+            {"type":"lifecycleEvent","version":1},
+            {"type":"profileEvent","version":1},
+            {"type":"profileMutation","version":1},
+            {"type":"jwtMutation","version":1},
+            {"type":"badJWT","version":1}
+        ]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,19 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1},{"type":"badJWT","version":1}]
+            [
+                {"type":"formWillAppear","version":2},
+                {"type":"formDisappeared","version":1},
+                {"type":"trackProfileEvent","version":1},
+                {"type":"trackAggregateEvent","version":1},
+                {"type":"openDeepLink","version":2},
+                {"type":"abort","version":1},
+                {"type":"lifecycleEvent","version":1},
+                {"type":"profileEvent","version":1},
+                {"type":"profileMutation","version":1},
+                {"type":"jwtMutation","version":1},
+                {"type":"badJWT","version":1}
+            ]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -150,7 +150,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":2},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1},{"type":"jwtMutation","version":1},{"type":"badJWT","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)


### PR DESCRIPTION
# Description
Adds an explicit `BadJWT` case to the in-app-forms native bridge protocol so a rejected auth token is surfaced with a distinct log line instead of being silently lumped into generic decode-failure warnings.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
Fender's in-app-forms webview emits `{"type":"BadJWT","data":{}}` over the native bridge when it rejects an injected JWT (bad signature, or a token that doesn't resolve to a profile). `IAFNativeBridgeEvent` had no matching case, so decoding failed against the fixed `TypeIdentifier` enum and the message was silently dropped into a generic "Failed to decode JSON" warning.

- Added `badJWT` case to `IAFNativeBridgeEvent` (enum + `TypeIdentifier` + decode + `version`/`name` switches).
- `IAFWebViewModel.handleNativeBridgeEvent` now handles `.badJWT` as a graceful no-op that logs a distinct warning noting the token was rejected.
- Added a decode test (`testBadJWT`) mirroring the existing `testHandShook` pattern.

This is the iOS half of the same protocol gap as MAGE-846 (Android).

## Test Plan
- `xcodebuild test -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:KlaviyoFormsTests/IAFNativeBridgeEventTests -only-testing:KlaviyoFormsTests/IAFWebViewModelTests` — all 39 tests pass, including the new `testBadJWT`.
- Manually verified decoding of a `{"type":"badJWT","data":{}}` payload logs `"KlaviyoJS rejected the injected auth token (BadJWT)"` at warning level instead of the generic decode-failure message.

## Related Issues/Tickets
MAGE-847 (this issue), related to MAGE-846 (Android BadJWT handling), MAGE-795, parent JWT project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid authentication tokens by the in-app form experience.
  * Added recognition and warning logging for rejected auth tokens via the new `badJWT` bridge event.

* **Tests**
  * Updated handshake expectations to include the new `badJWT` event entry.
  * Added decoding coverage to verify `badJWT` payloads are interpreted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->