### PR TITLE
fix(KlaviyoForms): invalidate cached auth token on BadJWT

### DIFF
--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -468,9 +468,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     /// still unexpired. Without this, the same rejected token would keep
     /// being served to every later WebView/form until it naturally expires
     /// or the app restarts. This is deliberately passive: it does not
-    /// attempt to fetch or push a replacement for the currently-open form —
-    /// see MAGE-1118 for why an active retry here needs separate design
-    /// alignment before it's built.
+    /// attempt to fetch or push a replacement for the currently-open form.
     @MainActor
     private func handleBadJWT() {
         Task {

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -36,6 +36,12 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let formLifecycleContinuation: AsyncStream<IAFLifecycleEvent>.Continuation
     private let (handshakeStream, handshakeContinuation) = AsyncStream.makeStream(of: Void.self)
 
+    /// Maximum number of fresh-token fetches attempted per WebView in response
+    /// to `badJWT`, so a provider that always returns an invalid token can't
+    /// retry forever.
+    private static let maxBadJWTRetryAttempts = 2
+    private var badJWTRetryAttempts = 0
+
     // MARK: - Scripts
 
     @MainActor
@@ -454,6 +460,38 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         case .badJWT:
             if #available(iOS 14.0, *) {
                 Logger.webViewLogger.warning("KlaviyoJS rejected the injected auth token (BadJWT)")
+            }
+            handleBadJWT()
+        }
+    }
+
+    /// Responds to a `badJWT` rejection by fetching a genuinely fresh token and
+    /// pushing it, resolving KlaviyoJS's pending `awaitNextSetJWT()`.
+    ///
+    /// The rejected token must be invalidated before re-fetching — the cache
+    /// would otherwise hand back the same bad token, since a `badJWT`
+    /// rejection isn't reflected in the token's own `exp` claim. Bounded by
+    /// ``maxBadJWTRetryAttempts`` since a provider that always returns an
+    /// invalid token would otherwise retry indefinitely.
+    @MainActor
+    private func handleBadJWT() {
+        guard badJWTRetryAttempts < Self.maxBadJWTRetryAttempts else {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning("BadJWT retry limit reached; no further attempts will be made")
+            }
+            return
+        }
+        badJWTRetryAttempts += 1
+
+        Task { @MainActor in
+            await AuthTokenManager.shared.clearTokenState()
+            do {
+                let token = try await AuthTokenManager.shared.currentToken(mode: .background)
+                await pushAuthToken(token)
+            } catch {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning("Unable to fetch a fresh auth token after BadJWT: \(error)")
+                }
             }
         }
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -36,12 +36,6 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
     private let formLifecycleContinuation: AsyncStream<IAFLifecycleEvent>.Continuation
     private let (handshakeStream, handshakeContinuation) = AsyncStream.makeStream(of: Void.self)
 
-    /// Maximum number of fresh-token fetches attempted per WebView in response
-    /// to `badJWT`, so a provider that always returns an invalid token can't
-    /// retry forever.
-    private static let maxBadJWTRetryAttempts = 2
-    private var badJWTRetryAttempts = 0
-
     // MARK: - Scripts
 
     @MainActor
@@ -465,62 +459,22 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         }
     }
 
-    /// Maximum number of internal fetch attempts ``fetchAndPushFreshToken(attempt:)``
-    /// makes per `badJWT` rejection before giving up. Separate from
-    /// ``maxBadJWTRetryAttempts``: that bounds how many *incoming* `badJWT`
-    /// messages trigger a recovery attempt at all; this bounds how hard a
-    /// single attempt tries before accepting defeat.
-    private static let maxInternalFetchAttempts = 3
-
-    /// Responds to a `badJWT` rejection by fetching a genuinely fresh token and
-    /// pushing it, resolving KlaviyoJS's pending `awaitNextSetJWT()`.
+    /// Responds to a `badJWT` rejection by dropping the now-known-bad cached
+    /// token, so it stops being handed back to every subsequent token
+    /// request for the rest of the session.
     ///
