### PR TITLE
feat(KlaviyoCore): QueueStore.drainAll + registry seam + load warning (MAGE-952)

### DIFF
--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -135,9 +135,9 @@ public final class QueueStore {
     /// `requestsInFlight.append(contentsOf: queue); queue.removeAll()`.
     public func drainAll(persist: PersistPolicy = .debounced) -> [KlaviyoRequest] {
         let drained = queueLock.withLock { () -> [KlaviyoRequest] in
-            let out = hydrated()
+            let drainedRequests = hydrated()
             queue = []
-            return out
+            return drainedRequests
         }
         schedulePersist(persist)
         return drained

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -129,6 +129,20 @@ public final class QueueStore {
         schedulePersist(persist)
     }
 
+    /// Atomically snapshots and clears the pending queue, returning the drained requests.
+    /// Snapshot + clear happen under a single `queueLock` acquisition so a concurrent `enqueue`
+    /// cannot interleave between read and clear. Parity with the flush loop's former
+    /// `requestsInFlight.append(contentsOf: queue); queue.removeAll()`.
+    public func drainAll(persist: PersistPolicy = .debounced) -> [KlaviyoRequest] {
+        let drained = queueLock.withLock { () -> [KlaviyoRequest] in
+            let out = hydrated()
+            queue = []
+            return out
+        }
+        schedulePersist(persist)
+        return drained
+    }
+
     /// Replaces the queue wholesale from an authoritative external source (migration only).
     /// Writes to disk before updating memory and throws on failure, since a read-back can't tell
     /// "persisted empty" from "load failed" (`hydrated()` folds both into `[]`). Always
@@ -228,7 +242,19 @@ public final class QueueStore {
     /// Loads from disk on first access; memory is authoritative thereafter. Call under `queueLock`.
     private func hydrated() -> [KlaviyoRequest] {
         if let queue { return queue }
-        let loaded = (try? diskIO.load()) ?? []
+        let loaded: [KlaviyoRequest]
+        do {
+            loaded = try diskIO.load()
+        } catch {
+            // A load failure is distinct from a legitimately empty/absent queue (the production
+            // loader returns `[]` for an absent file without throwing). We fall back to empty so the
+            // store stays usable, but the next persist then overwrites the on-disk file — which
+            // self-heals a corrupt file yet, in the rare case of a transiently-unreadable *valid*
+            // file, discards its backlog. Surface it so that loss is observable rather than silent.
+            // (Distinguishing corrupt-vs-transient to preserve the latter is a follow-up.)
+            emitWarning("QueueStore: failed to load persisted queue (\(error)); starting from empty")
+            loaded = []
+        }
         queue = loaded
         return loaded
     }
@@ -255,6 +281,12 @@ extension QueueStore {
             registry[apiKey] = store
             return store
         }
+    }
+
+    /// Test-support: injects a pre-built store for an apiKey so reducer tests can back the queue
+    /// with an in-memory spy instead of the production disk-backed store.
+    package static func register(_ store: QueueStore, for apiKey: String) {
+        registryLock.withLock { registry[apiKey] = store }
     }
 
     /// Test-support: clears the per-apiKey instance cache.

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -246,12 +246,7 @@ public final class QueueStore {
         do {
             loaded = try diskIO.load()
         } catch {
-            // A load failure is distinct from a legitimately empty/absent queue (the production
-            // loader returns `[]` for an absent file without throwing). We fall back to empty so the
-            // store stays usable, but the next persist then overwrites the on-disk file — which
-            // self-heals a corrupt file yet, in the rare case of a transiently-unreadable *valid*
-            // file, discards its backlog. Surface it so that loss is observable rather than silent.
-            // (Distinguishing corrupt-vs-transient to preserve the latter is a follow-up.)
+            // TODO: Distinguish corrupt-vs-transient to preserve the latter
             emitWarning("QueueStore: failed to load persisted queue (\(error)); starting from empty")
             loaded = []
         }

--- a/Sources/KlaviyoCore/QueueStore.swift
+++ b/Sources/KlaviyoCore/QueueStore.swift
@@ -246,7 +246,7 @@ public final class QueueStore {
         do {
             loaded = try diskIO.load()
         } catch {
-            // TODO: Distinguish corrupt-vs-transient to preserve the latter
+            // TODO: Distinguish corrupt-vs-transient load failure to preserve the latter
             emitWarning("QueueStore: failed to load persisted queue (\(error)); starting from empty")
             loaded = []
         }

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -59,9 +59,13 @@ public enum RequestEnqueuer {
         }
     }
 
-    public static func enqueueProfile(properties: [String: Any]) {
-        guard let identity = resolveIdentity() else { return }
-        let payload = RequestFactory.profilePayload(identity: identity, properties: properties)
+    /// Enqueues an already-built `CreateProfilePayload`. Unlike the other entry points, the caller
+    /// supplies the full payload — profiles carry structured attributes (firstName/lastName/title/
+    /// organization/image/location) that only the KlaviyoSwift `Profile` → `ProfilePayload` mapping
+    /// can populate, so building here (with just identity + flat properties) would drop them. The
+    /// payload already embeds identifiers + anonymousId; routing is the same as every other request:
+    /// apiKey present → `QueueStore`, absent → durable `UnattributedBuffer`. (MAGE-1141)
+    public static func enqueueProfile(payload: CreateProfilePayload) {
         route(buffered: .profile(payload)) { apiKey in
             KlaviyoRequest(endpoint: .createProfile(apiKey, payload))
         }

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -64,7 +64,7 @@ public enum RequestEnqueuer {
     /// organization/image/location) that only the KlaviyoSwift `Profile` → `ProfilePayload` mapping
     /// can populate, so building here (with just identity + flat properties) would drop them. The
     /// payload already embeds identifiers + anonymousId; routing is the same as every other request:
-    /// apiKey present → `QueueStore`, absent → durable `UnattributedBuffer`. (MAGE-1141)
+    /// apiKey present → `QueueStore`, absent → durable `UnattributedBuffer`.
     public static func enqueueProfile(payload: CreateProfilePayload) {
         route(buffered: .profile(payload)) { apiKey in
             KlaviyoRequest(endpoint: .createProfile(apiKey, payload))

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -13,7 +13,7 @@ import KlaviyoCore
 
 extension KlaviyoState {
     /// Resolves the profile for a token request, folding in and consuming any pending profile.
-    private mutating func resolveProfileConsumingPending() -> Profile {
+    private mutating func resolveAndConsumePendingProfile() -> Profile {
         let profile: Profile
         if let pendingProfile {
             profile = Profile.updateProfileWithProperties(
@@ -39,7 +39,7 @@ extension KlaviyoState {
             pushToken: pushToken,
             enablement: enablement,
             background: environment.getBackgroundSetting().rawValue,
-            profile: ProfilePayload(resolveProfileConsumingPending(), anonymousId: anonymousId)
+            profile: ProfilePayload(resolveAndConsumePendingProfile(), anonymousId: anonymousId)
         )
     }
 
@@ -77,65 +77,80 @@ extension KlaviyoState {
         guard let pendingProfile = pendingProfile else {
             return profile
         }
-        var attributes = profile.data.attributes
-        var location = profile.data.attributes.location ?? .init()
-        let properties = profile.data.attributes.properties.value as? [String: Any] ?? [:]
         let updatedProfile = Profile.updateProfileWithProperties(dict: pendingProfile)
-
-        if let firstName = updatedProfile.firstName {
-            attributes.firstName = attributes.firstName ?? firstName
-        }
-        if let lastName = updatedProfile.lastName {
-            attributes.lastName = attributes.lastName ?? lastName
-        }
-        if let title = updatedProfile.title {
-            attributes.title = attributes.title ?? title
-        }
-        if let organization = updatedProfile.organization {
-            attributes.organization = attributes.organization ?? organization
-        }
-        if !updatedProfile.properties.isEmpty {
-            attributes.properties = AnyCodable(
-                properties.merging(updatedProfile.properties, uniquingKeysWith: { _, new in new })
-            )
-        }
-
-        if let address1 = updatedProfile.location?.address1 {
-            location.address1 = location.address1 ?? address1
-        }
-        if let address2 = updatedProfile.location?.address2 {
-            location.address2 = location.address2 ?? address2
-        }
-        if let city = updatedProfile.location?.city {
-            location.city = location.city ?? city
-        }
-        if let region = updatedProfile.location?.region {
-            location.region = location.region ?? region
-        }
-        if let country = updatedProfile.location?.country {
-            location.country = location.country ?? country
-        }
-        if let zip = updatedProfile.location?.zip {
-            location.zip = location.zip ?? zip
-        }
-        if let image = updatedProfile.image {
-            attributes.image = attributes.image ?? image
-        }
-        if let latitude = updatedProfile.location?.latitude {
-            location.latitude = location.latitude ?? latitude
-        }
-        if let longitude = updatedProfile.location?.longitude {
-            location.longitude = location.longitude ?? longitude
-        }
-
-        attributes.location = location
+        var attributes = profile.data.attributes
+        mergePendingAttributes(from: updatedProfile, into: &attributes)
+        attributes.location = mergedLocation(from: updatedProfile, into: attributes.location ?? .init())
         self.pendingProfile = nil
 
         return .init(data: .init(attributes: attributes))
     }
 
-    /// Validates the requested channels against the profile's identifiers and builds the create-subscription
-    /// request. Emits a developer warning and returns `nil` when the request should not be enqueued.
+    /// Fills in profile attributes (name, title, organization, image, properties) from a pending
+    /// profile without overwriting values already present on the request.
+    private func mergePendingAttributes(
+        from pending: Profile,
+        into attributes: inout ProfilePayload.Attributes
+    ) {
+        if let firstName = pending.firstName {
+            attributes.firstName = attributes.firstName ?? firstName
+        }
+        if let lastName = pending.lastName {
+            attributes.lastName = attributes.lastName ?? lastName
+        }
+        if let title = pending.title {
+            attributes.title = attributes.title ?? title
+        }
+        if let organization = pending.organization {
+            attributes.organization = attributes.organization ?? organization
+        }
+        if let image = pending.image {
+            attributes.image = attributes.image ?? image
+        }
+        if !pending.properties.isEmpty {
+            let existing = attributes.properties.value as? [String: Any] ?? [:]
+            attributes.properties = AnyCodable(
+                existing.merging(pending.properties, uniquingKeysWith: { _, new in new })
+            )
+        }
+    }
+
+    /// Fills in location fields from a pending profile without overwriting values already present.
+    private func mergedLocation(
+        from pending: Profile,
+        into location: ProfilePayload.Attributes.Location
+    ) -> ProfilePayload.Attributes.Location {
+        var location = location
+        if let address1 = pending.location?.address1 {
+            location.address1 = location.address1 ?? address1
+        }
+        if let address2 = pending.location?.address2 {
+            location.address2 = location.address2 ?? address2
+        }
+        if let city = pending.location?.city {
+            location.city = location.city ?? city
+        }
+        if let region = pending.location?.region {
+            location.region = location.region ?? region
+        }
+        if let country = pending.location?.country {
+            location.country = location.country ?? country
+        }
+        if let zip = pending.location?.zip {
+            location.zip = location.zip ?? zip
+        }
+        if let latitude = pending.location?.latitude {
+            location.latitude = location.latitude ?? latitude
+        }
+        if let longitude = pending.location?.longitude {
+            location.longitude = location.longitude ?? longitude
+        }
+        return location
+    }
+
+    /// Validates the requested channels against the profile's identifiers and builds the
+    /// create-subscription request. Emits a developer warning and returns `nil` when the request
+    /// should not be enqueued.
     func buildSubscriptionRequest(
         apiKey: String,
         anonymousId: String,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -1,0 +1,197 @@
+//
+//  KlaviyoState+RequestBuilding.swift
+//
+//
+//  Created by Isobelle Lim on 8/27/26.
+//
+
+import AnyCodable
+import Foundation
+import KlaviyoCore
+
+// MARK: - Request-building helpers
+
+extension KlaviyoState {
+    /// Resolves the profile for a token request, folding in and consuming any pending profile.
+    private mutating func resolveProfileConsumingPending() -> Profile {
+        let profile: Profile
+        if let pendingProfile {
+            profile = Profile.updateProfileWithProperties(
+                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
+            )
+            self.pendingProfile = nil
+        } else {
+            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
+        }
+        return profile
+    }
+
+    /// Builds a push-token registration request, resolving (and consuming) any pending profile.
+    /// The `resolved` prefix marks the state-sourcing layer over the pure `RequestFactory.tokenRequest`.
+    mutating func resolvedTokenRequest(
+        apiKey: String,
+        anonymousId: String,
+        pushToken: String,
+        enablement: PushEnablement
+    ) -> KlaviyoRequest {
+        RequestFactory.tokenRequest(
+            apiKey: apiKey,
+            pushToken: pushToken,
+            enablement: enablement,
+            background: environment.getBackgroundSetting().rawValue,
+            profile: ProfilePayload(resolveProfileConsumingPending(), anonymousId: anonymousId)
+        )
+    }
+
+    mutating func enqueueProfileOrTokenRequest() {
+        guard let apiKey = apiKey,
+              let anonymousId = anonymousId else {
+            environment.emitDeveloperWarning("SDK internal error")
+            return
+        }
+        // if we have push data and we are switching emails
+        // we want to associate the token with the new email.
+        if let pushTokenData = pushTokenData {
+            self.pushTokenData = nil
+            let request = resolvedTokenRequest(
+                apiKey: apiKey,
+                anonymousId: anonymousId,
+                pushToken: pushTokenData.pushToken,
+                enablement: pushTokenData.pushEnablement
+            )
+            enqueueRequest(request: request)
+        } else {
+            enqueueProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
+        }
+    }
+
+    mutating func enqueueProfileRequest(apiKey: String, anonymousId: String) {
+        let payload = RequestFactory.profilePayload(
+            identity: requestIdentity(apiKey: apiKey, anonymousId: anonymousId)
+        )
+        let updatedPayload = updateRequestAndStateWithPendingProfile(profile: payload)
+        enqueueRequest(request: RequestFactory.profileRequest(apiKey: apiKey, payload: updatedPayload))
+    }
+
+    mutating func updateRequestAndStateWithPendingProfile(profile: CreateProfilePayload) -> CreateProfilePayload {
+        guard let pendingProfile = pendingProfile else {
+            return profile
+        }
+        var attributes = profile.data.attributes
+        var location = profile.data.attributes.location ?? .init()
+        let properties = profile.data.attributes.properties.value as? [String: Any] ?? [:]
+        let updatedProfile = Profile.updateProfileWithProperties(dict: pendingProfile)
+
+        if let firstName = updatedProfile.firstName {
+            attributes.firstName = attributes.firstName ?? firstName
+        }
+        if let lastName = updatedProfile.lastName {
+            attributes.lastName = attributes.lastName ?? lastName
+        }
+        if let title = updatedProfile.title {
+            attributes.title = attributes.title ?? title
+        }
+        if let organization = updatedProfile.organization {
+            attributes.organization = attributes.organization ?? organization
+        }
+        if !updatedProfile.properties.isEmpty {
+            attributes.properties = AnyCodable(
+                properties.merging(updatedProfile.properties, uniquingKeysWith: { _, new in new })
+            )
+        }
+
+        if let address1 = updatedProfile.location?.address1 {
+            location.address1 = location.address1 ?? address1
+        }
+        if let address2 = updatedProfile.location?.address2 {
+            location.address2 = location.address2 ?? address2
+        }
+        if let city = updatedProfile.location?.city {
+            location.city = location.city ?? city
+        }
+        if let region = updatedProfile.location?.region {
+            location.region = location.region ?? region
+        }
+        if let country = updatedProfile.location?.country {
+            location.country = location.country ?? country
+        }
+        if let zip = updatedProfile.location?.zip {
+            location.zip = location.zip ?? zip
+        }
+        if let image = updatedProfile.image {
+            attributes.image = attributes.image ?? image
+        }
+        if let latitude = updatedProfile.location?.latitude {
+            location.latitude = location.latitude ?? latitude
+        }
+        if let longitude = updatedProfile.location?.longitude {
+            location.longitude = location.longitude ?? longitude
+        }
+
+        attributes.location = location
+        self.pendingProfile = nil
+
+        return .init(data: .init(attributes: attributes))
+    }
+
+    /// Validates the requested channels against the profile's identifiers and builds the create-subscription
+    /// request. Emits a developer warning and returns `nil` when the request should not be enqueued.
+    func buildSubscriptionRequest(
+        apiKey: String,
+        anonymousId: String,
+        subscription: Subscription
+    ) -> KlaviyoRequest? {
+        let channels: SubscriptionChannels?
+        if let requestedChannels = subscription.channels {
+            if requestedChannels.needsEmail, email == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires an email for the requested channels, but email is not set."
+                )
+                return nil
+            }
+            if requestedChannels.needsPhone, phoneNumber == nil {
+                environment.emitDeveloperWarning(
+                    "Subscription requires a phone number for the requested channels, " +
+                        "but phone number is not set."
+                )
+                return nil
+            }
+
+            guard let mappedChannels = SubscriptionChannels(requestedChannels) else {
+                environment.emitDeveloperWarning(
+                    "Subscription channels were provided but none were enabled; request was not enqueued."
+                )
+                return nil
+            }
+            channels = mappedChannels
+        } else {
+            // allAvailableMarketing: omit the subscriptions object so the server defaults to marketing;
+            // requires at least one identifier to key channels on.
+            guard email != nil || phoneNumber != nil else {
+                environment.emitDeveloperWarning(
+                    "Subscription requires at least one identifier the API can key channels on, " +
+                        "but no identifiers are set."
+                )
+                return nil
+            }
+            channels = nil
+        }
+
+        let profile = ProfilePayload(
+            email: email,
+            phoneNumber: phoneNumber,
+            externalId: externalId,
+            subscriptions: channels,
+            anonymousId: anonymousId
+        )
+
+        let payload = CreateSubscriptionPayload(
+            listId: subscription.listId,
+            profile: profile,
+            customSource: subscription.customSource
+        )
+
+        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
+        return KlaviyoRequest(endpoint: endpoint)
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -217,67 +217,6 @@ struct KlaviyoState: Equatable, Codable {
         )
     }
 
-    /// Resolves the profile for a token request, folding in and consuming any pending profile.
-    private mutating func resolveProfileConsumingPending() -> Profile {
-        let profile: Profile
-        if let pendingProfile {
-            profile = Profile.updateProfileWithProperties(
-                email: email, phoneNumber: phoneNumber, externalId: externalId, dict: pendingProfile
-            )
-            self.pendingProfile = nil
-        } else {
-            profile = Profile(email: email, phoneNumber: phoneNumber, externalId: externalId)
-        }
-        return profile
-    }
-
-    /// Builds a push-token registration request, resolving (and consuming) any pending profile.
-    /// The `resolved` prefix marks the state-sourcing layer over the pure `RequestFactory.tokenRequest`.
-    mutating func resolvedTokenRequest(
-        apiKey: String,
-        anonymousId: String,
-        pushToken: String,
-        enablement: PushEnablement
-    ) -> KlaviyoRequest {
-        RequestFactory.tokenRequest(
-            apiKey: apiKey,
-            pushToken: pushToken,
-            enablement: enablement,
-            background: environment.getBackgroundSetting().rawValue,
-            profile: ProfilePayload(resolveProfileConsumingPending(), anonymousId: anonymousId)
-        )
-    }
-
-    mutating func enqueueProfileOrTokenRequest() {
-        guard let apiKey = apiKey,
-              let anonymousId = anonymousId else {
-            environment.emitDeveloperWarning("SDK internal error")
-            return
-        }
-        // if we have push data and we are switching emails
-        // we want to associate the token with the new email.
-        if let pushTokenData = pushTokenData {
-            self.pushTokenData = nil
-            let request = resolvedTokenRequest(
-                apiKey: apiKey,
-                anonymousId: anonymousId,
-                pushToken: pushTokenData.pushToken,
-                enablement: pushTokenData.pushEnablement
-            )
-            enqueueRequest(request: request)
-        } else {
-            enqueueProfileRequest(apiKey: apiKey, anonymousId: anonymousId)
-        }
-    }
-
-    mutating func enqueueProfileRequest(apiKey: String, anonymousId: String) {
-        let payload = RequestFactory.profilePayload(
-            identity: requestIdentity(apiKey: apiKey, anonymousId: anonymousId)
-        )
-        let updatedPayload = updateRequestAndStateWithPendingProfile(profile: payload)
-        enqueueRequest(request: RequestFactory.profileRequest(apiKey: apiKey, payload: updatedPayload))
-    }
-
     mutating func updateStateWithProfile(profile: Profile) {
         if let profileEmail = profile.email,
            profileEmail.isNotEmptyOrSame(as: self.email, identifier: "email") {
@@ -293,65 +232,6 @@ struct KlaviyoState: Equatable, Codable {
            profileExternalId.isNotEmptyOrSame(as: self.externalId, identifier: "external id") {
             externalId = profileExternalId.trimWhiteSpaceOrReturnNilIfEmpty()
         }
-    }
-
-    mutating func updateRequestAndStateWithPendingProfile(profile: CreateProfilePayload) -> CreateProfilePayload {
-        guard let pendingProfile = pendingProfile else {
-            return profile
-        }
-        var attributes = profile.data.attributes
-        var location = profile.data.attributes.location ?? .init()
-        let properties = profile.data.attributes.properties.value as? [String: Any] ?? [:]
-        let updatedProfile = Profile.updateProfileWithProperties(dict: pendingProfile)
-
-        if let firstName = updatedProfile.firstName {
-            attributes.firstName = attributes.firstName ?? firstName
-        }
-        if let lastName = updatedProfile.lastName {
-            attributes.lastName = attributes.lastName ?? lastName
-        }
-        if let title = updatedProfile.title {
-            attributes.title = attributes.title ?? title
-        }
-        if let organization = updatedProfile.organization {
-            attributes.organization = attributes.organization ?? organization
-        }
-        if !updatedProfile.properties.isEmpty {
-            attributes.properties = AnyCodable(properties.merging(updatedProfile.properties, uniquingKeysWith: { _, new in new }))
-        }
-
-        if let address1 = updatedProfile.location?.address1 {
-            location.address1 = location.address1 ?? address1
-        }
-        if let address2 = updatedProfile.location?.address2 {
-            location.address2 = location.address2 ?? address2
-        }
-        if let city = updatedProfile.location?.city {
-            location.city = location.city ?? city
-        }
-        if let region = updatedProfile.location?.region {
-            location.region = location.region ?? region
-        }
-        if let country = updatedProfile.location?.country {
-            location.country = location.country ?? country
-        }
-        if let zip = updatedProfile.location?.zip {
-            location.zip = location.zip ?? zip
-        }
-        if let image = updatedProfile.image {
-            attributes.image = attributes.image ?? image
-        }
-        if let latitude = updatedProfile.location?.latitude {
-            location.latitude = location.latitude ?? latitude
-        }
-        if let longitude = updatedProfile.location?.longitude {
-            location.longitude = location.longitude ?? longitude
-        }
-
-        attributes.location = location
-        self.pendingProfile = nil
-
-        return .init(data: .init(attributes: attributes))
     }
 
     var isIdentified: Bool {
@@ -401,63 +281,6 @@ struct KlaviyoState: Equatable, Codable {
         )
 
         return pushTokenData != newPushTokenData
-    }
-
-    /// Validates the requested channels against the profile's identifiers and builds the create-subscription
-    /// request. Emits a developer warning and returns `nil` when the request should not be enqueued.
-    func buildSubscriptionRequest(apiKey: String, anonymousId: String, subscription: Subscription) -> KlaviyoRequest? {
-        let channels: SubscriptionChannels?
-        if let requestedChannels = subscription.channels {
-            if requestedChannels.needsEmail, email == nil {
-                environment.emitDeveloperWarning(
-                    "Subscription requires an email for the requested channels, but email is not set."
-                )
-                return nil
-            }
-            if requestedChannels.needsPhone, phoneNumber == nil {
-                environment.emitDeveloperWarning(
-                    "Subscription requires a phone number for the requested channels, " +
-                        "but phone number is not set."
-                )
-                return nil
-            }
-
-            guard let mappedChannels = SubscriptionChannels(requestedChannels) else {
-                environment.emitDeveloperWarning(
-                    "Subscription channels were provided but none were enabled; request was not enqueued."
-                )
-                return nil
-            }
-            channels = mappedChannels
-        } else {
-            // allAvailableMarketing: omit the subscriptions object so the server defaults to marketing;
-            // requires at least one identifier to key channels on.
-            guard email != nil || phoneNumber != nil else {
-                environment.emitDeveloperWarning(
-                    "Subscription requires at least one identifier the API can key channels on, " +
-                        "but no identifiers are set."
-                )
-                return nil
-            }
-            channels = nil
-        }
-
-        let profile = ProfilePayload(
-            email: email,
-            phoneNumber: phoneNumber,
-            externalId: externalId,
-            subscriptions: channels,
-            anonymousId: anonymousId
-        )
-
-        let payload = CreateSubscriptionPayload(
-            listId: subscription.listId,
-            profile: profile,
-            customSource: subscription.customSource
-        )
-
-        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
-        return KlaviyoRequest(endpoint: endpoint)
     }
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/LegacyState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/LegacyState.swift
@@ -1,0 +1,40 @@
+//
+//  LegacyState.swift
+//  klaviyo-swift-sdk
+//
+//  Codable DTO for the pre-split legacy `klaviyo-{apiKey}-state.json` blob. Owned by the
+//  migration; decoupled from the runtime `KlaviyoState` so that type can be non-Codable.
+//
+
+import Foundation
+import KlaviyoCore
+
+struct LegacyState: Codable, Equatable {
+    var apiKey: String?
+    var identity: ProfileData
+    var pushTokenData: PushTokenData?
+    var queue: [KlaviyoRequest]
+
+    private enum CodingKeys: CodingKey { case apiKey, identity, queue, pushTokenData }
+    private enum LegacyCodingKeys: CodingKey { case email, anonymousId, phoneNumber, externalId }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        apiKey = try container.decodeIfPresent(String.self, forKey: .apiKey)
+        pushTokenData = try container.decodeIfPresent(PushTokenData.self, forKey: .pushTokenData)
+        queue = try container.decodeIfPresent([KlaviyoRequest].self, forKey: .queue) ?? []
+
+        if let identity = try container.decodeIfPresent(ProfileData.self, forKey: .identity) {
+            self.identity = identity
+        } else if let legacy = try? decoder.container(keyedBy: LegacyCodingKeys.self) {
+            identity = try ProfileData(
+                email: legacy.decodeIfPresent(String.self, forKey: .email),
+                phoneNumber: legacy.decodeIfPresent(String.self, forKey: .phoneNumber),
+                externalId: legacy.decodeIfPresent(String.self, forKey: .externalId),
+                anonymousId: legacy.decodeIfPresent(String.self, forKey: .anonymousId)
+            )
+        } else {
+            identity = ProfileData()
+        }
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/LegacyStateMigration.swift
+++ b/Sources/KlaviyoSwift/StateManagement/LegacyStateMigration.swift
@@ -44,7 +44,7 @@ func migrateLegacyStateIfNeeded(apiKey: String) {
 
 /// One write-verify-retire attempt. `true` once the canonical stores hold `decoded` and the
 /// legacy file can no longer be read back as still-legacy-shaped.
-private func attemptMigration(apiKey: String, legacyFile: URL, decoded: KlaviyoState) -> Bool {
+private func attemptMigration(apiKey: String, legacyFile: URL, decoded: LegacyState) -> Bool {
     SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
     IdentityStore.shared.update(decoded.identity)
     IdentityStore.shared.updatePushToken(decoded.pushTokenData)
@@ -78,10 +78,10 @@ private func attemptMigration(apiKey: String, legacyFile: URL, decoded: KlaviyoS
 /// Decodes and validates the legacy blob. Nil if absent, corrupt, already queue-only, claimed by
 /// a different apiKey, or missing a recoverable anonymousId — in every case, unchanged callers
 /// (`loadKlaviyoStateFromDisk`, etc.) are left to handle the file as they already do today.
-private func validatedLegacyState(apiKey: String, legacyFile: URL) -> KlaviyoState? {
+private func validatedLegacyState(apiKey: String, legacyFile: URL) -> LegacyState? {
     guard environment.fileClient.fileExists(legacyFile.path) else { return nil }
     guard let legacyData = try? environment.dataFromUrl(legacyFile) else { return nil }
-    guard let decoded: KlaviyoState = try? environment.decoder.decode(legacyData) else { return nil }
+    guard let decoded: LegacyState = try? environment.decoder.decode(legacyData) else { return nil }
     guard let decodedApiKey = decoded.apiKey else { return nil }
     guard decodedApiKey == apiKey else {
         environment.logger.error("LegacyStateMigration: legacy file for \(apiKey) claims a different apiKey.")
@@ -97,7 +97,7 @@ private func validatedLegacyState(apiKey: String, legacyFile: URL) -> KlaviyoSta
 
 /// Verifies all three stores from disk (not the singletons' cached values) before deletion, so a
 /// swallowed write failure can't slip through.
-private func verifyMigration(apiKey: String, decoded: KlaviyoState) -> Bool {
+private func verifyMigration(apiKey: String, decoded: LegacyState) -> Bool {
     guard loadPersisted(PersistedConfig.self, fileName: StoreFile.config)?.apiKey == apiKey else {
         return false
     }

--- a/Tests/KlaviyoCoreTests/QueueStoreTests.swift
+++ b/Tests/KlaviyoCoreTests/QueueStoreTests.swift
@@ -195,6 +195,17 @@ final class QueueStoreTests: XCTestCase {
                       "a persist failure must emit a developer warning")
     }
 
+    func testLoadFailureEmitsWarningAndFallsBackToEmpty() {
+        let diskIO = SpyDiskIO([request("a")])
+        diskIO.loadError = NSError(domain: "disk", code: 2)
+        var warnings: [String] = []
+        let store = makeStore(diskIO: diskIO, scheduler: ManualPersistScheduler(),
+                              warnings: { warnings.append($0) })
+        XCTAssertEqual(store.requests, [], "a load failure falls back to an empty queue")
+        XCTAssertTrue(warnings.contains { $0.contains("failed to load") },
+                      "a load failure must emit a developer warning rather than silently empty")
+    }
+
     // MARK: - Bounded size
 
     func testEnqueueEvictsOldestByEnqueuedAtAtCapacity() {
@@ -380,6 +391,65 @@ final class QueueStoreTests: XCTestCase {
         diskIO.loadError = NSError(domain: "corrupt", code: 1)
         let store = makeStore(diskIO: diskIO, scheduler: ManualPersistScheduler())
         XCTAssertEqual(store.requests, [])
+    }
+
+    // MARK: - drainAll
+
+    func testDrainAllReturnsAndClearsQueue() {
+        let disk = SpyDiskIO([request("a"), request("b")])
+        let scheduler = ManualPersistScheduler()
+        let store = makeStore(diskIO: disk, scheduler: scheduler)
+
+        let drained = store.drainAll()
+
+        XCTAssertEqual(drained.map(\.id), ["a", "b"], "drainAll returns the full queue in order")
+        XCTAssertEqual(store.requests, [], "queue is empty after drain")
+    }
+
+    func testDrainAllOnEmptyQueueReturnsEmptyAndStillSchedulesPersist() {
+        let disk = SpyDiskIO([])
+        let scheduler = ManualPersistScheduler()
+        let store = makeStore(diskIO: disk, scheduler: scheduler)
+
+        XCTAssertEqual(store.drainAll(), [])
+        // Debounced persist scheduled even for an empty drain (parity with today's removeAll save).
+        XCTAssertEqual(scheduler.scheduleCount, 1)
+    }
+
+    func testDrainAllPersistsClearedQueueWhenDebounceFires() {
+        let disk = SpyDiskIO([request("a")])
+        let scheduler = ManualPersistScheduler()
+        let store = makeStore(diskIO: disk, scheduler: scheduler)
+
+        _ = store.drainAll()
+        scheduler.fire()
+
+        XCTAssertEqual(disk.stored, [], "cleared queue is written to disk on debounce fire")
+    }
+
+    func testDrainAllSynchronousPersistsImmediately() {
+        let disk = SpyDiskIO([request("a")])
+        let scheduler = ManualPersistScheduler()
+        let store = makeStore(diskIO: disk, scheduler: scheduler)
+
+        _ = store.drainAll(persist: .synchronous)
+
+        XCTAssertEqual(disk.stored, [], "synchronous drain writes the empty queue before returning")
+        XCTAssertEqual(scheduler.scheduleCount, 0, "synchronous persist does not schedule a debounce")
+    }
+
+    // MARK: - register injection seam
+
+    func testRegisterInjectsStoreForApiKey() {
+        QueueStore.resetRegistry()
+        defer { QueueStore.resetRegistry() }
+        let disk = SpyDiskIO([request("seeded")])
+        let injected = makeStore(diskIO: disk, scheduler: ManualPersistScheduler())
+
+        QueueStore.register(injected, for: "abc")
+
+        XCTAssertTrue(QueueStore.store(for: "abc") === injected,
+                      "store(for:) returns the injected instance")
     }
 
     // MARK: - current() resolver

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -77,11 +77,30 @@ final class RequestEnqueuerTests: XCTestCase {
 
     // MARK: - enqueueProfile
 
-    func testProfileWithoutApiKeyBuffersProfilePayload() {
-        RequestEnqueuer.enqueueProfile(properties: ["k": "v"])
-        guard case .profile = UnattributedBuffer.shared.snapshot().first else {
+    func testProfileWithoutApiKeyBuffersFullPayload() {
+        // The caller supplies a fully-built payload, so structured attributes survive into the
+        // durable buffer (MAGE-1141).
+        let payload = CreateProfilePayload(data: ProfilePayload(
+            email: "ada@example.com", firstName: "Ada", anonymousId: "anon-1"
+        ))
+        RequestEnqueuer.enqueueProfile(payload: payload)
+
+        guard case let .profile(buffered) = UnattributedBuffer.shared.snapshot().first else {
             return XCTFail("expected .profile in buffer")
         }
+        XCTAssertEqual(buffered.data.attributes.firstName, "Ada")
+        XCTAssertNil(QueueStore.current()) // no queue exists pre-apiKey
+    }
+
+    func testProfileWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        let payload = CreateProfilePayload(data: ProfilePayload(
+            email: "ada@example.com", anonymousId: "anon-1"
+        ))
+        RequestEnqueuer.enqueueProfile(payload: payload)
+
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
     }
 
     // MARK: - enqueueAggregateEvent

--- a/Tests/KlaviyoSwiftTests/LegacyStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/LegacyStateTests.swift
@@ -8,28 +8,29 @@
 import XCTest
 
 final class LegacyStateTests: XCTestCase {
+    private func decodeLegacyState(_ json: String) throws -> LegacyState {
+        try JSONDecoder().decode(LegacyState.self, from: Data(json.utf8))
+    }
+
     func testDecodesNewFormatNestedIdentity() throws {
-        let json = Data("""
+        let decoded = try decodeLegacyState("""
         {"apiKey":"k","identity":{"email":"a@b.com","anonymousId":"anon"},"queue":[]}
-        """.utf8)
-        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        """)
         XCTAssertEqual(decoded.apiKey, "k")
         XCTAssertEqual(decoded.identity.email, "a@b.com")
         XCTAssertEqual(decoded.identity.anonymousId, "anon")
     }
 
     func testDecodesLegacyTopLevelIdentity() throws {
-        let json = Data("""
+        let decoded = try decodeLegacyState("""
         {"apiKey":"k","email":"a@b.com","anonymousId":"anon","queue":[]}
-        """.utf8)
-        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        """)
         XCTAssertEqual(decoded.identity.email, "a@b.com")
         XCTAssertEqual(decoded.identity.anonymousId, "anon")
     }
 
     func testDecodesQueueOnlyBlobWithEmptyIdentity() throws {
-        let json = Data("{\"queue\":[]}".utf8)
-        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        let decoded = try decodeLegacyState("{\"queue\":[]}")
         XCTAssertNil(decoded.apiKey)
         XCTAssertNil(decoded.identity.email)
     }

--- a/Tests/KlaviyoSwiftTests/LegacyStateTests.swift
+++ b/Tests/KlaviyoSwiftTests/LegacyStateTests.swift
@@ -1,0 +1,36 @@
+//
+//  LegacyStateTests.swift
+//  klaviyo-swift-sdk
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import XCTest
+
+final class LegacyStateTests: XCTestCase {
+    func testDecodesNewFormatNestedIdentity() throws {
+        let json = Data("""
+        {"apiKey":"k","identity":{"email":"a@b.com","anonymousId":"anon"},"queue":[]}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        XCTAssertEqual(decoded.apiKey, "k")
+        XCTAssertEqual(decoded.identity.email, "a@b.com")
+        XCTAssertEqual(decoded.identity.anonymousId, "anon")
+    }
+
+    func testDecodesLegacyTopLevelIdentity() throws {
+        let json = Data("""
+        {"apiKey":"k","email":"a@b.com","anonymousId":"anon","queue":[]}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        XCTAssertEqual(decoded.identity.email, "a@b.com")
+        XCTAssertEqual(decoded.identity.anonymousId, "anon")
+    }
+
+    func testDecodesQueueOnlyBlobWithEmptyIdentity() throws {
+        let json = Data("{\"queue\":[]}".utf8)
+        let decoded = try JSONDecoder().decode(LegacyState.self, from: json)
+        XCTAssertNil(decoded.apiKey)
+        XCTAssertNil(decoded.identity.email)
+    }
+}


### PR DESCRIPTION
# Description

Additive, dormant KlaviyoCore primitives for the MAGE-952 flush repoint, plus two behavior-preserving KlaviyoSwift refactors, split out of #706 so the large KlaviyoSwift change reviews on its own. Nothing consumes the new Core primitives yet — same pattern as MAGE-950/951 shipping their Core pieces ahead of the consumer.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Minor` Contains changes to the public API.
- [x] This is planned work for an upcoming release.

Public API delta: adds `QueueStore.drainAll(persist:)`. Adds a `package` `register(_:for:)` test seam. `restore()` unchanged. Replaces `RequestEnqueuer.enqueueProfile(properties:)` with `enqueueProfile(payload:)` (introduced in #703/MAGE-951, unused until the MAGE-952 consumer).

## Changelog / Code Overview

**KlaviyoCore (dormant primitives)**
- `drainAll(persist:)` — atomic snapshot-and-clear of the pending queue (the MAGE-952 flush loop leases through it).
- `register(_:for:)` — package test-injection seam so reducer tests can back the queue with an in-memory spy (`.test` file stubs are no-ops).
- `hydrated()` — emit a developer warning on a `diskIO.load()` failure before the empty fallback, so overwriting a valid-but-unreadable backlog is observable rather than silent.
- `RequestEnqueuer.enqueueProfile(payload:)` — takes a prebuilt `CreateProfilePayload` instead of identity + a flat properties dict, so the KlaviyoSwift consumer can carry a profile's structured attributes (name/title/organization/image/location) through the durable buffer rather than dropping them (unblocks MAGE-1141). No `UnattributedRequest`/on-disk change — the buffered case already stores a full payload.

**KlaviyoSwift (behavior-preserving refactors)**
- Extract `KlaviyoState` request-building helpers into an extension — pure relocation, no behavior change.
- Introduce a dedicated `LegacyState` Codable DTO that owns decoding of the legacy `klaviyo-{apiKey}-state.json` blob, and point `LegacyStateMigration` at it instead of `KlaviyoState`.

### Why `LegacyState`?

The only remaining reason `KlaviyoState` still conforms to `Codable` is that the one-time legacy-file migration decodes that on-disk blob directly into it. In the MAGE-952 flush repoint, persistence is owned by the canonical Core stores (QueueStore, IdentityStore, etc.) and `KlaviyoState` becomes a purely in-memory runtime type — it no longer needs to be serializable.

Moving the legacy blob's decoding into its own DTO lets the consumer PR (#706) drop `Codable` from `KlaviyoState`. Benefits:
- **Decouples the runtime type from the on-disk format.** The migration owns the legacy shape (including the old top-level-identity fallback); `KlaviyoState` is free to evolve without worrying about wire/disk compatibility.
- **Removes accidental persistence coupling.** Once `KlaviyoState` isn't `Codable`, nothing can silently re-serialize it to disk, keeping the canonical Core stores the single source of truth.
- **Isolates legacy quirks.** All the "read the pre-split blob" edge cases live in one migration-owned DTO with its own tests, rather than leaking into the runtime state type.

This change is behavior-preserving on its own — `LegacyState` decodes exactly what `KlaviyoState` did (new nested-identity format, legacy top-level identity, and queue-only blobs) — and simply unblocks the Codable removal on the consumer PR.

Behavior-preserving for existing flows.

## Test Plan
- `KlaviyoCoreTests` green (new `drainAll` tests, `register` test, load-failure warning test).
- `KlaviyoSwiftTests` green (new `LegacyStateTests` covering nested-identity, legacy top-level identity, and queue-only decoding).

## Related Issues/Tickets
- MAGE-952 (parent). Consumer PR: #706 (stacked on this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to atomically retrieve and clear all queued requests.
  * Added configurable persistence behavior when draining queued requests.
  * Added support for registering queue stores by API key.
  * Added structured request-building support for profiles, push tokens, and subscriptions.
  * Profile requests now preserve structured attributes when buffered or queued.

* **Bug Fixes**
  * Queue loading failures now emit a warning and safely fall back to an empty queue.
  * Improved migration of saved state from older formats, including legacy identity and queue data.
  * Invalid subscription configurations and missing identifiers now prevent invalid requests from being queued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

