### PR TITLE
fix(KlaviyoCore): restore automatic push-token dedup in the durable pre-init buffer (MAGE-1137)

### DIFF
--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -81,11 +81,9 @@ final class UnattributedBuffer {
         }
     }
 
-    /// A push-token registration is a snapshot of "the current token state" — a repeated pre-init
-    /// fire (e.g. multiple automatic APNs callbacks before `initialize()`) makes any earlier buffered
-    /// `.pushToken` redundant, so it's dropped in favor of the newest one rather than both being
-    /// drained and sent. Not provenance-aware (manual vs. automatic) — coalescing applies regardless
-    /// of which caller produced the request, since both build the same idempotent payload shape.
+    /// Repeated pre-init token buffering (e.g. multiple automatic APNs callbacks before
+    /// `initialize()`) drops any earlier buffered token — only the latest is kept, whether it came
+    /// from a manual or automatic call.
     func append(_ request: UnattributedRequest) {
         lock.withLock {
             hydrateIfNeeded()

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -81,9 +81,20 @@ final class UnattributedBuffer {
         }
     }
 
+    /// A push-token registration is a snapshot of "the current token state" — a repeated pre-init
+    /// fire (e.g. multiple automatic APNs callbacks before `initialize()`) makes any earlier buffered
+    /// `.pushToken` redundant, so it's dropped in favor of the newest one rather than both being
+    /// drained and sent. Not provenance-aware (manual vs. automatic) — coalescing applies regardless
+    /// of which caller produced the request, since both build the same idempotent payload shape.
     func append(_ request: UnattributedRequest) {
         lock.withLock {
             hydrateIfNeeded()
+            if case .pushToken = request {
+                entries.removeAll {
+                    if case .pushToken = $0.request { return true }
+                    return false
+                }
+            }
             if entries.count >= Self.maxBufferSize {
                 entries.removeFirst()
             }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -52,13 +52,20 @@ final class UnattributedBuffer {
     private var nextSequence: UInt64 = 1
 
     /// Loads from disk on first access; memory is authoritative thereafter. Call under `lock`.
+    /// Replays each persisted request through `addEntry`, so a file written before push-token
+    /// coalescing existed (or otherwise holding more than one buffered token) is normalized on
+    /// load instead of resurrecting the duplicates.
     private func hydrateIfNeeded() {
         guard !hydrated else { return }
         hydrated = true
-        if let persisted = loadPersisted(
+        guard let persisted = loadPersisted(
             PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed
-        ) {
-            entries = persisted.requests.map { assignSequence($0) }
+        ) else { return }
+        for request in persisted.requests {
+            addEntry(request)
+        }
+        if entries.count != persisted.requests.count {
+            persist()
         }
     }
 
@@ -81,22 +88,29 @@ final class UnattributedBuffer {
         }
     }
 
+    /// Adds one request to `entries`, applying cap-eviction and push-token coalescing. Shared by
+    /// `append` and hydration replay so both paths keep the same "at most one buffered token"
+    /// rule. Call under `lock`.
+    private func addEntry(_ request: UnattributedRequest) {
+        if case .pushToken = request {
+            entries.removeAll {
+                if case .pushToken = $0.request { return true }
+                return false
+            }
+        }
+        if entries.count >= Self.maxBufferSize {
+            entries.removeFirst()
+        }
+        entries.append(assignSequence(request))
+    }
+
     /// Repeated pre-init token buffering (e.g. multiple automatic APNs callbacks before
     /// `initialize()`) drops any earlier buffered token — only the latest is kept, whether it came
     /// from a manual or automatic call.
     func append(_ request: UnattributedRequest) {
         lock.withLock {
             hydrateIfNeeded()
-            if case .pushToken = request {
-                entries.removeAll {
-                    if case .pushToken = $0.request { return true }
-                    return false
-                }
-            }
-            if entries.count >= Self.maxBufferSize {
-                entries.removeFirst()
-            }
-            entries.append(assignSequence(request))
+            addEntry(request)
             persist()
         }
     }

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -152,6 +152,22 @@ final class RequestEnqueuerTests: XCTestCase {
         }
     }
 
+    func testRepeatedPushTokenWithoutApiKeyCoalescesToLatest() {
+        // Models repeated pre-init fires (e.g. multiple automatic APNs callbacks before
+        // `initialize()`) — only the latest token should survive in the buffer, not one entry
+        // per fire, so drain doesn't send N redundant register calls (MAGE-1137).
+        RequestEnqueuer.enqueuePushToken("token-1", enablement: .authorized)
+        RequestEnqueuer.enqueuePushToken("token-2", enablement: .authorized)
+        RequestEnqueuer.enqueuePushToken("token-3", enablement: .authorized)
+
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case let .pushToken(payload) = snap[0] else {
+            return XCTFail("expected .pushToken in buffer")
+        }
+        XCTAssertEqual(payload.data.attributes.token, "token-3")
+    }
+
     // MARK: - drainBuffer
 
     func testDrainMovesBufferedRequestsToQueueInFifoOrder() {

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -28,6 +28,15 @@ final class UnattributedBufferTests: XCTestCase {
         .aggregateEvent(Data(value.utf8))
     }
 
+    /// Terse push-token fixture — `value` only varies the token string, matching how a repeated
+    /// pre-init fire (manual or automatic) looks in practice: same shape, latest token wins.
+    private func token(_ value: String) -> UnattributedRequest {
+        .pushToken(PushTokenPayload(
+            pushToken: value, enablement: "AUTHORIZED", background: "AVAILABLE",
+            profile: ProfilePayload(anonymousId: "anon-1")
+        ))
+    }
+
     /// Reads the persisted buffer from the store directory production writes to.
     private func loadBuffer() -> PersistedUnattributedBuffer? {
         loadPersisted(PersistedUnattributedBuffer.self, fileName: StoreFile.unattributed)
@@ -121,11 +130,60 @@ final class UnattributedBufferTests: XCTestCase {
         XCTAssertNil(loadBuffer())
     }
 
+    // MARK: - Push-token coalescing
+
+    func testAppendCoalescesRepeatedPushTokenToLatest() {
+        let buffer = UnattributedBuffer()
+        buffer.append(token("a"))
+        buffer.append(token("b"))
+        buffer.append(token("c"))
+        XCTAssertEqual(buffer.snapshot(), [token("c")])
+    }
+
+    func testPushTokenCoalescingDoesNotAffectOtherBufferedRequests() {
+        let buffer = UnattributedBuffer()
+        buffer.append(agg("1"))
+        buffer.append(token("a"))
+        buffer.append(agg("2"))
+        buffer.append(token("b"))
+        // The stale token is dropped; other request types are untouched. The coalesced token
+        // is re-appended at the back rather than preserving its original position — acceptable
+        // since push-token requests are idempotent w.r.t. ordering against unrelated requests.
+        XCTAssertEqual(buffer.snapshot(), [agg("1"), agg("2"), token("b")])
+    }
+
+    func testPushTokenCoalescingDoesNotEvictOtherEntriesAtCap() {
+        let buffer = UnattributedBuffer()
+        for value in 0..<(UnattributedBuffer.maxBufferSize - 1) {
+            buffer.append(agg("\(value)"))
+        }
+        buffer.append(token("a")) // buffer now exactly at cap
+        buffer.append(token("b")) // coalesces token("a") away first, so nothing is evicted
+        let snap = buffer.snapshot()
+        XCTAssertEqual(snap.count, UnattributedBuffer.maxBufferSize)
+        XCTAssertEqual(snap.first, agg("0"), "coalescing a push token must not evict an unrelated entry")
+        XCTAssertEqual(snap.last, token("b"))
+    }
+
+    func testRemoveDrainedSurvivesConcurrentPushTokenCoalesce() {
+        let buffer = UnattributedBuffer()
+        buffer.append(token("1"))
+        // Model a drain: it snapshots the current buffer, then a concurrent automatic fire
+        // coalesces the just-drained token before the drain removes what it saw.
+        let (_, cursor) = buffer.drainSnapshot()
+        buffer.append(token("2"))
+        buffer.removeDrained(throughCursor: cursor)
+        // The coalesced replacement must survive — it was never part of the drained snapshot.
+        XCTAssertEqual(buffer.snapshot(), [token("2")])
+    }
+
     func testPersistedBufferRoundTripsAllFourCases() throws {
         let eventPayload = CreateEventPayload(
-            data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1"))
+            data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1")
+        )
         let profilePayload = CreateProfilePayload(
-            data: ProfilePayload(anonymousId: "anon-1"))
+            data: ProfilePayload(anonymousId: "anon-1")
+        )
         let tokenPayload = PushTokenPayload(
             pushToken: "tok", enablement: "AUTHORIZED", background: "AVAILABLE",
             profile: ProfilePayload(anonymousId: "anon-1")

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -165,6 +165,19 @@ final class UnattributedBufferTests: XCTestCase {
         XCTAssertEqual(snap.last, token("b"))
     }
 
+    func testHydrationCoalescesPersistedDuplicatePushTokens() {
+        // A file with more than one buffered token can only exist from before this coalescing
+        // existed (or from disk corruption) — hydration must clean it up, not just live appends.
+        savePersisted(
+            PersistedUnattributedBuffer(requests: [agg("1"), token("a"), token("b"), token("c")]),
+            fileName: StoreFile.unattributed
+        )
+        let buffer = UnattributedBuffer()
+        XCTAssertEqual(buffer.snapshot(), [agg("1"), token("c")])
+        // The normalized buffer must also be the one written back to disk.
+        XCTAssertEqual(loadBuffer()?.requests, [agg("1"), token("c")])
+    }
+
     func testRemoveDrainedSurvivesConcurrentPushTokenCoalesce() {
         let buffer = UnattributedBuffer()
         buffer.append(token("1"))
@@ -179,11 +192,9 @@ final class UnattributedBufferTests: XCTestCase {
 
     func testPersistedBufferRoundTripsAllFourCases() throws {
         let eventPayload = CreateEventPayload(
-            data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1")
-        )
+            data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1"))
         let profilePayload = CreateProfilePayload(
-            data: ProfilePayload(anonymousId: "anon-1")
-        )
+            data: ProfilePayload(anonymousId: "anon-1"))
         let tokenPayload = PushTokenPayload(
             pushToken: "tok", enablement: "AUTHORIZED", background: "AVAILABLE",
             profile: ProfilePayload(anonymousId: "anon-1")


### PR DESCRIPTION
# Description
Restores dedup for repeated pre-init push-token buffering, lost when MAGE-952 replaced the old in-memory `pendingRequests` (which deduped automatic-only fires) with the durable `UnattributedBuffer` (a plain FIFO append with no dedup for any request type). `setAutomaticPushToken` can fire before `initialize()`, and each fire was buffering a separate, redundant `.pushToken` register request.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
`UnattributedBuffer.append` now coalesces any repeated buffered `.pushToken` entry to the latest, rather than accumulating one per pre-init fire. Deliberately **not** provenance-aware (manual vs. automatic) — register-push-token is a last-write-wins upsert, and nothing else in the SDK distinguishes manual from automatic tokens post-init either, so coalescing applies uniformly. This is a narrow, intentional divergence from the pre-MAGE-952 behavior (which only deduped automatic fires); see the design discussion on the linked ticket.

A second commit closes a gap CodeRabbit caught in review: `hydrateIfNeeded()` only inherited whatever was on disk without normalizing it, so a buffer file written by a pre-fix build could still resurrect duplicate tokens on next launch. Both `append` and hydration replay now share the same coalesce+cap logic (`addEntry`).

## Test Plan
New coverage in `UnattributedBufferTests` and `RequestEnqueuerTests`:
- repeated `.pushToken` appends coalesce to the latest
- coalescing doesn't affect other buffered request types or trigger spurious cap-eviction
- a coalesce landing between `drainSnapshot()`/`removeDrained()` survives (doesn't get silently dropped)
- a persisted file with duplicate tokens is normalized on hydration
- full-path `RequestEnqueuer.enqueuePushToken` coalescing

Full `KlaviyoCoreTests` bundle (276 tests) green; SwiftLint/SwiftFormat clean.

## Related Issues/Tickets
MAGE-1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated push-token updates are now consolidated, retaining only the latest token.
  * Buffered requests preserve unrelated entries and avoid unnecessary eviction when capacity is reached.
  * Persisted duplicate entries are normalized when restored.
  * Requests added while buffered items are being processed are now retained correctly.
  * Buffer behavior is now applied consistently to restored and newly added requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->