### PR TITLE
ci: per-generation iOS runner matrix (macos-14/15/26)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,53 +12,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  library-macos-14:
+  library:
     name: Build and Run Unit Tests
-    runs-on: macos-14
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.continue_on_error }}
     permissions:
       contents: read
       checks: write
     env:
       GITHUB_CI: true
     strategy:
+      fail-fast: false
       matrix:
-        xcode: ['15.2', '15.4']
+        xcode: ['15.4', '16.4', '26.5']
         config: ['debug', 'release']
+        include:
+          - xcode: '15.4'
+            runner: macos-14
+            ios_runtime: 'iOS 17'
+            continue_on_error: false
+          - xcode: '16.4'
+            runner: macos-15
+            ios_runtime: 'iOS 18'
+            continue_on_error: false
+          - xcode: '26.5'
+            runner: macos-26
+            ios_runtime: 'iOS 26'
+            continue_on_error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Environment Variables
         run: env | grep GITHUB_CI
       - name: Run ${{ matrix.config }} tests
-        run: make XCODE=${{ matrix.xcode }} CONFIG=${{ matrix.config }} test-library
-
-      - uses: slidoapp/xcresulttool@v3.1.0
-        with:
-          path: TestResults-${{ matrix.xcode }}-${{ matrix.config }}.xcresult
-        if: success() || failure()
-
-  library-macos-15:
-    name: Build and Run Unit Tests
-    runs-on: macos-15
-    permissions:
-      contents: read
-      checks: write
-    env:
-      GITHUB_CI: true
-    strategy:
-      matrix:
-        xcode: ['16.4']
-        config: ['debug', 'release']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-      - name: Environment Variables
-        run: env | grep GITHUB_CI
-      - name: Run ${{ matrix.config }} tests
-        run: make XCODE=${{ matrix.xcode }} CONFIG=${{ matrix.config }} test-library
-
+        run: make XCODE=${{ matrix.xcode }} CONFIG=${{ matrix.config }} IOS_RUNTIME="${{ matrix.ios_runtime }}" test-library
       - uses: slidoapp/xcresulttool@v3.1.0
         with:
           path: TestResults-${{ matrix.xcode }}-${{ matrix.config }}.xcresult

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,7 +47,11 @@ jobs:
         run: env | grep GITHUB_CI
       - name: Run ${{ matrix.config }} tests
         run: make XCODE=${{ matrix.xcode }} CONFIG=${{ matrix.config }} IOS_RUNTIME="${{ matrix.ios_runtime }}" test-library
+      # slidoapp/xcresulttool@v3.1.0 shells out to the legacy `xcrun xcresulttool`
+      # commands that Xcode 26 removed (xcrun exits 64), so it can't parse the Xcode 26
+      # result bundle. Skip result parsing on the Xcode 26 line — the raw test output
+      # is still in the job log. Revisit if the action gains Xcode 26 support.
       - uses: slidoapp/xcresulttool@v3.1.0
         with:
           path: TestResults-${{ matrix.xcode }}-${{ matrix.config }}.xcresult
-        if: success() || failure()
+        if: (success() || failure()) && !startsWith(matrix.xcode, '26')

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,6 @@ jobs:
   library:
     name: Build and Run Unit Tests
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.continue_on_error }}
     permissions:
       contents: read
       checks: write
@@ -30,15 +29,12 @@ jobs:
           - xcode: '15.4'
             runner: macos-14
             ios_runtime: 'iOS 17'
-            continue_on_error: false
           - xcode: '16.4'
             runner: macos-15
             ios_runtime: 'iOS 18'
-            continue_on_error: false
           - xcode: '26.5'
             runner: macos-26
             ios_runtime: 'iOS 26'
-            continue_on_error: true
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CONFIG = debug
-XCODE = 15.2
+XCODE = 15.4
 # Simulator runtime *major family* to test against. Default is for local runs; CI
 # overrides per matrix row (macos-14 -> iOS 17, macos-15 -> iOS 18, macos-26 -> iOS 26)
 # so each runner tests its own OS generation. Resolved to the newest installed minor
