### PR TITLE
refactor(KlaviyoCore): consolidate first-party locks on UnfairLock

### DIFF
--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -32,7 +32,10 @@ final class EventBuffer {
     private let maxBufferSize: Int
     private let maxBufferAge: TimeInterval
     private let clock: () -> TimeInterval
-    private let queue = DispatchQueue(label: "com.klaviyo.eventBuffer", attributes: .concurrent)
+    // A single unfair lock guards `buffer`. The buffer holds at most `maxBufferSize` (~10) events, so
+    // a reader/writer scheme (concurrent queue + barrier) buys nothing here and a plain lock keeps the
+    // mutations synchronous — a read immediately after a write always sees it.
+    private let lock = UnfairLock()
 
     // MARK: - Initialization
 
@@ -61,57 +64,54 @@ final class EventBuffer {
             Logger.eventBuffer.info("📤 Buffering event: \(event.metric.name.value, privacy: .public)")
         }
 
-        queue.async(flags: .barrier) { [weak self] in
-            guard let self else { return }
-            let currentTime = self.clock()
+        let count = lock.withLock {
+            let currentTime = clock()
 
             // Clean old events from buffer (using monotonic clock to avoid issues with device clock changes)
-            self.buffer = self.buffer.filter { currentTime - $0.timestamp < self.maxBufferAge }
+            buffer = buffer.filter { currentTime - $0.timestamp < maxBufferAge }
 
             // Add new event
-            self.buffer.append(BufferedEvent(event: event, timestamp: currentTime))
+            buffer.append(BufferedEvent(event: event, timestamp: currentTime))
 
             // Keep only last N events
-            if self.buffer.count > self.maxBufferSize {
-                self.buffer = Array(self.buffer.suffix(self.maxBufferSize))
+            if buffer.count > maxBufferSize {
+                buffer = Array(buffer.suffix(maxBufferSize))
             }
+            return buffer.count
+        }
 
-            if #available(iOS 14.0, *) {
-                Logger.eventBuffer.info("💾 Buffer now has \(self.buffer.count) event(s)")
-            }
+        if #available(iOS 14.0, *) {
+            Logger.eventBuffer.info("💾 Buffer now has \(count) event(s)")
         }
     }
 
     /// Gets recent events from the buffer (within maxBufferAge).
     /// - Returns: Array of buffered events that haven't expired
     func getRecentEvents() -> [Event] {
-        queue.sync {
+        let recentEvents = lock.withLock { () -> [Event] in
             let currentTime = clock()
-            let recentEvents = buffer
+            return buffer
                 .filter { currentTime - $0.timestamp < maxBufferAge }
                 .map(\.event)
-
-            if #available(iOS 14.0, *) {
-                if recentEvents.isEmpty {
-                    Logger.eventBuffer.info("📭 Event buffer is empty - no events to replay")
-                } else {
-                    let names = recentEvents.map(\.metric.name.value).joined(separator: ", ")
-                    Logger.eventBuffer.info(
-                        "📬 Replaying \(recentEvents.count) buffered event(s): \(names, privacy: .public)"
-                    )
-                }
-            }
-
-            return recentEvents
         }
+
+        if #available(iOS 14.0, *) {
+            if recentEvents.isEmpty {
+                Logger.eventBuffer.info("📭 Event buffer is empty - no events to replay")
+            } else {
+                let names = recentEvents.map(\.metric.name.value).joined(separator: ", ")
+                Logger.eventBuffer.info(
+                    "📬 Replaying \(recentEvents.count) buffered event(s): \(names, privacy: .public)"
+                )
+            }
+        }
+
+        return recentEvents
     }
 
     /// Clears all events from the buffer.
     /// This is useful for testing to ensure clean state between tests.
     func clear() {
-        queue.async(flags: .barrier) { [weak self] in
-            guard let self else { return }
-            self.buffer.removeAll()
-        }
+        lock.withLock { buffer.removeAll() }
     }
 }

