### PR TITLE
feat(KlaviyoCore): export KlaviyoCore as a public SwiftPM product (MAGE-1030)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,10 @@ let package = Package(
     platforms: [.iOS(.v13)],
     products: [
         .library(
+            name: "KlaviyoCore",
+            targets: ["KlaviyoCore"]
+        ),
+        .library(
             name: "KlaviyoSwift",
             targets: ["KlaviyoSwift"]
         ),


### PR DESCRIPTION
## Summary

Adds `KlaviyoCore` to the `products` array in `Package.swift` so it is vended as a public SwiftPM `.library`.

In 5.4.0, `Event` and other shared types moved out of `KlaviyoSwift` into `KlaviyoCore`. Wrapper SDKs (Flutter, and future RN/Expo SPM paths) now `import KlaviyoCore` directly, but it was declared only as a SwiftPM **target**, not a **product** — external SPM consumers couldn't depend on it and relied on a non-guaranteed *implicit transitive import*.

CocoaPods already ships `KlaviyoCore.podspec`, so this simply brings SPM to parity. Additive, manifest-only change — no runtime or build-graph impact on existing consumers.

Surfaced by the Flutter SDK: https://github.com/klaviyo/klaviyo-flutter-sdk/pull/118#issuecomment-5173818199

Linear: MAGE-1030

## Changelog

- Export `KlaviyoCore` as a public SwiftPM library product.

## Test plan

- [x] `xcodebuild build -scheme klaviyo-swift-sdk-Package -destination "platform=iOS Simulator,name=iPhone 17 Pro"` → **BUILD SUCCEEDED**
- [x] `swift package describe` shows `KlaviyoCore` under products with target `KlaviyoCore`.
- Downstream check: an external SwiftPM package can now add `.product(name: "KlaviyoCore", package: "klaviyo-swift-sdk")` and `import KlaviyoCore` without relying on transitive imports.

## Notes / follow-ups

- **Wrapper-side (separate repo):** bump the Flutter iOS SPM constraint from `.upToNextMinor(from: "5.3.1")` (excludes 5.4.0) to admit 5.4.0 and declare the `KlaviyoCore` product dependency.
- **Deferred:** an access-level audit flagged ~24 `public` symbols apparently used only within KlaviyoCore that could be tightened to `internal`. Intentionally split out of this release-blocking change; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the KlaviyoCore library as an available Swift package product.
  * Enabled applications to build and integrate KlaviyoCore through Swift Package Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->