### PR TITLE
fix(KlaviyoSwiftExtension): keep action buttons when the open_url link is unusable (PUSH-1085)

### DIFF
--- a/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
+++ b/Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift
@@ -39,6 +39,15 @@ enum KlaviyoActionButtonParser {
 
     /// Parses action button definitions from a push notification payload.
     ///
+    /// A button is renderable when it has an `id`, a `label`, and a recognized `action` —
+    /// nothing more. A problem with its `url` degrades the button's *action*, not the button
+    /// itself: the tap falls through to the `.foreground` option and opens the app. Dropping
+    /// the button instead would silently discard what the sender configured, and would take
+    /// every other button on the notification with it whenever no button survives.
+    ///
+    /// The `open_url` scheme allowlist is therefore enforced at dispatch time, in
+    /// `KlaviyoSDK.handleActionButtonTap`, and not here.
+    ///
     /// - Parameter userInfo: The notification's userInfo dictionary
     /// - Returns: Array of parsed button definitions, or nil if none found
     static func parseActionButtons(from userInfo: [AnyHashable: Any]) -> [ActionButtonDefinition]? {
@@ -68,12 +77,14 @@ enum KlaviyoActionButtonParser {
 
             let url = buttonData["url"] as? String
 
-            // Validate action-url combinations
-            guard isValidActionURLCombination(action: action, url: url) else {
-                if #available(iOS 14.0, *) {
-                    Logger.actionButtons.warning("Button url is incompatible with its action. Skipping button: \(buttonData.description)")
-                }
-                continue
+            // Surface url/action mismatches without dropping the button — the tap will
+            // fall through to opening the app rather than resolving the intended action.
+            // `issue` embeds the sender-configured url, so it is marked private to match the
+            // equivalent `web_url` rejection warning in `UNNotificationResponse.klaviyoWebUrl`.
+            if let issue = urlIssue(for: action, url: url), #available(iOS 14.0, *) {
+                Logger.actionButtons.warning(
+                    "Button '\(id, privacy: .public)' will only open the app: \(issue, privacy: .private)"
+                )
             }
 
             definitions.append(ActionButtonDefinition(
@@ -104,28 +115,34 @@ enum KlaviyoActionButtonParser {
 
     // MARK: - Private Methods
 
-    /// Validates that an action type has the correct URL configuration.
+    /// Describes why `url` cannot satisfy `action`, or `nil` when the pairing is usable.
     ///
-    /// - `.openApp` actions should not have a URL
-    /// - `.deepLink` actions must have a parseable URL
-    /// - `.openUrl` actions must have a parseable URL whose scheme is in ``openUrlAllowedSchemes`` —
-    ///   unlisted schemes (e.g. `javascript:`, `file:`, `intent:`) are rejected silently
+    /// Purely diagnostic — this never decides whether a button renders. See the discussion in
+    /// ``parseActionButtons(from:)``.
     ///
     /// - Parameters:
-    ///   - action: The action type to validate
+    ///   - action: The button's action type
     ///   - url: The optional URL string
-    /// - Returns: `true` if the combination is valid, `false` otherwise
-    private static func isValidActionURLCombination(action: ActionType, url: String?) -> Bool {
+    /// - Returns: A message explaining the mismatch, or `nil` if there is none
+    private static func urlIssue(for action: ActionType, url: String?) -> String? {
         switch action {
         case .openApp:
-            return url == nil
+            return url == nil ? nil : "open_app buttons ignore the 'url' field"
         case .deepLink:
-            guard let urlString = url else { return false }
-            return URL(string: urlString) != nil
+            guard let urlString = url else { return "deep_link buttons require a 'url'" }
+            return URL(string: urlString) == nil ? "'\(urlString)' is not a parseable URL" : nil
         case .openUrl:
-            guard let urlString = url, let parsedUrl = URL(string: urlString) else { return false }
-            guard let scheme = parsedUrl.scheme?.lowercased() else { return false }
-            return openUrlAllowedSchemes.contains(scheme)
+            guard let urlString = url else { return "open_url buttons require a 'url'" }
+            guard let parsedUrl = URL(string: urlString) else {
+                return "'\(urlString)' is not a parseable URL"
+            }
+            guard let scheme = parsedUrl.scheme?.lowercased() else {
+                return "'\(urlString)' has no scheme; open_url needs a complete URL"
+            }
+            guard openUrlAllowedSchemes.contains(scheme) else {
+                return "scheme '\(scheme)' is not in the allowed list \(openUrlAllowedSchemes.sorted())"
+            }
+            return nil
         }
     }
 

--- a/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
+++ b/Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift
@@ -184,7 +184,7 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertNil(result, "Should return nil when all buttons are invalid")
     }
 
-    func testParseActionButtons_SkipsOpenAppWithURL() {
+    func testParseActionButtons_RendersOpenAppWithStrayURL() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -193,7 +193,7 @@ class KlaviyoActionButtonParserTests: XCTestCase {
                         "id": "com.klaviyo.test.openapp_with_url",
                         "label": "Open App",
                         "action": "open_app",
-                        "url": "myapp://invalid" // openApp should not have URL
+                        "url": "myapp://invalid" // openApp ignores the url field
                     ],
                     [
                         "id": "com.klaviyo.test.valid",
@@ -207,12 +207,11 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertNotNil(result, "Should return valid buttons")
-        XCTAssertEqual(result?.count, 1, "Should skip openApp button with URL")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid", "Should return only valid button")
+        XCTAssertEqual(result?.count, 2, "A stray url on open_app must not delete the button")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.openapp_with_url")
     }
 
-    func testParseActionButtons_SkipsDeepLinkWithoutURL() {
+    func testParseActionButtons_RendersDeepLinkWithoutURL() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -221,13 +220,12 @@ class KlaviyoActionButtonParserTests: XCTestCase {
                         "id": "com.klaviyo.test.deeplink_without_url",
                         "label": "Deep Link",
                         "action": "deep_link"
-                        // Missing URL - deepLink should have URL
+                        // Missing URL — the tap falls through to opening the app
                     ],
                     [
                         "id": "com.klaviyo.test.valid",
                         "label": "Valid Button",
                         "action": "open_app"
-                        // No URL for openApp is valid
                     ]
                 ]
             ]
@@ -235,9 +233,9 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertNotNil(result, "Should return valid buttons")
-        XCTAssertEqual(result?.count, 1, "Should skip deepLink button without URL")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid", "Should return only valid button")
+        XCTAssertEqual(result?.count, 2, "A missing deep_link url must not delete the button")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.deeplink_without_url")
+        XCTAssertNil(result?.first?.url)
     }
 
     // MARK: - Valid Button Tests
@@ -301,7 +299,36 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertEqual(result?.first?.url, "https://example.com/sale")
     }
 
-    func testParseActionButtons_SkipsOpenUrlWithoutURL() {
+    // MARK: - Render eligibility is independent of URL validity
+
+    /// A URL the SDK cannot open must not delete the button the marketer configured.
+    /// `URL(string: "www.cnn.com")` parses but has a nil scheme, so the allowlist check
+    /// used to reject it and — when it was the only button — the notification rendered
+    /// with no buttons at all.
+    func testParseActionButtons_RendersOpenUrlButtonWithSchemelessURL() {
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": {},
+                "action_buttons": [
+                    [
+                        "id": "com.klaviyo.test.schemeless",
+                        "label": "Read More",
+                        "action": "open_url",
+                        "url": "www.cnn.com"
+                    ]
+                ]
+            ]
+        ]
+
+        let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
+
+        XCTAssertEqual(result?.count, 1, "A scheme-less URL must not delete the button")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.schemeless")
+        XCTAssertEqual(result?.first?.label, "Read More")
+        XCTAssertEqual(result?.first?.url, "www.cnn.com", "The raw URL is preserved, not normalized")
+    }
+
+    func testParseActionButtons_RendersOpenUrlWithoutURL() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -310,7 +337,7 @@ class KlaviyoActionButtonParserTests: XCTestCase {
                         "id": "com.klaviyo.test.openurl_no_url",
                         "label": "Visit Site",
                         "action": "open_url"
-                        // Missing URL - open_url must have URL
+                        // Missing URL — the tap falls through to opening the app
                     ],
                     [
                         "id": "com.klaviyo.test.valid",
@@ -324,13 +351,14 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertNotNil(result, "Should return valid buttons")
-        XCTAssertEqual(result?.count, 1, "Should skip open_url button without URL")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+        XCTAssertEqual(result?.count, 2, "A missing open_url url must not delete the button")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.openurl_no_url")
     }
 
-    func testParseActionButtons_SkipsOpenUrlWithBlockedScheme() {
-        // Custom app schemes and other non-allowlisted schemes must be rejected.
+    /// A blocked scheme must still render the button — the allowlist is enforced at dispatch
+    /// time, so the tap opens the app instead of the URL. See
+    /// `KlaviyoSDKTests.testHandleActionButtonTap_OpenUrlButtonWithBlockedSchemeDoesNotDispatch`.
+    func testParseActionButtons_RendersOpenUrlWithBlockedScheme() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -353,9 +381,8 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertNotNil(result, "Should return valid buttons")
-        XCTAssertEqual(result?.count, 1, "Should skip open_url buttons with blocked schemes")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+        XCTAssertEqual(result?.count, 2, "A blocked scheme must not delete the button")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.openurl_custom_scheme")
     }
 
     // MARK: - Allowlisted non-web open_url schemes
@@ -428,7 +455,7 @@ class KlaviyoActionButtonParserTests: XCTestCase {
         XCTAssertEqual(result?.first?.id, "com.klaviyo.test.sms")
     }
 
-    func testParseActionButtons_SkipsOpenUrlWithIntentScheme() {
+    func testParseActionButtons_RendersOpenUrlWithIntentScheme() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -451,11 +478,11 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertEqual(result?.count, 1, "intent: should be blocked")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+        XCTAssertEqual(result?.count, 2, "intent: is blocked at dispatch time, not at render time")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.intent")
     }
 
-    func testParseActionButtons_SkipsOpenUrlWithJavascriptScheme() {
+    func testParseActionButtons_RendersOpenUrlWithJavascriptScheme() {
         let userInfo: [AnyHashable: Any] = [
             "body": [
                 "_k": {},
@@ -478,8 +505,8 @@ class KlaviyoActionButtonParserTests: XCTestCase {
 
         let result = KlaviyoActionButtonParser.parseActionButtons(from: userInfo)
 
-        XCTAssertEqual(result?.count, 1, "javascript: should be blocked")
-        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.valid")
+        XCTAssertEqual(result?.count, 2, "javascript: is blocked at dispatch time, not at render time")
+        XCTAssertEqual(result?.first?.id, "com.klaviyo.test.js")
     }
 
     func testParseActionButtons_AllowsDeepLinkWithHttpScheme() {

--- a/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift
@@ -906,4 +906,67 @@ class KlaviyoSDKTests: XCTestCase {
         }
         XCTAssertNotNil(eventAction, "Tap should still be tracked even when the scheme is blocked")
     }
+
+    /// A scheme-less `open_url` (e.g. `www.cnn.com`) now renders a tappable button, so the
+    /// dispatch path must be the thing that refuses it: the tap is tracked, the app comes to
+    /// the foreground, and nothing is handed to the external URL opener.
+    func testHandleActionButtonTap_OpenUrlButtonWithSchemelessURLDoesNotDispatch() throws {
+        let callback = XCTestExpectation(description: "callback is made")
+        let urlString = "www.cnn.com"
+        let actionId = "com.klaviyo.test.schemeless"
+
+        let userInfo: [AnyHashable: Any] = [
+            "body": [
+                "_k": "test_open_url_schemeless",
+                "action_buttons": [
+                    [
+                        "id": actionId,
+                        "label": "Read More",
+                        "action": "open_url",
+                        "url": urlString
+                    ]
+                ]
+            ]
+        ]
+
+        var capturedActions: [KlaviyoAction] = []
+        let eventDispatched = XCTestExpectation(description: "event action dispatched")
+        klaviyoSwiftEnvironment.send = { action in
+            capturedActions.append(action)
+            if case .enqueueEvent = action { eventDispatched.fulfill() }
+            return nil
+        }
+        let externalUrlNotInvoked = XCTestExpectation(
+            description: "openExternalURL must not be invoked for a scheme-less URL"
+        )
+        externalUrlNotInvoked.isInverted = true
+        DeepLinkManager.openExternalURLSpy = { _ in externalUrlNotInvoked.fulfill() }
+
+        let response = try UNNotificationResponse.with(
+            userInfo: userInfo,
+            actionIdentifier: actionId
+        )
+
+        let handled = klaviyo.handle(notificationResponse: response) {
+            callback.fulfill()
+        }
+
+        wait(for: [callback, eventDispatched], timeout: 1.0)
+        wait(for: [externalUrlNotInvoked], timeout: 0.3)
+        XCTAssertTrue(handled)
+
+        let eventAction = capturedActions.first { action in
+            if case let .enqueueEvent(event) = action {
+                return event.metric.name == ._openedPush
+            }
+            return false
+        }
+        XCTAssertNotNil(eventAction, "Tap should still be tracked even when the URL has no scheme")
+        if case let .enqueueEvent(event) = try XCTUnwrap(eventAction) {
+            XCTAssertEqual(
+                event.properties["Button Link"] as? String, urlString,
+                "The raw URL is still reported for analytics"
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Description
An `Open External URL` action button configured with a scheme-less link (e.g. `www.cnn.com`) rendered **no action buttons at all** on iOS. The `open_url` scheme allowlist was being used as a render-time eligibility gate; it now only gates dispatch, so a bad URL degrades the button's action instead of deleting the button.

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

> **Not yet verified on-device, and the XCTest suite has not been executed locally** — see Test Plan. Please treat CI as the first real run of these tests.
>
> iOS 13 compatibility: the new diagnostic is inside `#available(iOS 14.0, *)` (matching the existing `Logger` usage in this file). On iOS 13 the button still renders identically; only the log line is skipped.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No `public` or `package` declarations changed — everything is internal to `KlaviyoSwiftExtension`. `ActionType` and `URLSchemeAllowlist` (both mirrors) are untouched, so `URLSchemeAllowlistParityTests` still holds.

## Changelog / Code Overview

### Root cause
`URL(string: "www.cnn.com")` parses successfully but its `scheme` is `nil` — the whole string becomes a relative path. In `KlaviyoActionButtonParser.isValidActionURLCombination`, the `.openUrl` arm required a scheme in `openUrlAllowedSchemes`, so the button definition was `continue`'d away. With one button configured, `parseActionButtons` returned `nil`, and `KlaviyoExtension.handleActionButtons` returned early **before** setting `bestAttemptContent.categoryIdentifier` — no category, no buttons.

The deeper issue is a layering mistake: a **dispatch-time security gate was doing render-time eligibility work**. `createAction(from:)` never reads the URL — the `UNNotificationAction` is just `id` + `label` + `.foreground` — and the allowlist is already enforced at tap time in `KlaviyoSDK.handleActionButtonTap` / `UNNotificationResponse.klaviyoWebUrl`. So the render-time check bought no safety; its only observable effect was deleting the sender's button.

It was also inconsistent: a **body tap** with a bad `web_url` already degrades gracefully (`klaviyoWebUrl` returns `nil`, the app opens), while an **action button** with a bad url vanished.

### The change
`Sources/KlaviyoSwiftExtension/KlaviyoActionButtonParser.swift`

Establishes **render eligibility ≠ action validity**: a button renders iff it has `id`, `label`, and a recognized `action`. URL problems degrade the *action* — the tap falls through to `.foreground` and opens the app — and are logged with a specific reason.

- `isValidActionURLCombination(action:url:) -> Bool` → `urlIssue(for:url:) -> String?`, diagnostic-only, never gating.
- Applies to every URL-shaped case, not just `open_url`: `deep_link` missing url and `open_app` with a stray url also no longer delete the button. Structural problems (missing `id`/`label`, unrecognized `action`) still do.
- The log marks the url `privacy: .private`, matching the equivalent `web_url` rejection warning in `UNNotificationResponse.klaviyoWebUrl`.

**Unchanged, deliberately:** the allowlist contents, `handleActionButtonTap`, and `klaviyoWebUrl`. Blocked schemes (`javascript:`, `file:`, `intent:`, `smsto:`) are still never opened — they now render a button that opens the app.

### Why URLs are not normalized to `https://`
Fender's validation for this (klaviyo/fender#66002) **blocks** scheme-less input rather than normalizing — *"Enter a complete URL beginning with https://, http://, mailto:, tel:, or sms:."* Normalizing in the SDK would contradict that contract, and doing it on iOS only would diverge from Android. That fender fix is also editor-only — it explicitly notes API-created messages bypass validation entirely — which is exactly why the SDK still has to degrade gracefully rather than assume input is clean.

## Test Plan

### Automated
`Tests/KlaviyoSwiftExtensionTests/KlaviyoActionButtonParserTests.swift`
- **New:** `testParseActionButtons_RendersOpenUrlButtonWithSchemelessURL` — the exact ticket repro; also asserts the url is preserved verbatim, pinning the no-normalization decision.
- **Flipped (6)** — these pinned the bug and are renamed `Skips…` → `Renders…`: `OpenAppWithStrayURL`, `DeepLinkWithoutURL`, `OpenUrlWithoutURL`, `OpenUrlWithBlockedScheme`, `OpenUrlWithIntentScheme`, `OpenUrlWithJavascriptScheme`.
- Untouched: structural-skip tests and the allowlisted-scheme tests (`mailto:`/`tel:`/`sms:`).

`Tests/KlaviyoSwiftTests/KlaviyoSDKTests.swift`
- **New:** `testHandleActionButtonTap_OpenUrlButtonWithSchemelessURLDoesNotDispatch` — since the button now renders and is tappable, this proves the tap is tracked, `Button Link` still reports the raw url, and `openExternalURL` is **never** invoked (inverted expectation).

### ⚠️ What was *not* run
**`xcodebuild` could not run:** the dev machine has Command Line Tools only, no Xcode, and this package is iOS-only. **The XCTest files above have never been compiled or executed** — CI is their first run.

To get real red/green evidence anyway, I compiled a macOS harness against the **actual production sources** (`KlaviyoActionButtonParser` + `ActionType` + `URLSchemeAllowlist` + `Logger+Ext`) mirroring the XCTest assertions: **7 failures → 21/21 pass**. The initial failure was `got nil` — the reported bug reproduced exactly (the whole button set vanishing).

| Gate | Result |
|---|---|
| SwiftFormat (repo-pinned 0.51.2, via pre-commit) | **Passed** |
| SwiftLint `--strict` | Violation set **identical to baseline**; only pre-existing `file_length`/`type_body_length` counters on `KlaviyoSDKTests.swift` grow |
| macOS harness over production parser | **21/21** (from 7 failures) |
| XCTest suite | **Not run — no Xcode locally** |

### Manual repro (for the reviewer / QA)
1. Push with an action button, action = **Open External URL**, url = `www.cnn.com`.
2. Send preview, expand the notification.
   - **Before:** no buttons at all. **After:** the button renders.
3. Tap it → the app opens (CNN is not opened; the url is refused at dispatch). Console shows `Button '<id>' will only open the app: '<url>' has no scheme; open_url needs a complete URL`.
4. Regression: `https://www.cnn.com` still opens Safari; `mailto:`/`tel:`/`sms:` still work; `javascript:alert(1)` renders a button that only opens the app.

### Note for reviewers
`.swiftlint.yml` sets `included: - Source`, but the source directory is `Sources` — so `swiftlint` currently lints **zero files** in this repo, which is why so much existing code violates `line_length: 110`. Pre-existing and out of scope here, but probably worth its own ticket.

## Related Issues/Tickets
- Related to PUSH-1085
- Android counterpart: Related to PUSH-1095 (klaviyo/klaviyo-android-sdk)
- Sender-side validation: klaviyo/fender#66002 (PUSH-1084)