@@ -19,7 +19,7 @@ test-all: $(MAKE) CONFIG=debug test-library
 
 test-library:
 	@if [ -z "$(IOS_UDID)" ]; then \
-		echo "ERROR: no '$(IOS_RUNTIME)' iPhone Pro simulator on this runner. Bump IOS_RUNTIME to an installed runtime:"; \
+		echo "ERROR: no 'iPhone Pro' simulator for '$(IOS_RUNTIME_RESOLVED)' (family '$(IOS_RUNTIME)') on this runner. Bump IOS_RUNTIME to an installed runtime:"; \
 		xcrun simctl list runtimes; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 CONFIG = debug
 XCODE = 15.2
-# Pin the simulator runtime. Left unpinned, the macOS-15 runner picks its newest
-# installed simulator (currently iOS 26), where Swift-concurrency code hangs under
-# release optimization. iOS 18 is installed on both the macOS-14 and macOS-15 CI
-# runner images (independent of the selected Xcode — `xcode-select` does not remove
-# other installed runtimes), so all matrix jobs run on it consistently. Bump this
-# as the runner images move forward; the `test-library` guard below fails loudly if
-# the pinned runtime is ever missing.
+# Simulator runtime *major family* to test against. Default is for local runs; CI
+# overrides per matrix row (macos-14 -> iOS 17, macos-15 -> iOS 18, macos-26 -> iOS 26)
+# so each runner tests its own OS generation. Resolved to the newest installed minor
+# (e.g. "iOS 26" -> "iOS 26.5") below, so the choice is deterministic when several
+# minors are installed. The test-library guard fails loudly if none is installed.
+# Bump the CI majors in .github/workflows/swift.yml as runner images move forward.
 IOS_RUNTIME = iOS 18
-IOS_UDID = $(call udid_for,$(IOS_RUNTIME),iPhone \d\+ Pro [^M])
+IOS_RUNTIME_RESOLVED = $(call newest_ios_runtime,$(IOS_RUNTIME))
+IOS_UDID = $(call udid_for,$(IOS_RUNTIME_RESOLVED),iPhone \d\+ Pro [^M])
 PLATFORM_IOS = iOS Simulator,id=$(IOS_UDID)
 
 
@@ -38,4 +38,8 @@ test-library:
 
 define udid_for
 $(shell xcrun simctl list devices available '$(1)' | grep '$(2)' | sort -r | head -1 | awk -F '[()]' '{ print $$(NF-3) }')
+endef
+
+define newest_ios_runtime
+$(shell xcrun simctl list runtimes available | grep -oE '$(1)\.[0-9]+' | sort -V | tail -1)
 endef

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test-all: $(MAKE) CONFIG=debug test-library
 	$(MAKE) CONFIG=release test-library
 
 test-library:
+	@if [ -z "$(IOS_RUNTIME_RESOLVED)" ]; then \
+		echo "ERROR: no '$(IOS_RUNTIME)' runtime installed on this runner. Bump IOS_RUNTIME to an installed runtime:"; \
+		xcrun simctl list runtimes available; \
+		exit 1; \
+	fi
 	@if [ -z "$(IOS_UDID)" ]; then \
 		echo "ERROR: no 'iPhone Pro' simulator for '$(IOS_RUNTIME_RESOLVED)' (family '$(IOS_RUNTIME)') on this runner. Bump IOS_RUNTIME to an installed runtime:"; \
 		xcrun simctl list runtimes; \


### PR DESCRIPTION
# Description
Restructures the iOS unit-test CI into a per-generation runner matrix so each macOS runner tests the Xcode/iOS pairing it represents, and introduces iOS 26 coverage without letting the known MAGE-992 hang block merges. Targets `rel/5.4.0` because this change relies on PR #677's test-timeout backstop, which is on `rel/5.4.0` (not `master`).

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- validated the Makefile runtime resolution + guard locally; live CI matrix runs on this PR -->
- [ ] I have added sufficient unit/integration tests of my changes. <!-- N/A: CI config; verification is dry-run/resolution checks + the live matrix run -->
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports. <!-- 15.2 dropped from CI backs no declared floor; Xcode-15/Swift-5.9 line still covered by 15.4 -->

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes. <!-- CI-only, no SDK code change -->
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release. <!-- CI maintenance ahead of GitHub sunsetting macos-14 (~Nov 2026) -->

