### PR TITLE
fix: preserve call order in dispatchOnMainThread

### DIFF
--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -12,8 +12,8 @@ import OSLog
 import UIKit
 
 func dispatchOnMainThread(action: KlaviyoAction) {
-    Task { @MainActor in
-        klaviyoSwiftEnvironment.send(action)
+    DispatchQueue.main.async {
+        _ = klaviyoSwiftEnvironment.send(action)
     }
 }
 

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -90,8 +90,11 @@ public struct KlaviyoSDK {
     /// - Returns: a KlaviyoSDK instance
     @discardableResult
     public func initialize(with apiKey: String) -> KlaviyoSDK {
-        Task {
-            @MainActor in SharedStoreMirror.setup()
+        // Dispatched the same way as every other action so `.initialize` stays ordered ahead of
+        // calls that require it — a `Task` hop and a main-queue hop have no ordering guarantee
+        // relative to each other.
+        DispatchQueue.main.async {
+            SharedStoreMirror.setup()
             _ = klaviyoSwiftEnvironment.send(.initialize(apiKey))
         }
         klaviyoSwiftEnvironment.injectNotificationDelegate()

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -12,10 +12,8 @@ import OSLog
 import UIKit
 
 func dispatchOnMainThread(action: KlaviyoAction) {
-    Task {
-        await MainActor.run {
-            klaviyoSwiftEnvironment.send(action)
-        }
+    Task { @MainActor in
+        klaviyoSwiftEnvironment.send(action)
     }
 }
 

--- a/Sources/KlaviyoSwift/Klaviyo.swift
+++ b/Sources/KlaviyoSwift/Klaviyo.swift
@@ -90,9 +90,6 @@ public struct KlaviyoSDK {
     /// - Returns: a KlaviyoSDK instance
     @discardableResult
     public func initialize(with apiKey: String) -> KlaviyoSDK {
-        // Dispatched the same way as every other action so `.initialize` stays ordered ahead of
-        // calls that require it — a `Task` hop and a main-queue hop have no ordering guarantee
-        // relative to each other.
         DispatchQueue.main.async {
             SharedStoreMirror.setup()
             _ = klaviyoSwiftEnvironment.send(.initialize(apiKey))

--- a/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
@@ -1,0 +1,76 @@
+//
+//  DispatchOrderingTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoSwift
+import Foundation
+import KlaviyoCore
+import XCTest
+
+/// Regression coverage for out-of-order action dispatch through `dispatchOnMainThread`.
+@MainActor
+final class DispatchOrderingTests: XCTestCase {
+    private var savedCoreEnvironment: KlaviyoEnvironment!
+    private var savedEnvironment: KlaviyoSwiftEnvironment!
+
+    override func setUp() {
+        super.setUp()
+        savedCoreEnvironment = environment
+        savedEnvironment = klaviyoSwiftEnvironment
+        environment = KlaviyoEnvironment.test()
+        klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+    }
+
+    override func tearDown() {
+        environment = savedCoreEnvironment
+        klaviyoSwiftEnvironment = savedEnvironment
+        super.tearDown()
+    }
+
+    /// Consecutive dispatches must reduce in call order. Iterated because the pre-fix
+    /// implementation inverted probabilistically (~8% per pair on device).
+    func testConsecutiveDispatchesPreserveCallOrder() async {
+        let iterations = 250
+
+        for iteration in 0..<iterations {
+            let bothReduced = expectation(description: "both actions reduced (iteration \(iteration))")
+            let lock = NSLock()
+            var observed: [String] = []
+
+            klaviyoSwiftEnvironment.send = { action in
+                lock.lock()
+                observed.append(action.orderingLabel)
+                let isComplete = observed.count == 2
+                lock.unlock()
+                if isComplete { bothReduced.fulfill() }
+                return nil
+            }
+
+            dispatchOnMainThread(action: .setEmail("first@example.com"))
+            dispatchOnMainThread(action: .setPhoneNumber("+15005550006"))
+
+            await fulfillment(of: [bothReduced], timeout: 2.0)
+
+            lock.lock()
+            let result = observed
+            lock.unlock()
+
+            XCTAssertEqual(
+                result,
+                ["setEmail", "setPhoneNumber"],
+                "actions must reduce in call order (iteration \(iteration))"
+            )
+        }
+    }
+}
+
+extension KlaviyoAction {
+    fileprivate var orderingLabel: String {
+        switch self {
+        case .setEmail: return "setEmail"
+        case .setPhoneNumber: return "setPhoneNumber"
+        default: return "other"
+        }
+    }
+}

--- a/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
@@ -66,9 +66,8 @@ final class DispatchOrderingTests: XCTestCase {
         }
     }
 
-    /// `initialize(with:)` sends `.initialize` from inside a `Task`, so a synchronous
-    /// `dispatchOnMainThread` would let a following `set(email:)` reduce first — and
-    /// `.setEmail` requires initialization, so it would be dropped.
+    /// `initialize` and `dispatchOnMainThread` share `DispatchQueue.main`, so FIFO ordering
+    /// keeps `.initialize` ahead of a following `set(email:)`, which requires initialization.
     func testDispatchAfterInitializeIsNotReorderedBeforeInitialize() async {
         let bothReduced = expectation(description: "initialize and setEmail both reduced")
         let lock = NSLock()

--- a/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
@@ -63,6 +63,38 @@ final class DispatchOrderingTests: XCTestCase {
             )
         }
     }
+
+    /// `initialize(with:)` sends `.initialize` from inside a `Task`, so a synchronous
+    /// `dispatchOnMainThread` would let a following `set(email:)` reduce first — and
+    /// `.setEmail` requires initialization, so it would be dropped.
+    func testDispatchAfterInitializeIsNotReorderedBeforeInitialize() async {
+        let bothReduced = expectation(description: "initialize and setEmail both reduced")
+        let lock = NSLock()
+        var observed: [String] = []
+
+        klaviyoSwiftEnvironment.send = { action in
+            lock.lock()
+            switch action {
+            case .initialize: observed.append("initialize")
+            case .setEmail: observed.append("setEmail")
+            default: break
+            }
+            let done = observed.count == 2
+            lock.unlock()
+            if done { bothReduced.fulfill() }
+            return nil
+        }
+
+        _ = KlaviyoSDK().initialize(with: "test-key")
+        _ = KlaviyoSDK().set(email: "a@b.com")
+
+        await fulfillment(of: [bothReduced], timeout: 2.0)
+
+        lock.lock()
+        let result = observed
+        lock.unlock()
+        XCTAssertEqual(result, ["initialize", "setEmail"], "setEmail must not reduce before initialize")
+    }
 }
 
 extension KlaviyoAction {

--- a/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
+++ b/Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift
@@ -20,9 +20,11 @@ final class DispatchOrderingTests: XCTestCase {
         savedEnvironment = klaviyoSwiftEnvironment
         environment = KlaviyoEnvironment.test()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
+        SharedStoreMirror.reset()
     }
 
     override func tearDown() {
+        SharedStoreMirror.reset()
         environment = savedCoreEnvironment
         klaviyoSwiftEnvironment = savedEnvironment
         super.tearDown()


### PR DESCRIPTION
# Description
Consecutive Klaviyo SDK calls could reduce out of order — measured at ~8% of adjacent pairs on a physical device, ~11% under CPU load. Dispatching via the main queue restores call order. References MAGE-1026.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Not planned work — found while auditing the subscriptions API ahead of the 5.4.0 tag. `dispatchOnMainThread` is internal and the change is behavior-preserving apart from the ordering guarantee, so it should be safe to take in this release.

## Changelog / Code Overview

`dispatchOnMainThread` is the funnel for every public SDK method:

```swift
// before
Task { await MainActor.run { klaviyoSwiftEnvironment.send(action) } }

// after
DispatchQueue.main.async { _ = klaviyoSwiftEnvironment.send(action) }
```

`initialize(with:)` moves to the same mechanism. It previously sent `.initialize` from inside a `Task`, and **a `Task` hop and a main-queue hop have no ordering guarantee relative to each other** — so mixing them reintroduced the bug at the seam. On iOS 18+ a main-actor `Task` job happens to land on the main queue and order held; on iOS 17 it detours through the cooperative pool first and loses, letting a following `set(email:)` reduce before `.initialize` and be dropped for requiring initialization. CI caught this on both 15.4 jobs after the first fix landed.

The general lesson, which cost three attempts to learn: **partial application of an ordering fix is worse than none.** Any dispatch path that differs from its siblings reintroduces the race where they meet.

**The problem.** `dispatchOnMainThread` is a nonisolated global function, so each `Task` starts on the global cooperative pool and then suspends at the `await`. Ordering therefore depends on when each task *resumes*, and unstructured tasks resume in an unspecified order — two back-to-back calls can reduce in either order. Main-queue FIFO ordering is a documented guarantee on every OS version the SDK supports.

**Why it matters.** The README documents `set(email:)` followed by `create(subscription:)`. If the subscription reduces first, `buildSubscriptionRequest` sees `email == nil`, validation fails, and the request is dropped with only a developer warning — which is compiled out in release builds (`runtimeWarn` is wrapped in `#if DEBUG`). Silent loss of a consent record. `set(email:)` → `create(event:)` has the same exposure, surfacing as silent misattribution instead.

This is not new to the subscriptions work — it has been latent as long as this dispatch pattern has existed. It likely hasn't surfaced because real integrations set identity at login and subscribe much later, seconds apart, so the race window never opens. Both sample apps do exactly that (separate taps). The exposure is specifically *adjacent programmatic calls*, which is also what a future in-app-forms bridge would generate on every submission.

### Alternatives considered

Two other approaches were implemented and rejected with evidence. Recording them here so they don't get retried.

| Approach | Runs inline when already on main? | Ordering | Cost/dispatch |
|---|---|---|---|
| `Task { await MainActor.run { … } }` (current) | no | **broken everywhere** | — |
| `Task { @MainActor in … }` | no — always enqueues | **broken on Xcode 15.4 / iOS 17** | 477–591 ns |
| `MainActor.assumeIsolated` when on main | yes | **breaks `initialize`** | — |
| `DispatchQueue.main.async` (this PR) | no — always enqueues | ok everywhere | **153–162 ns** |

**1. `Task { @MainActor in … }` — fails on Xcode 15.4 / iOS 17.** Zero inversions locally and on device (iOS 26), but CI failed both 15.4 jobs with 16/250 inversions (~6.4%). Isolating the closure only enqueues directly on the main actor in newer runtimes; on older ones it still starts on the global pool and hops, reintroducing the race. It is also ~3× more expensive than the main queue (benchmark below) — `Task.init` allocates a task and runs the concurrency machinery, whereas `dispatch_async` enqueues a block. Notably it does **not** avoid a hop: `Task.init` always enqueues, even when the caller is already on the main actor.

**2. Version-conditional `MainActor.assumeIsolated` on 17+ — breaks `initialize`.** Skipping the hop looks attractive, but `initialize(with:)` sends `.initialize` from inside a `Task`. If `dispatchOnMainThread` runs synchronously, a following `set(email:)` executes *before* that `Task` body — and `.setEmail` has `requiresInitialization == true`, so the reducer drops it. That converts a ~8% probabilistic reorder into a 100% guaranteed drop on the most common integration sequence there is:

```
XCTAssertEqual failed: ("["setEmail", "initialize"]") is not equal to ("["initialize", "setEmail"]")
  - setEmail must not reduce before initialize
```

The async delay is load-bearing. `testDispatchAfterInitializeIsNotReorderedBeforeInitialize` pins this so the optimization can't be reintroduced silently.

A version-conditional split of the two *async* options (`Task` on 17+, main queue below) would be correct, but it adds an `#available` branch and a second code path in exchange for making modern iOS ~3× slower on this path.

**Dispatch cost benchmark** (200k dispatches, 3 runs, release build, M-series):

```
run 1:  Task{@MainActor}=498 ns   DispatchQueue.main.async=162 ns   ratio=3.08x
run 2:  Task{@MainActor}=591 ns   DispatchQueue.main.async=160 ns   ratio=3.68x
run 3:  Task{@MainActor}=477 ns   DispatchQueue.main.async=153 ns   ratio=3.13x
```

## Test Plan

**New tests:** `Tests/KlaviyoSwiftTests/DispatchOrderingTests.swift`

1. `testConsecutiveDispatchesPreserveCallOrder` — dispatches `.setEmail` then `.setPhoneNumber` back-to-back and asserts reduce order, 250 iterations (the pre-fix failure is probabilistic).
2. `testDispatchAfterInitializeIsNotReorderedBeforeInitialize` — guards against the synchronous-dispatch regression described above.

```bash
xcodebuild test -scheme klaviyo-swift-sdk-Package \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:KlaviyoSwiftTests/DispatchOrderingTests
```

Negative control — reverting the fix and re-running fails as expected, always with `["setPhoneNumber", "setEmail"]`:

```
DispatchOrderingTests.swift:59: error: XCTAssertEqual failed:
  ("["setPhoneNumber", "setEmail"]") is not equal to ("["setEmail", "setPhoneNumber"]")
  - actions must reduce in call order (iteration 24)
  ... also 51, 53, 105, 155, 171, 202, 219  (8/250 ~ 3.5% on simulator)
```

Full `klaviyo-swift-sdk-Package` suite: 299 tests, 0 failures. CI green on all six matrix jobs (Xcode 15.4 / 16.4 / 26.5 × debug / release).

### Device measurements

A standalone probe replicating the dispatch pattern, 100k trials per variant, on an iPhone 13 Pro (6-core, iOS 26.5):

| Variant | Idle | Under CPU load |
|---|---|---|
| `Task { await MainActor.run { … } }` (current) | **7.844%** | **11.403%** |
| `Task { @MainActor in … }` | 0% | 0% |
| `DispatchQueue.main.async` (this PR) | 0% | 0% |

Same probe on a 16-core Mac shows only 0.089% / 0.093% for the current implementation. Counter-intuitively the phone is far worse: on a wide pool both tasks get picked up almost immediately and enqueue order usually survives, while on a narrow heterogeneous 6-core pool (2P/4E) tasks land on efficiency cores, get descheduled, and the second regularly beats the first. Forcing the cooperative pool to a single thread (`LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`) yields **zero** inversions in 400k trials, confirming the mechanism requires two pool workers running concurrently.

Practical implication: **the bug gets worse on better hardware** — more performance cores means more exposure, the opposite of most concurrency bugs. That is likely part of why it never surfaced in testing on flagship dev devices doing UI-paced flows.

Note the device runs iOS 26, so it cannot distinguish the two working variants — only CI exercises the iOS 17 path where `Task { @MainActor in }` fails.

## Related Issues/Tickets

References MAGE-1026 — found while auditing the Subscriptions API for that investigation (bridging subscriptions to the in-app forms JS bridge) ahead of the 5.4.0 tag. This PR is a tangent, not a deliverable of that ticket. Discussion in #mobile-app-growth: https://klaviyo.slack.com/archives/C08GN96SF1B/p1785859142458979

**Reviewer note:** worth a look from someone with strong Swift concurrency opinions. The device/Mac percentages come from a probe that models `dispatchOnMainThread`'s shape rather than exercising the SDK end-to-end, so if the TCA store serializes sends in a way the model doesn't capture, the real-world rate could differ. The two regression tests do exercise the actual `dispatchOnMainThread`, and both fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering and reliability of SDK initialization and dispatched actions.
  * Ensured email updates are processed only after initialization completes.
  * Improved consistency when SDK operations are scheduled on the main thread.

* **Tests**
  * Added coverage for consecutive action dispatch ordering.
  * Added regression tests for initialization sequencing before email updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->