-    /// The rejected token must be invalidated before re-fetching — the cache
-    /// would otherwise hand back the same bad token, since a `badJWT`
-    /// rejection isn't reflected in the token's own `exp` claim. Bounded by
-    /// ``maxBadJWTRetryAttempts`` since a provider that always returns an
-    /// invalid token would otherwise retry indefinitely.
+    /// `AuthTokenManager` only tracks a token's own `exp` claim — it has no
+    /// way to know the backend rejected a token that, by that claim, is
+    /// still unexpired. Without this, the same rejected token would keep
+    /// being served to every later WebView/form until it naturally expires
+    /// or the app restarts. This is deliberately passive: it does not
+    /// attempt to fetch or push a replacement for the currently-open form —
+    /// see MAGE-1118 for why an active retry here needs separate design
+    /// alignment before it's built.
     @MainActor
     private func handleBadJWT() {
-        guard badJWTRetryAttempts < Self.maxBadJWTRetryAttempts else {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning("BadJWT retry limit reached; no further attempts will be made")
-            }
-            return
-        }
-        badJWTRetryAttempts += 1
-
-        Task { @MainActor in
+        Task {
             await AuthTokenManager.shared.clearTokenState()
-            await fetchAndPushFreshToken(attempt: 1)
-        }
-    }
-
-    /// Fetches a fresh token and pushes it, retrying internally on failure.
-    ///
-    /// `clearTokenState()` (called once by ``handleBadJWT()`` before this
-    /// runs) drops the proactive-refresh schedule as a side effect of
-    /// invalidating the rejected token — nothing re-arms it until a fetch
-    /// here succeeds. Without an internal retry, a single transient failure
-    /// (timeout, network blip) would leave this WebView with no scheduled
-    /// refresh and no cached token: no further recovery for the rest of its
-    /// lifetime, since ``handleBadJWT()`` only reacts to *new* `badJWT`
-    /// messages and fender may not send another. Retrying here — rather than
-    /// waiting on another `badJWT` — is what actually closes that gap.
-    @MainActor
-    private func fetchAndPushFreshToken(attempt: Int) async {
-        do {
-            let token = try await AuthTokenManager.shared.currentToken(mode: .background)
-            await pushAuthToken(token)
-        } catch {
-            if #available(iOS 14.0, *) {
-                Logger.webViewLogger.warning(
-                    "Unable to fetch a fresh auth token after BadJWT (attempt \(attempt)): \(error)"
-                )
-            }
-            guard attempt < Self.maxInternalFetchAttempts else { return }
-            try? await Task.sleep(nanoseconds: UInt64(attempt) * 250_000_000)
-            await fetchAndPushFreshToken(attempt: attempt + 1)
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -465,6 +465,13 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
         }
     }
 
+    /// Maximum number of internal fetch attempts ``fetchAndPushFreshToken(attempt:)``
+    /// makes per `badJWT` rejection before giving up. Separate from
+    /// ``maxBadJWTRetryAttempts``: that bounds how many *incoming* `badJWT`
+    /// messages trigger a recovery attempt at all; this bounds how hard a
+    /// single attempt tries before accepting defeat.
+    private static let maxInternalFetchAttempts = 3
+
     /// Responds to a `badJWT` rejection by fetching a genuinely fresh token and
     /// pushing it, resolving KlaviyoJS's pending `awaitNextSetJWT()`.
     ///
