### PR TITLE
fix(KlaviyoCore): arm connectivity retry on initial token-fetch failure (MAGE-883)

### DIFF
--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -435,7 +435,7 @@ package actor AuthTokenManager {
             // every acquisition path — the eager warm-up fetch, an interactive
             // `currentToken(mode:)` call, and `performScheduledRefresh()` —
             // funnels through this method, and it only ever runs when there is
-            // no valid cached token to serve (MAGE-883).
+            // no valid cached token to serve.
             if let urlError = error as? URLError, urlError.isConnectivityError {
                 armConnectivityRetry()
             }

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -83,13 +83,15 @@ package actor AuthTokenManager {
     /// can't leave the guard stuck or clear a newer generation's run.
     private var activeScheduledRefreshID: UUID?
 
-    /// `true` while a proactive refresh has failed for a network reason and the
+    /// `true` while a token fetch has failed for a network reason and the
     /// manager is awaiting connectivity before retrying. A single boolean (not a
     /// task) because connectivity comes through the existing ``lifecycleCancellable``
-    /// reachability sink: a network-classified failure arms it
-    /// (``performScheduledRefresh()``), the next reachable status consumes it
-    /// (``handleReachabilityChange()``), so flapping can't queue multiple retries.
-    /// Cleared by ``cancelInFlightWorkAndClearCache()``.
+    /// reachability sink: a network-classified failure arms it — inside
+    /// ``runFetch(fetchID:)``, so every acquisition path shares the same arming
+    /// logic (the eager warm-up fetch, an interactive ``currentToken(mode:)``
+    /// call, and ``performScheduledRefresh()`` alike) — the next reachable
+    /// status consumes it (``handleReachabilityChange()``), so flapping can't
+    /// queue multiple retries. Cleared by ``cancelInFlightWorkAndClearCache()``.
     private var isAwaitingConnectivityRetry = false
 
     /// Test-only window onto ``isAwaitingConnectivityRetry`` so suites can
@@ -197,8 +199,11 @@ package actor AuthTokenManager {
     ///
     /// The eager fetch is fire-and-forget so registration call sites stay
     /// responsive — failures during the warm-up surface only as logs (the same
-    /// logs ``currentToken(mode:)`` would emit). Calling this again later
-    /// replaces the previous provider.
+    /// logs ``currentToken(mode:)`` would emit). A connectivity-classified
+    /// warm-up failure still arms the connectivity retry despite being
+    /// fire-and-forget, since that classification lives in the shared
+    /// ``runFetch(fetchID:)`` this call eventually reaches. Calling this again
+    /// later replaces the previous provider.
     package func registerProvider(_ newProvider: @escaping AuthTokenProvider) async {
         cancelInFlightWorkAndClearCache()
         provider = newProvider
@@ -351,6 +356,15 @@ package actor AuthTokenManager {
     /// the manager once it finishes — but only if it is still the *current*
     /// fetch (a swap via ``registerProvider(_:)`` may have installed a newer
     /// one in the meantime).
+    ///
+    /// This is the single choke point every acquisition path shares — the eager
+    /// warm-up fetch in ``registerProvider(_:)``, an interactive
+    /// ``currentToken(mode:)`` call, and ``performScheduledRefresh()`` all reach
+    /// a fetch via ``startFetch()``, which only ever runs here. Because none of
+    /// them run unless the caller already determined there is no valid cached
+    /// token to serve, a connectivity-classified failure means the same thing
+    /// regardless of which path triggered it — hence connectivity-retry arming
+    /// is classified once here rather than at each call site.
     private func runFetch(fetchID: UUID) async throws -> String {
         defer {
             if inFlight?.id == fetchID {
@@ -416,6 +430,14 @@ package actor AuthTokenManager {
                 Logger.auth.error(
                     "AuthTokenManager: provider error: \(reason, privacy: .public)"
                 )
+            }
+            // Classified and armed here (rather than at each call site) because
+            // every acquisition path — the eager warm-up fetch, an interactive
+            // `currentToken(mode:)` call, and `performScheduledRefresh()` —
+            // funnels through this method, and it only ever runs when there is
+            // no valid cached token to serve (MAGE-883).
+            if let urlError = error as? URLError, urlError.isConnectivityError {
+                armConnectivityRetry()
             }
             throw error
         }
@@ -501,8 +523,9 @@ package actor AuthTokenManager {
     /// On failure: leaves the cached token in place — the cache only goes
     /// stale at `exp - leeway`, so a foreground transition or user fetch
     /// before then will retry. A *network-classified* failure also arms
-    /// ``isAwaitingConnectivityRetry`` so the next reachability restoration
-    /// re-fires this method (``handleReachabilityChange()``); other failures don't.
+    /// ``isAwaitingConnectivityRetry`` — inside ``runFetch(fetchID:)`` itself,
+    /// not here — so the next reachability restoration re-fires this method
+    /// (``handleReachabilityChange()``); other failures don't.
     ///
     /// Bails if a refresh is already mid-flight (``activeScheduledRefreshID`` set):
     /// the scheduled fire, the foreground "missed refresh" retry (case 2), and the
@@ -546,12 +569,9 @@ package actor AuthTokenManager {
                     "AuthTokenManager: refresh failed: \(reason, privacy: .public)"
                 )
             }
-            // Only network failures are worth waiting on — connectivity
-            // restoration addresses them; HTTP/validation/host errors would
-            // just fail again.
-            if let urlError = error as? URLError, urlError.isConnectivityError {
-                armConnectivityRetry()
-            }
+            // Connectivity-classified failures are already armed inside
+            // `runFetch` itself (its terminal catch), which this method reaches
+            // via `startFetch()`/`task.value` — nothing further to do here.
         }
     }
 
@@ -582,8 +602,10 @@ package actor AuthTokenManager {
             }
     }
 
-    /// Arms the connectivity-retry wait after a network-classified refresh failure,
-    /// kicking the retry immediately if the system *already* reports a usable path.
+    /// Arms the connectivity-retry wait after a network-classified token-fetch
+    /// failure — called from ``runFetch(fetchID:)``'s terminal catch, so every
+    /// acquisition path arms the same way — kicking the retry immediately if the
+    /// system *already* reports a usable path.
     ///
     /// Reachability is a transition stream with no "current value": if connectivity
     /// returned while the failing fetch was in flight, that transition has already

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -628,7 +628,7 @@ package actor AuthTokenManager {
         isAwaitingConnectivityRetry = true
         if #available(iOS 14.0, *) {
             Logger.auth.info(
-                "AuthTokenManager: network-classified refresh failure, awaiting connectivity"
+                "AuthTokenManager: network-classified token-fetch failure, awaiting connectivity"
             )
         }
         kickConnectivityRetryIfReachable()

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -436,7 +436,15 @@ package actor AuthTokenManager {
             // `currentToken(mode:)` call, and `performScheduledRefresh()` —
             // funnels through this method, and it only ever runs when there is
             // no valid cached token to serve.
-            if let urlError = error as? URLError, urlError.isConnectivityError {
+            //
+            // Guarded by the same `inFlight?.id == fetchID` generation check the
+            // `defer` above uses: a fetch cancelled by a `registerProvider(_:)`
+            // swap keeps running if the host's provider closure doesn't honor
+            // cancellation (see this method's doc), and could otherwise still
+            // arm a retry for a generation that's no longer current — including
+            // after a newer fetch already succeeded — spuriously re-invoking the
+            // provider on the next reachability change.
+            if inFlight?.id == fetchID, let urlError = error as? URLError, urlError.isConnectivityError {
                 armConnectivityRetry()
             }
             throw error

--- a/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
+++ b/Sources/KlaviyoCore/Auth/AuthTokenManager.swift
@@ -554,6 +554,15 @@ package actor AuthTokenManager {
             // may have rotated it while this run was suspended on `task.value`.
             if activeScheduledRefreshID == refreshID {
                 activeScheduledRefreshID = nil
+                // A connectivity-retry kick may have raced ahead of this guard
+                // clearing (see `fireConnectivityRetryIfArmed()`'s matching guard)
+                // and backed off without consuming the wait. Now that the guard is
+                // genuinely clear, give a still-armed wait a fresh, correctly-gated
+                // chance to fire instead of leaving it stranded until an unrelated
+                // reachability transition.
+                if isAwaitingConnectivityRetry {
+                    kickConnectivityRetryIfReachable()
+                }
             }
         }
         let task = inFlight?.task ?? startFetch()
@@ -612,15 +621,9 @@ package actor AuthTokenManager {
 
     /// Arms the connectivity-retry wait after a network-classified token-fetch
     /// failure — called from ``runFetch(fetchID:)``'s terminal catch, so every
-    /// acquisition path arms the same way — kicking the retry immediately if the
-    /// system *already* reports a usable path.
-    ///
-    /// Reachability is a transition stream with no "current value": if connectivity
-    /// returned while the failing fetch was in flight, that transition has already
-    /// passed and no future event would wake the wait. Consulting
-    /// ``currentReachability`` here mirrors `NWPathMonitor` delivering the current
-    /// path on subscribe; `nil`/unknown is treated as "no path". A kicked retry that
-    /// fails for a network reason re-arms, gated by a full fetch each iteration.
+    /// acquisition path arms the same way — then defers to
+    /// ``kickConnectivityRetryIfReachable()`` to retry immediately if the system
+    /// *already* reports a usable path.
     private func armConnectivityRetry() {
         isAwaitingConnectivityRetry = true
         if #available(iOS 14.0, *) {
@@ -628,6 +631,26 @@ package actor AuthTokenManager {
                 "AuthTokenManager: network-classified refresh failure, awaiting connectivity"
             )
         }
+        kickConnectivityRetryIfReachable()
+    }
+
+    /// Fires ``fireConnectivityRetryIfArmed()`` immediately if the system already
+    /// reports a usable path, without waiting for a future reachability transition.
+    ///
+    /// Reachability is a transition stream with no "current value": if connectivity
+    /// returned while the failing fetch was in flight, that transition has already
+    /// passed and no future event would wake the wait. Consulting
+    /// ``currentReachability`` here mirrors `NWPathMonitor` delivering the current
+    /// path on subscribe; `nil`/unknown is treated as "no path".
+    ///
+    /// Called both from ``armConnectivityRetry()`` (a fresh failure) and from
+    /// ``performScheduledRefresh()``'s `defer` (a kick that raced ahead of that
+    /// method's single-flight guard and backed off — see
+    /// ``fireConnectivityRetryIfArmed()`` — gets a fresh, correctly-gated attempt
+    /// once the guard genuinely clears). Deliberately does not re-log the "failure"
+    /// message ``armConnectivityRetry()`` does — a re-kick isn't a new failure, just
+    /// a delayed retry of one already logged.
+    private func kickConnectivityRetryIfReachable() {
         guard let status = currentReachability(), status != .notReachable else { return }
         if #available(iOS 14.0, *) {
             Logger.auth.info(
@@ -650,8 +673,20 @@ package actor AuthTokenManager {
     /// normal dedup/validate/reschedule/broadcast path. Clearing the flag *before*
     /// re-firing collapses concurrent triggers (transition + arm-time check) into a
     /// single retry; a network-failed retry re-arms via ``performScheduledRefresh()``.
+    ///
+    /// Backs off *without* consuming the wait while ``activeScheduledRefreshID`` is
+    /// set: that guard being up means some ``performScheduledRefresh()`` run's own
+    /// fetch may have *just* failed and armed this wait (via ``runFetch(fetchID:)``)
+    /// but not yet unwound past its `defer` — since that arm now happens in a
+    /// decoupled child task (the fetch's own `Task`, not `performScheduledRefresh`
+    /// itself), this call can race ahead of that `defer` clearing the guard.
+    /// Consuming the wait here regardless would silently drop it without ever
+    /// retrying, because the `performScheduledRefresh()` call below would just
+    /// bounce off its own still-set guard. Backing off instead leaves the wait
+    /// armed for that method's `defer` to re-kick once its guard is genuinely clear.
     private func fireConnectivityRetryIfArmed() async {
         guard isAwaitingConnectivityRetry else { return }
+        guard activeScheduledRefreshID == nil else { return }
         isAwaitingConnectivityRetry = false
         if #available(iOS 14.0, *) {
             Logger.auth.info("AuthTokenManager: connectivity available, retrying refresh")

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1228,13 +1228,13 @@ struct AuthTokenManagerRefreshTests {
         )
     }
 
-    // MARK: - Initial-acquisition connectivity retry (MAGE-883)
+    // MARK: - Initial-acquisition connectivity retry
 
     @Test
     func warmUpFetchFailureRetriesWhenConnectivityRestored() async throws {
-        // MAGE-883 repro: the very FIRST token fetch (registerProvider's eager
-        // warm-up) fails offline. Before the fix, nothing armed the connectivity
-        // wait for this path, so restoring connectivity did nothing. After the
+        // Repro: the very FIRST token fetch (registerProvider's eager warm-up)
+        // fails offline. Before the fix, nothing armed the connectivity wait
+        // for this path, so restoring connectivity did nothing. After the
         // fix, `runFetch` itself arms the wait regardless of which caller drove
         // the failing fetch — no scheduled refresh ever ran here.
         let secondToken = try makeJWT(
@@ -1282,11 +1282,11 @@ struct AuthTokenManagerRefreshTests {
 
     @Test
     func interactiveFetchFailureAlsoArmsConnectivityRetry() async throws {
-        // Confirms the uniform-arming decision from MAGE-883: an interactive
-        // (form-display) fetch failure arms the wait exactly like the warm-up
-        // and scheduled-refresh paths, since `runFetch` cannot distinguish its
-        // caller and any connectivity failure there means the manager currently
-        // has nothing cached to serve. Warms the cache via a normal
+        // Confirms the uniform-arming decision: an interactive (form-display)
+        // fetch failure arms the wait exactly like the warm-up and
+        // scheduled-refresh paths, since `runFetch` cannot distinguish its
+        // caller and any connectivity failure there means the manager
+        // currently has nothing cached to serve. Warms the cache via a normal
         // registration first, then clears it (retaining the provider) so a
         // subsequent *interactive* `currentToken(mode:)` call — not the
         // warm-up — is the one observing the failure.

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1411,7 +1411,10 @@ struct AuthTokenManagerRefreshTests {
         }
 
         let isArmed = await manager.isAwaitingConnectivityRetryForTesting
-        #expect(isArmed == false, "a stale fetch's failure must not arm a retry after a newer fetch already succeeded")
+        #expect(
+            isArmed == false,
+            "a stale fetch's failure must not arm a retry after a newer fetch already succeeded"
+        )
 
         let finalInvocations = await secondProviderCounter.value
         #expect(finalInvocations == 1, "a spurious retry would invoke the second provider again")

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1340,6 +1340,86 @@ struct AuthTokenManagerRefreshTests {
         #expect(delivered == secondToken, "an interactive fetch failure must retry once connectivity returns")
     }
 
+    @Test
+    func providerReplacedWhileFetchInFlightDoesNotArmStaleConnectivityRetry() async throws {
+        // Same reentrancy race as `providerReplacedWhileFetchInFlightDoesNotPoisonCache`
+        // (AuthTokenManagerTests.swift), but for the connectivity-retry arm rather
+        // than the cache write. A stale fetch from a replaced provider that
+        // eventually fails with a connectivity error must not arm the retry once
+        // a newer fetch already succeeded — `runFetch`'s failure path guards on
+        // the same `inFlight?.id == fetchID` generation check the success path
+        // and the `defer` both rely on.
+        //
+        // Reachability is injected `.notReachable` (unlike the sibling cache
+        // test, which uses the production initializer) so a spurious arm isn't
+        // immediately self-consumed by `armConnectivityRetry`'s already-reachable
+        // kick — that auto-consume would clear the flag regardless of whether
+        // the generation guard actually held, masking the very regression this
+        // test exists to catch. The final provider-invocation count is the
+        // second, independent signal: a masked spurious arm would still drive an
+        // extra fetch even if the flag read back `false` by the time we sample it.
+        let lifecycle = noopLifecycle()
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let firstProviderEntered = Latch()
+        let firstProviderRelease = Latch()
+
+        await manager.registerProvider {
+            await firstProviderEntered.open()
+            await firstProviderRelease.wait()
+            throw URLError(.notConnectedToInternet)
+        }
+        // Wait until the eager fetch has captured the first provider and is
+        // suspended inside `provider()` — precondition for the reentrancy race.
+        await firstProviderEntered.wait()
+
+        // Swap in a new provider. The new eager fetch caches `secondToken`.
+        let secondProviderCounter = CallCounter()
+        await manager.registerProvider {
+            await secondProviderCounter.increment()
+            return secondToken
+        }
+        try await secondProviderCounter.waitFor(atLeast: 1)
+
+        // Give the second (successful) fetch's completion time to land before
+        // releasing the stale first provider.
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        // Release the stale first provider. Its in-flight fetch now throws a
+        // connectivity-classified error — without the generation guard this
+        // would arm a spurious retry even though the manager already has a
+        // healthy cached token from the newer generation.
+        await firstProviderRelease.open()
+
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        let isArmed = await manager.isAwaitingConnectivityRetryForTesting
+        #expect(isArmed == false, "a stale fetch's failure must not arm a retry after a newer fetch already succeeded")
+
+        let finalInvocations = await secondProviderCounter.value
+        #expect(finalInvocations == 1, "a spurious retry would invoke the second provider again")
+
+        let result = try await manager.currentToken(mode: .background)
+        #expect(result == secondToken)
+    }
+
     // MARK: - unregisterProvider
 
     @Test

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerRefreshTests.swift
@@ -1228,6 +1228,118 @@ struct AuthTokenManagerRefreshTests {
         )
     }
 
+    // MARK: - Initial-acquisition connectivity retry (MAGE-883)
+
+    @Test
+    func warmUpFetchFailureRetriesWhenConnectivityRestored() async throws {
+        // MAGE-883 repro: the very FIRST token fetch (registerProvider's eager
+        // warm-up) fails offline. Before the fix, nothing armed the connectivity
+        // wait for this path, so restoring connectivity did nothing. After the
+        // fix, `runFetch` itself arms the wait regardless of which caller drove
+        // the failing fetch — no scheduled refresh ever ran here.
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        // Offline at registration so the warm-up fetch fails; flipped online
+        // just before the transition below.
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            if invocation == 1 { throw URLError(.notConnectedToInternet) } // warm-up, offline
+            return secondToken // connectivity-driven retry
+        }
+        try await counter.waitFor(atLeast: 1)
+        await awaitConnectivityWaitArmed(manager)
+
+        // Subscribe before restoring connectivity so the eventual broadcast is
+        // observable.
+        let stream = await manager.refreshes()
+
+        reachability.set(.reachableViaWiFi)
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+
+        let delivered = await firstElement(of: stream)
+        #expect(delivered == secondToken, "an offline warm-up failure must retry once connectivity returns")
+
+        let cached = try await manager.currentToken(mode: .background)
+        #expect(cached == secondToken)
+    }
+
+    @Test
+    func interactiveFetchFailureAlsoArmsConnectivityRetry() async throws {
+        // Confirms the uniform-arming decision from MAGE-883: an interactive
+        // (form-display) fetch failure arms the wait exactly like the warm-up
+        // and scheduled-refresh paths, since `runFetch` cannot distinguish its
+        // caller and any connectivity failure there means the manager currently
+        // has nothing cached to serve. Warms the cache via a normal
+        // registration first, then clears it (retaining the provider) so a
+        // subsequent *interactive* `currentToken(mode:)` call — not the
+        // warm-up — is the one observing the failure.
+        let firstToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "first"]
+        )
+        let secondToken = try makeJWT(
+            issuedAt: refSeconds - 60,
+            expiresAt: refSeconds + 3600,
+            extraClaims: ["sub": "second"]
+        )
+
+        let lifecycleSubject = PassthroughSubject<LifeCycleEvents, Never>()
+        let lifecycle = AppLifeCycleEvents(lifeCycleEvents: { lifecycleSubject.eraseToAnyPublisher() })
+        let clock = TestClock(referenceDate)
+        let gate = SleepGate()
+        let reachability = TestReachability(.notReachable)
+        let manager = makeManager(
+            lifeCycle: lifecycle,
+            clock: clock,
+            gate: gate,
+            reachabilityStatus: { reachability.status() }
+        )
+        let counter = CallCounter()
+
+        await manager.registerProvider {
+            let invocation = await counter.increment()
+            switch invocation {
+            case 1: return firstToken // warm-up succeeds
+            case 2: throw URLError(.notConnectedToInternet) // interactive call, offline
+            default: return secondToken // connectivity-driven retry
+            }
+        }
+        try await counter.waitFor(atLeast: 1)
+        await gate.waitUntilSleeping(atLeast: 1) // confirms warm-up cached firstToken
+
+        await manager.clearTokenState() // drops cache, retains provider
+
+        await #expect(throws: URLError.self) {
+            _ = try await manager.currentToken(mode: .interactive)
+        }
+        await awaitConnectivityWaitArmed(manager)
+
+        let stream = await manager.refreshes()
+        reachability.set(.reachableViaWiFi)
+        lifecycleSubject.send(.reachabilityChanged(status: .reachableViaWiFi))
+
+        let delivered = await firstElement(of: stream)
+        #expect(delivered == secondToken, "an interactive fetch failure must retry once connectivity returns")
+    }
+
     // MARK: - unregisterProvider
 
     @Test

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -391,60 +391,6 @@ struct AuthTokenManagerTests {
         let result = try await manager.currentToken(mode: .background)
         #expect(result == secondToken)
     }
-
-    @Test
-    func providerReplacedWhileFetchInFlightDoesNotArmStaleConnectivityRetry() async throws {
-        // Same reentrancy race as `providerReplacedWhileFetchInFlightDoesNotPoisonCache`,
-        // but for the connectivity-retry arm rather than the cache write. A stale
-        // fetch from a replaced provider that eventually fails with a connectivity
-        // error must not arm the retry once a newer fetch already succeeded —
-        // `runFetch`'s failure path guards on the same `inFlight?.id == fetchID`
-        // generation check the success path and the `defer` both rely on.
-        let manager = AuthTokenManager()
-        let secondToken = try makeJWT(extraClaims: ["sub": "user-b"])
-
-        let firstProviderEntered = Latch()
-        let firstProviderRelease = Latch()
-
-        await manager.registerProvider {
-            await firstProviderEntered.open()
-            await firstProviderRelease.wait()
-            throw URLError(.notConnectedToInternet)
-        }
-        // Wait until the eager fetch has captured the first provider and is
-        // suspended inside `provider()` — precondition for the reentrancy race.
-        await firstProviderEntered.wait()
-
-        // Swap in a new provider. The new eager fetch caches `secondToken`.
-        let secondProviderCounter = CallCounter()
-        await manager.registerProvider {
-            await secondProviderCounter.increment()
-            return secondToken
-        }
-        try await secondProviderCounter.waitFor(atLeast: 1)
-
-        // Give the second (successful) fetch's completion time to land before
-        // releasing the stale first provider.
-        for _ in 0..<10 {
-            await Task.yield()
-        }
-
-        // Release the stale first provider. Its in-flight fetch now throws a
-        // connectivity-classified error — without the generation guard this
-        // would arm a spurious retry even though the manager already has a
-        // healthy cached token from the newer generation.
-        await firstProviderRelease.open()
-
-        for _ in 0..<10 {
-            await Task.yield()
-        }
-
-        let isArmed = await manager.isAwaitingConnectivityRetryForTesting
-        #expect(isArmed == false, "a stale fetch's failure must not arm a retry after a newer fetch already succeeded")
-
-        let result = try await manager.currentToken(mode: .background)
-        #expect(result == secondToken)
-    }
 }
 
 // MARK: - Test helpers

--- a/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
+++ b/Tests/KlaviyoCoreTests/Auth/AuthTokenManagerTests.swift
@@ -391,6 +391,60 @@ struct AuthTokenManagerTests {
         let result = try await manager.currentToken(mode: .background)
         #expect(result == secondToken)
     }
+
+    @Test
+    func providerReplacedWhileFetchInFlightDoesNotArmStaleConnectivityRetry() async throws {
+        // Same reentrancy race as `providerReplacedWhileFetchInFlightDoesNotPoisonCache`,
+        // but for the connectivity-retry arm rather than the cache write. A stale
+        // fetch from a replaced provider that eventually fails with a connectivity
+        // error must not arm the retry once a newer fetch already succeeded —
+        // `runFetch`'s failure path guards on the same `inFlight?.id == fetchID`
+        // generation check the success path and the `defer` both rely on.
+        let manager = AuthTokenManager()
+        let secondToken = try makeJWT(extraClaims: ["sub": "user-b"])
+
+        let firstProviderEntered = Latch()
+        let firstProviderRelease = Latch()
+
+        await manager.registerProvider {
+            await firstProviderEntered.open()
+            await firstProviderRelease.wait()
+            throw URLError(.notConnectedToInternet)
+        }
+        // Wait until the eager fetch has captured the first provider and is
+        // suspended inside `provider()` — precondition for the reentrancy race.
+        await firstProviderEntered.wait()
+
+        // Swap in a new provider. The new eager fetch caches `secondToken`.
+        let secondProviderCounter = CallCounter()
+        await manager.registerProvider {
+            await secondProviderCounter.increment()
+            return secondToken
+        }
+        try await secondProviderCounter.waitFor(atLeast: 1)
+
+        // Give the second (successful) fetch's completion time to land before
+        // releasing the stale first provider.
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        // Release the stale first provider. Its in-flight fetch now throws a
+        // connectivity-classified error — without the generation guard this
+        // would arm a spurious retry even though the manager already has a
+        // healthy cached token from the newer generation.
+        await firstProviderRelease.open()
+
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        let isArmed = await manager.isAwaitingConnectivityRetryForTesting
+        #expect(isArmed == false, "a stale fetch's failure must not arm a retry after a newer fetch already succeeded")
+
+        let result = try await manager.currentToken(mode: .background)
+        #expect(result == secondToken)
+    }
 }
 
 // MARK: - Test helpers


### PR DESCRIPTION
# Description
The connectivity-driven retry mechanism (MAGE-683) only armed on a failed *scheduled* refresh. If the very first token fetch (the eager warm-up in `registerProvider`, or an interactive `currentToken` call before any token is cached) failed offline, nothing armed the wait, so restoring connectivity did nothing — the SDK stayed broken until an unrelated trigger happened to run.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
`armConnectivityRetry()` was only called from `performScheduledRefresh()`'s catch block. Moved the connectivity classification + arm call into `runFetch(fetchID:)`'s terminal catch instead — the single choke point every acquisition path (eager warm-up, interactive `currentToken(mode:)`, and `performScheduledRefresh()`) funnels through. `runFetch` only ever runs when there's no valid cached token to serve, so arming uniformly for any connectivity-classified failure there has no downside and closes the gap for every current and future acquisition path at once. Updated doc comments that described arming as tied specifically to the scheduled-refresh path. Removed the now-redundant classification from `performScheduledRefresh`'s catch.

## Test Plan
Added two tests to `AuthTokenManagerRefreshTests`:
- `warmUpFetchFailureRetriesWhenConnectivityRestored` — reproduces the reported gap: the eager warm-up fetch fails offline, connectivity restores, and a token is fetched/cached/broadcast with no other trigger.
- `interactiveFetchFailureAlsoArmsConnectivityRetry` — confirms an interactive (form-display) fetch failure arms the wait the same way.

All tests in `AuthTokenManagerRefreshTests` (new and pre-existing) pass. `swiftlint --fix --strict` and `swiftformat .` made no changes.

## Related Issues/Tickets
MAGE-883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token recovery after temporary connectivity failures during startup, interactive use, and scheduled refreshes.
  - Tokens now retry automatically when connectivity is restored, reducing interruptions to authenticated features.
  - Prevented outdated token requests from triggering unnecessary or duplicate retry attempts.
  - Improved scheduled refresh behavior when another refresh is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->