### PR TITLE
feat(KlaviyoCore): ungated enqueue entry point + durable unattributed buffer (MAGE-951)

### DIFF
--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -34,6 +34,37 @@ public struct RequestIdentity: Equatable {
     }
 }
 
+/// apiKey-free identity fields needed to build a request *payload*. Unlike ``RequestIdentity``
+/// it carries no apiKey, so it is usable before `initialize()` (e.g. the pre-apiKey buffer path).
+public struct PayloadIdentity: Equatable {
+    public let anonymousId: String
+    public let email: String?
+    public let phoneNumber: String?
+    public let externalId: String?
+
+    public init(
+        anonymousId: String,
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil
+    ) {
+        self.anonymousId = anonymousId
+        self.email = email
+        self.phoneNumber = phoneNumber
+        self.externalId = externalId
+    }
+
+    /// Drops the apiKey from a ``RequestIdentity``.
+    public init(_ identity: RequestIdentity) {
+        self.init(
+            anonymousId: identity.anonymousId,
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId
+        )
+    }
+}
+
 /// Pure construction of `KlaviyoRequest` values from domain inputs.
 public enum RequestFactory {
     public static func profileRequest(
@@ -53,32 +84,23 @@ public enum RequestFactory {
         identity: RequestIdentity,
         properties: [String: Any] = [:]
     ) -> CreateProfilePayload {
-        profilePayload(
-            anonymousId: identity.anonymousId,
-            email: identity.email,
-            phoneNumber: identity.phoneNumber,
-            externalId: identity.externalId,
-            properties: properties
-        )
+        profilePayload(identity: PayloadIdentity(identity), properties: properties)
     }
 
-    /// Builds a `CreateProfilePayload` from individual identity fields (no apiKey required).
+    /// Builds a `CreateProfilePayload` from apiKey-free identity fields.
     ///
     /// Use this when a profile payload must be constructed before an apiKey is available,
     /// e.g. in the pre-apiKey buffer path.
     public static func profilePayload(
-        anonymousId: String,
-        email: String?,
-        phoneNumber: String?,
-        externalId: String?,
+        identity: PayloadIdentity,
         properties: [String: Any] = [:]
     ) -> CreateProfilePayload {
         CreateProfilePayload(data: ProfilePayload(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
             properties: properties,
-            anonymousId: anonymousId
+            anonymousId: identity.anonymousId
         ))
     }
 
@@ -95,33 +117,23 @@ public enum RequestFactory {
         event: Event,
         pushToken: String?
     ) -> KlaviyoRequest {
-        let payload = eventPayload(
-            anonymousId: identity.anonymousId,
-            email: identity.email,
-            phoneNumber: identity.phoneNumber,
-            externalId: identity.externalId,
-            event: event,
-            pushToken: pushToken
-        )
+        let payload = eventPayload(identity: PayloadIdentity(identity), event: event, pushToken: pushToken)
         return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload), priority: event.priority)
     }
 