--- a/Sources/KlaviyoCore/EventBuffer.swift
+++ b/Sources/KlaviyoCore/EventBuffer.swift
@@ -69,11 +69,8 @@ final class EventBuffer {
 
             // Clean old events from buffer (using monotonic clock to avoid issues with device clock changes)
             buffer = buffer.filter { currentTime - $0.timestamp < maxBufferAge }
-
-            // Add new event
             buffer.append(BufferedEvent(event: event, timestamp: currentTime))
 
-            // Keep only last N events
             if buffer.count > maxBufferSize {
                 buffer = Array(buffer.suffix(maxBufferSize))
             }

--- a/Sources/KlaviyoCore/EventDispatching.swift
+++ b/Sources/KlaviyoCore/EventDispatching.swift
@@ -22,22 +22,20 @@ public protocol EventDispatching {
 public final class EventDispatcher {
     public static let shared = EventDispatcher()
 
-    private let lock = NSLock()
+    private let lock = UnfairLock()
     private var target: EventDispatching?
 
     /// Register the dispatch implementation (idempotent — replaces any prior target).
     public func register(_ target: EventDispatching) {
-        lock.lock()
-        self.target = target
-        lock.unlock()
+        lock.withLock { self.target = target }
     }
 
     /// Forward a command to the registered target. If none is registered, emit a loud
     /// developer warning rather than silently dropping (buffering is deferred follow-up work).
     public func dispatch(_ command: InboundCommand) {
-        lock.lock()
-        let currentTarget = target
-        lock.unlock() // release before forwarding — a downstream effect may re-enter dispatch
+        // Snapshot under the lock, then forward OUTSIDE it — a downstream effect may re-enter
+        // dispatch, and the lock is non-recursive.
+        let currentTarget = lock.withLock { target }
         if let currentTarget {
             currentTarget.dispatch(command)
         } else {
@@ -47,8 +45,6 @@ public final class EventDispatcher {
 
     /// Unregister the current target (test-support / Core reset surface).
     package func reset() {
-        lock.lock()
-        target = nil
-        lock.unlock()
+        lock.withLock { target = nil }
     }
 }

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -29,11 +29,13 @@ public protocol IdentityWriting {
 public final class IdentityStore: IdentityReading, IdentityWriting {
     public static let shared = IdentityStore()
 
+    // INVARIANT: never hold `lock` across `subject.send`. `lock` is a non-recursive `UnfairLock`;
+    // Combine delivers synchronously, so a subscriber that reads a lock-guarded accessor (e.g.
+    // `pushToken`) during delivery would deadlock. Always mutate under the lock, then emit outside it.
+    //
     // `subject` (CurrentValueSubject) is internally synchronized, so `.value` reads and `.send`
-    // need no external lock. `lock` guards only `hydrated`, `pushTokenValue`, and disk I/O, and is
-    // NEVER held across `subject.send`: Combine delivers synchronously, so a subscriber that reads a
-    // lock-guarded accessor (e.g. `pushToken`) during delivery would deadlock. Hydration may assign
-    // `subject.value` under the lock only because a fresh store has no subscribers yet.
+    // need no external lock. `lock` guards only `hydrated`, `pushTokenValue`, and disk I/O. Hydration
+    // may assign `subject.value` under the lock only because a fresh store has no subscribers yet.
     private let subject: CurrentValueSubject<ProfileData, Never>
     private let lock = UnfairLock()
     private var hydrated = false

--- a/Sources/KlaviyoCore/IdentityStore.swift
+++ b/Sources/KlaviyoCore/IdentityStore.swift
@@ -33,6 +33,12 @@ public final class IdentityStore: IdentityReading, IdentityWriting {
     // Combine delivers synchronously, so a subscriber that reads a lock-guarded accessor (e.g.
     // `pushToken`) during delivery would deadlock. Always mutate under the lock, then emit outside it.
     //
+    // SINGLE WRITER: all writes (`update`/`updatePushToken`) come from the TCA reducer's write-through
+    // defer, which runs serially, so persist-then-emit is never interleaved by a second writer. The
+    // lock therefore guards reads (accessors, publisher/stream delivery on arbitrary threads) racing a
+    // write — not writer-vs-writer. If a concurrent writer is ever introduced, persist and emit could
+    // reorder across threads; revisit this the way `QueueStore.persistCurrent` handles it.
+    //
     // `subject` (CurrentValueSubject) is internally synchronized, so `.value` reads and `.send`
     // need no external lock. `lock` guards only `hydrated`, `pushTokenValue`, and disk I/O. Hydration
     // may assign `subject.value` under the lock only because a fresh store has no subscribers yet.

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -70,15 +70,19 @@ public final class QueueStore {
     private let scheduler: PersistScheduler
     private let emitWarning: (String) -> Void
 
-    // guards `queue`; released before disk writes so I/O never blocks queue ops
+    // Two locks keep slow disk I/O off the hot queue path: `queueLock` guards the in-memory array
+    // and is released before any disk write, so a persist never blocks enqueue/prepend/reads.
+    // `persistLock` serializes writes and guards the debounce-coalescing state.
+    //
+    // LOCK ORDERING: when both are held, always acquire `persistLock` before `queueLock`, never the
+    // reverse. `persistCurrent` is the only nesting site (persistLock outer, queueLock inner); every
+    // other site takes exactly one lock. Preserve this order to stay deadlock-free.
     private let queueLock = UnfairLock()
-    private let persistLock = UnfairLock() // serializes writes + guards the debounce-coalescing state
+    private let persistLock = UnfairLock()
     private var queue: [KlaviyoRequest]? // nil until hydrated; authoritative once loaded
-    // Coalesces `.debounced` persists: the first mutation in a window schedules one callback and
-    // records its token here; later debounced mutations within the window coalesce onto it instead
-    // of scheduling their own. A synchronous persist — or the callback firing — clears it. `0` means
-    // no debounce is pending. `debounceSeq` mints unique tokens so a superseded callback can tell it
-    // is no longer the current one and no-op.
+    // Debounce-coalescing state (guarded by `persistLock`). `pendingDebounceToken` is the token of the
+    // window's scheduled callback, or `0` when none is pending; `debounceSeq` mints unique tokens.
+    // See `schedulePersist` for how a burst coalesces onto a single callback.
     private var pendingDebounceToken = 0
     private var debounceSeq = 0
 
@@ -142,12 +146,10 @@ public final class QueueStore {
 
     // MARK: Persistence
 
-    /// Either flushes inline (`.synchronous`) or schedules one debounced flush per window
-    /// (`.debounced`). A debounced burst coalesces to a single scheduled callback: only the first
-    /// mutation schedules, later ones piggyback on the pending token. A synchronous persist clears
-    /// the pending token so its still-scheduled callback no-ops when it fires. Coalescing is only an
-    /// optimization — correctness comes from `persistCurrent`, which always writes the current
-    /// authoritative queue, so a superseded fire can never persist stale state.
+    /// Flushes inline (`.synchronous`) or coalesces to one debounced flush per window (`.debounced`):
+    /// only the first mutation in a window schedules a callback, later ones piggyback on its token,
+    /// and a synchronous persist clears the token so its still-scheduled callback no-ops. Coalescing
+    /// is purely an optimization — see `persistCurrent` for why a superseded fire is always safe.
     private func schedulePersist(_ policy: PersistPolicy) {
         switch policy {
         case .synchronous:
@@ -175,10 +177,10 @@ public final class QueueStore {
         }
     }
 
-    /// Serializes the whole persist under `persistLock` and snapshots the *current* authoritative
-    /// queue at write time. Because every persist reads the latest memory and writes are serialized,
-    /// disk always converges to the newest state — there is no captured snapshot that can go stale.
-    /// `queueLock` is released before the disk write so I/O never blocks queue ops.
+    /// Snapshots the *current* queue at write time (not at schedule time) and writes it under
+    /// `persistLock`. Serialized writes of the latest memory mean disk always converges to the newest
+    /// state, so a superseded debounce fire can never persist stale data. `queueLock` is held only for
+    /// the snapshot and released before the disk write, so I/O never blocks queue ops.
     private func persistCurrent() {
         persistLock.withLock {
             let snapshot = queueLock.withLock { queue ?? [] }

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -71,8 +71,8 @@ public final class QueueStore {
     private let emitWarning: (String) -> Void
 
     // guards `queue`; released before disk writes so I/O never blocks queue ops
-    private let queueLock = NSLock()
-    private let persistLock = NSLock() // serializes writes + guards the debounce-coalescing state
+    private let queueLock = UnfairLock()
+    private let persistLock = UnfairLock() // serializes writes + guards the debounce-coalescing state
     private var queue: [KlaviyoRequest]? // nil until hydrated; authoritative once loaded
     // Coalesces `.debounced` persists: the first mutation in a window schedules one callback and
     // records its token here; later debounced mutations within the window coalesce onto it instead
@@ -99,27 +99,27 @@ public final class QueueStore {
     // MARK: Mutations
 
     public func enqueue(_ request: KlaviyoRequest, persist: PersistPolicy = .debounced) {
-        queueLock.lock()
-        var next = hydrated()
-        evictIfAtCapacity(&next)
-        if request.priority == .high {
-            next.insert(request, at: 0)
-        } else {
-            next.append(request)
+        queueLock.withLock {
+            var next = hydrated()
+            evictIfAtCapacity(&next)
+            if request.priority == .high {
+                next.insert(request, at: 0)
+            } else {
+                next.append(request)
+            }
+            queue = next
         }
-        queue = next
-        queueLock.unlock()
         schedulePersist(persist)
     }
 
     public func prepend(_ requests: [KlaviyoRequest],
                         persist: PersistPolicy = .debounced) {
         guard !requests.isEmpty else { return }
-        queueLock.lock()
-        var next = hydrated()
-        next.insert(contentsOf: requests, at: 0) // deliberately no eviction — see evictIfAtCapacity
-        queue = next
-        queueLock.unlock()
+        queueLock.withLock {
+            var next = hydrated()
+            next.insert(contentsOf: requests, at: 0) // deliberately no eviction — see evictIfAtCapacity
+            queue = next
+        }
         schedulePersist(persist)
     }
 
@@ -151,23 +151,24 @@ public final class QueueStore {
     private func schedulePersist(_ policy: PersistPolicy) {
         switch policy {
         case .synchronous:
-            persistLock.lock()
-            pendingDebounceToken = 0 // supersede any pending debounce; its callback will no-op
-            persistLock.unlock()
+            // supersede any pending debounce; its callback will no-op
+            persistLock.withLock { pendingDebounceToken = 0 }
             persistCurrent()
         case .debounced:
-            persistLock.lock()
-            guard pendingDebounceToken == 0 else { persistLock.unlock(); return } // coalesce
-            debounceSeq &+= 1
-            let token = debounceSeq
-            pendingDebounceToken = token
-            persistLock.unlock()
+            let token: Int? = persistLock.withLock {
+                guard pendingDebounceToken == 0 else { return nil } // coalesce onto the pending window
+                debounceSeq &+= 1
+                pendingDebounceToken = debounceSeq
+                return debounceSeq
+            }
+            guard let token else { return }
             scheduler.schedule(Self.debounceInterval) { [weak self] in
                 guard let self else { return }
-                self.persistLock.lock()
-                let isCurrent = self.pendingDebounceToken == token
-                if isCurrent { self.pendingDebounceToken = 0 }
-                self.persistLock.unlock()
+                let isCurrent = self.persistLock.withLock { () -> Bool in
+                    let current = self.pendingDebounceToken == token
+                    if current { self.pendingDebounceToken = 0 }
+                    return current
+                }
                 guard isCurrent else { return } // superseded → coalesced away
                 self.persistCurrent()
             }
@@ -179,27 +180,24 @@ public final class QueueStore {
     /// disk always converges to the newest state — there is no captured snapshot that can go stale.
     /// `queueLock` is released before the disk write so I/O never blocks queue ops.
     private func persistCurrent() {
-        persistLock.lock(); defer { persistLock.unlock() }
-        queueLock.lock()
-        let snapshot = queue ?? []
-        queueLock.unlock()
-        do {
-            try diskIO.save(snapshot)
-        } catch {
-            emitWarning("QueueStore: failed to persist queue (\(error))")
+        persistLock.withLock {
+            let snapshot = queueLock.withLock { queue ?? [] }
+            do {
+                try diskIO.save(snapshot)
+            } catch {
+                emitWarning("QueueStore: failed to persist queue (\(error))")
+            }
         }
     }
 
     // MARK: Reads
 
     public var requests: [KlaviyoRequest] {
-        queueLock.lock(); defer { queueLock.unlock() }
-        return hydrated()
+        queueLock.withLock { hydrated() }
     }
 
     public var count: Int {
-        queueLock.lock(); defer { queueLock.unlock() }
-        return hydrated().count
+        queueLock.withLock { hydrated().count }
     }
 
     /// Loads from disk on first access; memory is authoritative thereafter. Call under `queueLock`.
@@ -212,24 +210,24 @@ public final class QueueStore {
 }
 
 extension QueueStore {
-    private static let registryLock = NSLock()
+    private static let registryLock = UnfairLock()
     private static var registry: [String: QueueStore] = [:]
 
     /// Resolves the current apiKey from `SDKConfigStore` and returns the (cached) store for it,
     /// or `nil` if no apiKey is set yet (buffering pre-apiKey events is handled elsewhere).
     public static func current() -> QueueStore? {
         guard let apiKey = SDKConfigStore.shared.current.apiKey else { return nil }
-        registryLock.lock(); defer { registryLock.unlock() }
-        if let existing = registry[apiKey] { return existing }
-        let store = QueueStore(apiKey: apiKey)
-        registry[apiKey] = store
-        return store
+        return registryLock.withLock {
+            if let existing = registry[apiKey] { return existing }
+            let store = QueueStore(apiKey: apiKey)
+            registry[apiKey] = store
+            return store
+        }
     }
 
     /// Test-support: clears the per-apiKey instance cache.
     package static func resetRegistry() {
-        registryLock.lock(); defer { registryLock.unlock() }
-        registry.removeAll()
+        registryLock.withLock { registry.removeAll() }
     }
 }
 

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -36,6 +36,11 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
     // `current`, via `hydrateIfNeeded`) during delivery would deadlock. Always mutate under the lock,
     // then emit outside it.
     //
+    // SINGLE WRITER: all writes (`update`) come from the TCA reducer's write-through defer, which runs
+    // serially, so persist-then-emit is never interleaved by a second writer. The lock therefore
+    // guards reads (accessors, publisher/stream delivery on arbitrary threads) racing a write — not
+    // writer-vs-writer.
+    //
     // `subject` (CurrentValueSubject) is internally synchronized, so `.value` reads and `.send`
     // need no external lock. `lock` guards only `hydrated` and disk I/O. Hydration may assign
     // `subject.value` under the lock only because a fresh store has no subscribers yet.

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -31,11 +31,14 @@ public protocol ConfigWriting {
 public final class SDKConfigStore: ConfigReading, ConfigWriting {
     public static let shared = SDKConfigStore()
 
+    // INVARIANT: never hold `lock` across `subject.send`. `lock` is a non-recursive `UnfairLock`;
+    // Combine delivers synchronously, so a subscriber that reads a lock-guarded accessor (e.g.
+    // `current`, via `hydrateIfNeeded`) during delivery would deadlock. Always mutate under the lock,
+    // then emit outside it.
+    //
     // `subject` (CurrentValueSubject) is internally synchronized, so `.value` reads and `.send`
-    // need no external lock. `lock` guards only `hydrated` and disk I/O, and is NEVER held across
-    // `subject.send`: Combine delivers synchronously, so a subscriber that reads a lock-guarded
-    // accessor (e.g. `current`, via `hydrateIfNeeded`) during delivery would deadlock. Hydration
-    // may assign `subject.value` under the lock only because a fresh store has no subscribers yet.
+    // need no external lock. `lock` guards only `hydrated` and disk I/O. Hydration may assign
+    // `subject.value` under the lock only because a fresh store has no subscribers yet.
     private let subject: CurrentValueSubject<KlaviyoConfig, Never>
     private let lock = UnfairLock()
     private var hydrated = false

--- a/Sources/KlaviyoCore/SDKConfigStore.swift
+++ b/Sources/KlaviyoCore/SDKConfigStore.swift
@@ -82,9 +82,8 @@ public final class SDKConfigStore: ConfigReading, ConfigWriting {
 
     public func update(_ config: KlaviyoConfig) {
         hydrateIfNeeded()
-        // Persist under the lock so concurrent `update` calls can't interleave file writes
-        // (mirrors `IdentityStore`). The `config` param is written directly, so there is no
-        // stale-snapshot risk.
+        // Persist under the lock so concurrent `update` calls can't interleave file writes.
+        // The `config` param is written directly, so there is no stale-snapshot risk.
         lock.withLock {
             savePersisted(
                 PersistedConfig(version: PersistedConfig.currentVersion, apiKey: config.apiKey),

--- a/Sources/KlaviyoCore/UnfairLock.swift
+++ b/Sources/KlaviyoCore/UnfairLock.swift
@@ -16,7 +16,11 @@ import os
 ///
 /// Semantics inherited from `os_unfair_lock`: not recursive (re-entering `withLock` on the same thread
 /// deadlocks) and not fair, but priority-inversion safe (the kernel can boost the lock holder).
-final class UnfairLock {
+///
+/// This is the SDK's single first-party locking primitive for guarding simple critical sections —
+/// prefer it over `NSLock`/GCD for in-memory state. `@unchecked Sendable` is sound: the boxed
+/// `os_unfair_lock` is the synchronization, and `withLock` is its only access path.
+final class UnfairLock: @unchecked Sendable {
     private var _lock = os_unfair_lock_s()
 
     func withLock<R>(_ body: () throws -> R) rethrows -> R {

--- a/Sources/KlaviyoCore/Utils/Logger+Ext.swift
+++ b/Sources/KlaviyoCore/Utils/Logger+Ext.swift
@@ -17,23 +17,15 @@ import OSLog
 package final class KlaviyoLogConfig: @unchecked Sendable {
     package static let shared = KlaviyoLogConfig()
 
-    private let lock = NSLock()
+    private let lock = UnfairLock()
     private var _isLoggingEnabled: Bool = true
 
     private init() {}
 
     /// Whether logging is currently enabled across all Klaviyo SDK modules.
     package var isLoggingEnabled: Bool {
-        get {
-            lock.lock()
-            defer { lock.unlock() }
-            return _isLoggingEnabled
-        }
-        set {
-            lock.lock()
-            defer { lock.unlock() }
-            _isLoggingEnabled = newValue
-        }
+        get { lock.withLock { _isLoggingEnabled } }
+        set { lock.withLock { _isLoggingEnabled = newValue } }
     }
 }
 

--- a/Tests/KlaviyoCoreTests/EventBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/EventBufferTests.swift
@@ -28,9 +28,9 @@ class EventBufferTests: XCTestCase {
     // MARK: - Helpers
 
     /// A buffer whose clock the test controls, so age-based behavior is deterministic
-    /// without sleeping real time. `buffer(_:)` is an async barrier write, so callers
-    /// must `getRecentEvents()` (a synchronous, barrier-flushing read) to pin an event's
-    /// timestamp at the current `currentTime` before advancing the clock.
+    /// without sleeping real time. `buffer(_:)` mutates synchronously under the lock and
+    /// stamps the event with the current `currentTime` before returning, so tests can advance
+    /// the clock immediately afterward and rely on that pinned timestamp.
     private func makeClockedBuffer(
         maxBufferSize: Int = 5,
         maxBufferAge: TimeInterval = 2.0,
@@ -53,8 +53,8 @@ class EventBufferTests: XCTestCase {
         // Given
         let event = Event(name: .customEvent("test_event"))
 
-        // When — getRecentEvents() is a synchronous, barrier-flushing read, so it observes
-        // the preceding async buffer() write deterministically (no sleep needed).
+        // When — buffer() applies the write synchronously under the lock, so the following
+        // getRecentEvents() observes it deterministically (no sleep needed).
         eventBuffer.buffer(event)
         let events = eventBuffer.getRecentEvents()
 
@@ -191,9 +191,9 @@ class EventBufferTests: XCTestCase {
     }
 
     func testConcurrentReadingAndWriting() {
-        // Stress the reader/writer lock from many real threads: even iterations issue
-        // barrier writes, odd iterations issue reads. `concurrentPerform` fully joins
-        // all iterations before returning, so no work outlives the test.
+        // Stress the buffer's lock from many real threads: even iterations issue writes,
+        // odd iterations issue reads. `concurrentPerform` fully joins all iterations before
+        // returning, so no work outlives the test.
         DispatchQueue.concurrentPerform(iterations: 100) { index in
             if index.isMultiple(of: 2) {
                 eventBuffer.buffer(Event(name: .customEvent("event_\(index)")))
@@ -202,9 +202,9 @@ class EventBufferTests: XCTestCase {
             }
         }
 
-        // The 50 writes all landed and the size limit held. This final read is a
-        // barrier-flushing `queue.sync`, so it observes every enqueued write; with a
-        // frozen clock (nothing ages out) the buffer settles at exactly maxBufferSize.
+        // The 50 writes all landed and the size limit held. `buffer` mutates synchronously
+        // under the lock, so by the time `concurrentPerform` returns every write is applied;
+        // with a frozen clock (nothing ages out) the buffer settles at exactly maxBufferSize.
         let events = eventBuffer.getRecentEvents()
         XCTAssertEqual(events.count, 5, "50 concurrent writes should fill the buffer to its max size")
     }

--- a/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
+++ b/Tests/KlaviyoCoreTests/EventDispatcherTests.swift
@@ -88,6 +88,40 @@ final class EventDispatcherTests: XCTestCase {
         XCTAssertEqual(second.received.count, 1)
     }
 
+    // Thread-safe spy for the concurrency test: `dispatch` may be called from many threads at once,
+    // so its own bookkeeping must be synchronized independently of the code under test.
+    private final class CountingDispatcher: EventDispatching {
+        private let lock = UnfairLock()
+        private var _count = 0
+        var count: Int { lock.withLock { _count } }
+        func dispatch(_: InboundCommand) { lock.withLock { _count += 1 } }
+    }
+
+    // Stress concurrent register/dispatch/reset. Exercises the snapshot-under-lock-then-forward-
+    // outside path and the register/dispatch race on `target`. Success = no crash, no deadlock, and
+    // every dispatch either forwards to the currently-registered target or hits the warning path
+    // (never both, never a torn read). Meaningful under Thread Sanitizer.
+    func testConcurrentRegisterDispatchResetDoesNotRace() {
+        let dispatcher = EventDispatcher()
+        let target = CountingDispatcher()
+        environment.emitDeveloperWarning = { _ in } // may fire when dispatch races a reset; ignore
+        dispatcher.register(target)
+
+        DispatchQueue.concurrentPerform(iterations: 1000) { index in
+            switch index % 4 {
+            case 0: dispatcher.register(target)
+            case 1: dispatcher.reset()
+            default: dispatcher.dispatch(.aggregateEvent(Data()))
+            }
+        }
+
+        // Leave a deterministic final state: re-register and confirm forwarding still works.
+        dispatcher.register(target)
+        let before = target.count
+        dispatcher.dispatch(.aggregateEvent(Data()))
+        XCTAssertEqual(target.count, before + 1)
+    }
+
     // reset(): after reset(), dispatch should warn and not forward to the previous target.
     func testResetUnregistersTarget() {
         let dispatcher = EventDispatcher()

--- a/Tests/KlaviyoCoreTests/QueueStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/QueueStoreTests.swift
@@ -317,6 +317,56 @@ final class QueueStoreTests: XCTestCase {
                        "disk must match the in-memory queue exactly — no lost or reordered writes")
     }
 
+    /// Mixed-policy sibling of the convergence test: `.debounced` and `.synchronous` mutations run
+    /// concurrently, contending on `queueLock` (the array) and `persistLock` (the debounce-coalescing
+    /// state) at once. Debounced work is dropped by the scheduler; a final synchronous flush then
+    /// persists the settled queue, and disk must match memory exactly — no lost, duplicated, or
+    /// reordered writes from the interleaving. Meaningful under Thread Sanitizer.
+    func testConcurrentMixedPersistPoliciesConvergeOnFinalSyncFlush() {
+        let iterations = 100 // < maxQueueSize, so no eviction
+        let diskIO = SpyDiskIO()
+        // Drop debounced work; convergence is forced deterministically by the final synchronous flush.
+        let store = QueueStore(diskIO: diskIO.makeIO(),
+                               scheduler: QueueStore.PersistScheduler { _, _ in },
+                               emitWarning: { _ in })
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            let policy: PersistPolicy = index.isMultiple(of: 2) ? .debounced : .synchronous
+            store.enqueue(
+                request("req-\(index)", at: Date(timeIntervalSince1970: TimeInterval(index))),
+                persist: policy
+            )
+        }
+
+        // Flush the settled in-memory queue to disk after all concurrent work has joined.
+        store.enqueue(
+            request("flush", at: Date(timeIntervalSince1970: TimeInterval(iterations))),
+            persist: .synchronous
+        )
+
+        XCTAssertEqual(store.count, iterations + 1)
+        XCTAssertEqual(diskIO.stored.map(\.id), store.requests.map(\.id),
+                       "after a final synchronous flush, disk matches the in-memory queue exactly")
+    }
+
+    /// Stresses the static `registryLock`: many threads resolve `current()` for the same apiKey and
+    /// must all receive the one cached instance — no torn read that mints a duplicate store.
+    func testConcurrentCurrentResolvesSingleCachedInstance() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "concurrent-key"))
+        let collectLock = UnfairLock()
+        var resolved: [QueueStore] = []
+
+        DispatchQueue.concurrentPerform(iterations: 200) { _ in
+            if let store = QueueStore.current() {
+                collectLock.withLock { resolved.append(store) }
+            }
+        }
+
+        XCTAssertEqual(resolved.count, 200, "every resolution returned a store")
+        let first = resolved.first
+        XCTAssertTrue(resolved.allSatisfy { $0 === first }, "all resolutions share one cached instance")
+    }
+
     func testProductionSchedulerRunsScheduledWork() {
         let didRun = expectation(description: "scheduled work ran")
         QueueStore.PersistScheduler.production.schedule(0.01) { didRun.fulfill() }

--- a/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/SDKConfigStoreTests.swift
@@ -63,6 +63,38 @@ final class SDKConfigStoreTests: XCTestCase {
         XCTAssertNil(store.current.apiKey)
     }
 
+    // Two consumers subscribed before any write must each see the initial value followed by every
+    // update in order — no drops. Mirrors IdentityStore's concurrent-consumer test; exercises the
+    // never-hold-lock-across-send invariant under synchronous Combine delivery to multiple sinks.
+    func testStreamDeliversAllUpdatesToConcurrentConsumersNoDrops() async {
+        let store = SDKConfigStore()
+        let updates = (0..<100).map { KlaviyoConfig(apiKey: "key-\($0)") }
+
+        let streamA = store.stream()
+        let streamB = store.stream()
+
+        for update in updates {
+            store.update(update)
+        }
+
+        func collect(_ stream: AsyncStream<KlaviyoConfig>) async -> [KlaviyoConfig] {
+            var received: [KlaviyoConfig] = []
+            for await value in stream {
+                received.append(value)
+                if value == updates.last { break }
+            }
+            return received
+        }
+
+        async let receivedA = collect(streamA)
+        async let receivedB = collect(streamB)
+        let (resultA, resultB) = await (receivedA, receivedB)
+
+        let expected = [KlaviyoConfig()] + updates
+        XCTAssertEqual(resultA, expected)
+        XCTAssertEqual(resultB, expected)
+    }
+
     func testStreamYieldsCurrentValueThenUpdates() async {
         let store = SDKConfigStore()
         var iterator = store.stream().makeAsyncIterator()


### PR DESCRIPTION
# Description
Consolidates KlaviyoCore's in-memory synchronization on a single `UnfairLock` primitive, retiring first-party `NSLock` and EventBuffer's concurrent-queue+barrier scheme. Behavior-preserving refactor.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] This is planned work for an upcoming release.

Internal only — no public API changes. `UnfairLock` remains the iOS 13-floor hand-rolled equivalent of `OSAllocatedUnfairLock`.

## Changelog / Code Overview
- **UnfairLock** — marked `@unchecked Sendable`; documented as the canonical first-party lock for simple in-memory state.
- **QueueStore, EventDispatcher, KlaviyoLogConfig** — migrated `NSLock` → `UnfairLock` with scoped `withLock` (closure enforces balanced lock/unlock). QueueStore's `persistLock → queueLock` ordering preserved.
- **EventBuffer** — replaced concurrent `DispatchQueue` + `.barrier` reader/writer scheme with a single `UnfairLock`; mutations are now synchronous, so a read right after a write always observes it.
- **IdentityStore / SDKConfigStore** — added `INVARIANT:` markers for the never-hold-the-lock-across-`subject.send` contract (non-recursive lock + synchronous Combine delivery).
- **EventBufferTests** — updated comments that described the retired barrier mechanism.

Net: first-party `NSLock` eliminated from Core; in-memory lock mechanisms reduced from 5 to 1 (`UnfairLock`), with serial `DispatchQueue` retained only where GCD is used for its actual purpose (ordered async disk writes). `pruneCategory`'s GCD+semaphore bridge is intentionally left as-is.

## Test Plan
- `xcodebuild build -scheme KlaviyoSwift` (compiles KlaviyoCore) — succeeds.
- Full KlaviyoCore suite passes (51 tests), including concurrency stress tests (`concurrentPerform`) across QueueStore, EventBuffer, IdentityStore, SDKConfigStore, KlaviyoLogConfig.
- Re-ran the suite under **Thread Sanitizer** (`-enableThreadSanitizer YES`): 0 data races on the migrated locks.
- `swiftlint` clean on changed files.

## Related Issues/Tickets
Follow-up from the KlaviyoCore canonical-stores work (stacked on `mage-894`). See PR comment for the full lock analysis that motivated this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of event buffering, dispatching, queue management, identity handling, configuration, and logging during concurrent activity.
  * Ensured buffered events are immediately available after writes, with consistent retrieval and clearing behavior.
  * Improved consistency of queued data persistence and configuration updates.

* **Tests**
  * Expanded concurrency coverage for event dispatching, queue persistence, configuration updates, and cached store access.
  * Verified synchronous writes, immediate results, ordered updates, and reliable event forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->