### PR TITLE
fix(KlaviyoForms): map trackProfileEvent envelope to event fields (MAGE-1131)

### DIFF
--- a/Sources/KlaviyoCore/Models/APIModels/CreateEventPayload.swift
+++ b/Sources/KlaviyoCore/Models/APIModels/CreateEventPayload.swift
@@ -46,6 +46,7 @@ public struct CreateEventPayload: Equatable, Codable {
             public let profile: Profile
             public let time: Date
             public let value: Double?
+            public let valueCurrency: String?
             public let uniqueId: String
             public init(name: String,
                         properties: [String: Any]? = nil,
@@ -54,11 +55,13 @@ public struct CreateEventPayload: Equatable, Codable {
                         externalId: String? = nil,
                         anonymousId: String? = nil,
                         value: Double? = nil,
+                        valueCurrency: String? = nil,
                         time: Date? = nil,
                         uniqueId: String? = nil) {
                 metric = Metric(name: name)
                 self.properties = AnyCodable(properties ?? [:])
                 self.value = value
+                self.valueCurrency = valueCurrency
                 self.time = time ?? environment.date()
                 self.uniqueId = uniqueId ?? environment.uuid().uuidString
                 profile = Profile(
@@ -77,6 +80,7 @@ public struct CreateEventPayload: Equatable, Codable {
                 case profile
                 case time
                 case value
+                case valueCurrency = "value_currency"
                 case uniqueId = "unique_id"
             }
         }
@@ -90,6 +94,7 @@ public struct CreateEventPayload: Equatable, Codable {
                     externalId: String? = nil,
                     anonymousId: String? = nil,
                     value: Double? = nil,
+                    valueCurrency: String? = nil,
                     time: Date? = nil,
                     uniqueId: String? = nil,
                     pushToken: String? = nil) {
@@ -101,6 +106,7 @@ public struct CreateEventPayload: Equatable, Codable {
                 externalId: externalId,
                 anonymousId: anonymousId,
                 value: value,
+                valueCurrency: valueCurrency,
                 time: time,
                 uniqueId: uniqueId
             )

--- a/Sources/KlaviyoCore/Models/Event.swift
+++ b/Sources/KlaviyoCore/Models/Event.swift
@@ -62,6 +62,7 @@ public struct Event: Equatable {
     private let _properties: AnyCodable
     public let time: Date
     public let value: Double?
+    public let valueCurrency: String?
     public let uniqueId: String
     package let identifiers: Identifiers?
 
@@ -69,12 +70,14 @@ public struct Event: Equatable {
                  properties: [String: Any]? = nil,
                  identifiers: Identifiers? = nil,
                  value: Double? = nil,
+                 valueCurrency: String? = nil,
                  time: Date = environment.date(),
                  uniqueId: String = environment.uuid().uuidString) {
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
         self.time = time
         self.value = value
+        self.valueCurrency = valueCurrency
         self.uniqueId = uniqueId
         self.identifiers = identifiers
     }
@@ -84,15 +87,18 @@ public struct Event: Equatable {
     ///   - name: Name of the event. Must be less than 128 characters., pick from ``Event.EventName`` which can also contain custom events
     ///   - properties: Properties of this event.
     ///   - value: A numeric, monetary value to associate with this event. For example, the dollar amount of a purchase.
+    ///   - valueCurrency: The ISO 4217 currency code that `value` is denominated in, for example `USD`.
     ///   - uniqueId: A unique identifier for an event
     public init(name: EventName,
                 properties: [String: Any]? = nil,
                 value: Double? = nil,
+                valueCurrency: String? = nil,
                 uniqueId: String? = nil) {
         metric = .init(name: name)
         _properties = AnyCodable(properties ?? [:])
         identifiers = nil
         self.value = value
+        self.valueCurrency = valueCurrency
         time = environment.date()
         self.uniqueId = uniqueId ?? environment.uuid().uuidString
     }

--- a/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFPresentationManager.swift
@@ -240,6 +240,25 @@ class IAFPresentationManager {
         }
     }
 
+    /// Reserved event property keys recognized by the Klaviyo APIs.
+    enum ReservedPropertyKey {
+        static let valueCurrency = "$value_currency"
+    }
+
+    /// The properties object passed to KlaviyoJS for a native event.
+    ///
+    /// The onsite `dispatchProfileEvent(metric, uniqueId, time, value, properties)` signature has no
+    /// currency parameter, so an event's currency is carried inside `properties` under the reserved
+    /// `$value_currency` key. An existing `$value_currency` property is left as-is.
+    static func outboundProperties(for event: Event) -> [String: Any] {
+        guard let valueCurrency = event.valueCurrency else { return event.properties }
+        var properties = event.properties
+        if properties[ReservedPropertyKey.valueCurrency] == nil {
+            properties[ReservedPropertyKey.valueCurrency] = valueCurrency
+        }
+        return properties
+    }
+
     func handleProfileEventCreated(_ event: Event) async throws {
         guard let viewController = viewController else {
             if #available(iOS 14.0, *) {
@@ -267,7 +286,7 @@ class IAFPresentationManager {
 
             // Convert properties to JSON string to ensure proper object serialization, default to empty dict if serialization fails
             var propertiesJSON = "{}"
-            if let propertiesData = try? JSONSerialization.data(withJSONObject: event.properties) {
+            if let propertiesData = try? JSONSerialization.data(withJSONObject: Self.outboundProperties(for: event)) {
                 propertiesJSON = String(data: propertiesData, encoding: .utf8) ?? propertiesJSON
             }
 

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -345,6 +345,7 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                     name: .customEvent(metricName),
                     properties: properties,
                     value: envelope["value"] as? Double,
+                    valueCurrency: envelope["value_currency"] as? String,
                     uniqueId: envelope["unique_id"] as? String
                 ))
             )

--- a/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
+++ b/Sources/KlaviyoForms/InAppForms/IAFWebViewModel.swift
@@ -323,12 +323,31 @@ class IAFWebViewModel: KlaviyoWebViewModeling {
                 }
             }
         case let .trackProfileEvent(data):
-            if let jsonEventData = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-               let metricName = jsonEventData["metric"] as? String {
-                EventDispatcher.shared.dispatch(
-                    .createEvent(Event(name: .customEvent(metricName), properties: jsonEventData))
-                )
+            guard let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let metricName = envelope["metric"] as? String, !metricName.isEmpty else {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning(
+                        "trackProfileEvent payload is malformed or has no metric name — skipping event")
+                }
+                return
             }
+
+            let properties = envelope["properties"] as? [String: Any]
+            if properties == nil {
+                if #available(iOS 14.0, *) {
+                    Logger.webViewLogger.warning(
+                        "trackProfileEvent payload has no properties object — sending event without them")
+                }
+            }
+
+            EventDispatcher.shared.dispatch(
+                .createEvent(Event(
+                    name: .customEvent(metricName),
+                    properties: properties,
+                    value: envelope["value"] as? Double,
+                    uniqueId: envelope["unique_id"] as? String
+                ))
+            )
         case let .trackAggregateEvent(data):
             EventDispatcher.shared.dispatch(.aggregateEvent(data))
         case let .openDeepLink(url, formId, formName, buttonLabel, openExternally):

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -167,7 +167,7 @@ extension IAFNativeBridgeEvent {
         case .formsDataLoaded: return 1
         case .formWillAppear: return 2
         case .formDisappeared: return 1
-        case .trackProfileEvent: return 1
+        case .trackProfileEvent: return 2
         case .trackAggregateEvent: return 1
         case .openDeepLink: return 3
         case .abort: return 1

--- a/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
+++ b/Sources/KlaviyoForms/InAppForms/Models/IAFNativeBridgeEvent.swift
@@ -146,9 +146,10 @@ extension IAFNativeBridgeEvent {
     }
 
     private static var handshakeEvents: [IAFNativeBridgeEvent] {
-        // Events that JS is permitted to send. These are only used for their
-        // `name` and `version` properties — the associated values are placeholders
-        // and are never decoded.
+        // Message types and versions advertised to JS: inbound messages JS may send, plus
+        // outbound declarations (`lifecycleEvent`, `profileEvent`, `profileMutation`) for
+        // messages native sends to JS. Only `name` and `version` are read; the associated
+        // values are placeholders and are never decoded.
         [
             .formWillAppear(formId: nil, formName: nil, layout: nil),
             .formDisappeared(formId: nil, formName: nil),

--- a/Sources/KlaviyoSwift/EventPublish.swift
+++ b/Sources/KlaviyoSwift/EventPublish.swift
@@ -19,6 +19,7 @@ private func enrichEventWithMetadata(_ event: Event) -> Event {
         properties: enrichedProperties,
         identifiers: event.identifiers,
         value: event.value,
+        valueCurrency: event.valueCurrency,
         time: event.time,
         uniqueId: event.uniqueId
     )

--- a/Sources/KlaviyoSwift/Models/EventAPIExtension.swift
+++ b/Sources/KlaviyoSwift/Models/EventAPIExtension.swift
@@ -33,6 +33,7 @@ extension Event {
                      properties: properties,
                      identifiers: identifiers,
                      value: value,
+                     valueCurrency: valueCurrency,
                      time: time,
                      uniqueId: uniqueId)
     }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -514,6 +514,7 @@ struct KlaviyoReducer: ReducerProtocol {
                     externalId: event.identifiers?.externalId,
                     anonymousId: anonymousId,
                     value: event.value,
+                    valueCurrency: event.valueCurrency,
                     time: event.time,
                     uniqueId: event.uniqueId,
                     pushToken: state.pushTokenData?.pushToken

--- a/Tests/KlaviyoCoreTests/EncodableTests.swift
+++ b/Tests/KlaviyoCoreTests/EncodableTests.swift
@@ -28,6 +28,33 @@ final class EncodableTests: XCTestCase {
         assertSnapshot(matching: createEventPayload, as: .json(KlaviyoEnvironment.encoder))
     }
 
+    /// Encodes a `CreateEventPayload` and returns its `data.attributes` object.
+    private func encodedEventAttributes(value: Double? = nil, valueCurrency: String? = nil) throws -> [String: Any] {
+        let payload = CreateEventPayload(data: CreateEventPayload.Event(
+            name: "test",
+            anonymousId: "anon-id",
+            value: value,
+            valueCurrency: valueCurrency
+        ))
+        let json = try JSONSerialization.jsonObject(with: testEncoder.encode(payload))
+        let root = try XCTUnwrap(json as? [String: Any])
+        let data = try XCTUnwrap(root["data"] as? [String: Any])
+        return try XCTUnwrap(data["attributes"] as? [String: Any])
+    }
+
+    func testEventPayloadOmitsValueCurrencyWhenNil() throws {
+        let attributes = try encodedEventAttributes()
+        XCTAssertNil(attributes["value_currency"])
+        XCTAssertNil(attributes["valueCurrency"])
+        XCTAssertNil(attributes["value"])
+    }
+
+    func testEventPayloadEncodesValueCurrency() throws {
+        let attributes = try encodedEventAttributes(value: 9.99, valueCurrency: "USD")
+        XCTAssertEqual(attributes["value"] as? Double, 9.99)
+        XCTAssertEqual(attributes["value_currency"] as? String, "USD")
+    }
+
     func testTokenPayload() throws {
         let tokenPayload = PushTokenPayload(
             pushToken: "foo",

--- a/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFNativeBridgeEventTests.swift
@@ -20,7 +20,7 @@ struct IAFNativeBridgeEventTests {
             var version: Int
         }
         let expectedHandshake = """
-        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+        [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":2},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
         """
         let expectedData = try #require(expectedHandshake.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerOutboundEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerOutboundEventTests.swift
@@ -1,0 +1,64 @@
+//
+//  IAFPresentationManagerOutboundEventTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoForms
+import KlaviyoCore
+import XCTest
+
+/// Covers the properties object handed to KlaviyoJS for a native event. `dispatchProfileEvent` has no
+/// currency parameter, so currency has to ride inside `properties` to reach JS at all.
+@MainActor
+final class IAFPresentationManagerOutboundEventTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        environment = KlaviyoEnvironment.test()
+    }
+
+    private func outboundProperties(
+        properties: [String: Any]? = nil,
+        valueCurrency: String? = nil
+    ) -> [String: Any] {
+        let event = Event(
+            name: .customEvent("Placed Order"),
+            properties: properties,
+            value: 9.99,
+            valueCurrency: valueCurrency
+        )
+        return IAFPresentationManager.outboundProperties(for: event)
+    }
+
+    func testCarriesValueCurrencyUnderTheReservedKey() {
+        let properties = outboundProperties(properties: ["form_id": "1"], valueCurrency: "CAD")
+
+        XCTAssertEqual(properties["$value_currency"] as? String, "CAD")
+        XCTAssertEqual(properties["form_id"] as? String, "1")
+        XCTAssertEqual(properties.count, 2)
+    }
+
+    func testAddsNothingWhenCurrencyIsAbsent() {
+        let properties = outboundProperties(properties: ["form_id": "1"])
+
+        XCTAssertNil(properties["$value_currency"])
+        XCTAssertEqual(properties.count, 1)
+    }
+
+    func testDoesNotOverwriteACurrencyAlreadyInProperties() {
+        let properties = outboundProperties(
+            properties: ["$value_currency": "EUR"],
+            valueCurrency: "CAD"
+        )
+
+        XCTAssertEqual(properties["$value_currency"] as? String, "EUR")
+        XCTAssertEqual(properties.count, 1)
+    }
+
+    func testSerializesToValidJSONForTheBridge() throws {
+        let properties = outboundProperties(properties: ["form_id": "1"], valueCurrency: "CAD")
+
+        let data = try JSONSerialization.data(withJSONObject: properties)
+        let roundTripped = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(roundTripped["$value_currency"] as? String, "CAD")
+    }
+}

--- a/Tests/KlaviyoFormsTests/IAFPresentationManagerOutboundEventTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFPresentationManagerOutboundEventTests.swift
@@ -54,6 +54,40 @@ final class IAFPresentationManagerOutboundEventTests: XCTestCase {
         XCTAssertEqual(properties.count, 1)
     }
 
+    /// The source event must be left alone. Mutating it would strip or alter the instance held by
+    /// `EventBuffer` for replay, since the bridge runs after the event is buffered.
+    func testDoesNotMutateTheSourceEvent() {
+        let event = Event(
+            name: .customEvent("Placed Order"),
+            properties: ["form_id": "1"],
+            value: 9.99,
+            valueCurrency: "CAD"
+        )
+
+        let outbound = IAFPresentationManager.outboundProperties(for: event)
+
+        XCTAssertEqual(outbound["$value_currency"] as? String, "CAD")
+        XCTAssertNil(event.properties["$value_currency"], "the event's own properties must be untouched")
+        XCTAssertEqual(event.properties.count, 1)
+        XCTAssertEqual(event.valueCurrency, "CAD")
+    }
+
+    func testIsIdempotentAcrossRepeatedDispatches() {
+        let event = Event(
+            name: .customEvent("Placed Order"),
+            properties: ["form_id": "1"],
+            value: 9.99,
+            valueCurrency: "CAD"
+        )
+
+        let first = IAFPresentationManager.outboundProperties(for: event)
+        let second = IAFPresentationManager.outboundProperties(for: event)
+
+        XCTAssertEqual(first.count, second.count)
+        XCTAssertEqual(second["$value_currency"] as? String, "CAD")
+        XCTAssertEqual(second["form_id"] as? String, "1")
+    }
+
     func testSerializesToValidJSONForTheBridge() throws {
         let properties = outboundProperties(properties: ["form_id": "1"], valueCurrency: "CAD")
 

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -155,7 +155,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
         let expectedHandshakeString =
             """
-            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":1},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
+            [{"type":"formWillAppear","version":2},{"type":"formDisappeared","version":1},{"type":"trackProfileEvent","version":2},{"type":"trackAggregateEvent","version":1},{"type":"openDeepLink","version":3},{"type":"abort","version":1},{"type":"lifecycleEvent","version":1},{"type":"profileEvent","version":1},{"type":"profileMutation","version":1}]
             """
         let expectedData = try XCTUnwrap(expectedHandshakeString.data(using: .utf8))
         let expectedHandshakeData = try JSONDecoder().decode([TestableHandshakeData].self, from: expectedData)

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -507,6 +507,36 @@ final class IAFWebViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func testTrackProfileEventHonorsValueCurrency() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Placed Order",
+          "properties": { "form_id": "1" },
+          "value": 9.99,
+          "value_currency": "CAD"
+        }
+        """))
+
+        // Then - the currency rides the top level of the envelope, not the property bag
+        XCTAssertEqual(event.value, 9.99)
+        XCTAssertEqual(event.valueCurrency, "CAD")
+        XCTAssertEqual(event.properties.count, 1)
+        XCTAssertNil(event.properties["value_currency"])
+    }
+
+    @MainActor
+    func testTrackProfileEventOmitsValueCurrencyWhenAbsent() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        { "metric": "Placed Order", "properties": {}, "value": 9.99 }
+        """))
+
+        // Then
+        XCTAssertNil(event.valueCurrency)
+    }
+
+    @MainActor
     func testTrackProfileEventAcceptsIntegerValue() throws {
         // Given/When
         let event = try XCTUnwrap(createdEvent(from: """

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -464,8 +464,7 @@ final class IAFWebViewModelTests: XCTestCase {
 
     @MainActor
     func testTrackProfileEventIgnoresHoistedSiblings() throws {
-        // Given/When - onsite's interim v1 shape: the nested object plus the same keys
-        // hoisted alongside it, so already-released SDKs pick them up
+        // Given/When - the nested object plus the same keys repeated at the top level
         let event = try XCTUnwrap(createdEvent(from: """
         {
           "metric": "Form completed by profile",
@@ -480,7 +479,7 @@ final class IAFWebViewModelTests: XCTestCase {
         }
         """))
 
-        // Then - only the nested object is read; the hoisted duplicates change nothing
+        // Then - only the nested object is read; the top-level duplicates change nothing
         XCTAssertEqual(event.properties["form_id"] as? String, "1")
         XCTAssertEqual(event.properties["form_version_id"] as? Int, 2)
         XCTAssertEqual(event.properties["channel_type"] as? String, "IN_APP")
@@ -516,6 +515,17 @@ final class IAFWebViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(event.value, 10)
+    }
+
+    @MainActor
+    func testTrackProfileEventIgnoresNonNumericValue() throws {
+        // Given/When - `value` is a string, a shape the v2 contract (`value?: number`) does not allow
+        let event = try XCTUnwrap(createdEvent(from: """
+        { "metric": "Placed Order", "properties": {}, "value": "9.99" }
+        """))
+
+        // Then - the event still dispatches, without a value
+        XCTAssertNil(event.value)
     }
 
     @MainActor

--- a/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
+++ b/Tests/KlaviyoFormsTests/IAFWebViewModelTests.swift
@@ -409,37 +409,171 @@ final class IAFWebViewModelTests: XCTestCase {
         XCTAssertFalse(lifecycleEventFired, "Blocked scheme should skip navigation and lifecycle event")
     }
 
+    // MARK: - trackProfileEvent Tests
+
+    /// Sends a `trackProfileEvent` bridge message carrying `data`, and returns every command
+    /// that reached the Core `EventDispatcher`.
     @MainActor
-    func testTrackProfileEventDispatchesCreateEvent() throws {
-        // Given - a spy registered as the inbound-dispatch target
+    private func sendTrackProfileEvent(data: String) -> [InboundCommand] {
         let spyDispatcher = SpyDispatcher()
         EventDispatcher.shared.register(spyDispatcher)
         defer { EventDispatcher.shared.reset() }
 
-        // When - JS sends a trackProfileEvent bridge message
-        let scriptMessage = MockWKScriptMessage(
+        viewModel.handleScriptMessage(MockWKScriptMessage(
             name: "KlaviyoNativeBridge",
-            body: """
-            {
-              "type": "trackProfileEvent",
-              "data": {
-                "metric": "Viewed Product",
-                "foo": "bar"
-              }
-            }
-            """
-        )
-        viewModel.handleScriptMessage(scriptMessage)
+            body: "{ \"type\": \"trackProfileEvent\", \"data\": \(data) }"
+        ))
 
-        // Then - it routes through the EventDispatcher lane as .createEvent (no KlaviyoSwift dependency)
-        guard spyDispatcher.received.count == 1 else {
-            return XCTFail("expected 1 command, got \(spyDispatcher.received.count)")
+        return spyDispatcher.received
+    }
+
+    /// The `Event` dispatched for a `trackProfileEvent` message, or `nil` if the message
+    /// produced anything other than exactly one `.createEvent` command.
+    @MainActor
+    private func createdEvent(from data: String) -> Event? {
+        let received = sendTrackProfileEvent(data: data)
+        guard received.count == 1, case let .createEvent(event) = received[0] else { return nil }
+        return event
+    }
+
+    @MainActor
+    func testTrackProfileEventFlattensNestedProperties() throws {
+        // Given/When - the payload onsite sends: a metric plus a nested property object
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Form completed by profile",
+          "properties": {
+            "form_id": "1",
+            "form_version_id": 2,
+            "channel_type": "IN_APP",
+            "foo": "bar"
+          }
         }
-        guard case let .createEvent(event) = spyDispatcher.received[0] else {
-            return XCTFail("expected .createEvent, got \(spyDispatcher.received[0])")
-        }
-        XCTAssertEqual(event.metric.name, .customEvent("Viewed Product"))
+        """))
+
+        // Then - the nested object becomes the event's properties, flat and unwrapped
+        XCTAssertEqual(event.metric.name, .customEvent("Form completed by profile"))
+        XCTAssertEqual(event.properties["form_id"] as? String, "1")
+        XCTAssertEqual(event.properties["form_version_id"] as? Int, 2)
+        XCTAssertEqual(event.properties["channel_type"] as? String, "IN_APP")
         XCTAssertEqual(event.properties["foo"] as? String, "bar")
+        XCTAssertEqual(event.properties.count, 4)
+        XCTAssertNil(event.properties["metric"], "envelope keys must not become event properties")
+        XCTAssertNil(event.properties["properties"], "properties must be flattened, not nested")
+    }
+
+    @MainActor
+    func testTrackProfileEventIgnoresHoistedSiblings() throws {
+        // Given/When - onsite's interim v1 shape: the nested object plus the same keys
+        // hoisted alongside it, so already-released SDKs pick them up
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Form completed by profile",
+          "properties": {
+            "form_id": "1",
+            "form_version_id": 2,
+            "channel_type": "IN_APP"
+          },
+          "form_id": "1",
+          "form_version_id": 2,
+          "channel_type": "IN_APP"
+        }
+        """))
+
+        // Then - only the nested object is read; the hoisted duplicates change nothing
+        XCTAssertEqual(event.properties["form_id"] as? String, "1")
+        XCTAssertEqual(event.properties["form_version_id"] as? Int, 2)
+        XCTAssertEqual(event.properties["channel_type"] as? String, "IN_APP")
+        XCTAssertEqual(event.properties.count, 3)
+    }
+
+    @MainActor
+    func testTrackProfileEventHonorsValueAndUniqueId() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Placed Order",
+          "properties": { "form_id": "1" },
+          "value": 9.99,
+          "unique_id": "form-event-1"
+        }
+        """))
+
+        // Then - both ride the top level of the envelope, not the property bag
+        XCTAssertEqual(event.value, 9.99)
+        XCTAssertEqual(event.uniqueId, "form-event-1")
+        XCTAssertEqual(event.properties.count, 1)
+        XCTAssertNil(event.properties["value"])
+        XCTAssertNil(event.properties["unique_id"])
+    }
+
+    @MainActor
+    func testTrackProfileEventAcceptsIntegerValue() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        { "metric": "Placed Order", "properties": {}, "value": 10 }
+        """))
+
+        // Then
+        XCTAssertEqual(event.value, 10)
+    }
+
+    @MainActor
+    func testTrackProfileEventDefaultsValueAndUniqueIdWhenAbsent() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Form completed by profile",
+          "properties": { "form_id": "1" }
+        }
+        """))
+
+        // Then - no value, and a generated unique id (fixed by the test environment)
+        XCTAssertNil(event.value)
+        XCTAssertEqual(event.uniqueId, "00000000-0000-0000-0000-000000000001")
+    }
+
+    @MainActor
+    func testTrackProfileEventWithFlatPayloadDropsTopLevelKeys() throws {
+        // Given/When - a flat payload, with no nested property object
+        let event = try XCTUnwrap(createdEvent(from: """
+        {
+          "metric": "Viewed Product",
+          "foo": "bar"
+        }
+        """))
+
+        // Then - the metric is still tracked, but top-level keys are not event properties
+        XCTAssertEqual(event.metric.name, .customEvent("Viewed Product"))
+        XCTAssertTrue(event.properties.isEmpty)
+    }
+
+    @MainActor
+    func testTrackProfileEventWithNonObjectPropertiesStillDispatches() throws {
+        // Given/When
+        let event = try XCTUnwrap(createdEvent(from: """
+        { "metric": "Form completed by profile", "properties": "nope" }
+        """))
+
+        // Then
+        XCTAssertEqual(event.metric.name, .customEvent("Form completed by profile"))
+        XCTAssertTrue(event.properties.isEmpty)
+    }
+
+    @MainActor
+    func testTrackProfileEventWithoutUsableMetricDispatchesNothing() {
+        // Given/When/Then - a metric that is missing, non-string, or empty produces no event
+        XCTAssertTrue(sendTrackProfileEvent(data: """
+        { "properties": { "form_id": "1" } }
+        """).isEmpty, "a payload with no metric must not produce an event")
+
+        XCTAssertTrue(sendTrackProfileEvent(data: """
+        { "metric": 42, "properties": { "form_id": "1" } }
+        """).isEmpty, "a non-string metric must not produce an event")
+
+        XCTAssertTrue(sendTrackProfileEvent(data: """
+        { "metric": "", "properties": { "form_id": "1" } }
+        """).isEmpty, "an empty metric must not produce an event")
     }
 }
 