@@ -485,14 +492,35 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
 
         Task { @MainActor in
             await AuthTokenManager.shared.clearTokenState()
-            do {
-                let token = try await AuthTokenManager.shared.currentToken(mode: .background)
-                await pushAuthToken(token)
-            } catch {
-                if #available(iOS 14.0, *) {
-                    Logger.webViewLogger.warning("Unable to fetch a fresh auth token after BadJWT: \(error)")
-                }
+            await fetchAndPushFreshToken(attempt: 1)
+        }
+    }
+
+    /// Fetches a fresh token and pushes it, retrying internally on failure.
+    ///
+    /// `clearTokenState()` (called once by ``handleBadJWT()`` before this
+    /// runs) drops the proactive-refresh schedule as a side effect of
+    /// invalidating the rejected token — nothing re-arms it until a fetch
+    /// here succeeds. Without an internal retry, a single transient failure
+    /// (timeout, network blip) would leave this WebView with no scheduled
+    /// refresh and no cached token: no further recovery for the rest of its
+    /// lifetime, since ``handleBadJWT()`` only reacts to *new* `badJWT`
+    /// messages and fender may not send another. Retrying here — rather than
+    /// waiting on another `badJWT` — is what actually closes that gap.
+    @MainActor
+    private func fetchAndPushFreshToken(attempt: Int) async {
+        do {
+            let token = try await AuthTokenManager.shared.currentToken(mode: .background)
+            await pushAuthToken(token)
+        } catch {
+            if #available(iOS 14.0, *) {
+                Logger.webViewLogger.warning(
+                    "Unable to fetch a fresh auth token after BadJWT (attempt \(attempt)): \(error)"
+                )
             }
+            guard attempt < Self.maxInternalFetchAttempts else { return }
+            try? await Task.sleep(nanoseconds: UInt64(attempt) * 250_000_000)
+            await fetchAndPushFreshToken(attempt: attempt + 1)
         }
     }
 }

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -118,7 +118,7 @@ extension IAFNativeBridgeEvent {
 }
 
 extension IAFNativeBridgeEvent {
-    public static var handshake: String {
+    static var handshake: String {
         struct HandshakeData: Codable {
             var type: String
             var version: Int
@@ -146,6 +146,12 @@ extension IAFNativeBridgeEvent {
         // Events that JS is permitted to send. These are only used for their
         // `name` and `version` properties — the associated values are placeholders
         // and are never decoded.
+        //
+        // `badJWT` is deliberately absent: fender's handshake schema doesn't
+        // recognize it as an advertisable capability (it rejects the whole
+        // handshake as malformed if it's present) — fender sends `badJWT`
+        // unconditionally when it rejects a token, so native only needs to
+        // decode and handle it, never declare support for it upfront.
         [
             .formWillAppear(formId: nil, formName: nil, layout: nil),
             .formDisappeared(formId: nil, formName: nil),
@@ -156,8 +162,7 @@ extension IAFNativeBridgeEvent {
             .lifecycleEvent,
             .profileEvent,
             .profileMutation,
-            .jwtMutation,
-            .badJWT
+            .jwtMutation
         ]
     }
 

--- a/Tests/KlaviyoFormsTests/BadJWTTestHelpers.swift
+++ b/Tests/KlaviyoFormsTests/BadJWTTestHelpers.swift
@@ -1,0 +1,58 @@
+//
+//  BadJWTTestHelpers.swift
+//  klaviyo-swift-sdk
+//
+//  Shared fixtures for `.badJWT` handling tests: JWT minting and deterministic
+//  provider-invocation counting.
+//
+
+import Foundation
+
+/// Builds a JWT with `iat` slightly in the past and `exp` an hour ahead so it
+/// passes `JWTParser` validation in the present. Signature is a placeholder —
+/// `AuthTokenManager` never validates it.
+func makeTestJWT() throws -> String {
+    let nowSeconds = Date().timeIntervalSince1970
+    let payload: [String: Any] = [
+        "iat": nowSeconds - 60,
+        "exp": nowSeconds + 3600
+    ]
+    let header: [String: Any] = ["alg": "HS256", "typ": "JWT"]
+    let headerSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: header))
+    let payloadSeg = try base64URLEncode(JSONSerialization.data(withJSONObject: payload))
+    return "\(headerSeg).\(payloadSeg).signature"
+}
+
+private func base64URLEncode(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+/// Counts provider invocations and lets tests await a specific call count
+/// without sleeping.
+actor InvocationCounter {
+    private(set) var value = 0
+    private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    @discardableResult
+    func increment() -> Int {
+        value += 1
+        waiters = waiters.compactMap { waiter in
+            if value >= waiter.threshold {
+                waiter.continuation.resume()
+                return nil
+            }
+            return waiter
+        }
+        return value
+    }
+
+    func waitFor(atLeast threshold: Int) async {
+        if value >= threshold { return }
+        await withCheckedContinuation { continuation in
+            waiters.append((threshold, continuation))
+        }
+    }
+}

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 struct IAFNativeBridgeEventTests {
     @Test
-    func testHandshakeCreated() async throws {
+    func handshakeCreated() throws {
         struct TestableHandshakeData: Codable, Equatable {
             var type: String
             var version: Int
@@ -30,8 +30,7 @@ struct IAFNativeBridgeEventTests {
             {"type":"lifecycleEvent","version":1},
             {"type":"profileEvent","version":1},
             {"type":"profileMutation","version":1},
-            {"type":"jwtMutation","version":1},
-            {"type":"badJWT","version":1}
+            {"type":"jwtMutation","version":1}
         ]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
@@ -44,7 +43,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testHandShook() async throws {
+    func testHandShook() throws {
         let json = """
         {
           "type": "handShook",
@@ -58,7 +57,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testBadJWT() async throws {
+    func testBadJWT() throws {
         let json = """
         {
           "type": "badJWT",
@@ -72,7 +71,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testAbort() async throws {
+    func testAbort() throws {
         let json = """
         {
           "type": "abort",
@@ -93,7 +92,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingButtonLabel() async throws {
+    func decodeOpenDeepLinkMissingButtonLabel() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -121,7 +120,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithButtonLabel() async throws {
+    func decodeOpenDeepLinkWithButtonLabel() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -150,7 +149,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithoutFormContext() async throws {
+    func decodeOpenDeepLinkWithoutFormContext() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -176,7 +175,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppear() async throws {
+    func decodeFormWillAppear() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -187,7 +186,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -198,7 +197,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearMissingFormName() async throws {
+    func decodeFormWillAppearMissingFormName() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -208,7 +207,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -219,7 +218,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappeared() async throws {
+    func decodeFormDisappeared() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -230,7 +229,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -241,7 +240,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedWithoutPayload() async throws {
+    func decodeFormDisappearedWithoutPayload() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -249,7 +248,7 @@ struct IAFNativeBridgeEventTests {
         }
         """
 
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -260,7 +259,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeTrackProfileEvent() async throws {
+    func decodeTrackProfileEvent() throws {
         let json = """
         {
           "type": "trackProfileEvent",
@@ -300,7 +299,7 @@ struct IAFNativeBridgeEventTests {
     // MARK: - Missing Metadata Fields (parsing is permissive, nil for missing/empty)
 
     @Test
-    func testDecodeFormWillAppearMissingFormId() async throws {
+    func decodeFormWillAppearMissingFormId() throws {
         let json = """
         {
           "type": "formWillAppear",
@@ -309,7 +308,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -320,14 +319,14 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearEmptyData() async throws {
+    func decodeFormWillAppearEmptyData() throws {
         let json = """
         {
           "type": "formWillAppear",
           "data": {}
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -338,7 +337,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingFormId() async throws {
+    func decodeFormDisappearedMissingFormId() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -347,7 +346,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -358,7 +357,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingFormName() async throws {
+    func decodeFormDisappearedMissingFormName() throws {
         let json = """
         {
           "type": "formDisappeared",
@@ -367,7 +366,7 @@ struct IAFNativeBridgeEventTests {
           }
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -378,7 +377,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingFormId() async throws {
+    func decodeOpenDeepLinkMissingFormId() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -403,7 +402,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingFormName() async throws {
+    func decodeOpenDeepLinkMissingFormName() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -428,7 +427,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkEmptyData() async throws {
+    func decodeOpenDeepLinkEmptyData() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -448,7 +447,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkWithoutIosUrl() async throws {
+    func decodeOpenDeepLinkWithoutIosUrl() throws {
         let json = """
         {
           "type": "openDeepLink",
@@ -473,13 +472,13 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormWillAppearMissingDataKey() async throws {
+    func decodeFormWillAppearMissingDataKey() throws {
         let json = """
         {
           "type": "formWillAppear"
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formWillAppear(formId, formName, _) = event else {
             Issue.record("event type should be .formWillAppear but was '.\(event)'")
@@ -490,13 +489,13 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeFormDisappearedMissingDataKey() async throws {
+    func decodeFormDisappearedMissingDataKey() throws {
         let json = """
         {
           "type": "formDisappeared"
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let event = try JSONDecoder().decode(IAFNativeBridgeEvent.self, from: data)
         guard case let .formDisappeared(formId, formName) = event else {
             Issue.record("event type should be .formDisappeared but was '.\(event)'")
@@ -507,7 +506,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeOpenDeepLinkMissingDataKey() async throws {
+    func decodeOpenDeepLinkMissingDataKey() throws {
         let json = """
         {
           "type": "openDeepLink"
@@ -526,7 +525,7 @@ struct IAFNativeBridgeEventTests {
     }
 
     @Test
-    func testDecodeAggregateEvent() async throws {
+    func decodeAggregateEvent() throws {
         let json = """
         {
           "type": "trackAggregateEvent",

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
@@ -13,90 +13,66 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
     // MARK: - setup
 
     var viewModel: IAFWebViewModel!
-    var delegate: MockIAFWebViewDelegate!
 
     override func setUp() async throws {
         try await super.setUp()
 
         let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
         viewModel = IAFWebViewModel(url: fileUrl, apiKey: "abc123", profileData: nil)
-        delegate = MockIAFWebViewDelegate(viewModel: viewModel)
-        viewModel.delegate = delegate
     }
 
     override func tearDown() {
         viewModel = nil
-        delegate = nil
         super.tearDown()
     }
 
     // MARK: - tests
 
-    func testBadJWTFetchesFreshTokenAndPushesIt() async throws {
-        // Given — a registered provider
-        let freshToken = try makeTestJWT()
-        await AuthTokenManager.shared.registerProvider { freshToken }
-
-        // Let the eager warm-up fetch land first, so the assertion below
-        // observes only the badJWT-triggered push.
-        _ = try? await AuthTokenManager.shared.currentToken(mode: .background)
-
-        // When — KlaviyoJS rejects the injected token
-        sendBadJWT()
-
-        // Then — a fresh token is fetched and pushed, resolving KlaviyoJS's
-        // pending `awaitNextSetJWT()`
-        try await waitUntil(timeout: 2.0) {
-            tokenScripts().contains { $0.contains(freshToken) }
-        }
-
-        await AuthTokenManager.shared.unregisterProvider()
-    }
-
-    func testBadJWTRetryIsBoundedAfterRepeatedRejections() async throws {
-        // Given — a provider whose warm-up invocation can be awaited deterministically
+    func testBadJWTInvalidatesCachedToken() async throws {
+        // Given — a registered provider whose invocations can be counted deterministically
         let counter = InvocationCounter()
         await AuthTokenManager.shared.registerProvider {
             await counter.increment()
             return try makeTestJWT()
         }
 
-        // Consume the eager warm-up invocation before triggering any retries
+        // Consume the eager warm-up fetch, then confirm the cache is actually
+        // serving that token without invoking the provider again.
         await counter.waitFor(atLeast: 1)
+        _ = try await AuthTokenManager.shared.currentToken()
+        let baseline = await counter.value
+        XCTAssertEqual(baseline, 1, "Expected the cached token to be served without a new fetch")
 
-        // When — badJWT fires more times than the retry limit allows
-        for _ in 0..<5 {
-            sendBadJWT()
-        }
+        // When — KlaviyoJS rejects the injected token
+        sendBadJWT()
 
-        // Then — only the bounded number of retry attempts push a token, not
-        // one per rejection. Asserting on pushes rather than raw provider
-        // invocations: two retries firing back-to-back can race inside
-        // AuthTokenManager, with the second reusing the first's freshly
-        // cached token instead of triggering its own fetch — a harmless
-        // dedup, not a bug — so the push count is the stable signal here.
-        try await waitUntil(timeout: 2.0) {
-            tokenScripts().count == 2
+        // Then — the cache no longer serves the rejected token: the next
+        // fetch must hit the provider again rather than reusing it. The
+        // invalidation runs on a fire-and-forget Task, so poll for it.
+        var refetched = false
+        for _ in 0..<50 {
+            _ = try? await AuthTokenManager.shared.currentToken()
+            if await counter.value > baseline {
+                refetched = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
         }
-        await expectNoAdditionalPushes(beyond: 2, timeout: 0.5)
-        XCTAssertEqual(
-            tokenScripts().count, 2,
-            "BadJWT retries should be bounded, not one push per rejection"
+        XCTAssertTrue(
+            refetched,
+            "Expected badJWT to invalidate the cached token so the next fetch reaches the provider"
         )
 
         await AuthTokenManager.shared.unregisterProvider()
     }
 
-    func testBadJWTWithNoProviderRegisteredDoesNotPushOrCrash() async {
+    func testBadJWTWithNoProviderRegisteredDoesNotCrash() async {
         // Given — no auth token provider registered
         await AuthTokenManager.shared.unregisterProvider()
 
-        // When
+        // When / Then — no crash; clearing an already-empty cache is a no-op
         sendBadJWT()
-
-        // Then — no crash, and nothing is pushed since there's no token to fetch
-        await expectNoAdditionalPushes(beyond: 0, timeout: 0.5)
-        XCTAssertTrue(tokenScripts().isEmpty)
+        _ = try? await AuthTokenManager.shared.currentToken()
     }
 }
 
@@ -111,45 +87,5 @@ extension IAFWebViewModelBadJWTTests {
             """
         )
         viewModel.handleScriptMessage(scriptMessage)
-    }
-
-    /// The auth-token update scripts among everything the delegate has evaluated.
-    private func tokenScripts() -> [String] {
-        delegate.evaluatedScripts.filter { $0.contains("data-klaviyo-jwt") }
-    }
-
-    /// Polls `condition` until it returns `true` or `timeout` elapses. Used for
-    /// work kicked off by a fire-and-forget `Task` (like `.badJWT` handling)
-    /// that isn't otherwise directly awaitable from the test.
-    private func waitUntil(timeout: TimeInterval, condition: () -> Bool) async throws {
-        let deadline = Date().addingTimeInterval(timeout)
-        while !condition() {
-            if Date() > deadline {
-                XCTFail("Condition not met within \(timeout) seconds")
-                return
-            }
-            try await Task.sleep(nanoseconds: 20_000_000)
-        }
-    }
-
-    /// Asserts no further token pushes land beyond `count` within `timeout`,
-    /// via an inverted `XCTestExpectation` rather than a fixed sleep — a
-    /// regression is caught (and the wait ends) as soon as an extra push
-    /// appears, instead of only being checked after always waiting out a
-    /// fixed delay.
-    private func expectNoAdditionalPushes(beyond count: Int, timeout: TimeInterval) async {
-        let noExcessPush = XCTestExpectation(description: "no token push beyond \(count)")
-        noExcessPush.isInverted = true
-        let watcher = Task {
-            while !Task.isCancelled {
-                if tokenScripts().count > count {
-                    noExcessPush.fulfill()
-                    return
-                }
-                try? await Task.sleep(nanoseconds: 20_000_000)
-            }
-        }
-        await fulfillment(of: [noExcessPush], timeout: timeout)
-        watcher.cancel()
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
@@ -8,13 +8,13 @@ import KlaviyoCore
 import WebKit
 import XCTest
 
+@MainActor
 final class IAFWebViewModelBadJWTTests: XCTestCase {
     // MARK: - setup
 
     var viewModel: IAFWebViewModel!
     var delegate: MockIAFWebViewDelegate!
 
-    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
@@ -32,7 +32,6 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
 
     // MARK: - tests
 
-    @MainActor
     func testBadJWTFetchesFreshTokenAndPushesIt() async throws {
         // Given — a registered provider
         let freshToken = try makeTestJWT()
@@ -54,7 +53,6 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
         await AuthTokenManager.shared.unregisterProvider()
     }
 
-    @MainActor
     func testBadJWTRetryIsBoundedAfterRepeatedRejections() async throws {
         // Given — a provider whose warm-up invocation can be awaited deterministically
         let counter = InvocationCounter()
@@ -80,7 +78,7 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
         try await waitUntil(timeout: 2.0) {
             tokenScripts().count == 2
         }
-        try await Task.sleep(nanoseconds: 300_000_000) // let any excess retries (bug case) land
+        await expectNoAdditionalPushes(beyond: 2, timeout: 0.5)
         XCTAssertEqual(
             tokenScripts().count, 2,
             "BadJWT retries should be bounded, not one push per rejection"
@@ -89,8 +87,7 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
         await AuthTokenManager.shared.unregisterProvider()
     }
 
-    @MainActor
-    func testBadJWTWithNoProviderRegisteredDoesNotPushOrCrash() async throws {
+    func testBadJWTWithNoProviderRegisteredDoesNotPushOrCrash() async {
         // Given — no auth token provider registered
         await AuthTokenManager.shared.unregisterProvider()
 
@@ -98,7 +95,7 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
         sendBadJWT()
 
         // Then — no crash, and nothing is pushed since there's no token to fetch
-        try await Task.sleep(nanoseconds: 300_000_000)
+        await expectNoAdditionalPushes(beyond: 0, timeout: 0.5)
         XCTAssertTrue(tokenScripts().isEmpty)
     }
 }
@@ -106,7 +103,6 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
 // MARK: - Helpers
 
 extension IAFWebViewModelBadJWTTests {
-    @MainActor
     private func sendBadJWT() {
         let scriptMessage = MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
@@ -118,7 +114,6 @@ extension IAFWebViewModelBadJWTTests {
     }
 
     /// The auth-token update scripts among everything the delegate has evaluated.
-    @MainActor
     private func tokenScripts() -> [String] {
         delegate.evaluatedScripts.filter { $0.contains("data-klaviyo-jwt") }
     }
@@ -126,7 +121,6 @@ extension IAFWebViewModelBadJWTTests {
     /// Polls `condition` until it returns `true` or `timeout` elapses. Used for
     /// work kicked off by a fire-and-forget `Task` (like `.badJWT` handling)
     /// that isn't otherwise directly awaitable from the test.
-    @MainActor
     private func waitUntil(timeout: TimeInterval, condition: () -> Bool) async throws {
         let deadline = Date().addingTimeInterval(timeout)
         while !condition() {
@@ -136,5 +130,26 @@ extension IAFWebViewModelBadJWTTests {
             }
             try await Task.sleep(nanoseconds: 20_000_000)
         }
+    }
+
+    /// Asserts no further token pushes land beyond `count` within `timeout`,
+    /// via an inverted `XCTestExpectation` rather than a fixed sleep — a
+    /// regression is caught (and the wait ends) as soon as an extra push
+    /// appears, instead of only being checked after always waiting out a
+    /// fixed delay.
+    private func expectNoAdditionalPushes(beyond count: Int, timeout: TimeInterval) async {
+        let noExcessPush = XCTestExpectation(description: "no token push beyond \(count)")
+        noExcessPush.isInverted = true
+        let watcher = Task {
+            while !Task.isCancelled {
+                if tokenScripts().count > count {
+                    noExcessPush.fulfill()
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+        }
+        await fulfillment(of: [noExcessPush], timeout: timeout)
+        watcher.cancel()
     }
 }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
@@ -48,20 +48,21 @@ final class IAFWebViewModelBadJWTTests: XCTestCase {
 
         // Then — the cache no longer serves the rejected token: the next
         // fetch must hit the provider again rather than reusing it. The
-        // invalidation runs on a fire-and-forget Task, so poll for it.
-        var refetched = false
-        for _ in 0..<50 {
-            _ = try? await AuthTokenManager.shared.currentToken()
-            if await counter.value > baseline {
-                refetched = true
-                break
+        // invalidation runs on a fire-and-forget Task, so probe
+        // `currentToken()` until it lands, blocking on the counter (not a
+        // fixed sleep) via an expectation with a bounded timeout.
+        let refetched = XCTestExpectation(description: "cache invalidated; provider hit again")
+        let prober = Task {
+            while !Task.isCancelled {
+                _ = try? await AuthTokenManager.shared.currentToken()
+                if await counter.value > baseline {
+                    refetched.fulfill()
+                    return
+                }
             }
-            try await Task.sleep(nanoseconds: 20_000_000)
         }
-        XCTAssertTrue(
-            refetched,
-            "Expected badJWT to invalidate the cached token so the next fetch reaches the provider"
-        )
+        await fulfillment(of: [refetched], timeout: 2.0)
+        prober.cancel()
 
         await AuthTokenManager.shared.unregisterProvider()
     }

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelBadJWTTests.swift
@@ -1,0 +1,140 @@
+//
+//  IAFWebViewModelBadJWTTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoForms
+import KlaviyoCore
+import WebKit
+import XCTest
+
+final class IAFWebViewModelBadJWTTests: XCTestCase {
+    // MARK: - setup
+
+    var viewModel: IAFWebViewModel!
+    var delegate: MockIAFWebViewDelegate!
+
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let fileUrl = try XCTUnwrap(Bundle.module.url(forResource: "IAFUnitTest", withExtension: "html"))
+        viewModel = IAFWebViewModel(url: fileUrl, apiKey: "abc123", profileData: nil)
+        delegate = MockIAFWebViewDelegate(viewModel: viewModel)
+        viewModel.delegate = delegate
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        delegate = nil
+        super.tearDown()
+    }
+
+    // MARK: - tests
+
+    @MainActor
+    func testBadJWTFetchesFreshTokenAndPushesIt() async throws {
+        // Given — a registered provider
+        let freshToken = try makeTestJWT()
+        await AuthTokenManager.shared.registerProvider { freshToken }
+
+        // Let the eager warm-up fetch land first, so the assertion below
+        // observes only the badJWT-triggered push.
+        _ = try? await AuthTokenManager.shared.currentToken(mode: .background)
+
+        // When — KlaviyoJS rejects the injected token
+        sendBadJWT()
+
+        // Then — a fresh token is fetched and pushed, resolving KlaviyoJS's
+        // pending `awaitNextSetJWT()`
+        try await waitUntil(timeout: 2.0) {
+            tokenScripts().contains { $0.contains(freshToken) }
+        }
+
+        await AuthTokenManager.shared.unregisterProvider()
+    }
+
+    @MainActor
+    func testBadJWTRetryIsBoundedAfterRepeatedRejections() async throws {
+        // Given — a provider whose warm-up invocation can be awaited deterministically
+        let counter = InvocationCounter()
+        await AuthTokenManager.shared.registerProvider {
+            await counter.increment()
+            return try makeTestJWT()
+        }
+
+        // Consume the eager warm-up invocation before triggering any retries
+        await counter.waitFor(atLeast: 1)
+
+        // When — badJWT fires more times than the retry limit allows
+        for _ in 0..<5 {
+            sendBadJWT()
+        }
+
+        // Then — only the bounded number of retry attempts push a token, not
+        // one per rejection. Asserting on pushes rather than raw provider
+        // invocations: two retries firing back-to-back can race inside
+        // AuthTokenManager, with the second reusing the first's freshly
+        // cached token instead of triggering its own fetch — a harmless
+        // dedup, not a bug — so the push count is the stable signal here.
+        try await waitUntil(timeout: 2.0) {
+            tokenScripts().count == 2
+        }
+        try await Task.sleep(nanoseconds: 300_000_000) // let any excess retries (bug case) land
+        XCTAssertEqual(
+            tokenScripts().count, 2,
+            "BadJWT retries should be bounded, not one push per rejection"
+        )
+
+        await AuthTokenManager.shared.unregisterProvider()
+    }
+
+    @MainActor
+    func testBadJWTWithNoProviderRegisteredDoesNotPushOrCrash() async throws {
+        // Given — no auth token provider registered
+        await AuthTokenManager.shared.unregisterProvider()
+
+        // When
+        sendBadJWT()
+
+        // Then — no crash, and nothing is pushed since there's no token to fetch
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertTrue(tokenScripts().isEmpty)
+    }
+}
+
+// MARK: - Helpers
+
+extension IAFWebViewModelBadJWTTests {
+    @MainActor
+    private func sendBadJWT() {
+        let scriptMessage = MockWKScriptMessage(
+            name: "KlaviyoNativeBridge",
+            body: """
+            {"type":"badJWT","data":{}}
+            """
+        )
+        viewModel.handleScriptMessage(scriptMessage)
+    }
+
+    /// The auth-token update scripts among everything the delegate has evaluated.
+    @MainActor
+    private func tokenScripts() -> [String] {
+        delegate.evaluatedScripts.filter { $0.contains("data-klaviyo-jwt") }
+    }
+
+    /// Polls `condition` until it returns `true` or `timeout` elapses. Used for
+    /// work kicked off by a fire-and-forget `Task` (like `.badJWT` handling)
+    /// that isn't otherwise directly awaitable from the test.
+    @MainActor
+    private func waitUntil(timeout: TimeInterval, condition: () -> Bool) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() > deadline {
+                XCTFail("Condition not met within \(timeout) seconds")
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -160,8 +160,7 @@ final class IAFWebViewModelTests: XCTestCase {
                 {"type":"lifecycleEvent","version":1},
                 {"type":"profileEvent","version":1},
                 {"type":"profileMutation","version":1},
-                {"type":"jwtMutation","version":1},
-                {"type":"badJWT","version":1}
+                {"type":"jwtMutation","version":1}
             ]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))


### PR DESCRIPTION
# Description
Replaces the closed MAGE-1086/#701 with a narrower fix: when fender rejects the injected auth token via `badJWT`, invalidate the cached token so it isn't served to every subsequent form for the rest of the session. Does not attempt any active retry — see MAGE-1118 for that discussion.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release (part of `feat/jwts-for-personalized-forms`).

## Changelog / Code Overview
- `IAFWebViewModel.swift`: on `.badJWT`, call `AuthTokenManager.shared.clearTokenState()` to drop the cached (now-known-bad) token. `AuthTokenManager` only tracks a token's own `exp` claim, so without this the same rejected token would keep being served to every later WebView/form for the rest of the session. Deliberately passive — no fetch/retry/push for the currently-open form.
- `IAFNativeBridgeEvent.swift`: carried forward from the closed PR #701 unchanged — removes `.badJWT` from the advertised handshake capabilities (fender's schema doesn't accept it as an advertisable capability, only as a message it sends; advertising it made the whole handshake malformed). This part of the original PR was uncontested and already confirmed working end-to-end in the test app.
- `IAFWebViewModelBadJWTTests.swift`: rewritten for the new scope — confirms a `badJWT` rejection causes the next token fetch to reach the provider again instead of reusing the cached one, and confirms no crash when no provider is registered.

## Test Plan
- `xcodebuild test -scheme klaviyo-swift-sdk-Package -only-testing:KlaviyoFormsTests` — all 62 tests pass.
- Handshake fix already manually verified end-to-end in the iOS test app (carried forward unchanged from #701).

## Related Issues/Tickets
MAGE-1117 (this PR). Follows from MAGE-1086 (closed — scope split, see closing comment) and PR #701 (closed without merging). See MAGE-1118 for the deferred "should the SDK actively retry" design question.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid authentication tokens by clearing cached token state when detected.
  * Prevented invalid tokens from being sent to the currently open form.
  * Preserved stable behavior when no token provider is configured.

* **Tests**
  * Added coverage for invalid-token handling, cache invalidation, and asynchronous token-provider behavior.
  * Updated bridge-event tests and handshake expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->