## Changelog / Code Overview
**`.github/workflows/swift.yml`** — collapsed the two `library-macos-14` / `library-macos-15` jobs into one matrix job:

| Runner | Xcode | iOS runtime | Configs | Blocking |
|--------|-------|-------------|---------|----------|
| `macos-14` | `15.4` | `iOS 17` | debug, release | yes |
| `macos-15` | `16.4` | `iOS 18` | debug, release | yes |
| `macos-26` | `26.5` | `iOS 26` | debug, release | yes |

- Base matrix axes stay `xcode` + `config` with `runner`/`ios_runtime` merged via `include` keyed on `xcode`, so GitHub appends only `(xcode, config)` to the check name — the four `(15.4|16.4, debug|release)` check names are **byte-for-byte unchanged** (no branch-protection churn). `15.2` is dropped.
- `fail-fast: false`; `actions/checkout@v3 → v4`.
- The `xcresulttool` reporting step is skipped on the Xcode 26 line — `slidoapp/xcresulttool@v3.1.0` calls the legacy `xcrun xcresulttool` API that Xcode 26 removed (raw test output still lands in the job log).

**`Makefile`** — `IOS_RUNTIME` is now a **major-family** pin that CI overrides per matrix row; a new jq-free `newest_ios_runtime` helper resolves it to the newest installed minor (`sort -V | tail -1`) deterministically. The existing `IOS_UDID` guard and the `-test-timeouts-enabled`/120/300 flags (MAGE-992 backstop) are preserved; guard message clarified to name the resolved runtime; stale local `XCODE` default bumped `15.2 → 15.4`.

**iOS 26 is enforced (blocking):** the MAGE-992 hang turned out to be an **Xcode-16.4-building-for-iOS-26 toolchain artifact**, not a real iOS 26 defect. With this matrix pairing iOS 26 with the matching **Xcode 26.5**, the full suite — including the hang-prone `KlaviyoFormsTests` (`testPreloadWebsiteNoActionTimeout` runs and passes in ~1.15s, **not** skipped) — passes under **release** optimization on 2/2 runs. So the iOS 26 cells are blocking, giving real enforced coverage. See MAGE-992 for the evidence.

## Test Plan
1. This PR's CI run dispatches 6 cells; confirm each selects the intended Xcode and resolves the intended iOS runtime (`15.4→iOS 17.x`, `16.4→iOS 18.x`, `26.5→iOS 26.x`).
2. All six cells pass both configs (evidence: runs 30843700314 and 30844677318 — full suite `** TEST SUCCEEDED **` on `26.5 release`, hang-prone forms tests included).
3. Local Makefile checks: `make IOS_RUNTIME="iOS 99" test-library` fails loudly via the guard; `newest_ios_runtime` resolves to the highest installed minor.

**Post-merge (repo admin):** update required status checks to the current six contexts — `Build and Run Unit Tests (15.4|16.4|26.5, debug|release)` — and **remove** the retired `(15.2, debug)` / `(15.2, release)`. The `15.4`/`16.4` names are unchanged. Follow-up (~Nov 2026): drop the `macos-14` rows when the runner retires. Optional follow-up: add `actionlint` as a workflow-lint CI job.

## Related Issues/Tickets
- MAGE-992 — iOS 26 Swift-concurrency hang. **This PR provides the evidence to close it:** the hang is an Xcode-16.4-toolchain-for-iOS-26 artifact; the matched Xcode 26.5 toolchain runs the full (unskipped) suite green under release.
- PR #677 — MAGE-992 de-flake (test timeouts + iOS 18 pin) that this change builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated library testing across supported macOS, Xcode, and iOS runtime combinations.
  * Added coverage for both debug and release configurations.
  * Improved simulator selection by automatically using the newest installed compatible iOS runtime.
  * Enhanced test setup errors when required runtimes or simulators are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->