--- a/Tests/KlaviyoSwiftTests/EventAPIExtensionTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventAPIExtensionTests.swift
@@ -18,6 +18,7 @@ final class EventAPIExtensionTests: XCTestCase {
             name: .customEvent("test"),
             properties: ["foo": "bar"],
             value: 42,
+            valueCurrency: "USD",
             uniqueId: "unique-id"
         )
 
@@ -34,6 +35,7 @@ final class EventAPIExtensionTests: XCTestCase {
         // Existing fields are preserved.
         XCTAssertEqual(updated.properties["foo"] as? String, "bar")
         XCTAssertEqual(updated.value, 42)
+        XCTAssertEqual(updated.valueCurrency, "USD")
         XCTAssertEqual(updated.uniqueId, "unique-id")
         XCTAssertEqual(updated.metric.name, .customEvent("test"))
         // Non-opened-push events never receive a push token.

--- a/Tests/KlaviyoSwiftTests/EventPublishTests.swift
+++ b/Tests/KlaviyoSwiftTests/EventPublishTests.swift
@@ -99,6 +99,7 @@ final class EventPublishTests: XCTestCase {
             properties: ["item_id": "12345"],
             identifiers: Event.Identifiers(email: "test@example.com", phoneNumber: "+15555555555"),
             value: 99.99,
+            valueCurrency: "USD",
             time: testTime,
             uniqueId: testUniqueId
         )
@@ -110,6 +111,7 @@ final class EventPublishTests: XCTestCase {
         XCTAssertNotNil(receivedEvent)
         XCTAssertEqual(receivedEvent?.metric.name.value, "Added to Cart")
         XCTAssertEqual(receivedEvent?.value, 99.99)
+        XCTAssertEqual(receivedEvent?.valueCurrency, "USD")
         XCTAssertEqual(receivedEvent?.time, testTime)
         XCTAssertEqual(receivedEvent?.uniqueId, testUniqueId)
         XCTAssertEqual(receivedEvent?.identifiers?.email, "test@example.com")

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -643,6 +643,35 @@ class StateManagementTests: XCTestCase {
     }
 
     @MainActor
+    func testEnqueueEventCarriesValueAndCurrencyIntoPayload() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        let event = Event(name: .customEvent("Placed Order"), value: 9.99, valueCurrency: "CAD")
+        await store.send(.enqueueEvent(event)) {
+            try $0.enqueueRequest(
+                request: KlaviyoRequest(
+                    endpoint: .createEvent(
+                        XCTUnwrap($0.apiKey),
+                        CreateEventPayload(
+                            data: CreateEventPayload.Event(
+                                name: event.metric.name.value,
+                                properties: event.properties,
+                                anonymousId: initialState.anonymousId!,
+                                value: 9.99,
+                                valueCurrency: "CAD",
+                                time: event.time,
+                                uniqueId: event.uniqueId,
+                                pushToken: initialState.pushTokenData!.pushToken
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @MainActor
     func testEnqueueEventWhenInitilizingSendsEvent() async throws {
         let setBadgeExpectation = expectation(description: "BadgeManager.setBadgeCount(0) called on start")
         BadgeManager.setBadgeCountSpy = { count in


### PR DESCRIPTION
# Description

The in-app forms bridge handler for `trackProfileEvent` passed the **entire** `data` envelope as the event's properties instead of `data["properties"]`. Onsite sends `{ metric, properties }`, so events landed with their properties nested one level too deep — unusable in segment/flow filters — plus a duplicated `metric` key. Android has always read this correctly.

**No in-app-forms feature that creates profile-level events has shipped yet.** The path was dormant, which is why this survived. No production data impact; caught before launch.

This PR also adds `value_currency` support to the event model. Making `value` reachable from a form while leaving currency unrepresentable leaves a monetary amount ambiguous, and `value_currency` has been a top-level attribute on `POST /client/events` for as long as the endpoint has been documented — the SDK simply never had a field for it.

## Base branch — read before flagging the failing check

Repo convention is that `{initials}/*` branches may not merge to `master`; they target the active `rel/*`. 5.4.0 has shipped and merged, so **there is no open release branch to target right now**. This is drafted against `master` deliberately and will be retargeted once a `rel/*` is cut. The required base-branch status check failing here is expected, not an oversight.

## Release dependency — do not ship this SDK first

This must **not** release until fender's `trackProfileEvent.v2` mapper is live on the production CDN. `mapNativeEvents.ts` resolves handshake versions by exact match and throws `InvalidContext` when a declared version has no mapper. That aborts the whole forms integration at listener-wiring time — breaking **all** forms, not just this event.

The v2 handshake bump and the handler fix must also ship **together** (they do, in this PR). A fixed handler still advertising v1 would be sent the v1 compatibility payload, find no `data["properties"]`, and emit events with empty properties.

`value_currency` carries no such dependency. It has been accepted by `POST /client/events` since the oldest published revision of the API, so there is nothing to gate and no revision to bump.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

The public API change is purely additive and source-compatible: `Event` gains a `public let valueCurrency: String?`, and both its `public` and `package` initializers gain a `valueCurrency: String? = nil` parameter. Every existing call site compiles unchanged — the parameter is defaulted and is inserted in declaration order between `value` and `uniqueId`, so calls that pass either or both of those still type-check. Nothing was removed, renamed, or made required.

No milestone label yet — see the base-branch note above; it goes on with the retarget.

## Changelog / Code Overview

**`IAFWebViewModel.handleNativeBridgeEvent`**
- Read event properties from `data["properties"]` rather than the whole envelope.
- Read `value` and `unique_id` from the envelope into `Event.init`. Previously top-level `value` was always `nil`, so form-driven revenue attribution was inexpressible, and `unique_id` was always a fresh UUID, so a form-supplied idempotency key could never be honored.
- Read `value_currency` from the envelope as well. The handler now accepts the **full envelope contract** rather than only the subset onsite happens to emit today. This is not speculative feature work: the position is that the SDK should never be the reason a field can't be used later, and the native side is the slow half of that loop — onsite ships to the CDN, the SDK ships through the App Store and then through every integrator's own release. Reading a field the web side *could* send costs one typed accessor now and removes a release-cycle dependency later. The read is `as? String`, so an absent or non-string key yields `nil`.
- Log the failure paths. A malformed payload previously produced no event and no log at any level; Android logs at ERROR.

**`IAFNativeBridgeEvent`**
- Bump `trackProfileEvent` to version `2` in the handshake. This is how onsite knows to stop sending this SDK the v1 compatibility payload.
- Correct the `handshakeEvents` comment, which described the array as "Events that JS is permitted to send". That is wrong for `lifecycleEvent`, `profileEvent` and `profileMutation`, which are outbound (native → JS) declarations.

**`value_currency` threaded end to end (KlaviyoCore + KlaviyoSwift)**
- `Event` gains `valueCurrency: String?` (ISO 4217), defaulted to `nil` in both initializers.
- `CreateEventPayload.Event.Attributes` gains the field with an explicit `value_currency` coding key, matching the `uniqueId` → `unique_id` precedent. Being optional, it is omitted from the encoded body when unset — the existing `testEventPayload` snapshot is byte-for-byte unchanged, which is the confirmation that no request shape changed for callers who don't set it.
- The field is carried through every place an `Event` is copied or rebuilt, not just the two ends: `updateEventWithIdentifiers`, the reducer's `enqueueEvent` payload construction, and `enrichEventWithMetadata` on the public `EventBus` path. Each of those reconstructs the `Event` positionally, so an unthreaded field would silently vanish mid-flight rather than fail to compile.
**Outbound bridge (native → JS): currency now reaches KlaviyoJS.** I originally left `IAFPresentationManager.handleProfileEventCreated` alone on the grounds that `dispatchProfileEvent(metric, uniqueId, time, value, properties)` has a fixed arity owned by onsite. That was the wrong conclusion, and the Android author's review of their equivalent path is what surfaced it: because `valueCurrency` is a discrete field on Swift's `Event` rather than a member of `properties`, currency reached JS through **no** channel at all — no positional slot, and not in the property bag either. Android's `JsBridge.profileEvent` pops `$value`/`$event_id`/`_time` into positional args but leaves `$value_currency` in `properties`, so it arrives there. Form targeting on currency would have worked on Android and silently not on iOS.

The fix needs no signature change and no onsite work: `properties` is already a passthrough object, so currency now travels in it under the same reserved `$value_currency` key Android uses. The JS-visible shape is now identical on both platforms. An existing `$value_currency` property is not overwritten. The construction is extracted as `IAFPresentationManager.outboundProperties(for:)` because `viewController` is typed as the concrete `KlaviyoWebViewController` and the test mock conforms to `KlaviyoWebViewDelegate`, so the emitted script string is not capturable without refactoring that wiring — the extraction gets the behavior under test without it.

This does mean iOS sends currency to JS inside `properties` while sending it to the API only as a top-level attribute. That asymmetry is deliberate: each boundary gets the shape that boundary defines.

`outboundProperties(for:)` does not mutate the event it is given. That matters because the bridge runs *after* the event has been buffered for replay by `EventBuffer`, so mutating the source would strip or alter the instance a later replay re-sends. Today it is structural rather than earned — `Event` is a struct whose stored properties are all `let`, and `EventBuffer.BufferedEvent` holds it by value — but Android hit exactly this bug class on their equivalent path (their positional-argument pops mutate the buffered instance, so a replayed event loses `$value`), so it is pinned by `testDoesNotMutateTheSourceEvent` and `testIsIdempotentAcrossRepeatedDispatches` against a future rewrite that reintroduces in-place mutation.

**Why the existing test missed the bug:** it used a *flat* `data` payload, a shape onsite has never sent. Rather than delete it, it has been repurposed as an explicit contract test (`testTrackProfileEventWithFlatPayloadDropsTopLevelKeys`) alongside a new test built from onsite's real v1 payload.

**Cross-platform parity with Android (klaviyo-android-sdk#538), coordinated with that author.** The **top-level attribute is identical** on both platforms: same key `value_currency`, same ISO-4217 string, omitted when unset. Both forms bridges read `value_currency` off the `trackProfileEvent` envelope. Reviewers should know about two differences, one forced and one pre-existing.

*Public surface differs, forced by the models.* Android's `Event` is a property bag keyed by `EventKey`, so currency needs a reserved key constant (`EventKey.VALUE_CURRENCY = "$value_currency"`) plus a `setValueCurrency` setter to mirror `value`/`setValue`. Swift's `Event` carries discrete typed stored properties and has **no reserved-key namespace at all** — there is no `$value` or `$event_id` constant anywhere in this repo — so `Event.valueCurrency` is the entire surface. Neither side can adopt the other's shape without rewriting its `Event` model.

*Request bodies are not byte-identical, and that predates this PR.* Android's `EventApiRequest` sends `PROPERTIES to event.toMap()`, so a reserved key set through the property bag is emitted **twice** — once as the top-level attribute and again inside `properties`. Its own source says so: *"it'd be cleaner if we popped `$value` and `$event_id`, so that they aren't included in the properties map too, but that would be a breaking change on the SDK side."* That duplication already applies to `value`/`$value` today and will extend to currency. Swift has no property bag to leak from, so it sends the top-level attribute only. **The stored events converge anyway, and that is now checked rather than assumed.** The events pipeline materializes `event_properties.$value_currency` from the top-level `value_currency` attribute, so `{{ event|lookup:'$value_currency' }}` resolves for an iOS-originated event too and the wire-level duplication has no effect on what gets stored. Two independent P0 cases in the events team's "Core Data — Data Residency V1 End-to-End Test Plan" post `value_currency` top-level with **no** `$value_currency` in `properties` and expect it present as an event property: [EVENTS-2069](https://linear.app/klaviyo/issue/EVENTS-2069) (EVT-022), which additionally groups `metric-aggregates` by `["$value_currency"]` and expects the split by currency, and [EVENTS-2055](https://linear.app/klaviyo/issue/EVENTS-2055) (EVT-018).

The direction is worth stating precisely because it is the opposite of the `$value` behavior: **`$value` and `$event_id` are lifted *out* of `event_properties`; `$value_currency` is materialized *into* them.** EVENTS-2055 asserts both halves in one sentence.

Evidence grade, stated plainly so a reviewer can discount it appropriately: internal QA documentation of *expected* behavior, two independent cases agreeing, authored by the events team — not a live API call against production. Good enough to settle an SDK design choice; worth an events-team confirmation before anyone builds a flow template that depends on it.

Swift deliberately does **not** mirror the currency into `properties` as `$value_currency` on the API payload (the way the Python SDK does). Given the back-population above, mirroring would be pure duplication of a property the pipeline populates on its own, on top of being inconsistent with how this SDK already handles `value`. Note this is specifically about the *API* payload — the outbound JS bridge is a different boundary and does carry the reserved key, for the reason in the next section.

**Known, chosen cross-platform difference:** iOS's `as? Double` rejects a numeric *string* for `value`; Android's `optDouble` coerces it. Only reachable on malformed input, since onsite's v2 type declares `value?: number`. Each side matches its own model conventions. Pinned by `testTrackProfileEventIgnoresNonNumericValue`.

## Test Plan

`make test-library` from the repo root — full suite green — 634 test cases passed, 0 failures, `** TEST SUCCEEDED **` (iPhone 16 Pro, iOS 18.6).

Eleven `trackProfileEvent` cases in `IAFWebViewModelTests` cover: nested properties flattened correctly; top-level envelope keys excluded; `value` / `unique_id` honored; `value_currency` honored; `value_currency` absent yields `nil`; integer `value` accepted; non-numeric `value` ignored; absent `value` / `unique_id` defaults; flat payload drops top-level keys; non-object `properties` still dispatches; missing / non-string / empty `metric` dispatches nothing. Handshake literals in `IAFNativeBridgeEventTests` and `IAFWebViewModelTests` assert `trackProfileEvent` version `2`.

`value_currency` coverage specifically:
- `EncodableTests.testEventPayloadOmitsValueCurrencyWhenNil` / `testEventPayloadEncodesValueCurrency` — encoded body omits the key when unset, emits `"value_currency": "USD"` when set.
- `EncodableTests.testEventPayload` — the committed snapshot is unchanged, confirming no shape change to existing requests.
- `StateManagementTests.testEnqueueEventCarriesValueAndCurrencyIntoPayload` — TCA `TestStore` round-trip asserting the field survives the reducer's rebuild into the enqueued request. Verified this test is not vacuous: temporarily removing the one reducer line makes it fail with `− valueCurrency: "CAD"` / `+ valueCurrency: nil`.
- `EventAPIExtensionTests.testStampsIdentifiersAndPreservesFields` — preserved across identifier stamping.
- `EventPublishTests.testPublishEvent_PreservesEventAttributes` — preserved across enrichment onto the public `EventBus`.

Outbound bridge coverage — `IAFPresentationManagerOutboundEventTests`: currency carried under `$value_currency`; nothing added when currency is absent; an existing `$value_currency` property not overwritten; the source event not mutated; repeated dispatches idempotent; the result still serializes to valid JSON for the `evaluateJavaScript` call.

Formatting/lint via `pre-commit run --files <changed paths>` (pinned SwiftFormat 0.51.2) — clean.

End-to-end verification of the bridge changes requires the fender companion below on a dev server; see that PR's test plan.

## Related Issues/Tickets

Closes MAGE-1131

MAGE-1128 was the umbrella ticket for this work; it has since been split and now covers the onsite/fender side only.

Companion PRs:
- fender — https://github.com/klaviyo/fender/pull/67872 (must deploy first; see release dependency above)
- klaviyo-android-sdk — https://github.com/klaviyo/klaviyo-android-sdk/pull/538
