### PR TITLE
fix(KlaviyoSwift): use named tuple access in SharedStoreMirror sink closure

### DIFF
--- a/Sources/KlaviyoSwift/SharedStoreMirror.swift
+++ b/Sources/KlaviyoSwift/SharedStoreMirror.swift
@@ -23,9 +23,9 @@ enum SharedStoreMirror {
             // TCA dispatches state changes on the main thread, so the two writes are observed
             // together. Write config before identity: IdentityStore.update(_:) notifies observers
             // synchronously, so an identity observer must not see a stale apiKey.
-            .sink { identity, apiKey in
-                SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
-                IdentityStore.shared.update(identity)
+            .sink { result in
+                SDKConfigStore.shared.update(KlaviyoConfig(apiKey: result.apiKey))
+                IdentityStore.shared.update(result.identity)
             }
     }
 


### PR DESCRIPTION
# Description
Fixes a compilation failure in the Flutter and Expo example apps caused by tuple destructuring in the `SharedStoreMirror` sink closure. The fix switches from destructured tuple parameters to accessing named properties via a single result variable.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
**Changed:** `SharedStoreMirror.setup()` — replaced tuple destructuring in the `.sink` closure:

```swift
// Before (caused compilation failure in Flutter/Expo)
.sink { identity, apiKey in
    SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
    IdentityStore.shared.update(identity)
}

// After
.sink { result in
    SDKConfigStore.shared.update(KlaviyoConfig(apiKey: result.apiKey))
    IdentityStore.shared.update(result.identity)
}
```

The preceding `.map` already produces a named tuple `(identity:, apiKey:)`, so switching to explicit property access resolves the ambiguity the Swift compiler hit in the example app build environments.

## Test Plan
1. Build the Flutter example app — confirm it compiles without error.
2. Build the Expo example app — confirm it compiles without error.
3. Run the KlaviyoSwift test suite: `make test-library`

## Related Issues/Tickets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of identity and API key updates.
  * Ensured SDK configuration and identity information continue updating in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->