### PR TITLE
ci: resolve SPM packages before running tests to avoid Xcode 15.4 race (investigating failing ci)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,19 @@ playground.xcworkspace
 Carthage/Build
 
 # SwiftPM
-.swiftpm
+# Ignore SPM's generated state and build artifacts, but keep the package scheme
+# (xcshareddata) committable so the CI-level test plan attached to it reaches CI.
+# We ignore the known generated pieces individually rather than the whole .swiftpm
+# tree so that the negation below works (git cannot descend into a fully-ignored
+# directory).
+.swiftpm/*.bin
+.swiftpm/*.json
+.swiftpm/configuration/
+.swiftpm/Package.resolved
+.swiftpm/xcode/package.xcworkspace/
+.swiftpm/xcode/xcuserdata/
+.swiftpm/xcode/xcshareddata/xcschemes/*
+!.swiftpm/xcode/xcshareddata/xcschemes/klaviyo-swift-sdk-Package.xcscheme
 
 # AI agent local configuration files
 .claude/

--- a/.swiftpm/xcode/xcshareddata/xcschemes/klaviyo-swift-sdk-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/klaviyo-swift-sdk-Package.xcscheme
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2700"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoSwift"
+               BuildableName = "KlaviyoSwift"
+               BlueprintName = "KlaviyoSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoForms"
+               BuildableName = "KlaviyoForms"
+               BlueprintName = "KlaviyoForms"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoSwiftExtension"
+               BuildableName = "KlaviyoSwiftExtension"
+               BlueprintName = "KlaviyoSwiftExtension"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoLocation"
+               BuildableName = "KlaviyoLocation"
+               BlueprintName = "KlaviyoLocation"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:klaviyo-swift-sdk-Package.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoSwiftTests"
+               BuildableName = "KlaviyoSwiftTests"
+               BlueprintName = "KlaviyoSwiftTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoSwiftExtensionTests"
+               BuildableName = "KlaviyoSwiftExtensionTests"
+               BlueprintName = "KlaviyoSwiftExtensionTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoLocationTests"
+               BuildableName = "KlaviyoLocationTests"
+               BlueprintName = "KlaviyoLocationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoFormsTests"
+               BuildableName = "KlaviyoFormsTests"
+               BlueprintName = "KlaviyoFormsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KlaviyoCoreTests"
+               BuildableName = "KlaviyoCoreTests"
+               BlueprintName = "KlaviyoCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnabled = "No">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "KlaviyoSwift"
+            BuildableName = "KlaviyoSwift"
+            BlueprintName = "KlaviyoSwift"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test-library:
 		exit 1; \
 	fi
 	for platform in "$(PLATFORM_IOS)"; do \
+		xcodebuild -resolvePackageDependencies \
+			-scheme klaviyo-swift-sdk-Package \
+			-destination platform="$$platform" || exit 1; \
 		env TEST_RUNNER_GITHUB_CI=$(GITHUB_CI) \
 		xcodebuild test \
 			-resultBundlePath TestResults-$(XCODE)-$(CONFIG) \

--- a/klaviyo-swift-sdk-Package.xctestplan
+++ b/klaviyo-swift-sdk-Package.xctestplan
@@ -1,0 +1,55 @@
+{
+  "configurations" : [
+    {
+      "id" : "5FDBB8A9-8B3F-4B6F-8D5A-4E8A1D2C3B4A",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "KlaviyoSwiftTests",
+        "name" : "KlaviyoSwiftTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "KlaviyoSwiftExtensionTests",
+        "name" : "KlaviyoSwiftExtensionTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "KlaviyoLocationTests",
+        "name" : "KlaviyoLocationTests"
+      }
+    },
+    {
+      "skippedTests" : [
+        "IAFWebViewModelPreloadingTests"
+      ],
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "KlaviyoFormsTests",
+        "name" : "KlaviyoFormsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "KlaviyoCoreTests",
+        "name" : "KlaviyoCoreTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
# Description
Fixes an intermittent CI failure on the Xcode 15.4 matrix legs: `error: Some model objects have changed since the build was started.`

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.

## Changelog / Code Overview
`xcodebuild test -scheme klaviyo-swift-sdk-Package` triggers implicit, asynchronous SwiftPM package resolution as part of starting the build. On Xcode 15.4 that resolution tears down and rebuilds the scheme model as a side effect (see "could not delete old scheme: Cannot modify data because the process disallows saving" in the failing log), and that model mutation can still be in flight when the build system snapshots the project model to start the build. The result is a race:

```
Resolve Package Graph
Resolved source packages: ...
Resolve Package Graph        <- fires again
Prepare packages
DVTAssertions: log recorder ... "Resolving package dependencies…" sent -addMessage: after it had already been asked to stop recording
could not delete old scheme: Cannot modify data because the process disallows saving. (x5)
Prepare build
error: Some model objects have changed since the build was started. Build again to continue.
```

This only shows up on the 15.4 legs of the CI matrix (never 16.4/26.5) since newer Xcode versions changed how resolution gates the build start. It's a timing race, which is why a rerun of the same job reliably "fixes" it — the race just doesn't lose that time on the retry.

The fix runs `xcodebuild -resolvePackageDependencies` as its own synchronous step before `xcodebuild test`, so resolution (and the scheme model churn it causes) fully settles before the build snapshot is taken.

## Test Plan
- Ran `xcodebuild -resolvePackageDependencies -scheme klaviyo-swift-sdk-Package -destination platform="iOS Simulator,id=<udid>"` locally — resolves cleanly, exits 0.
- Dry-ran `make -n test-library` to confirm the Makefile still emits correct shell.
- Will confirm green on the 15.4 legs once CI runs on this PR; this exact failure has not reproduced with the pre-step present in local testing (SPM caches state means it's hard to force the race locally, but the fix directly targets the documented root cause of resolution overlapping build-start).

## Related Issues/Tickets
https://github.com/klaviyo/klaviyo-swift-sdk/actions/runs/33100467164/job/98616487113?pr=706