### PR TITLE
fix(state): avoid Int(infinity) trap in .flushQueue while offline [MAGE-1023]

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -285,8 +285,8 @@ struct KlaviyoReducer: ReducerProtocol {
             if state.flushing {
                 return .none
             }
-            // Offline parks `flushInterval` at `.infinity`, which the backoff below would trap
-            // converting to `Int`. No point draining the queue with no network anyway.
+            // The priority path can dispatch `.flushQueue` while offline, where `flushInterval` is
+            // `.infinity` — the backoff below would trap on `Int()`, and draining is pointless.
             guard state.flushInterval.isFinite else {
                 return .none
             }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -285,11 +285,8 @@ struct KlaviyoReducer: ReducerProtocol {
             if state.flushing {
                 return .none
             }
-            // Offline parks `flushInterval` at `.infinity` (see `.networkConnectivityChanged`),
-            // which also cancels the flush timer — but the priority path (opened push, geofence)
-            // dispatches `.flushQueue` unconditionally, so we can still land here while offline.
-            // Bail out: there is nothing to gain from draining the queue with no network, and it
-            // keeps a non-finite interval out of the `Int` conversion below, which would trap.
+            // Offline parks `flushInterval` at `.infinity`, which the backoff below would trap
+            // converting to `Int`. No point draining the queue with no network anyway.
             guard state.flushInterval.isFinite else {
                 return .none
             }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -285,6 +285,14 @@ struct KlaviyoReducer: ReducerProtocol {
             if state.flushing {
                 return .none
             }
+            // Offline parks `flushInterval` at `.infinity` (see `.networkConnectivityChanged`),
+            // which also cancels the flush timer — but the priority path (opened push, geofence)
+            // dispatches `.flushQueue` unconditionally, so we can still land here while offline.
+            // Bail out: there is nothing to gain from draining the queue with no network, and it
+            // keeps a non-finite interval out of the `Int` conversion below, which would trap.
+            guard state.flushInterval.isFinite else {
+                return .none
+            }
             if case let .retryWithBackoff(requestCount, totalCount, backOff) = state.retryState {
                 let newBackOff = max(backOff - Int(state.flushInterval), 0)
                 if newBackOff > 0 {

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -500,6 +500,32 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.flushQueue)
     }
 
+    @MainActor
+    func testFlushQueueWhileOfflineWithoutBackoffDoesNotDrainQueue() async {
+        // The guard sits above the backoff block, so it also stops the non-backoff `.retry` path —
+        // which never crashed, but draining while offline only burns attempts. Pins that half:
+        // the queue must stay put rather than moving into requestsInFlight.
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.retryState = .retry(1)
+        let request = initialState.buildProfileRequest(
+            apiKey: initialState.apiKey!,
+            anonymousId: initialState.anonymousId!
+        )
+        initialState.queue = [request]
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.networkConnectivityChanged(.notReachable)) {
+            $0.flushInterval = Double.infinity
+        }
+        _ = await store.receive(.cancelInFlightRequests) {
+            $0.flushing = false
+        }
+
+        // Queue is non-empty on purpose — with an empty queue `.flushQueue` returns early anyway
+        // and this test would pass with or without the guard.
+        _ = await store.send(.flushQueue)
+    }
+
     // MARK: - Missing api key for token request
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -474,6 +474,37 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.networkConnectivityChanged(.reachableViaWWAN))
     }
 
