### PR TITLE
feat: create client subscription methods 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,4 +52,5 @@ identifier_name:
     - id
     - URL
     - GlobalAPIKey
+    - sms
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, codeclimate, junit, html, emoji, sonarqube, markdown, github-actions-logging)

--- a/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/SPMExample/SPMExampleAutomatic/AppDelegate.swift
@@ -16,6 +16,10 @@ import SwiftUI
 import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    // [OPTIONAL] To demo list subscriptions, set a list ID from your account.
+    // Leave `nil` to hide the Subscribe button entirely.
+    static let subscriptionListId: String? = nil
+
     // MARK: - Private members
 
     private var email: String? {

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -19,8 +19,8 @@ import SwiftUI
 import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    // [OPTIONAL] To demo list subscriptions, set a list ID from your account.
-    // Leave `nil` to hide the subscribe toggle entirely.
+    // STEP2D: [OPTIONAL] To demo list subscriptions, set a list ID from your account.
+    // Leave `nil` to hide the Subscribe button entirely.
     static let subscriptionListId: String? = nil
 
     // MARK: - Private members

--- a/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/AppDelegate.swift
@@ -19,6 +19,10 @@ import SwiftUI
 import UIKit
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    // [OPTIONAL] To demo list subscriptions, set a list ID from your account.
+    // Leave `nil` to hide the subscribe toggle entirely.
+    static let subscriptionListId: String? = nil
+
     // MARK: - Private members
 
     private var email: String? {

--- a/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/ContentView.swift
@@ -85,6 +85,15 @@ class AppState: ObservableObject {
         KlaviyoSDK().create(event: .init(name: .addedToCartMetric, properties: propertiesDictionary))
     }
 
+    /// Grants marketing consent on every channel the tracked profile has an identifier for.
+    func subscribeToList(listId: String) {
+        KlaviyoSDK().create(
+            subscription: .allAvailableMarketing(
+                listId: listId
+            )
+        )
+    }
+
     func removeFromCart(_ item: MenuItem) {
         if let index = cartItems.firstIndex(where: { $0.id == item.id }) {
             cartItems.remove(at: index)

--- a/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
@@ -5,6 +5,7 @@ struct LoginView: View {
     @State private var email: String = ""
     @State private var zipcode: String = ""
     @State private var rememberMe: Bool = true
+    @State private var subscribeToMarketing: Bool = false
 
     var body: some View {
         ScrollView {
@@ -69,6 +70,16 @@ struct LoginView: View {
                             .toggleStyle(SwitchToggleStyle(tint: .blue))
                     }
 
+                    // Collect marketing consent at signup, shown only when a list ID is configured
+                    if AppDelegate.subscriptionListId != nil {
+                        Toggle(isOn: $subscribeToMarketing) {
+                            Text("Subscribe to email marketing")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        .toggleStyle(SwitchToggleStyle(tint: .blue))
+                    }
+
                     Button(action: login) {
                         Text("Get Started")
                             .font(.headline)
@@ -96,6 +107,11 @@ struct LoginView: View {
 
     private func login() {
         appState.login(email: email, zipcode: zipcode)
+
+        // Subscribe after login so the profile already has the email set
+        if subscribeToMarketing, let listId = AppDelegate.subscriptionListId {
+            appState.subscribeToList(listId: listId)
+        }
     }
 
     private var isFormInvalid: Bool {

--- a/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
+++ b/Examples/KlaviyoSwiftExamples/Shared/LoginView.swift
@@ -73,7 +73,7 @@ struct LoginView: View {
                     // Collect marketing consent at signup, shown only when a list ID is configured
                     if AppDelegate.subscriptionListId != nil {
                         Toggle(isOn: $subscribeToMarketing) {
-                            Text("Subscribe to email marketing")
+                            Text("Subscribe to marketing")
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
                         }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The `create` method takes an event object as an argument. The event can be const
 
 The SDK can create a subscription and consent record for email, SMS, and Whatsapp channels based on the profile's email and phone number attributes — via the [Create Client Subscription API](https://developers.klaviyo.com/en/reference/create_client_subscription). One of either email or phone number must be provided. WhatsApp BSUID support is coming soon.
 
-Set the profile's email and/or phone number **before** subscribing. A subscribe call that requests a channel whose identifier has not been set is not enqueued (a developer warning is logged).
+Set the profile's email and/or phone number **before** subscribing. A subscribe call that requests a channel whose identifier has not been set is not sent and is dropped at replay time (a developer warning is logged).
 
 Profiles can be opted into multiple channels — for example email marketing, SMS marketing, and SMS transactional. Specify the channel(s) to subscribe by providing a `channels` value on `Subscription`. If you include `channels`, only those channels will be subscribed. If you use `Subscription.allAvailableMarketing` (no `subscriptions` object is sent), subscriptions are defaulted to `MARKETING`.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   - [Anonymous Tracking Notice](#anonymous-tracking-notice)
 - [Event tracking](#event-tracking)
   - [Arguments](#arguments)
+- [List Subscriptions](#list-subscriptions)
+  - [Arguments](#arguments-1)
 - [Push Notifications](#push-notifications)
   - [Prerequisites](#prerequisites)
   - [Option A — Automatic integration](#option-a--automatic-integration)
@@ -243,6 +245,51 @@ The `create` method takes an event object as an argument. The event can be const
 - [required] `name`: The name of the event you want to track, as a `EventName` enum. A list of common Klaviyo defined event metrics can be found in `Event.EventName`. You can also create custom events by using the `CustomEvent` enum case of `Event.EventName`
 - `properties`: A dictionary of properties that are specific to the event. This argument is optional.
 - `value`: A numeric value (`Double`) to associate with this event. For example, the dollar amount of a purchase.
+
+## List Subscriptions
+
+The SDK can create a subscription and consent record for email, SMS, and Whatsapp channels based on the profile's email and phone number attributes — via the [Create Client Subscription API](https://developers.klaviyo.com/en/reference/create_client_subscription). One of either email or phone number must be provided. WhatsApp BSUID support is coming soon.
+
+Set the profile's email and/or phone number **before** subscribing. A subscribe call that requests a channel whose identifier has not been set is not enqueued (a developer warning is logged).
+
+Profiles can be opted into multiple channels — for example email marketing, SMS marketing, and SMS transactional. Specify the channel(s) to subscribe by providing a `channels` value on `Subscription`. If you include `channels`, only those channels will be subscribed. If you use `Subscription.allAvailableMarketing` (no `subscriptions` object is sent), subscriptions are defaulted to `MARKETING`.
+
+Subscriptions to push notifications are not created through this API — use the existing [`set(pushToken:)`](#collecting-push-tokens) registration path instead.
+
+```swift
+KlaviyoSDK().set(email: "johnpork@demo.com")
+KlaviyoSDK().set(phoneNumber: "+15005550006")
+
+// Subscribe to a list, defaulting to MARKETING consent for every channel
+// available from the identifiers you've set:
+KlaviyoSDK().create(subscription: .allAvailableMarketing(listId: "XXXXXX"))
+
+// Or request specific channels and consent types:
+let subscription = Subscription(
+    listId: "XXXXXX",
+    channels: .init(
+        email: .marketing,
+        sms: [.marketing, .transactional],
+        whatsapp: [.marketing, .transactional]
+    ),
+    customSource: "iOS in-app form"
+)
+KlaviyoSDK().create(subscription: subscription)
+```
+### Arguments
+
+The `create(subscription:)` method takes a `Subscription`. Construct one with either:
+
+- `Subscription.allAvailableMarketing(listId:customSource:)` — omits the `subscriptions` object so the API defaults to `MARKETING` consent for every channel available from the profile's identifiers.
+- `Subscription(listId:channels:customSource:)` — sends a `subscriptions` object for only the channels you name. `channels` is required on this initializer so a broad grant is never the result of an omitted argument.
+
+`Subscription.Channels` takes optional `email`, `sms`, and `whatsapp` values. Each channel exposes only the consent sub-types the API supports for it — pass one value (e.g. `.marketing`) or multiple (e.g. `[.marketing, .transactional]`):
+
+The consent types per channel include:
+- `email`: `.marketing`, `.openTracking`
+- `sms` / `whatsapp`: `.marketing`, `.transactional`
+
+`customSource` is an optional free-text label describing where the signup originated (e.g. a form or screen name), stored as the consent record's source.
 
 ## Push Notifications
 

--- a/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/CreateSubscriptionPayload.swift
@@ -1,0 +1,54 @@
+//
+//  CreateSubscriptionPayload.swift
+//
+//
+//  Created by Aahil Nishad on 7/7/26.
+//
+
+import Foundation
+
+public struct CreateSubscriptionPayload: Equatable, Codable {
+    public let data: SubscriptionData
+
+    public init(listId: String, profile: ProfilePayload, customSource: String? = nil) {
+        data = SubscriptionData(listId: listId, profile: profile, customSource: customSource)
+    }
+
+    public struct SubscriptionData: Equatable, Codable {
+        public let type = "subscription"
+        public let attributes: Attributes
+        public let relationships: Relationships
+
+        public init(listId: String, profile: ProfilePayload, customSource: String?) {
+            attributes = Attributes(customSource: customSource, profile: .init(data: profile))
+            relationships = Relationships(list: .init(data: .init(id: listId)))
+        }
+
+        public struct Attributes: Equatable, Codable {
+            public let customSource: String?
+            public let profile: Profile
+
+            enum CodingKeys: String, CodingKey {
+                case customSource = "custom_source"
+                case profile
+            }
+
+            public struct Profile: Equatable, Codable {
+                public let data: ProfilePayload
+            }
+        }
+
+        public struct Relationships: Equatable, Codable {
+            public let list: ListRelationship
+
+            public struct ListRelationship: Equatable, Codable {
+                public let data: ListData
+
+                public struct ListData: Equatable, Codable {
+                    public let type = "list"
+                    public let id: String
+                }
+            }
+        }
+    }
+}

--- a/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/ProfilePayload.swift
@@ -8,9 +8,7 @@
 import AnyCodable
 import Foundation
 
-/**
- Internal structure which has details not needed by the API.
- */
+/// Internal structure which has details not needed by the API.
 public struct ProfilePayload: Equatable, Codable {
     var type = "profile"
     public struct Attributes: Equatable, Codable {
@@ -25,6 +23,7 @@ public struct ProfilePayload: Equatable, Codable {
         public var image: String?
         public var location: Location?
         public var properties: AnyCodable
+        public var subscriptions: SubscriptionChannels?
         enum CodingKeys: String, CodingKey {
             case email
             case phoneNumber = "phone_number"
@@ -37,19 +36,23 @@ public struct ProfilePayload: Equatable, Codable {
             case image
             case location
             case properties
+            case subscriptions
         }
 
-        public init(email: String? = nil,
-                    phoneNumber: String? = nil,
-                    externalId: String? = nil,
-                    firstName: String? = nil,
-                    lastName: String? = nil,
-                    organization: String? = nil,
-                    title: String? = nil,
-                    image: String? = nil,
-                    location: Location? = nil,
-                    properties: [String: Any]? = nil,
-                    anonymousId: String) {
+        public init(
+            email: String? = nil,
+            phoneNumber: String? = nil,
+            externalId: String? = nil,
+            firstName: String? = nil,
+            lastName: String? = nil,
+            organization: String? = nil,
+            title: String? = nil,
+            image: String? = nil,
+            location: Location? = nil,
+            properties: [String: Any]? = nil,
+            subscriptions: SubscriptionChannels? = nil,
+            anonymousId: String
+        ) {
             self.email = email
             self.phoneNumber = phoneNumber
             self.externalId = externalId
@@ -60,6 +63,7 @@ public struct ProfilePayload: Equatable, Codable {
             self.image = image
             self.location = location
             self.properties = AnyCodable(properties ?? [:])
+            self.subscriptions = subscriptions
             self.anonymousId = anonymousId
         }
 
@@ -73,15 +77,17 @@ public struct ProfilePayload: Equatable, Codable {
             public var region: String?
             public var zip: String?
             public var timezone: String?
-            public init(address1: String? = nil,
-                        address2: String? = nil,
-                        city: String? = nil,
-                        country: String? = nil,
-                        latitude: Double? = nil,
-                        longitude: Double? = nil,
-                        region: String? = nil,
-                        zip: String? = nil,
-                        timezone: String? = nil) {
+            public init(
+                address1: String? = nil,
+                address2: String? = nil,
+                city: String? = nil,
+                country: String? = nil,
+                latitude: Double? = nil,
+                longitude: Double? = nil,
+                region: String? = nil,
+                zip: String? = nil,
+                timezone: String? = nil
+            ) {
                 self.address1 = address1
                 self.address2 = address2
                 self.city = city
@@ -97,17 +103,20 @@ public struct ProfilePayload: Equatable, Codable {
 
     public var attributes: Attributes
 
-    public init(email: String? = nil,
-                phoneNumber: String? = nil,
-                externalId: String? = nil,
-                firstName: String? = nil,
-                lastName: String? = nil,
-                organization: String? = nil,
-                title: String? = nil,
-                image: String? = nil,
-                location: Attributes.Location? = nil,
-                properties: [String: Any]? = nil,
-                anonymousId: String) {
+    public init(
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil,
+        organization: String? = nil,
+        title: String? = nil,
+        image: String? = nil,
+        location: Attributes.Location? = nil,
+        properties: [String: Any]? = nil,
+        subscriptions: SubscriptionChannels? = nil,
+        anonymousId: String
+    ) {
         attributes = Attributes(
             email: email,
             phoneNumber: phoneNumber,
@@ -119,6 +128,7 @@ public struct ProfilePayload: Equatable, Codable {
             image: image,
             location: location,
             properties: properties,
+            subscriptions: subscriptions,
             anonymousId: anonymousId
         )
     }

--- a/Sources/KlaviyoCore/Models/APIModels/SubscriptionChannels.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/SubscriptionChannels.swift
@@ -1,0 +1,72 @@
+//
+//  SubscriptionChannels.swift
+//
+//
+//  Created by Aahil Nishad on 7/14/26.
+//
+
+import Foundation
+
+/// `subscriptions` object on a profile: one entry per channel. Each channel exposes only the consent
+/// sub-types the API supports for it — email: `marketing` + `open_tracking`; SMS and WhatsApp:
+/// `marketing` + `transactional`. Every consent value is `{ "consent": "SUBSCRIBED" }`.
+public struct SubscriptionChannels: Equatable, Codable {
+    public let email: EmailConsent?
+    public let sms: MarketingTransactionalConsent?
+    public let whatsapp: MarketingTransactionalConsent?
+
+    public init(
+        email: EmailConsent? = nil,
+        sms: MarketingTransactionalConsent? = nil,
+        whatsapp: MarketingTransactionalConsent? = nil
+    ) {
+        self.email = email
+        self.sms = sms
+        self.whatsapp = whatsapp
+    }
+}
+
+public struct SubscriptionConsent: Equatable, Codable {
+    public let consent: String
+
+    private init(consent: String) {
+        self.consent = consent
+    }
+
+    public static let subscribed = SubscriptionConsent(
+        consent: "SUBSCRIBED"
+    )
+}
+
+/// EMAIL channel consent: `marketing` and/or `open_tracking`.
+public struct EmailConsent: Equatable, Codable {
+    public let marketing: SubscriptionConsent?
+    public let openTracking: SubscriptionConsent?
+
+    enum CodingKeys: String, CodingKey {
+        case marketing
+        case openTracking = "open_tracking"
+    }
+
+    public init(
+        marketing: SubscriptionConsent? = nil,
+        openTracking: SubscriptionConsent? = nil
+    ) {
+        self.marketing = marketing
+        self.openTracking = openTracking
+    }
+}
+
+/// SMS and WhatsApp channel consent: `marketing` and/or `transactional`.
+public struct MarketingTransactionalConsent: Equatable, Codable {
+    public let marketing: SubscriptionConsent?
+    public let transactional: SubscriptionConsent?
+
+    public init(
+        marketing: SubscriptionConsent? = nil,
+        transactional: SubscriptionConsent? = nil
+    ) {
+        self.marketing = marketing
+        self.transactional = transactional
+    }
+}

--- a/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
+++ b/Sources/KlaviyoCore/Networking/KlaviyoEndpoint.swift
@@ -15,6 +15,7 @@ public enum KlaviyoEndpoint: Equatable, Codable {
     case registerPushToken(_ apiKey: String, _ payload: PushTokenPayload)
     case unregisterPushToken(_ apiKey: String, _ payload: UnregisterPushTokenPayload)
     case aggregateEvent(_ apiKey: String, _ payload: AggregateEventPayload)
+    case createSubscription(_ apiKey: String, _ payload: CreateSubscriptionPayload)
     case resolveDestinationURL(trackingLink: URL, profileInfo: ProfilePayload)
     case logTrackingLinkClicked(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
     case fetchGeofences(_ apiKey: String, latitude: Double?, longitude: Double?)
@@ -28,7 +29,7 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     public var headers: [String: String] {
         switch self {
-        case .createProfile, .createEvent, .unregisterPushToken, .aggregateEvent:
+        case .createProfile, .createEvent, .unregisterPushToken, .aggregateEvent, .createSubscription:
             return [:]
         case .registerPushToken:
             guard let value = environment.sdkFeatures()?.headerValue(for: .pushTokenRegistration) else {
@@ -64,7 +65,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
              let .createEvent(apiKey, _),
              let .registerPushToken(apiKey, _),
              let .unregisterPushToken(apiKey, _),
-             let .aggregateEvent(apiKey, _):
+             let .aggregateEvent(apiKey, _),
+             let .createSubscription(apiKey, _):
             return [URLQueryItem(name: "company_id", value: apiKey)]
         case let .fetchGeofences(apiKey, _, _):
             return [
@@ -78,7 +80,12 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     var httpMethod: HTTPMethod {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent:
+        case .createProfile,
+             .createEvent,
+             .registerPushToken,
+             .unregisterPushToken,
+             .aggregateEvent,
+             .createSubscription:
             return .post
         case .resolveDestinationURL, .logTrackingLinkClicked, .fetchGeofences:
             return .get
@@ -87,7 +94,13 @@ public enum KlaviyoEndpoint: Equatable, Codable {
 
     public func baseURL() throws -> URL {
         switch self {
-        case .createProfile, .createEvent, .registerPushToken, .unregisterPushToken, .aggregateEvent, .fetchGeofences:
+        case .createProfile,
+             .createEvent,
+             .registerPushToken,
+             .unregisterPushToken,
+             .aggregateEvent,
+             .createSubscription,
+             .fetchGeofences:
             guard environment.apiURL().scheme != nil,
                   environment.apiURL().host != nil,
                   let url = environment.apiURL().url else {
@@ -130,6 +143,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
             return "/client/push-token-unregister/"
         case .aggregateEvent:
             return "/onsite/track-analytics"
+        case .createSubscription:
+            return "/client/subscriptions"
         case let .resolveDestinationURL(trackingLink, _), let .logTrackingLinkClicked(trackingLink, _, _):
             return trackingLink.path
         case .fetchGeofences:
@@ -157,6 +172,8 @@ public enum KlaviyoEndpoint: Equatable, Codable {
             return try environment.encodeJSON(payload)
         case let .aggregateEvent(_, payload):
             return payload
+        case let .createSubscription(_, payload):
+            return try environment.encodeJSON(payload)
         case .resolveDestinationURL, .logTrackingLinkClicked, .fetchGeofences:
             return nil
         }

--- a/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
+++ b/Sources/KlaviyoCore/Networking/SDKRequestIterator.swift
@@ -49,6 +49,7 @@ public struct SDKRequest: Identifiable, Equatable {
         case resolveDestinationURL(trackingLink: URL)
         case logTrackingLinkClicked(trackingLink: URL, clickTime: Date)
         case fetchGeofences
+        case createSubscription(listId: String, ProfileInfo)
 
         fileprivate static func fromEndpoint(request: KlaviyoRequest) -> RequestType {
             switch request.endpoint {
@@ -87,6 +88,15 @@ public struct SDKRequest: Identifiable, Equatable {
                 return .logTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
             case .fetchGeofences:
                 return .fetchGeofences
+            case let .createSubscription(_, payload):
+                let attrs = payload.data.attributes.profile.data.attributes
+                return .createSubscription(
+                    listId: payload.data.relationships.list.data.id,
+                    ProfileInfo(email: attrs.email,
+                                phoneNumber: attrs.phoneNumber,
+                                externalId: attrs.externalId,
+                                anonymousId: attrs.anonymousId)
+                )
             }
         }
     }

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -179,6 +179,23 @@ public struct KlaviyoSDK {
         dispatchOnMainThread(action: .enqueueEvent(event))
     }
 
+    /// Creates a subscription and consent record for the email, SMS, and/or WhatsApp channels.
+    ///
+    /// This method subscribes the currently tracked profile to the specified Klaviyo list.
+    /// The profile must have at least an email address or phone number set (email keys the email
+    /// channel; phone number keys the SMS and WhatsApp channels).
+    ///
+    /// Use ``Subscription/allAvailableMarketing(listId:customSource:)`` to grant MARKETING consent on
+    /// the channels the profile has identifiers for (email and SMS), or the
+    /// ``Subscription/init(listId:channels:customSource:)`` initializer with a ``Subscription/Channels``
+    /// value to name specific channels and sub-types.
+    ///
+    /// - Parameter subscription: A ``Subscription`` with the list ID, the channels to request consent
+    ///   for, and an optional `customSource` label.
+    public func create(subscription: Subscription) {
+        dispatchOnMainThread(action: .enqueueSubscription(subscription))
+    }
+
     /// Set the current user's push token. This will be associated with profile and can be used to send them push notifications.
     /// - Parameter pushToken: data object containing a push token.
     public func set(pushToken: Data) {

--- a/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/ProfileAPIExtension.swift
@@ -31,41 +31,45 @@ extension String {
     }
 }
 
-extension Profile {
-    func toAPIModel(
+extension ProfilePayload {
+    /// Builds the API profile payload from a ``Profile``, letting the caller override the identifiers
+    /// (email, phone number, external ID) that are tracked separately on state.
+    init(
+        _ profile: Profile,
         email: String? = nil,
         phoneNumber: String? = nil,
         externalId: String? = nil,
         anonymousId: String
-    ) -> ProfilePayload {
-        ProfilePayload(
-            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? self.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
-            firstName: firstName,
-            lastName: lastName,
-            organization: organization,
-            title: title,
-            image: image,
-            location: location?.toAPILocation,
-            properties: properties,
+    ) {
+        self.init(
+            email: email?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.email?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            phoneNumber: phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.phoneNumber?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            externalId: externalId?.trimWhiteSpaceOrReturnNilIfEmpty() ?? profile.externalId?.trimWhiteSpaceOrReturnNilIfEmpty(),
+            firstName: profile.firstName,
+            lastName: profile.lastName,
+            organization: profile.organization,
+            title: profile.title,
+            image: profile.image,
+            location: profile.location.map { Attributes.Location($0) },
+            properties: profile.properties,
             anonymousId: anonymousId
         )
     }
 }
 
-extension Profile.Location {
-    var toAPILocation: ProfilePayload.Attributes.Location {
-        ProfilePayload.Attributes.Location(
-            address1: address1,
-            address2: address2,
-            city: city,
-            country: country,
-            latitude: latitude,
-            longitude: longitude,
-            region: region,
-            zip: zip,
-            timezone: timezone
+extension ProfilePayload.Attributes.Location {
+    /// Maps a ``Profile/Location`` to the API location object.
+    init(_ location: Profile.Location) {
+        self.init(
+            address1: location.address1,
+            address2: location.address2,
+            city: location.city,
+            country: location.country,
+            latitude: location.latitude,
+            longitude: location.longitude,
+            region: location.region,
+            zip: location.zip,
+            timezone: location.timezone
         )
     }
 }

--- a/Sources/KlaviyoSwift/Models/Subscription.swift
+++ b/Sources/KlaviyoSwift/Models/Subscription.swift
@@ -1,0 +1,91 @@
+//
+//  Subscription.swift
+//
+//
+//  Created by Aahil Nishad on 7/7/26.
+//
+
+import Foundation
+
+/// Represents a subscription request to subscribe a profile to a Klaviyo list.
+public struct Subscription: Equatable, Sendable {
+    /// The ID of the Klaviyo list to subscribe the profile to.
+    public let listId: String
+
+    /// The channels to request consent for, or `nil` to defer to the server's default of MARKETING
+    /// consent on every identified channel. `nil` is only reachable through
+    /// ``allAvailableMarketing(listId:customSource:)`` — the public initializer requires channels so a
+    /// broad grant is never the result of an omitted argument.
+    public let channels: Channels?
+
+    /// Free-text label describing where this signup originated (e.g. a form or screen name).
+    /// Stored as the consent record's `$source`, pass an explicit value to override, or `nil` to omit it entirely.
+    public let customSource: String?
+
+    /// The channels to request consent for. Mirrors the API's `subscriptions` object: each channel
+    /// exposes only the consent sub-types it supports, so invalid combinations (transactional email,
+    /// open-tracking SMS) don't compile. Combine sub-types with array-literal syntax, e.g.
+    /// `.init(sms: [.marketing, .transactional])`.
+    public struct Channels: Equatable, Sendable {
+        /// Consent sub-types to request on the EMAIL channel.
+        public let email: Email?
+        /// Consent sub-types to request on the SMS channel.
+        public let sms: Messaging?
+        /// Consent sub-types to request on the WhatsApp channel.
+        public let whatsapp: Messaging?
+
+        public init(email: Email? = nil, sms: Messaging? = nil, whatsapp: Messaging? = nil) {
+            self.email = email
+            self.sms = sms
+            self.whatsapp = whatsapp
+        }
+
+        /// Consent sub-types supported on the EMAIL channel.
+        public struct Email: OptionSet, Equatable, Sendable {
+            public let rawValue: Int
+            public init(rawValue: Int) { self.rawValue = rawValue }
+
+            /// Email marketing consent.
+            public static let marketing = Email(rawValue: 1 << 0)
+            /// Email open-tracking consent.
+            public static let openTracking = Email(rawValue: 1 << 1)
+        }
+
+        /// Consent sub-types supported on the SMS and WhatsApp channels.
+        public struct Messaging: OptionSet, Equatable, Sendable {
+            public let rawValue: Int
+            public init(rawValue: Int) { self.rawValue = rawValue }
+
+            /// Marketing consent.
+            public static let marketing = Messaging(rawValue: 1 << 0)
+            /// Transactional messaging consent.
+            public static let transactional = Messaging(rawValue: 1 << 1)
+        }
+    }
+
+    /// Creates a subscription request for the given channels.
+    /// - Parameters:
+    ///   - listId: The ID of the Klaviyo list to subscribe the profile to.
+    ///   - channels: The channels and sub-types to request consent for.
+    ///   - customSource: Optional signup-source label stored as the consent record's `$source`.
+    ///     Omitted from the request when `nil` (the default).
+    public init(listId: String, channels: Channels, customSource: String? = nil) {
+        self.init(listId: listId, channels: .some(channels), customSource: customSource)
+    }
+
+    private init(listId: String, channels: Channels?, customSource: String?) {
+        self.listId = listId
+        self.channels = channels
+        self.customSource = customSource
+    }
+
+    /// Creates a subscription that grants MARKETING consent on every channel the profile has an
+    /// identifier for (email → email marketing, phone → SMS marketing). Mirrors the server's default
+    /// behavior when no `subscriptions` object is sent, but requesting it is a deliberate call.
+    /// - Parameters:
+    ///   - listId: The ID of the Klaviyo list to subscribe the profile to.
+    ///   - customSource: Optional signup-source label stored as the consent record's `$source`.
+    public static func allAvailableMarketing(listId: String, customSource: String? = nil) -> Subscription {
+        Subscription(listId: listId, channels: nil, customSource: customSource)
+    }
+}

--- a/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
@@ -18,29 +18,38 @@ extension Subscription.Channels {
     var needsPhone: Bool {
         sms?.isEmpty == false || whatsapp?.isEmpty == false
     }
+}
 
+extension EmailConsent {
+    /// Maps the requested EMAIL sub-types to the API consent object, or `nil` when none were named.
+    init?(_ options: Subscription.Channels.Email) {
+        guard !options.isEmpty else { return nil }
+        self.init(
+            marketing: options.contains(.marketing) ? .subscribed : nil,
+            openTracking: options.contains(.openTracking) ? .subscribed : nil
+        )
+    }
+}
+
+extension MarketingTransactionalConsent {
+    /// Maps the requested SMS/WhatsApp sub-types to the API consent object, or `nil` when none were named.
+    init?(_ options: Subscription.Channels.Messaging) {
+        guard !options.isEmpty else { return nil }
+        self.init(
+            marketing: options.contains(.marketing) ? .subscribed : nil,
+            transactional: options.contains(.transactional) ? .subscribed : nil
+        )
+    }
+}
+
+extension SubscriptionChannels {
     /// Maps the requested channels to the API's `subscriptions` object, or `nil` when no sub-types
     /// were named (nothing to send).
-    var toAPIModel: SubscriptionChannels? {
-        let emailConsent = email.flatMap { set -> EmailConsent? in
-            guard !set.isEmpty else { return nil }
-            return EmailConsent(
-                marketing: set.contains(.marketing) ? .subscribed : nil,
-                openTracking: set.contains(.openTracking) ? .subscribed : nil
-            )
-        }
-        let smsConsent = messagingConsent(sms)
-        let whatsappConsent = messagingConsent(whatsapp)
-
-        guard emailConsent != nil || smsConsent != nil || whatsappConsent != nil else { return nil }
-        return SubscriptionChannels(email: emailConsent, sms: smsConsent, whatsapp: whatsappConsent)
-    }
-
-    private func messagingConsent(_ set: Messaging?) -> MarketingTransactionalConsent? {
-        guard let set, !set.isEmpty else { return nil }
-        return MarketingTransactionalConsent(
-            marketing: set.contains(.marketing) ? .subscribed : nil,
-            transactional: set.contains(.transactional) ? .subscribed : nil
-        )
+    init?(_ channels: Subscription.Channels) {
+        let email = channels.email.flatMap(EmailConsent.init)
+        let sms = channels.sms.flatMap(MarketingTransactionalConsent.init)
+        let whatsapp = channels.whatsapp.flatMap(MarketingTransactionalConsent.init)
+        guard email != nil || sms != nil || whatsapp != nil else { return nil }
+        self.init(email: email, sms: sms, whatsapp: whatsapp)
     }
 }

--- a/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/SubscriptionAPIExtension.swift
@@ -1,0 +1,46 @@
+//
+//  SubscriptionAPIExtension.swift
+//
+//
+//  Created by Aahil Nishad on 7/14/26.
+//
+
+import Foundation
+import KlaviyoCore
+
+extension Subscription.Channels {
+    /// Whether the requested channels need an email identifier on the profile.
+    var needsEmail: Bool {
+        email?.isEmpty == false
+    }
+
+    /// Whether the requested channels need a phone number identifier on the profile.
+    var needsPhone: Bool {
+        sms?.isEmpty == false || whatsapp?.isEmpty == false
+    }
+
+    /// Maps the requested channels to the API's `subscriptions` object, or `nil` when no sub-types
+    /// were named (nothing to send).
+    var toAPIModel: SubscriptionChannels? {
+        let emailConsent = email.flatMap { set -> EmailConsent? in
+            guard !set.isEmpty else { return nil }
+            return EmailConsent(
+                marketing: set.contains(.marketing) ? .subscribed : nil,
+                openTracking: set.contains(.openTracking) ? .subscribed : nil
+            )
+        }
+        let smsConsent = messagingConsent(sms)
+        let whatsappConsent = messagingConsent(whatsapp)
+
+        guard emailConsent != nil || smsConsent != nil || whatsappConsent != nil else { return nil }
+        return SubscriptionChannels(email: emailConsent, sms: smsConsent, whatsapp: whatsappConsent)
+    }
+
+    private func messagingConsent(_ set: Messaging?) -> MarketingTransactionalConsent? {
+        guard let set, !set.isEmpty else { return nil }
+        return MarketingTransactionalConsent(
+            marketing: set.contains(.marketing) ? .subscribed : nil,
+            transactional: set.contains(.transactional) ? .subscribed : nil
+        )
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
+++ b/Sources/KlaviyoSwift/StateManagement/APIRequestErrorHandling.swift
@@ -11,7 +11,13 @@ import KlaviyoCore
 extension KlaviyoEndpoint {
     var maxRetries: Int {
         switch self {
-        case .createProfile, .registerPushToken, .unregisterPushToken, .createEvent, .aggregateEvent, .logTrackingLinkClicked:
+        case .createProfile,
+             .registerPushToken,
+             .unregisterPushToken,
+             .createEvent,
+             .aggregateEvent,
+             .logTrackingLinkClicked,
+             .createSubscription:
             return 50
         case .resolveDestinationURL, .fetchGeofences:
             return 1

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -343,7 +343,7 @@ struct KlaviyoState: Equatable, Codable {
                     pushToken: tokenData.pushToken,
                     enablement: tokenData.pushEnablement.rawValue,
                     background: tokenData.pushBackground.rawValue,
-                    profile: Profile().toAPIModel(anonymousId: anonymousId)
+                    profile: ProfilePayload(Profile(), anonymousId: anonymousId)
                 )
 
                 let request = KlaviyoRequest(
@@ -403,7 +403,7 @@ struct KlaviyoState: Equatable, Codable {
             pushToken: pushToken,
             enablement: enablement.rawValue,
             background: environment.getBackgroundSetting().rawValue,
-            profile: profile.toAPIModel(anonymousId: anonymousId)
+            profile: ProfilePayload(profile, anonymousId: anonymousId)
         )
         let endpoint = KlaviyoEndpoint.registerPushToken(apiKey, payload)
         return KlaviyoRequest(endpoint: endpoint)
@@ -440,7 +440,7 @@ struct KlaviyoState: Equatable, Codable {
                 return nil
             }
 
-            guard let mappedChannels = requestedChannels.toAPIModel else {
+            guard let mappedChannels = SubscriptionChannels(requestedChannels) else {
                 environment.emitDeveloperWarning(
                     "Subscription channels were provided but none were enabled; request was not enqueued."
                 )

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -27,6 +27,7 @@ struct KlaviyoState: Equatable, Codable {
         case setEmail(String)
         case setExternalId(String)
         case setPhoneNumber(String)
+        case subscription(Subscription)
     }
 
     struct PushTokenData: Equatable, Codable {
@@ -417,6 +418,63 @@ struct KlaviyoState: Equatable, Codable {
             anonymousId: anonymousId
         )
         let endpoint = KlaviyoEndpoint.unregisterPushToken(apiKey, payload)
+        return KlaviyoRequest(endpoint: endpoint)
+    }
+
+    /// Validates the requested channels against the profile's identifiers and builds the create-subscription
+    /// request. Emits a developer warning and returns `nil` when the request should not be enqueued.
+    func buildSubscriptionRequest(apiKey: String, anonymousId: String, subscription: Subscription) -> KlaviyoRequest? {
+        let channels: SubscriptionChannels?
+        if let requestedChannels = subscription.channels {
+            if requestedChannels.needsEmail, email == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires an email for the requested channels, but email is not set."
+                )
+                return nil
+            }
+            if requestedChannels.needsPhone, phoneNumber == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires a phone number for the requested channels, " +
+                        "but phone number is not set."
+                )
+                return nil
+            }
+
+            guard let mappedChannels = requestedChannels.toAPIModel else {
+                environment.emitDeveloperWarning(
+                    "Subscription channels were provided but none were enabled; request was not enqueued."
+                )
+                return nil
+            }
+            channels = mappedChannels
+        } else {
+            // allAvailableMarketing: omit the subscriptions object so the server defaults to marketing;
+            // requires at least one identifier to key channels on.
+            guard email != nil || phoneNumber != nil else {
+                environment.emitDeveloperWarning(
+                    "Subscription requires at least one identifier the API can key channels on, " +
+                        "but no identifiers are set."
+                )
+                return nil
+            }
+            channels = nil
+        }
+
+        let profile = ProfilePayload(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            subscriptions: channels,
+            anonymousId: anonymousId
+        )
+
+        let payload = CreateSubscriptionPayload(
+            listId: subscription.listId,
+            profile: profile,
+            customSource: subscription.customSource
+        )
+
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
         return KlaviyoRequest(endpoint: endpoint)
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -105,6 +105,9 @@ enum KlaviyoAction: Equatable {
     /// when there is an profile to be sent to klaviyo it's added to the queue
     case enqueueProfile(Profile)
 
+    /// when there is a subscription to be sent to klaviyo it's added to the queue
+    case enqueueSubscription(Subscription)
+
     /// when setting individual profile props
     case setProfileProperty(Profile.ProfileKey, AnyEncodable)
 
@@ -127,7 +130,7 @@ enum KlaviyoAction: Equatable {
         case let .enqueueEvent(event) where event.metric.name == ._openedPush || event.metric.isGeofenceEvent:
             return false
 
-        case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .resetProfile, .resetStateAndDequeue, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
+        case .enqueueAggregateEvent, .enqueueEvent, .enqueueProfile, .enqueueSubscription, .resetProfile, .resetStateAndDequeue, .setEmail, .setExternalId, .setPhoneNumber, .setProfileProperty, .setPushEnablement, .setPushToken:
             return true
 
         case .cancelInFlightRequests, .completeInitialization, .deQueueCompletedResults, .flushQueue, .initialize, .networkConnectivityChanged, .requestFailed, .sendRequest, .start, .stop, .trackingLinkReceived, .trackingLinkResolutionFailed:
@@ -220,6 +223,8 @@ struct KlaviyoReducer: ReducerProtocol {
                         await send(.setExternalId(externalId))
                     case let .setPhoneNumber(phoneNumber):
                         await send(.setPhoneNumber(phoneNumber))
+                    case let .subscription(subscription):
+                        await send(.enqueueSubscription(subscription))
                     }
                 }
                 await send(.start)
@@ -506,6 +511,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 baseEffect,
                 .fireAndForget { enrichAndPublishEvent(event) }
             ])
+
         case let .enqueueAggregateEvent(payload):
             guard case .initialized = state.initalizationState,
                   let apiKey = state.apiKey
@@ -584,6 +590,26 @@ struct KlaviyoReducer: ReducerProtocol {
                 request = KlaviyoRequest(
                     endpoint: KlaviyoEndpoint.createProfile(apiKey, CreateProfilePayload(data: profilePayload))
                 )
+            }
+            state.enqueueRequest(request: request)
+
+            return .none
+
+        case let .enqueueSubscription(subscription):
+            guard case .initialized = state.initalizationState,
+                  let apiKey = state.apiKey,
+                  let anonymousId = state.anonymousId
+            else {
+                state.pendingRequests.append(.subscription(subscription))
+                return .none
+            }
+
+            guard let request = state.buildSubscriptionRequest(
+                apiKey: apiKey,
+                anonymousId: anonymousId,
+                subscription: subscription
+            ) else {
+                return .none
             }
             state.enqueueRequest(request: request)
 

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -569,7 +569,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
             let request: KlaviyoRequest!
 
-            let profilePayload = profile.toAPIModel(
+            let profilePayload = ProfilePayload(
+                profile,
                 email: state.email,
                 phoneNumber: state.phoneNumber,
                 externalId: state.externalId,

--- a/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
+++ b/Tests/KlaviyoCoreTests/KlaviyoEndpointTests.swift
@@ -399,4 +399,138 @@ final class KlaviyoEndpointTests: XCTestCase {
         let geofenceEventUrlRequest = try geofenceEventRequest.urlRequest(attemptInfo: attemptInfo)
         XCTAssertEqual(geofenceEventUrlRequest.value(forHTTPHeaderField: "revision"), "2026-01-15")
     }
+
+    // MARK: - Create Subscription Tests
+
+    func testCreateSubscriptionEndpointUrlRequest() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.test
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/client/subscriptions")
+        XCTAssertEqual(request.url?.query, "company_id=test_api_key")
+        XCTAssertNotNil(request.httpBody)
+
+        let body = try XCTUnwrap(request.httpBody)
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        XCTAssertNil(attributes["custom_source"])
+
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        XCTAssertNil(
+            profileAttrs["subscriptions"],
+            "omitting channels must omit subscriptions so the API can default to MARKETING"
+        )
+    }
+
+    func testCreateSubscriptionEndpointWithChannels() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.testWithChannels
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/client/subscriptions")
+        XCTAssertEqual(request.url?.query, "company_id=test_api_key")
+        XCTAssertNotNil(request.httpBody)
+
+        let body = try XCTUnwrap(request.httpBody, "createSubscription request must include an httpBody")
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+
+        let relationships = try XCTUnwrap(data["relationships"] as? [String: Any])
+        let list = try XCTUnwrap(relationships["list"] as? [String: Any])
+        let listData = try XCTUnwrap(list["data"] as? [String: Any])
+        XCTAssertEqual(listData["type"] as? String, "list")
+        XCTAssertEqual(listData["id"] as? String, "test-list-id")
+
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        XCTAssertNil(attributes["list_id"], "list must be a relationship, not a flat attribute")
+        XCTAssertNil(
+            attributes["subscriptions"],
+            "consent must be nested inside the profile, not at top level"
+        )
+        XCTAssertEqual(attributes["custom_source"] as? String, "unit-test")
+
+        // attributes.profile.data.attributes.subscriptions.email.marketing.consent == "SUBSCRIBED"
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        let subscriptions = try XCTUnwrap(profileAttrs["subscriptions"] as? [String: Any])
+
+        // Email: marketing + open_tracking.
+        let email = try XCTUnwrap(subscriptions["email"] as? [String: Any])
+        XCTAssertEqual((email["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((email["open_tracking"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+
+        // SMS: marketing + transactional.
+        let sms = try XCTUnwrap(subscriptions["sms"] as? [String: Any])
+        XCTAssertEqual((sms["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((sms["transactional"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+
+        // WhatsApp: marketing + transactional.
+        let whatsapp = try XCTUnwrap(subscriptions["whatsapp"] as? [String: Any])
+        XCTAssertEqual((whatsapp["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertEqual((whatsapp["transactional"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+    }
+
+    func testCreateSubscriptionEndpointWithPartialChannels() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.testWithPartialChannels
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+
+        // When
+        let request = try endpoint.urlRequest()
+
+        // Then
+        let body = try XCTUnwrap(request.httpBody, "createSubscription request must include an httpBody")
+        let jsonObject = try JSONSerialization.jsonObject(with: body, options: [])
+        let json = try XCTUnwrap(jsonObject as? [String: Any])
+        let data = try XCTUnwrap(json["data"] as? [String: Any])
+        let attributes = try XCTUnwrap(data["attributes"] as? [String: Any])
+        let profile = try XCTUnwrap(attributes["profile"] as? [String: Any])
+        let profileData = try XCTUnwrap(profile["data"] as? [String: Any])
+        let profileAttrs = try XCTUnwrap(profileData["attributes"] as? [String: Any])
+        let subscriptions = try XCTUnwrap(profileAttrs["subscriptions"] as? [String: Any])
+
+        // Only the requested sub-type is present.
+        let sms = try XCTUnwrap(subscriptions["sms"] as? [String: Any])
+        XCTAssertEqual((sms["marketing"] as? [String: Any])?["consent"] as? String, "SUBSCRIBED")
+        XCTAssertNil(sms["transactional"], "unrequested sms.transactional must be absent from the payload")
+
+        // Unrequested channels are entirely absent.
+        XCTAssertNil(subscriptions["email"], "unrequested email channel must be absent from the payload")
+        XCTAssertNil(subscriptions["whatsapp"], "unrequested whatsapp channel must be absent from the payload")
+    }
+
+    func testCreateSubscriptionEndpointRevision() throws {
+        // Given
+        let apiKey = "test_api_key"
+        let payload = CreateSubscriptionPayload.test
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+        let attemptInfo = try RequestAttemptInfo(attemptNumber: 1, maxAttempts: 50)
+        let request = KlaviyoRequest(endpoint: endpoint)
+
+        // When
+        let urlRequest = try request.urlRequest(attemptInfo: attemptInfo)
+
+        // Then
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "revision"), "2026-01-15")
+    }
 }

--- a/Tests/KlaviyoCoreTests/TestUtils.swift
+++ b/Tests/KlaviyoCoreTests/TestUtils.swift
@@ -209,3 +209,39 @@ extension ProfilePayload {
         anonymousId: "foo"
     )
 }
+
+extension CreateSubscriptionPayload {
+    static let test = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(email: "test@example.com", anonymousId: "anon-id")
+    )
+
+    static let testWithChannels = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(
+            email: "test@example.com",
+            phoneNumber: "+15005550006",
+            subscriptions: SubscriptionChannels(
+                email: EmailConsent(marketing: .subscribed, openTracking: .subscribed),
+                sms: MarketingTransactionalConsent(marketing: .subscribed, transactional: .subscribed),
+                whatsapp: MarketingTransactionalConsent(marketing: .subscribed, transactional: .subscribed)
+            ),
+            anonymousId: "anon-id"
+        ),
+        customSource: "unit-test"
+    )
+
+    /// A single sub-type on a single channel, to verify partial combinations serialize correctly:
+    /// the requested sub-type is present and every unrequested channel/sub-type is absent.
+    static let testWithPartialChannels = CreateSubscriptionPayload(
+        listId: "test-list-id",
+        profile: ProfilePayload(
+            email: "test@example.com",
+            phoneNumber: "+15005550006",
+            subscriptions: SubscriptionChannels(
+                sms: MarketingTransactionalConsent(marketing: .subscribed)
+            ),
+            anonymousId: "anon-id"
+        )
+    )
+}

--- a/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoModelsTest.swift
@@ -7,6 +7,7 @@
 
 @testable import KlaviyoSwift
 import Foundation
+import KlaviyoCore
 import XCTest
 
 class KlaviyoModelsTest: XCTestCase {
@@ -30,7 +31,7 @@ class KlaviyoModelsTest: XCTestCase {
             properties: ["order amount": "a lot of money"]
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(anonymousId: anonymousId)
+        let apiProfile = ProfilePayload(profile, anonymousId: anonymousId)
 
         XCTAssertEqual(apiProfile.attributes.email, profile.email)
         XCTAssertEqual(apiProfile.attributes.phoneNumber, profile.phoneNumber)
@@ -59,7 +60,8 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
+        let apiProfile = ProfilePayload(
+            profile,
             email: "walter.white@breakingbad.com",
             phoneNumber: "1800-better-call-saul",
             externalId: "999",
@@ -85,8 +87,10 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
-            anonymousId: anonymousId)
+        let apiProfile = ProfilePayload(
+            profile,
+            anonymousId: anonymousId
+        )
 
         XCTAssertNil(apiProfile.attributes.email)
         XCTAssertNil(apiProfile.attributes.phoneNumber)
@@ -105,7 +109,8 @@ class KlaviyoModelsTest: XCTestCase {
             lastName: "White"
         )
         let anonymousId = "C10H15N"
-        let apiProfile = profile.toAPIModel(
+        let apiProfile = ProfilePayload(
+            profile,
             email: "test@blob.com    ",
             phoneNumber: "+12345678901    ",
             externalId: "a       ",

--- a/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoStateTests.swift
@@ -131,7 +131,7 @@ final class KlaviyoStateTests: XCTestCase {
         let eventRequest = KlaviyoRequest(endpoint: .createEvent("foo", createEventPayload))
 
         let profile = Profile.test
-        let payload = CreateProfilePayload(data: profile.toAPIModel(anonymousId: "foo"))
+        let payload = CreateProfilePayload(data: ProfilePayload(profile, anonymousId: "foo"))
 
         let profileRequest = KlaviyoRequest(endpoint: .createProfile("foo", payload))
         let tokenPayload = PushTokenPayload(

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -634,8 +634,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )
@@ -664,7 +666,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.enqueueProfile(profile)) {
             // No reset (same email), so anonymousId unchanged
             // A createProfile request should be enqueued with the updated attributes
-            let profilePayload = profile.toAPIModel(
+            let profilePayload = ProfilePayload(
+                profile,
                 email: $0.email,
                 phoneNumber: $0.phoneNumber,
                 externalId: $0.externalId,
@@ -711,8 +714,10 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "different@email.com", phoneNumber: "+15555555555")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "different@email.com", phoneNumber: "+15555555555"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )
@@ -758,7 +763,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: profile.toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(profile, anonymousId: $0.anonymousId!)
                     )
                 )
             )
@@ -803,8 +808,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile()
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(Profile(), anonymousId: $0.anonymousId!)
                     )
                 )
             )

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -802,4 +802,275 @@ class StateManagementTests: XCTestCase {
             $0.flushing = false
         }
     }
+
+    // MARK: - enqueueSubscription
+
+    @MainActor
+    func testEnqueueSubscription() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionWithChannels() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription(
+            listId: "list-123",
+            channels: .init(email: .marketing, sms: .marketing)
+        )
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(
+                email: "test@example.com",
+                phoneNumber: "+15005550006",
+                subscriptions: SubscriptionChannels(
+                    email: EmailConsent(marketing: .subscribed),
+                    sms: MarketingTransactionalConsent(marketing: .subscribed)
+                ),
+                anonymousId: anonymousId
+            )
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    /// Overrides `environment.emitDeveloperWarning` with an expectation that fulfills only when a
+    /// warning containing `fragment` fires, pinning down which guard in enqueueSubscription was taken.
+    @MainActor
+    private func expectSubscriptionWarning(
+        containing fragment: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "developer warning containing: \(fragment)")
+        environment.emitDeveloperWarning = { message in
+            XCTAssertTrue(
+                message.contains(fragment),
+                "expected warning containing \"\(fragment)\" but got \"\(message)\"",
+                file: file,
+                line: line
+            )
+            expectation.fulfill()
+        }
+        return expectation
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionWhenInitializingReplaysAfterCompleteInitialization() async throws {
+        var initialState = INITILIZING_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.subscription(subscription)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS) {
+            $0.enqueueRequest(request: request)
+        }
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionMissingIdentifiersDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "at least one identifier")
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription.allAvailableMarketing(listId: "list-123")))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPendingSetEmailBeforeSubscriptionSucceedsOnReplay() async throws {
+        let initialState = INITILIZING_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        let email = "test@example.com"
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+
+        var stateWithEmail = initialState
+        stateWithEmail.email = email
+        let profileRequest = stateWithEmail.buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
+        let subscriptionPayload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: email, anonymousId: anonymousId)
+        )
+        let subscriptionRequest = KlaviyoRequest(
+            endpoint: .createSubscription(apiKey, subscriptionPayload)
+        )
+
+        await store.send(.setEmail(email)) {
+            $0.pendingRequests = [.setEmail(email)]
+        }
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.setEmail(email), .subscription(subscription)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        await store.receive(.setEmail(email), timeout: TIMEOUT_NANOSECONDS) {
+            $0.email = email
+            $0.enqueueRequest(request: profileRequest)
+        }
+
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS) {
+            $0.enqueueRequest(request: subscriptionRequest)
+        }
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPendingSubscriptionBeforeSetEmailDropsSubscriptionOnReplay() async throws {
+        let expectation = expectSubscriptionWarning(containing: "at least one identifier")
+        let initialState = INITILIZING_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        let email = "test@example.com"
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+
+        var stateWithEmail = initialState
+        stateWithEmail.email = email
+        let profileRequest = stateWithEmail.buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.pendingRequests = [.subscription(subscription)]
+        }
+        await store.send(.setEmail(email)) {
+            $0.pendingRequests = [.subscription(subscription), .setEmail(email)]
+        }
+
+        await store.send(.completeInitialization(initialState)) {
+            $0.pendingRequests = []
+            $0.initalizationState = .initialized
+        }
+
+        // FIFO: subscription replays before setEmail, so identifier validation fails.
+        await store.receive(.enqueueSubscription(subscription), timeout: TIMEOUT_NANOSECONDS)
+        await fulfillment(of: [expectation])
+
+        await store.receive(.setEmail(email), timeout: TIMEOUT_NANOSECONDS) {
+            $0.email = email
+            $0.enqueueRequest(request: profileRequest)
+        }
+
+        XCTAssertFalse(
+            store.state.queue.contains { request in
+                if case .createSubscription = request.endpoint { return true }
+                return false
+            }
+        )
+
+        await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
+        await store.receive(.setBadgeCount(0))
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionAllAvailableMarketingWithPhoneOnly() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        let subscription = Subscription.allAvailableMarketing(listId: "list-123")
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(phoneNumber: "+15005550006", anonymousId: anonymousId)
+        )
+        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+
+        await store.send(.enqueueSubscription(subscription)) {
+            $0.enqueueRequest(request: request)
+        }
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionEmptyChannelsDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "none were enabled")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init())))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionEmailChannelWithoutEmailDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "requires an email")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "+15005550006"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init(email: .marketing))))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
+
+    @MainActor
+    func testEnqueueSubscriptionPhoneChannelWithoutPhoneDoesNotEnqueue() async throws {
+        let expectation = expectSubscriptionWarning(containing: "requires a phone number")
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "test@example.com"
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        await store.send(.enqueueSubscription(Subscription(listId: "list-123", channels: .init(sms: .marketing))))
+        await fulfillment(of: [expectation])
+        XCTAssertTrue(store.state.queue.isEmpty)
+    }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -808,6 +808,17 @@ class StateManagementTests: XCTestCase {
 
     // MARK: - enqueueSubscription
 
+    /// Builds the `KlaviyoRequest` a subscription enqueue is expected to produce.
+    private func expectedSubscriptionRequest(
+        apiKey: String,
+        listId: String = "list-123",
+        profile: ProfilePayload
+    ) -> KlaviyoRequest {
+        KlaviyoRequest(
+            endpoint: .createSubscription(apiKey, CreateSubscriptionPayload(listId: listId, profile: profile))
+        )
+    }
+
     @MainActor
     func testEnqueueSubscription() async throws {
         var initialState = INITIALIZED_TEST_STATE()
@@ -817,11 +828,10 @@ class StateManagementTests: XCTestCase {
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
         let subscription = Subscription.allAvailableMarketing(listId: "list-123")
-        let payload = CreateSubscriptionPayload(
-            listId: "list-123",
+        let request = expectedSubscriptionRequest(
+            apiKey: apiKey,
             profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
         )
-        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
 
         await store.send(.enqueueSubscription(subscription)) {
             $0.enqueueRequest(request: request)
@@ -841,8 +851,8 @@ class StateManagementTests: XCTestCase {
             listId: "list-123",
             channels: .init(email: .marketing, sms: .marketing)
         )
-        let payload = CreateSubscriptionPayload(
-            listId: "list-123",
+        let request = expectedSubscriptionRequest(
+            apiKey: apiKey,
             profile: ProfilePayload(
                 email: "test@example.com",
                 phoneNumber: "+15005550006",
@@ -853,7 +863,6 @@ class StateManagementTests: XCTestCase {
                 anonymousId: anonymousId
             )
         )
-        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
 
         await store.send(.enqueueSubscription(subscription)) {
             $0.enqueueRequest(request: request)
@@ -890,11 +899,10 @@ class StateManagementTests: XCTestCase {
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
         let subscription = Subscription.allAvailableMarketing(listId: "list-123")
-        let payload = CreateSubscriptionPayload(
-            listId: "list-123",
+        let request = expectedSubscriptionRequest(
+            apiKey: apiKey,
             profile: ProfilePayload(email: "test@example.com", anonymousId: anonymousId)
         )
-        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
 
         await store.send(.enqueueSubscription(subscription)) {
             $0.pendingRequests = [.subscription(subscription)]
@@ -912,7 +920,6 @@ class StateManagementTests: XCTestCase {
         await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
-        await store.receive(.setBadgeCount(0))
     }
 
     @MainActor
@@ -938,12 +945,9 @@ class StateManagementTests: XCTestCase {
         var stateWithEmail = initialState
         stateWithEmail.email = email
         let profileRequest = stateWithEmail.buildProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
-        let subscriptionPayload = CreateSubscriptionPayload(
-            listId: "list-123",
+        let subscriptionRequest = expectedSubscriptionRequest(
+            apiKey: apiKey,
             profile: ProfilePayload(email: email, anonymousId: anonymousId)
-        )
-        let subscriptionRequest = KlaviyoRequest(
-            endpoint: .createSubscription(apiKey, subscriptionPayload)
         )
 
         await store.send(.setEmail(email)) {
@@ -970,7 +974,6 @@ class StateManagementTests: XCTestCase {
         await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
-        await store.receive(.setBadgeCount(0))
     }
 
     @MainActor
@@ -1018,7 +1021,6 @@ class StateManagementTests: XCTestCase {
         await store.receive(.start, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.flushQueue, timeout: TIMEOUT_NANOSECONDS)
         await store.receive(.setPushEnablement(PushEnablement.authorized), timeout: TIMEOUT_NANOSECONDS)
-        await store.receive(.setBadgeCount(0))
     }
 
     @MainActor
@@ -1030,11 +1032,10 @@ class StateManagementTests: XCTestCase {
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
         let subscription = Subscription.allAvailableMarketing(listId: "list-123")
-        let payload = CreateSubscriptionPayload(
-            listId: "list-123",
+        let request = expectedSubscriptionRequest(
+            apiKey: apiKey,
             profile: ProfilePayload(phoneNumber: "+15005550006", anonymousId: anonymousId)
         )
-        let request = KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
 
         await store.send(.enqueueSubscription(subscription)) {
             $0.enqueueRequest(request: request)

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -565,7 +565,8 @@ class StateManagementTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile.test.toAPIModel(
+                        profile: ProfilePayload(
+                            Profile.test,
                             anonymousId: initialState.anonymousId!
                         )
                     )
@@ -593,8 +594,10 @@ class StateManagementTests: XCTestCase {
                         pushToken: initialState.pushTokenData!.pushToken,
                         enablement: initialState.pushTokenData!.pushEnablement.rawValue,
                         background: initialState.pushTokenData!.pushBackground.rawValue,
-                        profile: Profile(email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg")
-                            .toAPIModel(anonymousId: $0.anonymousId!)
+                        profile: ProfilePayload(
+                            Profile(email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg"),
+                            anonymousId: $0.anonymousId!
+                        )
                     )
                 )
             )


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Adds a public KlaviyoSDK.create(subscription:) API that enqueues POST /client/subscriptions so integrators can subscribe the current profile to a list with optional per-channel consent (email / SMS / WhatsApp) and an optional customSource.

A subscription that's missing identifiers at replay time is dropped with a developer warning rather than re-buffered.

Implementation of BSUID for the whatsapp channel is not yet implemented, waiting on that to be added to the current API revision.

See API docs:
https://developers.klaviyo.com/en/reference/create_client_subscription

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.


## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Public `Subscription` model + `KlaviyoSDK.create(subscription:)`
- `KlaviyoEndpoint.createSubscription` → `/client/subscriptions` with JSON:API list relationship and nested profile `subscriptions` consent
- Reuses `ProfilePayload` for the embedded profile; channel consent lives in `SubscriptionChannels`
- Validates identifiers against requested channels; buffers requests while initializing (same pattern as events/profiles)
- Warns and drops empty explicit channel configs so they are not collapsed into API default MARKETING consent
- Push marketing via `subscriptions.push` intentionally out of scope (existing `set(pushToken:)` path)

## Test Plan
- [x] `KlaviyoEndpointTests` — URL, revision, wire shape with/without channels (nil `subscriptions` omitted)
- [x] `StateManagementTests` — enqueue happy path, channels, init buffering, missing identifiers, empty channels
- [x] Manual: initialize SDK, set email/phone, call `create(subscription:)`, confirm 202 from `/client/subscriptions` in proxy/logs


## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating email, SMS, and WhatsApp marketing subscriptions with optional channel-specific consent and custom source details.
  * Added a subscription API to the SDK, including queuing, initialization handling, identifier validation, and retry support.
  * Added an optional marketing opt-in toggle to the example app’s login flow.

* **Documentation**
  * Added guidance for creating list subscriptions, supported consent types, prerequisites, and push notification behavior.

* **Bug Fixes**
  * Improved profile payload construction and identifier trimming consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->