-    /// Builds a `CreateEventPayload` from individual identity fields (no apiKey required).
+    /// Builds a `CreateEventPayload` from apiKey-free identity fields.
     ///
     /// Use this when an event payload must be constructed before an apiKey is available,
     /// e.g. in the pre-apiKey buffer path.
     public static func eventPayload(
-        anonymousId: String,
-        email: String?,
-        phoneNumber: String?,
-        externalId: String?,
+        identity: PayloadIdentity,
         event: Event,
         pushToken: String?
     ) -> CreateEventPayload {
         let stamped = event.updateEventWithIdentifiers(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
             pushToken: pushToken
         )
         return CreateEventPayload(
@@ -131,7 +143,7 @@ public enum RequestFactory {
                 email: stamped.identifiers?.email,
                 phoneNumber: stamped.identifiers?.phoneNumber,
                 externalId: stamped.identifiers?.externalId,
-                anonymousId: anonymousId,
+                anonymousId: identity.anonymousId,
                 value: stamped.value,
                 time: stamped.time,
                 uniqueId: stamped.uniqueId,
@@ -153,31 +165,28 @@ public enum RequestFactory {
         return KlaviyoRequest(endpoint: .unregisterPushToken(identity.apiKey, payload))
     }
 
-    /// Builds a `PushTokenPayload` from individual identity fields (no apiKey required).
+    /// Builds a `PushTokenPayload` from apiKey-free identity fields.
     ///
     /// Constructs an empty-properties `ProfilePayload` internally, matching how the live
     /// push-token registration path resolves the profile before calling ``tokenRequest``.
     /// Use this when a token payload must be constructed before an apiKey is available,
     /// e.g. in the pre-apiKey buffer path.
     public static func tokenPayload(
-        anonymousId: String,
-        email: String?,
-        phoneNumber: String?,
-        externalId: String?,
+        identity: PayloadIdentity,
         pushToken: String,
         enablement: PushEnablement,
-        background: String
+        background: PushBackground
     ) -> PushTokenPayload {
         PushTokenPayload(
             pushToken: pushToken,
             enablement: enablement.rawValue,
-            background: background,
+            background: background.rawValue,
             profile: ProfilePayload(
-                email: email,
-                phoneNumber: phoneNumber,
-                externalId: externalId,
+                email: identity.email,
+                phoneNumber: identity.phoneNumber,
+                externalId: identity.externalId,
                 properties: [:],
-                anonymousId: anonymousId
+                anonymousId: identity.anonymousId
             )
         )
     }

--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -53,12 +53,32 @@ public enum RequestFactory {
         identity: RequestIdentity,
         properties: [String: Any] = [:]
     ) -> CreateProfilePayload {
-        CreateProfilePayload(data: ProfilePayload(
+        profilePayload(
+            anonymousId: identity.anonymousId,
             email: identity.email,
             phoneNumber: identity.phoneNumber,
             externalId: identity.externalId,
+            properties: properties
+        )
+    }
+
+    /// Builds a `CreateProfilePayload` from individual identity fields (no apiKey required).
+    ///
+    /// Use this when a profile payload must be constructed before an apiKey is available,
+    /// e.g. in the pre-apiKey buffer path.
+    public static func profilePayload(
+        anonymousId: String,
+        email: String?,
+        phoneNumber: String?,
+        externalId: String?,
+        properties: [String: Any] = [:]
+    ) -> CreateProfilePayload {
+        CreateProfilePayload(data: ProfilePayload(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
             properties: properties,
-            anonymousId: identity.anonymousId
+            anonymousId: anonymousId
         ))
     }
 
@@ -75,26 +95,48 @@ public enum RequestFactory {
         event: Event,
         pushToken: String?
     ) -> KlaviyoRequest {
-        let stamped = event.updateEventWithIdentifiers(
+        let payload = eventPayload(
+            anonymousId: identity.anonymousId,
             email: identity.email,
             phoneNumber: identity.phoneNumber,
             externalId: identity.externalId,
+            event: event,
             pushToken: pushToken
         )
-        let payload = CreateEventPayload(
+        return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload), priority: event.priority)
+    }
+
+    /// Builds a `CreateEventPayload` from individual identity fields (no apiKey required).
+    ///
+    /// Use this when an event payload must be constructed before an apiKey is available,
+    /// e.g. in the pre-apiKey buffer path.
+    public static func eventPayload(
+        anonymousId: String,
+        email: String?,
+        phoneNumber: String?,
+        externalId: String?,
+        event: Event,
+        pushToken: String?
+    ) -> CreateEventPayload {
+        let stamped = event.updateEventWithIdentifiers(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            pushToken: pushToken
+        )
+        return CreateEventPayload(
             data: CreateEventPayload.Event(
                 name: stamped.metric.name.value,
                 properties: stamped.properties,
                 email: stamped.identifiers?.email,
                 phoneNumber: stamped.identifiers?.phoneNumber,
                 externalId: stamped.identifiers?.externalId,
-                anonymousId: identity.anonymousId,
+                anonymousId: anonymousId,
                 value: stamped.value,
                 time: stamped.time,
                 uniqueId: stamped.uniqueId,
                 pushToken: pushToken
             ))
-        return KlaviyoRequest(endpoint: .createEvent(identity.apiKey, payload), priority: stamped.priority)
     }
 
     public static func unregisterRequest(
@@ -109,6 +151,35 @@ public enum RequestFactory {
             anonymousId: identity.anonymousId
         )
         return KlaviyoRequest(endpoint: .unregisterPushToken(identity.apiKey, payload))
+    }
+
+    /// Builds a `PushTokenPayload` from individual identity fields (no apiKey required).
+    ///
+    /// Constructs an empty-properties `ProfilePayload` internally, matching how the live
+    /// push-token registration path resolves the profile before calling ``tokenRequest``.
+    /// Use this when a token payload must be constructed before an apiKey is available,
+    /// e.g. in the pre-apiKey buffer path.
+    public static func tokenPayload(
+        anonymousId: String,
+        email: String?,
+        phoneNumber: String?,
+        externalId: String?,
+        pushToken: String,
+        enablement: PushEnablement,
+        background: String
+    ) -> PushTokenPayload {
+        PushTokenPayload(
+            pushToken: pushToken,
+            enablement: enablement.rawValue,
+            background: background,
+            profile: ProfilePayload(
+                email: email,
+                phoneNumber: phoneNumber,
+                externalId: externalId,
+                properties: [:],
+                anonymousId: anonymousId
+            )
+        )
     }
 
     public static func tokenRequest(

--- a/Sources/KlaviyoCore/Persistence/StorePersistence.swift
+++ b/Sources/KlaviyoCore/Persistence/StorePersistence.swift
@@ -38,6 +38,7 @@ public struct PersistedConfig: Codable, Equatable {
 public enum StoreFile {
     public static let identity = "klaviyo-identity.json"
     public static let config = "klaviyo-config.json"
+    public static let unattributed = "klaviyo-unattributed.json"
 }
 
 // MARK: - Load / save helpers

--- a/Sources/KlaviyoCore/Persistence/StorePersistence.swift
+++ b/Sources/KlaviyoCore/Persistence/StorePersistence.swift
@@ -43,16 +43,21 @@ public enum StoreFile {
 
 // MARK: - Load / save helpers
 
-func storeFileURL(_ fileName: String) -> URL {
-    environment.fileClient.libraryDirectory()
+/// Resolves the on-disk URL for a store file. Defaults to the legacy `Library` root
+/// (`libraryDirectory`) for pre-existing identity/config files; new files pass an explicit
+/// `directory` (e.g. `applicationSupportDirectory()`) to opt into the canonical support home.
+func storeFileURL(_ fileName: String, directory: URL? = nil) -> URL {
+    (directory ?? environment.fileClient.libraryDirectory())
         .appendingPathComponent(fileName, isDirectory: false)
 }
 
-/// Loads a decodable value from the named file in the library directory.
+/// Loads a decodable value from the named file in `directory` (defaults to the library root).
 /// Returns `nil` if the file is absent or cannot be decoded;
 /// an undecodable file is removed to avoid repeated failures.
-public func loadPersisted<T: Decodable>(_ type: T.Type, fileName: String) -> T? {
-    let fileURL = storeFileURL(fileName)
+public func loadPersisted<T: Decodable>(
+    _ type: T.Type, fileName: String, directory: URL? = nil
+) -> T? {
+    let fileURL = storeFileURL(fileName, directory: directory)
     guard environment.fileClient.fileExists(fileURL.path) else { return nil }
     guard let data = try? environment.dataFromUrl(fileURL) else {
         environment.logger.error("Unable to read \(fileName); removing.")
@@ -67,10 +72,10 @@ public func loadPersisted<T: Decodable>(_ type: T.Type, fileName: String) -> T? 
     return value
 }
 
-/// Removes the named file from the library directory if it exists.
+/// Removes the named file from `directory` (defaults to the library root) if it exists.
 /// Logs on failure; never throws to the caller.
-func removePersisted(fileName: String) {
-    let fileURL = storeFileURL(fileName)
+func removePersisted(fileName: String, directory: URL? = nil) {
+    let fileURL = storeFileURL(fileName, directory: directory)
     guard environment.fileClient.fileExists(fileURL.path) else { return }
     do {
         try environment.fileClient.removeItem(fileURL.path)
@@ -79,12 +84,12 @@ func removePersisted(fileName: String) {
     }
 }
 
-/// Persists an encodable value to the named file in the library directory.
+/// Persists an encodable value to the named file in `directory` (defaults to the library root).
 /// Logs on failure; never throws to the caller.
-public func savePersisted(_ value: some Encodable, fileName: String) {
+public func savePersisted(_ value: some Encodable, fileName: String, directory: URL? = nil) {
     do {
         let data = try environment.encodeJSON(value)
-        try environment.fileClient.write(data, storeFileURL(fileName))
+        try environment.fileClient.write(data, storeFileURL(fileName, directory: directory))
     } catch {
         environment.logger.error("Unable to persist \(fileName).")
     }

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -218,8 +218,15 @@ extension QueueStore {
     /// Resolves the current apiKey from `SDKConfigStore` and returns the (cached) store for it,
     /// or `nil` if no apiKey is set yet (buffering pre-apiKey events is handled elsewhere).
     public static func current() -> QueueStore? {
-        guard let apiKey = SDKConfigStore.shared.current.apiKey else { return nil }
-        return registryLock.withLock {
+        SDKConfigStore.shared.current.apiKey.map(store(for:))
+    }
+
+    /// Returns the (cached) store for a specific apiKey, creating it on first use. Callers that
+    /// have already captured an apiKey use this instead of ``current()`` so queue resolution can't
+    /// race a concurrent `SDKConfigStore` change — a request built for one key always lands in that
+    /// key's queue, never another key's or dropped.
+    public static func store(for apiKey: String) -> QueueStore {
+        registryLock.withLock {
             if let existing = registry[apiKey] { return existing }
             let store = QueueStore(apiKey: apiKey)
             registry[apiKey] = store

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -30,13 +30,15 @@ public enum RequestEnqueuer {
     }
 
     /// The single routing rule: apiKey present → build a request and enqueue it to `QueueStore`;
-    /// apiKey absent → append the apiKey-free payload to the `UnattributedBuffer`.
+    /// apiKey absent → append the apiKey-free payload to the `UnattributedBuffer`. The queue is
+    /// resolved from the *captured* apiKey (`store(for:)`, not `current()`), so a concurrent
+    /// `SDKConfigStore` change can't route the request to another key's queue or drop it.
     private static func route(
         buffered: UnattributedRequest,
         build: (_ apiKey: String) -> KlaviyoRequest
     ) {
         if let apiKey = SDKConfigStore.shared.current.apiKey {
-            QueueStore.current()?.enqueue(build(apiKey))
+            QueueStore.store(for: apiKey).enqueue(build(apiKey))
         } else {
             UnattributedBuffer.shared.append(buffered)
         }
@@ -96,16 +98,9 @@ public enum RequestEnqueuer {
         }
         let (buffered, cursor) = UnattributedBuffer.shared.drainSnapshot()
         guard !buffered.isEmpty else { return }
-        // Defensive: `QueueStore.current()` only returns nil when no apiKey is set, and the mismatch
-        // guard above already returns in that case — so this is unreachable today. Retained (and
-        // warned) so a future change that can yield a nil queue never drops the buffer silently.
-        guard let queue = QueueStore.current() else {
-            environment.emitDeveloperWarning(
-                "RequestEnqueuer.drainBuffer: no QueueStore for the active apiKey; " +
-                    "buffered requests are retained for a later drain"
-            )
-            return
-        }
+        // Resolve the queue from the validated `apiKey` (not `current()`) so a concurrent config
+        // change between the guard above and here can't misroute the drained requests.
+        let queue = QueueStore.store(for: apiKey)
 
         for (index, request) in buffered.enumerated() {
             let isLast = index == buffered.count - 1

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -88,10 +88,11 @@ public enum RequestEnqueuer {
     }
 
     /// Moves every buffered request into `QueueStore`, stamping `apiKey` into each endpoint, then
-    /// clears the buffer. At-least-once: the final enqueue persists synchronously so the queue is
-    /// durable before the buffer file is removed. A crash in the gap re-drains next launch (a
-    /// dedup-able duplicate, never silent loss). Built + tested here; called by MAGE-952's
-    /// slimmed `initialize(apiKey:)`.
+    /// removes only the drained FIFO prefix. At-least-once: the final enqueue persists synchronously
+    /// so the queue is durable before the buffer is trimmed. A crash in the gap re-drains next launch
+    /// (a dedup-able duplicate, never silent loss). Removing the exact drained prefix — rather than
+    /// clearing wholesale — means a request appended concurrently during the drain survives instead
+    /// of being wiped. Built + tested here; called by the slimmed `initialize(apiKey:)` in MAGE-952.
     ///
     /// - Precondition: `apiKey` must equal `SDKConfigStore.shared.current.apiKey` — the key
     ///   `QueueStore.current()` resolves. If they diverge the drain is skipped to prevent
@@ -130,6 +131,6 @@ public enum RequestEnqueuer {
                 )
             }
         }
-        UnattributedBuffer.shared.clear()
+        UnattributedBuffer.shared.removeDrained(buffered.count)
     }
 }

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -13,11 +13,13 @@ import Foundation
 /// No reducer routing. See MAGE-951; caller cutover is MAGE-952.
 public enum RequestEnqueuer {
     public static func enqueueEvent(_ event: Event) {
-        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+        let identity = IdentityStore.shared.current
+        // Defensive: IdentityStore mints anonymousId on first access (MAGE-894), so this
+        // branch is unreachable in practice. Retained against future minting-policy changes.
+        guard let anonymousId = identity.anonymousId else {
             environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
             return
         }
-        let identity = IdentityStore.shared.current
         let pushToken = IdentityStore.shared.pushToken?.pushToken
         let payload = RequestFactory.eventPayload(
             anonymousId: anonymousId, email: identity.email,
@@ -43,11 +45,12 @@ public enum RequestEnqueuer {
     }
 
     public static func enqueueProfile(properties: [String: Any]) {
-        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+        let identity = IdentityStore.shared.current
+        // Defensive: see enqueueEvent comment — unreachable under current minting policy.
+        guard let anonymousId = identity.anonymousId else {
             environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
             return
         }
-        let identity = IdentityStore.shared.current
         let payload = RequestFactory.profilePayload(
             anonymousId: anonymousId, email: identity.email,
             phoneNumber: identity.phoneNumber, externalId: identity.externalId,
@@ -63,11 +66,12 @@ public enum RequestEnqueuer {
     }
 
     public static func enqueuePushToken(_ token: String, enablement: PushEnablement) {
-        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+        let identity = IdentityStore.shared.current
+        // Defensive: see enqueueEvent comment — unreachable under current minting policy.
+        guard let anonymousId = identity.anonymousId else {
             environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
             return
         }
-        let identity = IdentityStore.shared.current
         let payload = RequestFactory.tokenPayload(
             anonymousId: anonymousId, email: identity.email,
             phoneNumber: identity.phoneNumber, externalId: identity.externalId,
@@ -88,7 +92,18 @@ public enum RequestEnqueuer {
     /// durable before the buffer file is removed. A crash in the gap re-drains next launch (a
     /// dedup-able duplicate, never silent loss). Built + tested here; called by MAGE-952's
     /// slimmed `initialize(apiKey:)`.
+    ///
+    /// - Precondition: `apiKey` must equal `SDKConfigStore.shared.current.apiKey` — the key
+    ///   `QueueStore.current()` resolves. If they diverge the drain is skipped to prevent
+    ///   requests being stamped with one key but written into another key's queue file.
     public static func drainBuffer(apiKey: String) {
+        if apiKey != SDKConfigStore.shared.current.apiKey {
+            environment.emitDeveloperWarning(
+                "RequestEnqueuer.drainBuffer: apiKey does not match the active SDKConfigStore " +
+                    "apiKey; skipping drain to prevent key mismatch in QueueStore"
+            )
+            return
+        }
         let buffered = UnattributedBuffer.shared.snapshot()
         guard !buffered.isEmpty, let queue = QueueStore.current() else { return }
 

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -1,0 +1,85 @@
+//
+//  RequestEnqueuer.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 8/19/26.
+//
+
+import Foundation
+
+/// Ungated Core enqueue entry point. Reads identity + apiKey from the shared stores itself,
+/// so callers never thread identity or check for an apiKey. apiKey present → build + enqueue
+/// to `QueueStore`; apiKey absent → build an apiKey-free payload → `UnattributedBuffer`.
+/// No reducer routing. See MAGE-951; caller cutover is MAGE-952.
+public enum RequestEnqueuer {
+    public static func enqueueEvent(_ event: Event) {
+        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
+            return
+        }
+        let identity = IdentityStore.shared.current
+        let pushToken = IdentityStore.shared.pushToken?.pushToken
+        let payload = RequestFactory.eventPayload(
+            anonymousId: anonymousId, email: identity.email,
+            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
+            event: event, pushToken: pushToken
+        )
+
+        if let apiKey = SDKConfigStore.shared.current.apiKey {
+            QueueStore.current()?.enqueue(
+                KlaviyoRequest(endpoint: .createEvent(apiKey, payload), priority: event.priority))
+        } else {
+            UnattributedBuffer.shared.append(.event(payload, event.priority))
+        }
+    }
+
+    public static func enqueueAggregateEvent(_ payload: Data) {
+        if let apiKey = SDKConfigStore.shared.current.apiKey {
+            QueueStore.current()?.enqueue(
+                KlaviyoRequest(endpoint: .aggregateEvent(apiKey, payload)))
+        } else {
+            UnattributedBuffer.shared.append(.aggregateEvent(payload))
+        }
+    }
+
+    public static func enqueueProfile(properties: [String: Any]) {
+        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
+            return
+        }
+        let identity = IdentityStore.shared.current
+        let payload = RequestFactory.profilePayload(
+            anonymousId: anonymousId, email: identity.email,
+            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
+            properties: properties
+        )
+
+        if let apiKey = SDKConfigStore.shared.current.apiKey {
+            QueueStore.current()?.enqueue(
+                KlaviyoRequest(endpoint: .createProfile(apiKey, payload)))
+        } else {
+            UnattributedBuffer.shared.append(.profile(payload))
+        }
+    }
+
+    public static func enqueuePushToken(_ token: String, enablement: PushEnablement) {
+        guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
+            return
+        }
+        let identity = IdentityStore.shared.current
+        let payload = RequestFactory.tokenPayload(
+            anonymousId: anonymousId, email: identity.email,
+            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
+            pushToken: token, enablement: enablement,
+            background: environment.getBackgroundSetting().rawValue
+        )
+
+        if let apiKey = SDKConfigStore.shared.current.apiKey {
+            QueueStore.current()?.enqueue(
+                KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload)))
+        } else {
+            UnattributedBuffer.shared.append(.pushToken(payload))
+        }
+    }
+}

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -105,7 +105,7 @@ public enum RequestEnqueuer {
             )
             return
         }
-        let buffered = UnattributedBuffer.shared.snapshot()
+        let (buffered, cursor) = UnattributedBuffer.shared.drainSnapshot()
         guard !buffered.isEmpty, let queue = QueueStore.current() else { return }
 
         for (index, request) in buffered.enumerated() {
@@ -131,6 +131,6 @@ public enum RequestEnqueuer {
                 )
             }
         }
-        UnattributedBuffer.shared.removeDrained(buffered.count)
+        UnattributedBuffer.shared.removeDrained(throughCursor: cursor)
     }
 }

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -12,78 +12,67 @@ import Foundation
 /// to `QueueStore`; apiKey absent → build an apiKey-free payload → `UnattributedBuffer`.
 /// No reducer routing. See MAGE-951; caller cutover is MAGE-952.
 public enum RequestEnqueuer {
-    public static func enqueueEvent(_ event: Event) {
-        let identity = IdentityStore.shared.current
-        // Defensive: IdentityStore mints anonymousId on first access (MAGE-894), so this
-        // branch is unreachable in practice. Retained against future minting-policy changes.
-        guard let anonymousId = identity.anonymousId else {
-            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
-            return
-        }
-        let pushToken = IdentityStore.shared.pushToken?.pushToken
-        let payload = RequestFactory.eventPayload(
-            anonymousId: anonymousId, email: identity.email,
-            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
-            event: event, pushToken: pushToken
-        )
+    static let missingAnonymousIdWarning = "RequestEnqueuer: missing anonymousId"
 
+    /// Resolves the current identity, or emits a warning and returns `nil`. `anonymousId` is minted
+    /// on first access under the current single-minter policy, so `nil` is defensive and
+    /// unreachable in practice — retained against future minting-policy changes.
+    private static func resolveIdentity() -> PayloadIdentity? {
+        let identity = IdentityStore.shared.current
+        guard let anonymousId = identity.anonymousId else {
+            environment.emitDeveloperWarning(missingAnonymousIdWarning)
+            return nil
+        }
+        return PayloadIdentity(
+            anonymousId: anonymousId, email: identity.email,
+            phoneNumber: identity.phoneNumber, externalId: identity.externalId
+        )
+    }
+
+    /// The single routing rule: apiKey present → build a request and enqueue it to `QueueStore`;
+    /// apiKey absent → append the apiKey-free payload to the `UnattributedBuffer`.
+    private static func route(
+        buffered: UnattributedRequest,
+        build: (_ apiKey: String) -> KlaviyoRequest
+    ) {
         if let apiKey = SDKConfigStore.shared.current.apiKey {
-            QueueStore.current()?.enqueue(
-                KlaviyoRequest(endpoint: .createEvent(apiKey, payload), priority: event.priority))
+            QueueStore.current()?.enqueue(build(apiKey))
         } else {
-            UnattributedBuffer.shared.append(.event(payload, event.priority))
+            UnattributedBuffer.shared.append(buffered)
+        }
+    }
+
+    public static func enqueueEvent(_ event: Event) {
+        guard let identity = resolveIdentity() else { return }
+        let pushToken = IdentityStore.shared.pushToken?.pushToken
+        let payload = RequestFactory.eventPayload(identity: identity, event: event, pushToken: pushToken)
+        route(buffered: .event(payload, event.priority)) { apiKey in
+            KlaviyoRequest(endpoint: .createEvent(apiKey, payload), priority: event.priority)
         }
     }
 
     public static func enqueueAggregateEvent(_ payload: Data) {
-        if let apiKey = SDKConfigStore.shared.current.apiKey {
-            QueueStore.current()?.enqueue(
-                KlaviyoRequest(endpoint: .aggregateEvent(apiKey, payload)))
-        } else {
-            UnattributedBuffer.shared.append(.aggregateEvent(payload))
+        route(buffered: .aggregateEvent(payload)) { apiKey in
+            KlaviyoRequest(endpoint: .aggregateEvent(apiKey, payload))
         }
     }
 
     public static func enqueueProfile(properties: [String: Any]) {
-        let identity = IdentityStore.shared.current
-        // Defensive: see enqueueEvent comment — unreachable under current minting policy.
-        guard let anonymousId = identity.anonymousId else {
-            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
-            return
-        }
-        let payload = RequestFactory.profilePayload(
-            anonymousId: anonymousId, email: identity.email,
-            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
-            properties: properties
-        )
-
-        if let apiKey = SDKConfigStore.shared.current.apiKey {
-            QueueStore.current()?.enqueue(
-                KlaviyoRequest(endpoint: .createProfile(apiKey, payload)))
-        } else {
-            UnattributedBuffer.shared.append(.profile(payload))
+        guard let identity = resolveIdentity() else { return }
+        let payload = RequestFactory.profilePayload(identity: identity, properties: properties)
+        route(buffered: .profile(payload)) { apiKey in
+            KlaviyoRequest(endpoint: .createProfile(apiKey, payload))
         }
     }
 
     public static func enqueuePushToken(_ token: String, enablement: PushEnablement) {
-        let identity = IdentityStore.shared.current
-        // Defensive: see enqueueEvent comment — unreachable under current minting policy.
-        guard let anonymousId = identity.anonymousId else {
-            environment.emitDeveloperWarning("RequestEnqueuer: missing anonymousId")
-            return
-        }
+        guard let identity = resolveIdentity() else { return }
         let payload = RequestFactory.tokenPayload(
-            anonymousId: anonymousId, email: identity.email,
-            phoneNumber: identity.phoneNumber, externalId: identity.externalId,
-            pushToken: token, enablement: enablement,
-            background: environment.getBackgroundSetting().rawValue
+            identity: identity, pushToken: token, enablement: enablement,
+            background: environment.getBackgroundSetting()
         )
-
-        if let apiKey = SDKConfigStore.shared.current.apiKey {
-            QueueStore.current()?.enqueue(
-                KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload)))
-        } else {
-            UnattributedBuffer.shared.append(.pushToken(payload))
+        route(buffered: .pushToken(payload)) { apiKey in
+            KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload))
         }
     }
 
@@ -106,7 +95,17 @@ public enum RequestEnqueuer {
             return
         }
         let (buffered, cursor) = UnattributedBuffer.shared.drainSnapshot()
-        guard !buffered.isEmpty, let queue = QueueStore.current() else { return }
+        guard !buffered.isEmpty else { return }
+        // Defensive: `QueueStore.current()` only returns nil when no apiKey is set, and the mismatch
+        // guard above already returns in that case — so this is unreachable today. Retained (and
+        // warned) so a future change that can yield a nil queue never drops the buffer silently.
+        guard let queue = QueueStore.current() else {
+            environment.emitDeveloperWarning(
+                "RequestEnqueuer.drainBuffer: no QueueStore for the active apiKey; " +
+                    "buffered requests are retained for a later drain"
+            )
+            return
+        }
 
         for (index, request) in buffered.enumerated() {
             let isLast = index == buffered.count - 1

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -82,4 +82,39 @@ public enum RequestEnqueuer {
             UnattributedBuffer.shared.append(.pushToken(payload))
         }
     }
+
+    /// Moves every buffered request into `QueueStore`, stamping `apiKey` into each endpoint, then
+    /// clears the buffer. At-least-once: the final enqueue persists synchronously so the queue is
+    /// durable before the buffer file is removed. A crash in the gap re-drains next launch (a
+    /// dedup-able duplicate, never silent loss). Built + tested here; called by MAGE-952's
+    /// slimmed `initialize(apiKey:)`.
+    public static func drainBuffer(apiKey: String) {
+        let buffered = UnattributedBuffer.shared.snapshot()
+        guard !buffered.isEmpty, let queue = QueueStore.current() else { return }
+
+        for (index, request) in buffered.enumerated() {
+            let isLast = index == buffered.count - 1
+            let policy: PersistPolicy = isLast ? .synchronous : .debounced
+            switch request {
+            case let .event(payload, priority):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .createEvent(apiKey, payload), priority: priority),
+                    persist: policy
+                )
+            case let .aggregateEvent(payload):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .aggregateEvent(apiKey, payload)), persist: policy
+                )
+            case let .profile(payload):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .createProfile(apiKey, payload)), persist: policy
+                )
+            case let .pushToken(payload):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload)), persist: policy
+                )
+            }
+        }
+        UnattributedBuffer.shared.clear()
+    }
 }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -27,3 +27,64 @@ struct PersistedUnattributedBuffer: Codable, Equatable {
         self.requests = requests
     }
 }
+
+/// Durable, device-scoped sink for request-generating calls made before an apiKey is known.
+/// Ungated: usable without `initialize()`. Not observed — no Combine subject. All mutations
+/// write through synchronously; `RequestEnqueuer` owns the drain-into-QueueStore orchestration.
+final class UnattributedBuffer {
+    static let shared = UnattributedBuffer()
+    static let maxBufferSize = 200
+
+    private let lock = UnfairLock()
+    private var hydrated = false
+    private var requests: [UnattributedRequest] = []
+
+    /// Loads from disk on first access; memory is authoritative thereafter. Call under `lock`.
+    private func hydrateIfNeeded() {
+        guard !hydrated else { return }
+        hydrated = true
+        if let persisted = loadPersisted(
+            PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed
+        ) {
+            requests = persisted.requests
+        }
+    }
+
+    func append(_ request: UnattributedRequest) {
+        lock.withLock {
+            hydrateIfNeeded()
+            if requests.count >= Self.maxBufferSize {
+                requests.removeFirst()
+            }
+            requests.append(request)
+            savePersisted(
+                PersistedUnattributedBuffer(requests: requests),
+                fileName: StoreFile.unattributed
+            )
+        }
+    }
+
+    func snapshot() -> [UnattributedRequest] {
+        lock.withLock {
+            hydrateIfNeeded()
+            return requests
+        }
+    }
+
+    func clear() {
+        lock.withLock {
+            requests = []
+            hydrated = true
+            removePersisted(fileName: StoreFile.unattributed)
+        }
+    }
+
+    /// Clears persisted state, in-memory cache, and re-arms hydration (test isolation only).
+    package func reset() {
+        lock.withLock {
+            hydrated = false
+            requests = []
+            removePersisted(fileName: StoreFile.unattributed)
+        }
+    }
+}

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -1,0 +1,29 @@
+//
+//  UnattributedBuffer.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 8/19/26.
+//
+
+import Foundation
+
+/// One request-generating call captured before an apiKey was known. Stored apiKey-free
+/// (the apiKey is stamped into the endpoint at drain). Named to echo `UnattributedBuffer`.
+enum UnattributedRequest: Codable, Equatable {
+    case event(CreateEventPayload, RequestPriority)
+    case aggregateEvent(Data)
+    case profile(CreateProfilePayload)
+    case pushToken(PushTokenPayload)
+}
+
+/// Versioned on-disk shape for the buffer file (`klaviyo-unattributed.json`).
+struct PersistedUnattributedBuffer: Codable, Equatable {
+    static let currentVersion = 1
+    var version: Int
+    var requests: [UnattributedRequest]
+
+    init(version: Int = currentVersion, requests: [UnattributedRequest] = []) {
+        self.version = version
+        self.requests = requests
+    }
+}

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -39,14 +39,32 @@ final class UnattributedBuffer {
     private var hydrated = false
     private var requests: [UnattributedRequest] = []
 
+    /// Canonical home for new SDK support files, matching `QueueStore` (the store this buffer
+    /// drains into). Resolved per-access so tests can swap the environment's file client.
+    private var storeDirectory: URL { environment.fileClient.applicationSupportDirectory() }
+
     /// Loads from disk on first access; memory is authoritative thereafter. Call under `lock`.
     private func hydrateIfNeeded() {
         guard !hydrated else { return }
         hydrated = true
         if let persisted = loadPersisted(
-            PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed
+            PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed,
+            directory: storeDirectory
         ) {
             requests = persisted.requests
+        }
+    }
+
+    /// Writes the current in-memory buffer through to disk (or removes the file when empty).
+    /// Call under `lock`.
+    private func persist() {
+        if requests.isEmpty {
+            removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
+        } else {
+            savePersisted(
+                PersistedUnattributedBuffer(requests: requests),
+                fileName: StoreFile.unattributed, directory: storeDirectory
+            )
         }
     }
 
@@ -57,10 +75,7 @@ final class UnattributedBuffer {
                 requests.removeFirst()
             }
             requests.append(request)
-            savePersisted(
-                PersistedUnattributedBuffer(requests: requests),
-                fileName: StoreFile.unattributed
-            )
+            persist()
         }
     }
 
@@ -71,11 +86,24 @@ final class UnattributedBuffer {
         }
     }
 
+    /// Removes the first `count` requests — the FIFO prefix a drain has already enqueued — and
+    /// persists the remainder, all under one lock. Unlike `clear()`, requests appended
+    /// concurrently during a drain sit past the prefix and survive, preserving at-least-once.
+    func removeDrained(_ count: Int) {
+        lock.withLock {
+            hydrateIfNeeded()
+            let removalCount = min(count, requests.count)
+            guard removalCount > 0 else { return }
+            requests.removeFirst(removalCount)
+            persist()
+        }
+    }
+
     func clear() {
         lock.withLock {
             requests = []
             hydrated = true
-            removePersisted(fileName: StoreFile.unattributed)
+            removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         }
     }
 
@@ -84,7 +112,7 @@ final class UnattributedBuffer {
         lock.withLock {
             hydrated = false
             requests = []
-            removePersisted(fileName: StoreFile.unattributed)
+            removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         }
     }
 }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -35,9 +35,19 @@ final class UnattributedBuffer {
     static let shared = UnattributedBuffer()
     static let maxBufferSize = 200
 
+    /// A buffered request tagged with a process-local, monotonically increasing sequence. The
+    /// sequence — not the array index — identifies an item across cap-eviction and appends, so a
+    /// drain can trim exactly what it snapshotted. Sequences are in-memory only (reassigned on
+    /// hydrate); durability comes from the persisted `UnattributedRequest`s alone.
+    private struct Entry {
+        let sequence: UInt64
+        let request: UnattributedRequest
+    }
+
     private let lock = UnfairLock()
     private var hydrated = false
-    private var requests: [UnattributedRequest] = []
+    private var entries: [Entry] = []
+    private var nextSequence: UInt64 = 0
 
     /// Canonical home for new SDK support files, matching `QueueStore` (the store this buffer
     /// drains into). Resolved per-access so tests can swap the environment's file client.
@@ -51,18 +61,24 @@ final class UnattributedBuffer {
             PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed,
             directory: storeDirectory
         ) {
-            requests = persisted.requests
+            entries = persisted.requests.map { assignSequence($0) }
         }
+    }
+
+    /// Wraps a request in an `Entry` with the next sequence. Call under `lock`.
+    private func assignSequence(_ request: UnattributedRequest) -> Entry {
+        defer { nextSequence += 1 }
+        return Entry(sequence: nextSequence, request: request)
     }
 
     /// Writes the current in-memory buffer through to disk (or removes the file when empty).
     /// Call under `lock`.
     private func persist() {
-        if requests.isEmpty {
+        if entries.isEmpty {
             removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         } else {
             savePersisted(
-                PersistedUnattributedBuffer(requests: requests),
+                PersistedUnattributedBuffer(requests: entries.map(\.request)),
                 fileName: StoreFile.unattributed, directory: storeDirectory
             )
         }
@@ -71,10 +87,10 @@ final class UnattributedBuffer {
     func append(_ request: UnattributedRequest) {
         lock.withLock {
             hydrateIfNeeded()
-            if requests.count >= Self.maxBufferSize {
-                requests.removeFirst()
+            if entries.count >= Self.maxBufferSize {
+                entries.removeFirst()
             }
-            requests.append(request)
+            entries.append(assignSequence(request))
             persist()
         }
     }
@@ -82,26 +98,37 @@ final class UnattributedBuffer {
     func snapshot() -> [UnattributedRequest] {
         lock.withLock {
             hydrateIfNeeded()
-            return requests
+            return entries.map(\.request)
         }
     }
 
-    /// Removes the first `count` requests — the FIFO prefix a drain has already enqueued — and
-    /// persists the remainder, all under one lock. Unlike `clear()`, requests appended
-    /// concurrently during a drain sit past the prefix and survive, preserving at-least-once.
-    func removeDrained(_ count: Int) {
+    /// Atomic drain snapshot: the buffered requests plus a `cursor` identifying them. Pass the
+    /// cursor back to `removeDrained(throughCursor:)` after enqueuing to remove exactly those
+    /// items — even if cap-eviction or a concurrent append reshaped the buffer in between.
+    func drainSnapshot() -> (requests: [UnattributedRequest], cursor: UInt64) {
         lock.withLock {
             hydrateIfNeeded()
-            let removalCount = min(count, requests.count)
-            guard removalCount > 0 else { return }
-            requests.removeFirst(removalCount)
+            return (entries.map(\.request), entries.last?.sequence ?? 0)
+        }
+    }
+
+    /// Removes every buffered request whose sequence is `<= cursor` — the items a drain has
+    /// already enqueued — and persists the remainder, all under one lock. Front-eviction only
+    /// drops even-lower sequences and appends only mint higher ones, so an item appended
+    /// concurrently during a drain survives instead of being swept up, preserving at-least-once.
+    func removeDrained(throughCursor cursor: UInt64) {
+        lock.withLock {
+            hydrateIfNeeded()
+            let before = entries.count
+            entries.removeAll { $0.sequence <= cursor }
+            guard entries.count != before else { return }
             persist()
         }
     }
 
     func clear() {
         lock.withLock {
-            requests = []
+            entries = []
             hydrated = true
             removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         }
@@ -111,7 +138,8 @@ final class UnattributedBuffer {
     package func reset() {
         lock.withLock {
             hydrated = false
-            requests = []
+            entries = []
+            nextSequence = 0
             removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         }
     }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// One request-generating call captured before an apiKey was known. Stored apiKey-free
-/// (the apiKey is stamped into the endpoint at drain). Named to echo `UnattributedBuffer`.
+/// (the apiKey is stamped into the endpoint at drain).
 enum UnattributedRequest: Codable, Equatable {
     case event(CreateEventPayload, RequestPriority)
     case aggregateEvent(Data)
@@ -47,7 +47,9 @@ final class UnattributedBuffer {
     private let lock = UnfairLock()
     private var hydrated = false
     private var entries: [Entry] = []
-    private var nextSequence: UInt64 = 0
+    /// Starts at 1 so the `0` cursor `drainSnapshot()` returns for an empty buffer can never
+    /// match a real entry's sequence.
+    private var nextSequence: UInt64 = 1
 
     /// Canonical home for new SDK support files, matching `QueueStore` (the store this buffer
     /// drains into). Resolved per-access so tests can swap the environment's file client.
@@ -139,7 +141,7 @@ final class UnattributedBuffer {
         lock.withLock {
             hydrated = false
             entries = []
-            nextSequence = 0
+            nextSequence = 1
             removePersisted(fileName: StoreFile.unattributed, directory: storeDirectory)
         }
     }

--- a/Tests/KlaviyoCoreTests/QueueStoreRegistryTests.swift
+++ b/Tests/KlaviyoCoreTests/QueueStoreRegistryTests.swift
@@ -1,0 +1,36 @@
+//
+//  QueueStoreRegistryTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 8/20/26.
+//
+
+@testable import KlaviyoCore
+import XCTest
+
+final class QueueStoreRegistryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        SDKConfigStore.shared.reset()
+        QueueStore.resetRegistry()
+    }
+
+    override func tearDown() {
+        SDKConfigStore.shared.reset()
+        QueueStore.resetRegistry()
+        super.tearDown()
+    }
+
+    func testStoreForKeyResolvesIndependentlyOfConfig() {
+        // No apiKey set, yet store(for:) returns a usable store for the captured key — proving queue
+        // resolution never re-reads SDKConfigStore and so can't race a config change. current()
+        // delegates to it for the active key, returning the same cached instance.
+        XCTAssertNil(QueueStore.current())
+        let store = QueueStore.store(for: "pk-1")
+        store.enqueue(KlaviyoRequest(endpoint: .createProfile("pk-1", CreateProfilePayload(data: .test))))
+        XCTAssertEqual(store.count, 1)
+        XCTAssertTrue(store === QueueStore.store(for: "pk-1"), "same key returns the cached instance")
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        XCTAssertTrue(QueueStore.current() === store, "current() resolves to store(for: activeKey)")
+    }
+}

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -183,4 +183,28 @@ final class RequestEnqueuerTests: XCTestCase {
                            "on-disk queue nil but in-memory count should be 1")
         }
     }
+
+    func testDrainWithMismatchedApiKeyIsSkipped() {
+        // Configure the active SDK key to "pk-1" and buffer one event.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        // Reset to no-apiKey so the event lands in the buffer, then drain with wrong key.
+        SDKConfigStore.shared.reset()
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("buffered")))
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 1, "pre-condition: event buffered")
+
+        // Set active key back to "pk-1" so QueueStore resolves it, then drain with a wrong key.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        var warnings: [String] = []
+        environment.emitDeveloperWarning = { warnings.append($0) }
+
+        RequestEnqueuer.drainBuffer(apiKey: "pk-2")
+
+        // Buffer must NOT have been cleared — at-least-once preservation.
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 1,
+                       "buffer should be intact when apiKeys mismatch")
+        // The pk-1 queue must be empty — no requests written to the wrong queue.
+        XCTAssertEqual(QueueStore.current()?.count, 0,
+                       "pk-1 QueueStore should be empty after skipped drain")
+        XCTAssertFalse(warnings.isEmpty, "a developer warning should have been emitted")
+    }
 }

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -31,8 +31,13 @@ final class RequestEnqueuerTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - enqueueEvent
+
     func testEventWithoutApiKeyGoesToBuffer() {
         // no apiKey set
+        // IdentityStore mints anonymousId on first access (MAGE-894 single minter), so it is always
+        // non-nil here — the anonymousId guard in RequestEnqueuer is defensive, never reached.
+        XCTAssertNotNil(IdentityStore.shared.current.anonymousId)
         RequestEnqueuer.enqueueEvent(Event(name: .customEvent("X")))
         let snap = UnattributedBuffer.shared.snapshot()
         XCTAssertEqual(snap.count, 1)
@@ -57,10 +62,74 @@ final class RequestEnqueuerTests: XCTestCase {
         XCTAssertEqual(requests.first?.priority, .high)
     }
 
+    func testHighPriorityEventInBufferStoresHighPriority() {
+        // no apiKey set — event goes to UnattributedBuffer; assert the priority is preserved
+        RequestEnqueuer.enqueueEvent(
+            Event(name: .customEvent("urgent"), properties: nil, identifiers: nil,
+                  value: nil, priority: .high))
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case let .event(_, priority) = snap[0] else {
+            return XCTFail("expected .event in buffer")
+        }
+        XCTAssertEqual(priority, .high)
+    }
+
+    // MARK: - enqueueProfile
+
     func testProfileWithoutApiKeyBuffersProfilePayload() {
         RequestEnqueuer.enqueueProfile(properties: ["k": "v"])
         guard case .profile = UnattributedBuffer.shared.snapshot().first else {
             return XCTFail("expected .profile in buffer")
+        }
+    }
+
+    // MARK: - enqueueAggregateEvent
+
+    func testAggregateEventWithoutApiKeyGoesToBuffer() {
+        let payload = Data("test-aggregate".utf8)
+        RequestEnqueuer.enqueueAggregateEvent(payload)
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case let .aggregateEvent(bufferedPayload) = snap[0] else {
+            return XCTFail("expected .aggregateEvent in buffer")
+        }
+        XCTAssertEqual(bufferedPayload, payload)
+        XCTAssertNil(QueueStore.current())
+    }
+
+    func testAggregateEventWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        let payload = Data("test-aggregate".utf8)
+        RequestEnqueuer.enqueueAggregateEvent(payload)
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
+        let request = QueueStore.current()?.requests.first
+        guard case .aggregateEvent = request?.endpoint else {
+            return XCTFail("expected .aggregateEvent endpoint in QueueStore")
+        }
+    }
+
+    // MARK: - enqueuePushToken
+
+    func testPushTokenWithoutApiKeyGoesToBuffer() {
+        RequestEnqueuer.enqueuePushToken("device-token-abc", enablement: .authorized)
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case .pushToken = snap[0] else {
+            return XCTFail("expected .pushToken in buffer")
+        }
+        XCTAssertNil(QueueStore.current())
+    }
+
+    func testPushTokenWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.enqueuePushToken("device-token-abc", enablement: .authorized)
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
+        let request = QueueStore.current()?.requests.first
+        guard case .registerPushToken = request?.endpoint else {
+            return XCTFail("expected .registerPushToken endpoint in QueueStore")
         }
     }
 }

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -1,0 +1,66 @@
+//
+//  RequestEnqueuerTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 8/19/26.
+//
+
+@testable import KlaviyoCore
+import XCTest
+
+final class RequestEnqueuerTests: XCTestCase {
+    private var fileIO: FileIODouble!
+
+    override func setUp() {
+        super.setUp()
+        fileIO = FileIODouble()
+        environment = fileIO.makeEnvironment()
+        UnattributedBuffer.shared.reset()
+        SDKConfigStore.shared.reset()
+        IdentityStore.shared.reset()
+        QueueStore.resetRegistry()
+    }
+
+    override func tearDown() {
+        UnattributedBuffer.shared.reset()
+        SDKConfigStore.shared.reset()
+        IdentityStore.shared.reset()
+        QueueStore.resetRegistry()
+        environment = KlaviyoEnvironment.test()
+        fileIO = nil
+        super.tearDown()
+    }
+
+    func testEventWithoutApiKeyGoesToBuffer() {
+        // no apiKey set
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("X")))
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case .event = snap[0] else { return XCTFail("expected .event in buffer") }
+        XCTAssertNil(QueueStore.current()) // no queue exists pre-apiKey
+    }
+
+    func testEventWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("X")))
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
+    }
+
+    func testPriorityEventFrontInsertsInQueue() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("normal")))
+        RequestEnqueuer.enqueueEvent(
+            Event(name: .customEvent("urgent"), properties: nil, identifiers: nil,
+                  value: nil, priority: .high))
+        let requests = QueueStore.current()!.requests
+        XCTAssertEqual(requests.first?.priority, .high)
+    }
+
+    func testProfileWithoutApiKeyBuffersProfilePayload() {
+        RequestEnqueuer.enqueueProfile(properties: ["k": "v"])
+        guard case .profile = UnattributedBuffer.shared.snapshot().first else {
+            return XCTFail("expected .profile in buffer")
+        }
+    }
+}

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -132,4 +132,55 @@ final class RequestEnqueuerTests: XCTestCase {
             return XCTFail("expected .registerPushToken endpoint in QueueStore")
         }
     }