+    // MARK: - Flush queue while offline during retry backoff
+
+    @MainActor
+    func testFlushQueueWhileOfflineDuringBackoffDoesNotTrap() async {
+        // Going offline parks `flushInterval` at `.infinity` and cancels the flush timer — but the
+        // priority path (opened push / geofence) dispatches `.flushQueue` unconditionally, so we can
+        // still land in `.flushQueue` while offline. With `retryState` in backoff, the countdown
+        // computes `backOff - Int(state.flushInterval)`, and `Int(Double.infinity)` traps in Swift,
+        // taking down the host app. `.flushQueue` must no-op instead, leaving the backoff intact so
+        // it resumes when connectivity returns.
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.retryState = .retryWithBackoff(
+            requestCount: 1,
+            totalRetryCount: 1,
+            currentBackoff: 30
+        )
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.networkConnectivityChanged(.notReachable)) {
+            $0.flushInterval = Double.infinity
+        }
+        // Also clears `flushing`, so the `if state.flushing` bail-out below does NOT mask the
+        // conversion — without the guard this test reaches the trap.
+        _ = await store.receive(.cancelInFlightRequests) {
+            $0.flushing = false
+        }
+
+        // No state mutation and no follow-on effect: notably `retryState` keeps its backoff.
+        _ = await store.send(.flushQueue)
+    }
+
     // MARK: - Missing api key for token request
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -478,12 +478,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
     @MainActor
     func testFlushQueueWhileOfflineDuringBackoffDoesNotTrap() async {
-        // Going offline parks `flushInterval` at `.infinity` and cancels the flush timer — but the
-        // priority path (opened push / geofence) dispatches `.flushQueue` unconditionally, so we can
-        // still land in `.flushQueue` while offline. With `retryState` in backoff, the countdown
-        // computes `backOff - Int(state.flushInterval)`, and `Int(Double.infinity)` traps in Swift,
-        // taking down the host app. `.flushQueue` must no-op instead, leaving the backoff intact so
-        // it resumes when connectivity returns.
+        // Offline + backoff: the priority path can dispatch `.flushQueue` while `flushInterval` is
+        // `.infinity`, where the backoff countdown used to trap converting it to `Int`.
         var initialState = INITIALIZED_TEST_STATE()
         initialState.retryState = .retryWithBackoff(
             requestCount: 1,
@@ -495,8 +491,7 @@ class StateManagementEdgeCaseTests: XCTestCase {
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
         }
-        // Also clears `flushing`, so the `if state.flushing` bail-out below does NOT mask the
-        // conversion — without the guard this test reaches the trap.
+        // Also clears `flushing` — otherwise `.flushQueue` bails early and this test is vacuous.
         _ = await store.receive(.cancelInFlightRequests) {
             $0.flushing = false
         }


### PR DESCRIPTION
# Description

`Int(Double.infinity)` traps in Swift. `.flushQueue` could reach that conversion while the SDK was backing off with no connectivity, hard-crashing the host app (a `fatalError`-class precondition failure, not a catchable error). Guards `.flushQueue` on a finite flush interval. Closes MAGE-1023.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

No public API change; crash fix only. Targeting `rel/5.4.0`.

## Changelog / Code Overview

Three pre-existing pieces combined into a crash:

1. `.networkConnectivityChanged(.notReachable)` parks `state.flushInterval` at `Double.infinity` and cancels the flush timer.
2. `.flushQueue`'s backoff countdown computes `max(backOff - Int(state.flushInterval), 0)` — `Int(.infinity)` traps.
3. The priority path (opened push / geofence) dispatches `.flushQueue` **unconditionally**, so the cancelled timer doesn't save us. `.flushQueue`'s existing guards don't stop it either: `.initialized` passes, and `state.flushing` is `false` because `.requestFailed` cleared it.

The fix bails out of `.flushQueue` when `flushInterval` isn't finite:

```swift
guard state.flushInterval.isFinite else {
    return .none
}
```

Chosen over `Int(clamping:)` because it's the more correct semantic — there's no point draining a queue with no network, and clamping would let the retry proceed offline, burning attempts on requests that cannot succeed. It also keeps any *future* arithmetic on `flushInterval` safe, and `isFinite` covers NaN as well as infinity. The backoff is left untouched, so it resumes when connectivity returns.

**Not a 5.4.0 regression** — all three pieces exist unchanged on `master`. What this release changes is how *reachable* precondition 1 is: the retryable set went from `[429, 500, 502, 503, 504]` to 429 plus all of 500–599, and edge failures during an incident correlate strongly with degraded client connectivity. So the scenario the RCA work targeted also arms this crash. `master` picks this up automatically via the standard release merge-forward when `rel/5.4.0` lands — `rel/*` is always merged back, so no separate port is needed.

### Two deliberate side effects of the guard's placement

It sits above the `retryWithBackoff` block, so it stops more than the crashing path. Both are intended and both are now documented:

1. **The non-backoff `.retry` path also stops draining while offline.** That path never crashed, but draining with no network only burns attempts and inflates `X-Klaviyo-Attempt-Count` on requests that cannot succeed. Pinned by `testFlushQueueWhileOfflineWithoutBackoffDoesNotDrainQueue` — without it, someone could later move the guard down inside the backoff block, still fix the crash, still pass the suite, and silently revert this half.
2. **A pending profile is deferred, not lost, while offline.** The guard also precedes `if state.pendingProfile != nil { state.enqueueProfileOrTokenRequest() }`, so a pending profile no longer converts into a queued request until the next online `.flushQueue`. Verified non-destructive: `pendingProfile` is a `[Profile.ProfileKey: AnyEncodable]` dictionary that `setProfileProperty` merges into per key, so successive offline updates accumulate (last write wins per property) rather than clobbering each other.

## Test Plan

New reducer test, `testFlushQueueWhileOfflineDuringBackoffDoesNotTrap`, following the documented repro: `retryState` in `.retryWithBackoff` -> `.networkConnectivityChanged(.notReachable)` -> `.flushQueue`.

**Verified the test is not vacuous** — with the guard stashed it reproduces the exact reported trap and the test process dies:

```
Fatal error: Double value cannot be converted to Int because it is either infinite or NaN
** TEST FAILED **
```

With the guard: full package suite green, **296 tests, 0 failures**. SwiftLint/SwiftFormat clean.

One ordering subtlety worth noting for reviewers: `INITIALIZED_TEST_STATE()` has `flushing: true`, which would make `.flushQueue` bail at the earlier `if state.flushing` check and render the test vacuous. The test asserts through `.cancelInFlightRequests` (which clears `flushing`) first, so it genuinely reaches the conversion.

Not manually re-repro'd on a device — the reporter confirmed the device repro steps, and the reducer test covers the same path deterministically.

*Unchecked box:* team test docs. The Q2 manual UAT plan already exercises offline-during-backoff generally; a targeted "offline + backoff + tap a push" row is worth adding to the test sheet, but I didn't want to bundle a shared-doc edit into this fix.

## Related Issues/Tickets

- Closes MAGE-1023
- Context: project "SDK Networking RCA Items"; exposure increased by the widened 5xx retry range in the 5.4.0 rollup (#667).
- The absolute-deadline refactor tracked in the related parity ticket removes this `Int(Double)` conversion entirely and would supersede this guard.

-- Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when connectivity is lost during retry backoff.
  - Queue flushing now safely pauses offline instead of triggering errors or draining queued requests.
  - Preserved retry timing and state while the device remains offline.

- **Tests**
  - Added coverage for offline queue flushing with and without retry backoff.
  - Verified queued requests remain intact until connectivity is restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