+
+    // MARK: - drainBuffer
+
+    func testDrainMovesBufferedRequestsToQueueInFifoOrder() {
+        // Buffer three events with no apiKey.
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("1")))
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("2")))
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("3")))
+
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 3)
+    }
+
+    func testDrainPreservesPriorityFrontInsert() {
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("normal")))
+        RequestEnqueuer.enqueueEvent(
+            Event(name: .customEvent("urgent"), properties: nil, identifiers: nil,
+                  value: nil, priority: .high))
+
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+
+        XCTAssertEqual(QueueStore.current()?.requests.first?.priority, .high)
+    }
+
+    func testDrainEmptyBufferIsNoOp() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+        XCTAssertEqual(QueueStore.current()?.count, 0)
+    }
+
+    func testDrainPersistsQueueBeforeClearingBuffer() {
+        RequestEnqueuer.enqueueEvent(Event(name: .customEvent("1")))
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+        // Buffer file must be gone.
+        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
+        // Queue must be durable on disk (synchronous final enqueue).
+        let onDisk = loadPersisted(PersistedQueue.self, fileName: "klaviyo-pk-1-queue.json")
+        if let onDisk {
+            XCTAssertEqual(onDisk.requests.count, 1)
+        } else {
+            // applicationSupportDirectory resolved differently than libraryDirectory in this env;
+            // fall back to the in-memory store count.
+            XCTAssertEqual(QueueStore.current()?.count, 1,
+                           "on-disk queue nil but in-memory count should be 1")
+        }
+    }
 }

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -146,6 +146,12 @@ final class RequestEnqueuerTests: XCTestCase {
 
         XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
         XCTAssertEqual(QueueStore.current()?.count, 3)
+        // Verify FIFO order, not just count: reversing the drain would still pass a count check.
+        let names = (QueueStore.current()?.requests ?? []).compactMap { request -> String? in
+            guard case let .createEvent(_, payload) = request.endpoint else { return nil }
+            return payload.data.attributes.metric.data.attributes.name
+        }
+        XCTAssertEqual(names, ["1", "2", "3"], "drain must preserve FIFO order")
     }
 
     func testDrainPreservesPriorityFrontInsert() {
@@ -171,17 +177,16 @@ final class RequestEnqueuerTests: XCTestCase {
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
         RequestEnqueuer.drainBuffer(apiKey: "pk-1")
         // Buffer file must be gone.
-        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
-        // Queue must be durable on disk (synchronous final enqueue).
-        let onDisk = loadPersisted(PersistedQueue.self, fileName: "klaviyo-pk-1-queue.json")
-        if let onDisk {
-            XCTAssertEqual(onDisk.requests.count, 1)
-        } else {
-            // applicationSupportDirectory resolved differently than libraryDirectory in this env;
-            // fall back to the in-memory store count.
-            XCTAssertEqual(QueueStore.current()?.count, 1,
-                           "on-disk queue nil but in-memory count should be 1")
-        }
+        XCTAssertNil(loadPersisted(
+            PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed,
+            directory: storeDirectory()
+        ))
+        // Queue must be durable on disk (synchronous final enqueue), resolved through the same
+        // store directory production writes to.
+        let onDisk = loadPersisted(
+            PersistedQueue.self, fileName: "klaviyo-pk-1-queue.json", directory: storeDirectory()
+        )
+        XCTAssertEqual(onDisk?.requests.count, 1)
     }
 
     func testDrainWithMismatchedApiKeyIsSkipped() {

--- a/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
@@ -70,15 +70,11 @@ final class RequestFactoryTests: XCTestCase {
     // MARK: - apiKey-free payload builders
 
     func testEventPayloadMatchesEventRequestPayload() {
-        let identity = RequestIdentity(
-            apiKey: "pk", anonymousId: "anon", email: "a@b.co"
-        )
         let event = Event(name: .customEvent("X"), properties: ["k": "v"])
 
         let viaRequest = RequestFactory.eventRequest(identity: identity, event: event, pushToken: "tok")
         let payload = RequestFactory.eventPayload(
-            anonymousId: "anon", email: "a@b.co", phoneNumber: nil, externalId: nil,
-            event: event, pushToken: "tok"
+            identity: PayloadIdentity(identity), event: event, pushToken: "tok"
         )
 
         guard case let .createEvent(_, requestPayload) = viaRequest.endpoint else {
@@ -88,14 +84,15 @@ final class RequestFactoryTests: XCTestCase {
     }
 
     func testTokenPayloadMatchesTokenRequestPayload() {
+        let payloadIdentity = PayloadIdentity(anonymousId: "anon")
         let profile = ProfilePayload(anonymousId: "anon")
         let viaRequest = RequestFactory.tokenRequest(
             apiKey: "pk", pushToken: "tok", enablement: .authorized,
-            background: "AVAILABLE", profile: profile
+            background: PushBackground.available.rawValue, profile: profile
         )
         let payload = RequestFactory.tokenPayload(
-            anonymousId: "anon", email: nil, phoneNumber: nil, externalId: nil,
-            pushToken: "tok", enablement: .authorized, background: "AVAILABLE"
+            identity: payloadIdentity, pushToken: "tok",
+            enablement: .authorized, background: .available
         )
 
         guard case let .registerPushToken(_, requestPayload) = viaRequest.endpoint else {
@@ -104,19 +101,14 @@ final class RequestFactoryTests: XCTestCase {
         XCTAssertEqual(payload, requestPayload)
     }
 
-    func testProfilePayloadDelegatesToFieldBasedBuilder() {
-        let identity = RequestIdentity(
-            apiKey: "pk", anonymousId: "anon", email: "a@b.co",
-            phoneNumber: "+15559990000", externalId: "ext"
-        )
+    func testProfilePayloadRequestIdentityOverloadDelegates() {
         let properties: [String: Any] = ["foo": "bar"]
 
-        let viaIdentity = RequestFactory.profilePayload(identity: identity, properties: properties)
-        let viaFields = RequestFactory.profilePayload(
-            anonymousId: "anon", email: "a@b.co", phoneNumber: "+15559990000",
-            externalId: "ext", properties: properties
+        let viaRequestIdentity = RequestFactory.profilePayload(identity: identity, properties: properties)
+        let viaPayloadIdentity = RequestFactory.profilePayload(
+            identity: PayloadIdentity(identity), properties: properties
         )
 
-        XCTAssertEqual(viaIdentity, viaFields)
+        XCTAssertEqual(viaRequestIdentity, viaPayloadIdentity)
     }
 }

--- a/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
@@ -66,4 +66,57 @@ final class RequestFactoryTests: XCTestCase {
         let props = payload.data.attributes.properties.value as? [String: Any]
         XCTAssertEqual(props?["Push Token"] as? String, "tok")
     }
+
+    // MARK: - apiKey-free payload builders
+
+    func testEventPayloadMatchesEventRequestPayload() {
+        let identity = RequestIdentity(
+            apiKey: "pk", anonymousId: "anon", email: "a@b.co"
+        )
+        let event = Event(name: .customEvent("X"), properties: ["k": "v"])
+
+        let viaRequest = RequestFactory.eventRequest(identity: identity, event: event, pushToken: "tok")
+        let payload = RequestFactory.eventPayload(
+            anonymousId: "anon", email: "a@b.co", phoneNumber: nil, externalId: nil,
+            event: event, pushToken: "tok"
+        )
+
+        guard case let .createEvent(_, requestPayload) = viaRequest.endpoint else {
+            return XCTFail("expected createEvent endpoint")
+        }
+        XCTAssertEqual(payload, requestPayload)
+    }
+
+    func testTokenPayloadMatchesTokenRequestPayload() {
+        let profile = ProfilePayload(anonymousId: "anon")
+        let viaRequest = RequestFactory.tokenRequest(
+            apiKey: "pk", pushToken: "tok", enablement: .authorized,
+            background: "AVAILABLE", profile: profile
+        )
+        let payload = RequestFactory.tokenPayload(
+            anonymousId: "anon", email: nil, phoneNumber: nil, externalId: nil,
+            pushToken: "tok", enablement: .authorized, background: "AVAILABLE"
+        )
+
+        guard case let .registerPushToken(_, requestPayload) = viaRequest.endpoint else {
+            return XCTFail("expected registerPushToken endpoint")
+        }
+        XCTAssertEqual(payload, requestPayload)
+    }
+
+    func testProfilePayloadDelegatesToFieldBasedBuilder() {
+        let identity = RequestIdentity(
+            apiKey: "pk", anonymousId: "anon", email: "a@b.co",
+            phoneNumber: "+15559990000", externalId: "ext"
+        )
+        let properties: [String: Any] = ["foo": "bar"]
+
+        let viaIdentity = RequestFactory.profilePayload(identity: identity, properties: properties)
+        let viaFields = RequestFactory.profilePayload(
+            anonymousId: "anon", email: "a@b.co", phoneNumber: "+15559990000",
+            externalId: "ext", properties: properties
+        )
+
+        XCTAssertEqual(viaIdentity, viaFields)
+    }
 }

--- a/Tests/KlaviyoCoreTests/StorePersistenceTests.swift
+++ b/Tests/KlaviyoCoreTests/StorePersistenceTests.swift
@@ -38,6 +38,22 @@ final class StorePersistenceTests: XCTestCase {
         XCTAssertNil(loadPersisted(PersistedConfig.self, fileName: StoreFile.config))
     }
 
+    func testSaveAndLoadHonorExplicitDirectory() {
+        let appSupport = environment.fileClient.libraryDirectory()
+            .appendingPathComponent("Application Support/com.klaviyo", isDirectory: true)
+        let config = PersistedConfig(version: 1, apiKey: "pk-1")
+
+        savePersisted(config, fileName: StoreFile.config, directory: appSupport)
+
+        // Readable from the same directory it was written to.
+        XCTAssertEqual(
+            loadPersisted(PersistedConfig.self, fileName: StoreFile.config, directory: appSupport),
+            config
+        )
+        // Not visible under the default library root — proves the directory seam is honored.
+        XCTAssertNil(loadPersisted(PersistedConfig.self, fileName: StoreFile.config))
+    }
+
     func testPersistedIdentityJSONCarriesVersionKey() throws {
         let identity = PersistedIdentity(version: 1, profile: ProfileData(), pushToken: nil)
         let json = try environment.encodeJSON(identity)

--- a/Tests/KlaviyoCoreTests/Support/StoreTestHelpers.swift
+++ b/Tests/KlaviyoCoreTests/Support/StoreTestHelpers.swift
@@ -1,0 +1,16 @@
+//
+//  StoreTestHelpers.swift
+//  klaviyo-swift-sdk
+//
+//  Shared persistence helpers for store tests.
+//
+
+@testable import KlaviyoCore
+import Foundation
+
+/// The directory production store code writes to (`applicationSupportDirectory()` in production;
+/// aliased to the library root by `FileIODouble`). Tests resolve persisted files through this so
+/// their assertions exercise the real write path instead of passing vacuously against the default.
+func storeDirectory() -> URL {
+    environment.fileClient.applicationSupportDirectory()
+}

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -70,23 +70,41 @@ final class UnattributedBufferTests: XCTestCase {
         XCTAssertEqual(snap.last, .aggregateEvent(Data("newest".utf8)))
     }
 
-    func testRemoveDrainedRemovesPrefixAndKeepsItemsAppendedDuringDrain() {
+    func testRemoveDrainedKeepsItemsAppendedDuringDrain() {
         let buffer = UnattributedBuffer()
         buffer.append(.aggregateEvent(Data("1".utf8)))
         buffer.append(.aggregateEvent(Data("2".utf8)))
         // Model a drain: it snapshots the current 2 items, then a 3rd is appended
-        // (a concurrent enqueue that saw no apiKey) before the drained prefix is removed.
-        let drainedCount = buffer.snapshot().count
+        // (a concurrent enqueue that saw no apiKey) before the drained items are removed.
+        let (_, cursor) = buffer.drainSnapshot()
         buffer.append(.aggregateEvent(Data("3".utf8)))
-        buffer.removeDrained(drainedCount)
-        // Only the drained prefix is gone; the concurrently-appended item survives.
+        buffer.removeDrained(throughCursor: cursor)
+        // Only the drained items are gone; the concurrently-appended item survives.
         XCTAssertEqual(buffer.snapshot(), [.aggregateEvent(Data("3".utf8))])
+    }
+
+    func testDrainDoesNotDropAppendWhenCapEvictsDuringDrain() {
+        let buffer = UnattributedBuffer()
+        for value in 0..<UnattributedBuffer.maxBufferSize {
+            buffer.append(.aggregateEvent(Data("\(value)".utf8)))
+        }
+        let (_, cursor) = buffer.drainSnapshot() // maxBufferSize items
+        // Concurrent enqueue during the drain: the buffer is at cap, so append evicts the
+        // oldest (front) and stores the newest at the back.
+        buffer.append(.aggregateEvent(Data("newest".utf8)))
+        buffer.removeDrained(throughCursor: cursor)
+        // The item appended during the drain must survive, not be swept up by the trim.
+        XCTAssertEqual(
+            buffer.snapshot(), [.aggregateEvent(Data("newest".utf8))],
+            "item appended during a cap-evicting drain must survive"
+        )
     }
 
     func testRemoveDrainedAllEmptiesMemoryAndRemovesFile() {
         let buffer = UnattributedBuffer()
         buffer.append(.aggregateEvent(Data("a".utf8)))
-        buffer.removeDrained(1)
+        let (_, cursor) = buffer.drainSnapshot()
+        buffer.removeDrained(throughCursor: cursor)
         XCTAssertEqual(buffer.snapshot(), [])
         XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
     }

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -23,6 +23,61 @@ final class UnattributedBufferTests: XCTestCase {
         super.tearDown()
     }
 
+    func testAppendPersistsSynchronously() {
+        let buffer = UnattributedBuffer()
+        buffer.append(.aggregateEvent(Data("a".utf8)))
+        // Read straight off disk — append must write through before returning.
+        let onDisk = loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed)
+        XCTAssertEqual(onDisk?.requests, [.aggregateEvent(Data("a".utf8))])
+    }
+
+    func testHydratesFromDiskOnFirstAccess() {
+        savePersisted(
+            PersistedUnattributedBuffer(requests: [.aggregateEvent(Data("x".utf8))]),
+            fileName: StoreFile.unattributed
+        )
+        let buffer = UnattributedBuffer()
+        XCTAssertEqual(buffer.snapshot(), [.aggregateEvent(Data("x".utf8))])
+    }
+
+    func testAbsentFileYieldsEmpty() {
+        XCTAssertEqual(UnattributedBuffer().snapshot(), [])
+    }
+
+    func testCorruptFileYieldsEmptyAndRemovesFile() throws {
+        // Write bytes that are not valid PersistedUnattributedBuffer JSON.
+        try environment.fileClient.write(
+            Data("not json".utf8),
+            environment.fileClient.libraryDirectory()
+                .appendingPathComponent(StoreFile.unattributed)
+        )
+        let buffer = UnattributedBuffer()
+        XCTAssertEqual(buffer.snapshot(), [])
+        XCTAssertFalse(environment.fileClient.fileExists(
+            environment.fileClient.libraryDirectory()
+                .appendingPathComponent(StoreFile.unattributed).path))
+    }
+
+    func testCapEvictsOldestWhenFull() {
+        let buffer = UnattributedBuffer()
+        for i in 0..<UnattributedBuffer.maxBufferSize {
+            buffer.append(.aggregateEvent(Data("\(i)".utf8)))
+        }
+        buffer.append(.aggregateEvent(Data("newest".utf8)))
+        let snap = buffer.snapshot()
+        XCTAssertEqual(snap.count, UnattributedBuffer.maxBufferSize)
+        XCTAssertEqual(snap.first, .aggregateEvent(Data("1".utf8))) // "0" evicted
+        XCTAssertEqual(snap.last, .aggregateEvent(Data("newest".utf8)))
+    }
+
+    func testClearEmptiesMemoryAndRemovesFile() {
+        let buffer = UnattributedBuffer()
+        buffer.append(.aggregateEvent(Data("a".utf8)))
+        buffer.clear()
+        XCTAssertEqual(buffer.snapshot(), [])
+        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
+    }
+
     func testPersistedBufferRoundTripsAllFourCases() throws {
         let eventPayload = CreateEventPayload(
             data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1"))

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -70,6 +70,27 @@ final class UnattributedBufferTests: XCTestCase {
         XCTAssertEqual(snap.last, .aggregateEvent(Data("newest".utf8)))
     }
 
+    func testRemoveDrainedRemovesPrefixAndKeepsItemsAppendedDuringDrain() {
+        let buffer = UnattributedBuffer()
+        buffer.append(.aggregateEvent(Data("1".utf8)))
+        buffer.append(.aggregateEvent(Data("2".utf8)))
+        // Model a drain: it snapshots the current 2 items, then a 3rd is appended
+        // (a concurrent enqueue that saw no apiKey) before the drained prefix is removed.
+        let drainedCount = buffer.snapshot().count
+        buffer.append(.aggregateEvent(Data("3".utf8)))
+        buffer.removeDrained(drainedCount)
+        // Only the drained prefix is gone; the concurrently-appended item survives.
+        XCTAssertEqual(buffer.snapshot(), [.aggregateEvent(Data("3".utf8))])
+    }
+
+    func testRemoveDrainedAllEmptiesMemoryAndRemovesFile() {
+        let buffer = UnattributedBuffer()
+        buffer.append(.aggregateEvent(Data("a".utf8)))
+        buffer.removeDrained(1)
+        XCTAssertEqual(buffer.snapshot(), [])
+        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
+    }
+
     func testClearEmptiesMemoryAndRemovesFile() {
         let buffer = UnattributedBuffer()
         buffer.append(.aggregateEvent(Data("a".utf8)))

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -1,0 +1,50 @@
+//
+//  UnattributedBufferTests.swift
+//  klaviyo-swift-sdk
+//
+//  Created by Isobelle Lim on 8/19/26.
+//
+
+@testable import KlaviyoCore
+import XCTest
+
+final class UnattributedBufferTests: XCTestCase {
+    private var fileIO: FileIODouble!
+
+    override func setUp() {
+        super.setUp()
+        fileIO = FileIODouble()
+        environment = fileIO.makeEnvironment()
+    }
+
+    override func tearDown() {
+        environment = KlaviyoEnvironment.test()
+        fileIO = nil
+        super.tearDown()
+    }
+
+    func testPersistedBufferRoundTripsAllFourCases() throws {
+        let eventPayload = CreateEventPayload(
+            data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1"))
+        let profilePayload = CreateProfilePayload(
+            data: ProfilePayload(anonymousId: "anon-1"))
+        let tokenPayload = PushTokenPayload(
+            pushToken: "tok", enablement: "AUTHORIZED", background: "AVAILABLE",
+            profile: ProfilePayload(anonymousId: "anon-1")
+        )
+        let original = PersistedUnattributedBuffer(
+            version: PersistedUnattributedBuffer.currentVersion,
+            requests: [
+                .event(eventPayload, .high),
+                .aggregateEvent(Data("agg".utf8)),
+                .profile(profilePayload),
+                .pushToken(tokenPayload)
+            ]
+        )
+
+        let data = try environment.encodeJSON(original)
+        let decoded: PersistedUnattributedBuffer = try environment.decoder.decode(data)
+
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -23,21 +23,33 @@ final class UnattributedBufferTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Terse aggregate-event fixture.
+    private func agg(_ value: String) -> UnattributedRequest {
+        .aggregateEvent(Data(value.utf8))
+    }
+
+    /// Reads the persisted buffer from the store directory production writes to.
+    private func loadBuffer() -> PersistedUnattributedBuffer? {
+        loadPersisted(
+            PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed,
+            directory: storeDirectory()
+        )
+    }
+
     func testAppendPersistsSynchronously() {
         let buffer = UnattributedBuffer()
-        buffer.append(.aggregateEvent(Data("a".utf8)))
+        buffer.append(agg("a"))
         // Read straight off disk — append must write through before returning.
-        let onDisk = loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed)
-        XCTAssertEqual(onDisk?.requests, [.aggregateEvent(Data("a".utf8))])
+        XCTAssertEqual(loadBuffer()?.requests, [agg("a")])
     }
 
     func testHydratesFromDiskOnFirstAccess() {
         savePersisted(
-            PersistedUnattributedBuffer(requests: [.aggregateEvent(Data("x".utf8))]),
-            fileName: StoreFile.unattributed
+            PersistedUnattributedBuffer(requests: [agg("x")]),
+            fileName: StoreFile.unattributed, directory: storeDirectory()
         )
         let buffer = UnattributedBuffer()
-        XCTAssertEqual(buffer.snapshot(), [.aggregateEvent(Data("x".utf8))])
+        XCTAssertEqual(buffer.snapshot(), [agg("x")])
     }
 
     func testAbsentFileYieldsEmpty() {
@@ -46,75 +58,70 @@ final class UnattributedBufferTests: XCTestCase {
 
     func testCorruptFileYieldsEmptyAndRemovesFile() throws {
         // Write bytes that are not valid PersistedUnattributedBuffer JSON.
-        try environment.fileClient.write(
-            Data("not json".utf8),
-            environment.fileClient.libraryDirectory()
-                .appendingPathComponent(StoreFile.unattributed)
-        )
+        let fileURL = storeDirectory().appendingPathComponent(StoreFile.unattributed)
+        try environment.fileClient.write(Data("not json".utf8), fileURL)
         let buffer = UnattributedBuffer()
         XCTAssertEqual(buffer.snapshot(), [])
-        XCTAssertFalse(environment.fileClient.fileExists(
-            environment.fileClient.libraryDirectory()
-                .appendingPathComponent(StoreFile.unattributed).path))
+        XCTAssertFalse(environment.fileClient.fileExists(fileURL.path))
     }
 
     func testCapEvictsOldestWhenFull() {
         let buffer = UnattributedBuffer()
-        for i in 0..<UnattributedBuffer.maxBufferSize {
-            buffer.append(.aggregateEvent(Data("\(i)".utf8)))
+        for value in 0..<UnattributedBuffer.maxBufferSize {
+            buffer.append(agg("\(value)"))
         }
-        buffer.append(.aggregateEvent(Data("newest".utf8)))
+        buffer.append(agg("newest"))
         let snap = buffer.snapshot()
         XCTAssertEqual(snap.count, UnattributedBuffer.maxBufferSize)
-        XCTAssertEqual(snap.first, .aggregateEvent(Data("1".utf8))) // "0" evicted
-        XCTAssertEqual(snap.last, .aggregateEvent(Data("newest".utf8)))
+        XCTAssertEqual(snap.first, agg("1")) // "0" evicted
+        XCTAssertEqual(snap.last, agg("newest"))
     }
 
     func testRemoveDrainedKeepsItemsAppendedDuringDrain() {
         let buffer = UnattributedBuffer()
-        buffer.append(.aggregateEvent(Data("1".utf8)))
-        buffer.append(.aggregateEvent(Data("2".utf8)))
+        buffer.append(agg("1"))
+        buffer.append(agg("2"))
         // Model a drain: it snapshots the current 2 items, then a 3rd is appended
         // (a concurrent enqueue that saw no apiKey) before the drained items are removed.
         let (_, cursor) = buffer.drainSnapshot()
-        buffer.append(.aggregateEvent(Data("3".utf8)))
+        buffer.append(agg("3"))
         buffer.removeDrained(throughCursor: cursor)
         // Only the drained items are gone; the concurrently-appended item survives.
-        XCTAssertEqual(buffer.snapshot(), [.aggregateEvent(Data("3".utf8))])
+        XCTAssertEqual(buffer.snapshot(), [agg("3")])
     }
 
     func testDrainDoesNotDropAppendWhenCapEvictsDuringDrain() {
         let buffer = UnattributedBuffer()
         for value in 0..<UnattributedBuffer.maxBufferSize {
-            buffer.append(.aggregateEvent(Data("\(value)".utf8)))
+            buffer.append(agg("\(value)"))
         }
         let (_, cursor) = buffer.drainSnapshot() // maxBufferSize items
         // Concurrent enqueue during the drain: the buffer is at cap, so append evicts the
         // oldest (front) and stores the newest at the back.
-        buffer.append(.aggregateEvent(Data("newest".utf8)))
+        buffer.append(agg("newest"))
         buffer.removeDrained(throughCursor: cursor)
         // The item appended during the drain must survive, not be swept up by the trim.
         XCTAssertEqual(
-            buffer.snapshot(), [.aggregateEvent(Data("newest".utf8))],
+            buffer.snapshot(), [agg("newest")],
             "item appended during a cap-evicting drain must survive"
         )
     }
 
     func testRemoveDrainedAllEmptiesMemoryAndRemovesFile() {
         let buffer = UnattributedBuffer()
-        buffer.append(.aggregateEvent(Data("a".utf8)))
+        buffer.append(agg("a"))
         let (_, cursor) = buffer.drainSnapshot()
         buffer.removeDrained(throughCursor: cursor)
         XCTAssertEqual(buffer.snapshot(), [])
-        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
+        XCTAssertNil(loadBuffer())
     }
 
     func testClearEmptiesMemoryAndRemovesFile() {
         let buffer = UnattributedBuffer()
-        buffer.append(.aggregateEvent(Data("a".utf8)))
+        buffer.append(agg("a"))
         buffer.clear()
         XCTAssertEqual(buffer.snapshot(), [])
-        XCTAssertNil(loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed))
+        XCTAssertNil(loadBuffer())
     }
 
     func testPersistedBufferRoundTripsAllFourCases() throws {
@@ -130,7 +137,7 @@ final class UnattributedBufferTests: XCTestCase {
             version: PersistedUnattributedBuffer.currentVersion,
             requests: [
                 .event(eventPayload, .high),
-                .aggregateEvent(Data("agg".utf8)),
+                agg("agg"),
                 .profile(profilePayload),
                 .pushToken(tokenPayload)
             ]


### PR DESCRIPTION
# Description
Adds an ungated Core enqueue entry point (`RequestEnqueuer`) and a durable pre-apiKey buffer (`UnattributedBuffer`) to `KlaviyoCore`. Request-generating calls produced before `initialize(apiKey:)` now persist durably and drain into `QueueStore` once an apiKey is known — replacing the in-memory `KlaviyoState.pendingRequests` parking that is lost on cold kill today. (MAGE-951)

## Due Diligence
- [x] I have tested this on a simulator or a physical device. (`KlaviyoCoreTests` 222/0 on iPhone 17 Pro sim)
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable. — N/A (internal, uncalled until MAGE-952)
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Minor` Contains changes to the public API (`RequestEnqueuer`, new `RequestFactory` payload builders).
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release (iOS modularization; targets `feat/modularization-2`).

## Changelog / Code Overview
**Additive / Level 1 — the TCA reducer is untouched and these components are UNCALLED in this PR.** The caller cutover (delete `state.pendingRequests`, repoint the flush loop at `QueueStore`, slim `initialize()`, wire `drainBuffer`, immediate-flush on priority) is **MAGE-952**.

- **`UnattributedBuffer.swift`** (new) — internal, device-scoped durable store (`klaviyo-unattributed.json` in the library dir). `UnfairLock` hydrate-once + synchronous write-through, 200-item cap, `snapshot`/`clear`/`package reset()`. Stores `UnattributedRequest` (an apiKey-free enum of Core payloads: event+priority / aggregate `Data` / profile / pushToken) via a versioned `PersistedUnattributedBuffer` DTO. Reuses the existing `StorePersistence` helpers (free corrupt-file self-heal).
- **`RequestEnqueuer.swift`** (new) — public, stateless `enum`; the ungated entry point. `enqueueEvent` / `enqueueAggregateEvent` / `enqueueProfile` / `enqueuePushToken` read identity + apiKey from the shared stores themselves and route: **apiKey present** → build via `RequestFactory` → `QueueStore.current()`; **absent** → append the apiKey-free payload to the buffer. `drainBuffer(apiKey:)` stamps the apiKey onto each buffered payload and moves them into `QueueStore` **at-least-once** (FIFO; final enqueue is `.synchronous` so the queue is durable before the buffer is cleared — a crash in the gap re-drains next launch, a dedup-able duplicate via the event `unique_id`, never silent loss).
- **`RequestFactory.swift`** — extracted apiKey-free, identity-field-based payload builders (`eventPayload` / `profilePayload` / `tokenPayload`); the existing request builders now delegate to them (byte-identical output, verified by parity tests). No behavior change.
- **`StorePersistence.swift`** — added `StoreFile.unattributed`.

Design doc: [Ungated Enqueue + Unattributed Buffer Design (MAGE-951)](https://linear.app/klaviyo/document/ungated-enqueue-unattributed-buffer-design-mage-951-587d3c0edc04)

## Test Plan
```
xcodebuild test -scheme klaviyo-swift-sdk-Package \
  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
  -only-testing:KlaviyoCoreTests
```
→ **222 pass, 0 fail.** Coverage: buffer hydrate-once / synchronous persist / corrupt-file self-heal / 200-cap eviction / clear; `RequestFactory` payload parity (extracted == inline); `RequestEnqueuer` routing for all four methods on both apiKey paths + buffer-path priority; `drainBuffer` FIFO order, priority front-insert, durable-before-clear, empty no-op, and apiKey-mismatch skip.

**Notes for reviewers**
- Intentionally uncalled until **MAGE-952** (which this PR blocks).
- `drainBuffer(apiKey:)` guards against apiKey divergence: if the passed apiKey ≠ the active `SDKConfigStore` apiKey (the key `QueueStore.current()` resolves), it warns and returns **without** clearing the buffer, to avoid misrouting. An alternative is to drop the parameter and derive the key internally — open to input for the 952 wiring.
- Carry-forward for MAGE-952: token custom-properties parity — `tokenPayload` uses `properties: [:]`, while the live `resolvedTokenRequest` merges a pending profile; 952 must not drop token profile attributes.

## Related Issues/Tickets
- MAGE-951 (this) · blocks MAGE-952 · blocked-by (merged): MAGE-903, MAGE-894, MAGE-950

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enqueueing events, profiles, aggregate events, and push tokens before an API key is available.
  * Buffered requests are persisted, processed in FIFO order, and drained when a valid API key is supplied.
  * Added support for optional persistence directories and unattributed data.
  * Added API-key-free payload creation using anonymous, email, phone, or external identities.

* **Bug Fixes**
  * Preserved request priority and identity details during buffering and processing.
  * Prevented invalid API keys from draining buffered requests.

* **Tests**
  * Expanded coverage for buffering, persistence, draining, payload creation, and data isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->