### PR TITLE
feat(KlaviyoSwift): durable pre-init buffering for subscriptions, tracking-link clicks & reset (MAGE-1136)

### DIFF
--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -82,20 +82,16 @@ public enum RequestEnqueuer {
         }
     }
 
-    /// Enqueues an already-built `CreateSubscriptionPayload`. Like `enqueueProfile`, the caller
-    /// supplies the full payload — subscription channel validation lives in the KlaviyoSwift
-    /// `Subscription` → payload mapping. The payload is apiKey-free; routing is the same as every
-    /// other request: apiKey present → `QueueStore`, absent → durable `UnattributedBuffer`.
+    /// Mirrors `enqueueProfile`: the caller supplies the built payload (channel validation lives in
+    /// the KlaviyoSwift `Subscription` → payload mapping).
     public static func enqueueSubscription(payload: CreateSubscriptionPayload) {
         route(buffered: .subscription(payload)) { apiKey in
             KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
         }
     }
 
-    /// Enqueues a tracking-link click log. The `logTrackingLinkClicked` endpoint is apiKey-free, so
-    /// the `build` closure ignores its `apiKey` argument; routing still keys the target `QueueStore`
-    /// on the apiKey. Identity is resolved here (like `enqueueEvent`) so a pre-init click that failed
-    /// destination resolution parks its click-log in the durable buffer instead of being dropped.
+    /// The `logTrackingLinkClicked` endpoint is apiKey-free, so the `build` closure ignores `apiKey`
+    /// (routing still keys the target `QueueStore` on it). Identity is resolved here, like `enqueueEvent`.
     public static func enqueueTrackingLinkClicked(trackingLink: URL, clickTime: Date) {
         guard let identity = resolveIdentity() else { return }
         let profileInfo = ProfilePayload(

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -82,6 +82,29 @@ public enum RequestEnqueuer {
         }
     }
 
+    /// Enqueues a tracking-link click log. The `logTrackingLinkClicked` endpoint is apiKey-free, so
+    /// the `build` closure ignores its `apiKey` argument; routing still keys the target `QueueStore`
+    /// on the apiKey. Identity is resolved here (like `enqueueEvent`) so a pre-init click that failed
+    /// destination resolution parks its click-log in the durable buffer instead of being dropped.
+    public static func enqueueTrackingLinkClicked(trackingLink: URL, clickTime: Date) {
+        guard let identity = resolveIdentity() else { return }
+        let profileInfo = ProfilePayload(
+            email: identity.email,
+            phoneNumber: identity.phoneNumber,
+            externalId: identity.externalId,
+            anonymousId: identity.anonymousId
+        )
+        route(
+            buffered: .trackingLinkClick(
+                trackingLink: trackingLink, clickTime: clickTime, profileInfo: profileInfo
+            )
+        ) { _ in
+            KlaviyoRequest(endpoint: .logTrackingLinkClicked(
+                trackingLink: trackingLink, clickTime: clickTime, profileInfo: profileInfo
+            ))
+        }
+    }
+
     /// Moves every buffered request into `QueueStore`, stamping `apiKey` into each endpoint, then
     /// removes only the drained FIFO prefix. At-least-once: the final enqueue persists synchronously
     /// so the queue is durable before the buffer is trimmed. A crash in the gap re-drains next launch
@@ -126,6 +149,12 @@ public enum RequestEnqueuer {
             case let .pushToken(payload):
                 queue.enqueue(
                     KlaviyoRequest(endpoint: .registerPushToken(apiKey, payload)), persist: policy
+                )
+            case let .trackingLinkClick(trackingLink, clickTime, profileInfo):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .logTrackingLinkClicked(
+                        trackingLink: trackingLink, clickTime: clickTime, profileInfo: profileInfo
+                    )), persist: policy
                 )
             }
         }

--- a/Sources/KlaviyoCore/RequestEnqueuer.swift
+++ b/Sources/KlaviyoCore/RequestEnqueuer.swift
@@ -82,6 +82,16 @@ public enum RequestEnqueuer {
         }
     }
 
+    /// Enqueues an already-built `CreateSubscriptionPayload`. Like `enqueueProfile`, the caller
+    /// supplies the full payload — subscription channel validation lives in the KlaviyoSwift
+    /// `Subscription` → payload mapping. The payload is apiKey-free; routing is the same as every
+    /// other request: apiKey present → `QueueStore`, absent → durable `UnattributedBuffer`.
+    public static func enqueueSubscription(payload: CreateSubscriptionPayload) {
+        route(buffered: .subscription(payload)) { apiKey in
+            KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+        }
+    }
+
     /// Enqueues a tracking-link click log. The `logTrackingLinkClicked` endpoint is apiKey-free, so
     /// the `build` closure ignores its `apiKey` argument; routing still keys the target `QueueStore`
     /// on the apiKey. Identity is resolved here (like `enqueueEvent`) so a pre-init click that failed
@@ -155,6 +165,10 @@ public enum RequestEnqueuer {
                     KlaviyoRequest(endpoint: .logTrackingLinkClicked(
                         trackingLink: trackingLink, clickTime: clickTime, profileInfo: profileInfo
                     )), persist: policy
+                )
+            case let .subscription(payload):
+                queue.enqueue(
+                    KlaviyoRequest(endpoint: .createSubscription(apiKey, payload)), persist: policy
                 )
             }
         }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -17,6 +17,9 @@ enum UnattributedRequest: Codable, Equatable {
     /// The `logTrackingLinkClicked` endpoint is already apiKey-free, so the buffered case carries the
     /// same associated values the endpoint takes; the drain wraps them directly (no apiKey stamping).
     case trackingLinkClick(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
+    /// `CreateSubscriptionPayload` is apiKey-free (identity lives in the payload, apiKey stamps the
+    /// endpoint at drain), so a pre-init subscribe buffers like a profile — no KlaviyoSwift seam.
+    case subscription(CreateSubscriptionPayload)
 }
 
 /// Versioned on-disk shape for the buffer file (`klaviyo-unattributed.json`).

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -14,6 +14,9 @@ enum UnattributedRequest: Codable, Equatable {
     case aggregateEvent(Data)
     case profile(CreateProfilePayload)
     case pushToken(PushTokenPayload)
+    /// The `logTrackingLinkClicked` endpoint is already apiKey-free, so the buffered case carries the
+    /// same associated values the endpoint takes; the drain wraps them directly (no apiKey stamping).
+    case trackingLinkClick(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
 }
 
 /// Versioned on-disk shape for the buffer file (`klaviyo-unattributed.json`).

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -14,7 +14,6 @@ enum UnattributedRequest: Codable, Equatable {
     case aggregateEvent(Data)
     case profile(CreateProfilePayload)
     case pushToken(PushTokenPayload)
-    /// Its endpoint is already apiKey-free, so the drain wraps these values without stamping a key.
     case trackingLinkClick(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
     case subscription(CreateSubscriptionPayload)
 }

--- a/Sources/KlaviyoCore/UnattributedBuffer.swift
+++ b/Sources/KlaviyoCore/UnattributedBuffer.swift
@@ -14,11 +14,8 @@ enum UnattributedRequest: Codable, Equatable {
     case aggregateEvent(Data)
     case profile(CreateProfilePayload)
     case pushToken(PushTokenPayload)
-    /// The `logTrackingLinkClicked` endpoint is already apiKey-free, so the buffered case carries the
-    /// same associated values the endpoint takes; the drain wraps them directly (no apiKey stamping).
+    /// Its endpoint is already apiKey-free, so the drain wraps these values without stamping a key.
     case trackingLinkClick(trackingLink: URL, clickTime: Date, profileInfo: ProfilePayload)
-    /// `CreateSubscriptionPayload` is apiKey-free (identity lives in the payload, apiKey stamps the
-    /// endpoint at drain), so a pre-init subscribe buffers like a profile — no KlaviyoSwift seam.
     case subscription(CreateSubscriptionPayload)
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -165,8 +165,7 @@ extension KlaviyoState {
 
     /// Validates channels against the profile's identifiers and builds the apiKey-free
     /// `CreateSubscriptionPayload`. Emits a developer warning and returns `nil` when the request
-    /// should not be enqueued. Split out so the pre-init path can buffer the payload (apiKey stamped
-    /// at drain) while the initialized path wraps it in the endpoint immediately.
+    /// should not be enqueued. Split from `buildSubscriptionRequest` so the pre-init path can buffer it.
     func buildSubscriptionPayload(
         anonymousId: String,
         subscription: Subscription

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -156,6 +156,21 @@ extension KlaviyoState {
         anonymousId: String,
         subscription: Subscription
     ) -> KlaviyoRequest? {
+        guard let payload = buildSubscriptionPayload(anonymousId: anonymousId, subscription: subscription)
+        else {
+            return nil
+        }
+        return KlaviyoRequest(endpoint: .createSubscription(apiKey, payload))
+    }
+
+    /// Validates channels against the profile's identifiers and builds the apiKey-free
+    /// `CreateSubscriptionPayload`. Emits a developer warning and returns `nil` when the request
+    /// should not be enqueued. Split out so the pre-init path can buffer the payload (apiKey stamped
+    /// at drain) while the initialized path wraps it in the endpoint immediately.
+    func buildSubscriptionPayload(
+        anonymousId: String,
+        subscription: Subscription
+    ) -> CreateSubscriptionPayload? {
         let channels: SubscriptionChannels?
         if let requestedChannels = subscription.channels {
             if requestedChannels.needsEmail, email == nil {
@@ -200,13 +215,10 @@ extension KlaviyoState {
             anonymousId: anonymousId
         )
 
-        let payload = CreateSubscriptionPayload(
+        return CreateSubscriptionPayload(
             listId: subscription.listId,
             profile: profile,
             customSource: subscription.customSource
         )
-
-        let endpoint = KlaviyoEndpoint.createSubscription(apiKey, payload)
-        return KlaviyoRequest(endpoint: endpoint)
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -683,13 +683,19 @@ struct KlaviyoReducer: ReducerProtocol {
                   let apiKey = state.apiKey,
                   let anonymousId = state.anonymousId
             else {
-                // Subscriptions carry a KlaviyoSwift-only payload that the Core `UnattributedBuffer`
-                // (apiKey-free Core payloads only) cannot hold, so a pre-init subscription can't be
-                // durably buffered like other intents. Warn rather than silently drop.
-                // TODO(MAGE-952 follow-up): extend the durable buffer to cover subscriptions.
-                environment.emitDeveloperWarning(
-                    "Subscription requested before initialize(); ignored. Initialize the SDK first."
-                )
+                // Pre-init: mirror the initialized path against the canonical persisted identity, then
+                // buffer the apiKey-free payload through the ungated `RequestEnqueuer` (apiKey stamped
+                // at drain) so a subscribe issued before initialize() survives instead of being
+                // dropped (MAGE-1136).
+                state.identity = IdentityStore.shared.current
+                guard let anonymousId = state.anonymousId,
+                      let payload = state.buildSubscriptionPayload(
+                          anonymousId: anonymousId, subscription: subscription
+                      )
+                else {
+                    return .none
+                }
+                RequestEnqueuer.enqueueSubscription(payload: payload)
                 return .none
             }
 

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -768,6 +768,14 @@ struct KlaviyoReducer: ReducerProtocol {
             // Kept in the reducer only for the enqueue below (a state mutation).
             // Folds into `TrackingLinkManager` once the queue is canonical in
             // KlaviyoCore.
+            guard case .initialized = state.initalizationState, state.apiKey != nil else {
+                // Pre-init: route through the ungated `RequestEnqueuer` (identity resolved from the
+                // canonical `IdentityStore`) so a click that fails resolution before initialize() is
+                // parked in the durable buffer instead of dropped by the apiKey-gated
+                // `state.enqueueRequest` (MAGE-1136).
+                RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
+                return .none
+            }
             let profileInfo = ProfilePayload(
                 email: state.email,
                 phoneNumber: state.phoneNumber,

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -683,10 +683,8 @@ struct KlaviyoReducer: ReducerProtocol {
                   let apiKey = state.apiKey,
                   let anonymousId = state.anonymousId
             else {
-                // Pre-init: mirror the initialized path against the canonical persisted identity, then
-                // buffer the apiKey-free payload through the ungated `RequestEnqueuer` (apiKey stamped
-                // at drain) so a subscribe issued before initialize() survives instead of being
-                // dropped (MAGE-1136).
+                // Pre-init: seed identity from the canonical store, build the apiKey-free payload, and
+                // buffer it via the ungated `RequestEnqueuer` so a pre-init subscribe survives (MAGE-1136).
                 state.identity = IdentityStore.shared.current
                 guard let anonymousId = state.anonymousId,
                       let payload = state.buildSubscriptionPayload(
@@ -713,15 +711,12 @@ struct KlaviyoReducer: ReducerProtocol {
         case .resetProfile:
             guard case .initialized = state.initalizationState
             else {
-                // Pre-init parity: clear the persisted identity so a reset issued before initialize()
-                // doesn't leave the prior profile in `IdentityStore`. Seed the full identity first so
-                // `state.reset` sees the real prior identity, then push the reset identity to
-                // `IdentityStore` synchronously (like `setPreInitIdentifier`) — the write-through
-                // `defer` fires only at RETURN, too late for the token re-register below to read the
-                // new anon. `preserveTokenData: false` because the built-in re-register path needs an
-                // apiKey; instead we re-register any persisted token against the new anon through the
-                // ungated `RequestEnqueuer` (buffered pre-init). The already-buffered old-identity
-                // profile still drains at initialize(), matching post-init reset (MAGE-1136).
+                // Pre-init parity with post-init reset. Write the reset identity to `IdentityStore`
+                // synchronously before re-registering the token: like `setPreInitIdentifier`, the
+                // write-through `defer` fires only at RETURN — too late for `RequestEnqueuer` to read
+                // the new anon. `preserveTokenData: false` since its built-in re-register needs an
+                // apiKey; we re-register via the ungated `RequestEnqueuer` instead. The already-buffered
+                // old-identity profile still drains at init, matching post-init reset (MAGE-1136).
                 state.identity = IdentityStore.shared.current
                 let tokenData = IdentityStore.shared.pushToken
                 state.reset(preserveTokenData: false)
@@ -793,10 +788,8 @@ struct KlaviyoReducer: ReducerProtocol {
             // Folds into `TrackingLinkManager` once the queue is canonical in
             // KlaviyoCore.
             guard case .initialized = state.initalizationState, state.apiKey != nil else {
-                // Pre-init: route through the ungated `RequestEnqueuer` (identity resolved from the
-                // canonical `IdentityStore`) so a click that fails resolution before initialize() is
-                // parked in the durable buffer instead of dropped by the apiKey-gated
-                // `state.enqueueRequest` (MAGE-1136).
+                // Pre-init: buffer via the ungated `RequestEnqueuer` instead of the apiKey-gated
+                // `state.enqueueRequest`, which would drop the click (MAGE-1136).
                 RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
                 return .none
             }

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -711,12 +711,12 @@ struct KlaviyoReducer: ReducerProtocol {
         case .resetProfile:
             guard case .initialized = state.initalizationState
             else {
-                // Pre-init parity with post-init reset. Write the reset identity to `IdentityStore`
-                // synchronously before re-registering the token: like `setPreInitIdentifier`, the
-                // write-through `defer` fires only at RETURN — too late for `RequestEnqueuer` to read
-                // the new anon. `preserveTokenData: false` since its built-in re-register needs an
-                // apiKey; we re-register via the ungated `RequestEnqueuer` instead. The already-buffered
-                // old-identity profile still drains at init, matching post-init reset (MAGE-1136).
+                // Pre-init reset, mirroring the post-init path. Persist the reset identity to
+                // `IdentityStore` synchronously before the re-register below: the write-through
+                // `defer` runs too late for `RequestEnqueuer` to read the new anon.
+                // `preserveTokenData: false` skips reset's apiKey-gated re-register; we use the
+                // ungated `RequestEnqueuer` instead. A profile buffered under the old identity
+                // still drains at init (MAGE-1136).
                 state.identity = IdentityStore.shared.current
                 let tokenData = IdentityStore.shared.pushToken
                 state.reset(preserveTokenData: false)
@@ -784,9 +784,10 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
         case let .trackingLinkResolutionFailed(trackingLink, clickTime):
-            // Kept in the reducer only for the enqueue below (a state mutation).
-            // Folds into `TrackingLinkManager` once the queue is canonical in
-            // KlaviyoCore.
+            // In the reducer only because it's a TCA action whose post-init path reads identity
+            // from `state`. Once the flush engine becomes a Core actor queue and this reducer is
+            // retired, the case folds into `TrackingLinkManager`, which reads identity from the
+            // canonical stores and enqueues directly.
             guard case .initialized = state.initalizationState, state.apiKey != nil else {
                 // Pre-init: buffer via the ungated `RequestEnqueuer` instead of the apiKey-gated
                 // `state.enqueueRequest`, which would drop the click (MAGE-1136).

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -713,6 +713,24 @@ struct KlaviyoReducer: ReducerProtocol {
         case .resetProfile:
             guard case .initialized = state.initalizationState
             else {
+                // Pre-init parity: clear the persisted identity so a reset issued before initialize()
+                // doesn't leave the prior profile in `IdentityStore`. Seed the full identity first so
+                // `state.reset` sees the real prior identity, then push the reset identity to
+                // `IdentityStore` synchronously (like `setPreInitIdentifier`) — the write-through
+                // `defer` fires only at RETURN, too late for the token re-register below to read the
+                // new anon. `preserveTokenData: false` because the built-in re-register path needs an
+                // apiKey; instead we re-register any persisted token against the new anon through the
+                // ungated `RequestEnqueuer` (buffered pre-init). The already-buffered old-identity
+                // profile still drains at initialize(), matching post-init reset (MAGE-1136).
+                state.identity = IdentityStore.shared.current
+                let tokenData = IdentityStore.shared.pushToken
+                state.reset(preserveTokenData: false)
+                IdentityStore.shared.update(state.identity)
+                if let tokenData = tokenData {
+                    RequestEnqueuer.enqueuePushToken(
+                        tokenData.pushToken, enablement: tokenData.pushEnablement
+                    )
+                }
                 return .none
             }
             state.reset()

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -11,6 +11,9 @@ import XCTest
 final class RequestEnqueuerTests: XCTestCase {
     private var fileIO: FileIODouble!
 
+    /// Shared fixture: a tracking link whose destination fails to resolve before initialize().
+    private let trackingLinkURL = URL(string: "https://klaviyo.com/tracking/abc")!
+
     override func setUp() {
         super.setUp()
         fileIO = FileIODouble()
@@ -215,21 +218,23 @@ final class RequestEnqueuerTests: XCTestCase {
     func testTrackingLinkClickWithoutApiKeyGoesToBuffer() {
         // A universal-link click that fails destination resolution before initialize() must park
         // its click-log in the durable buffer instead of being dropped (MAGE-1136).
-        let url = URL(string: "https://klaviyo.com/tracking/abc")!
-        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+        RequestEnqueuer.enqueueTrackingLinkClicked(
+            trackingLink: trackingLinkURL, clickTime: environment.date()
+        )
         let snap = UnattributedBuffer.shared.snapshot()
         XCTAssertEqual(snap.count, 1)
         guard case let .trackingLinkClick(trackingLink, _, _) = snap[0] else {
             return XCTFail("expected .trackingLinkClick in buffer")
         }
-        XCTAssertEqual(trackingLink, url)
+        XCTAssertEqual(trackingLink, trackingLinkURL)
         XCTAssertNil(QueueStore.current())
     }
 
     func testTrackingLinkClickWithApiKeyGoesToQueueStore() {
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
-        let url = URL(string: "https://klaviyo.com/tracking/abc")!
-        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+        RequestEnqueuer.enqueueTrackingLinkClicked(
+            trackingLink: trackingLinkURL, clickTime: environment.date()
+        )
         XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
         XCTAssertEqual(QueueStore.current()?.count, 1)
         guard case .logTrackingLinkClicked = QueueStore.current()?.requests.first?.endpoint else {
@@ -271,8 +276,9 @@ final class RequestEnqueuerTests: XCTestCase {
     }
 
     func testDrainMapsTrackingLinkClickToLogEndpoint() {
-        let url = URL(string: "https://klaviyo.com/tracking/abc")!
-        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+        RequestEnqueuer.enqueueTrackingLinkClicked(
+            trackingLink: trackingLinkURL, clickTime: environment.date()
+        )
 
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
         RequestEnqueuer.drainBuffer(apiKey: "pk-1")
@@ -283,7 +289,7 @@ final class RequestEnqueuerTests: XCTestCase {
         else {
             return XCTFail("expected .logTrackingLinkClicked endpoint after drain")
         }
-        XCTAssertEqual(trackingLink, url)
+        XCTAssertEqual(trackingLink, trackingLinkURL)
     }
 
     func testDrainEmptyBufferIsNoOp() {

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -168,6 +168,33 @@ final class RequestEnqueuerTests: XCTestCase {
         XCTAssertEqual(payload.data.attributes.token, "token-3")
     }
 
+    // MARK: - enqueueTrackingLinkClicked
+
+    func testTrackingLinkClickWithoutApiKeyGoesToBuffer() {
+        // A universal-link click that fails destination resolution before initialize() must park
+        // its click-log in the durable buffer instead of being dropped (MAGE-1136).
+        let url = URL(string: "https://klaviyo.com/tracking/abc")!
+        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case let .trackingLinkClick(trackingLink, _, _) = snap[0] else {
+            return XCTFail("expected .trackingLinkClick in buffer")
+        }
+        XCTAssertEqual(trackingLink, url)
+        XCTAssertNil(QueueStore.current())
+    }
+
+    func testTrackingLinkClickWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        let url = URL(string: "https://klaviyo.com/tracking/abc")!
+        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
+        guard case .logTrackingLinkClicked = QueueStore.current()?.requests.first?.endpoint else {
+            return XCTFail("expected .logTrackingLinkClicked endpoint in QueueStore")
+        }
+    }
+
     // MARK: - drainBuffer
 
     func testDrainMovesBufferedRequestsToQueueInFifoOrder() {
@@ -199,6 +226,22 @@ final class RequestEnqueuerTests: XCTestCase {
         RequestEnqueuer.drainBuffer(apiKey: "pk-1")
 
         XCTAssertEqual(QueueStore.current()?.requests.first?.priority, .high)
+    }
+
+    func testDrainMapsTrackingLinkClickToLogEndpoint() {
+        let url = URL(string: "https://klaviyo.com/tracking/abc")!
+        RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: url, clickTime: environment.date())
+
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        guard case let .logTrackingLinkClicked(trackingLink, _, _) =
+            QueueStore.current()?.requests.first?.endpoint
+        else {
+            return XCTFail("expected .logTrackingLinkClicked endpoint after drain")
+        }
+        XCTAssertEqual(trackingLink, url)
     }
 
     func testDrainEmptyBufferIsNoOp() {

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -168,6 +168,48 @@ final class RequestEnqueuerTests: XCTestCase {
         XCTAssertEqual(payload.data.attributes.token, "token-3")
     }
 
+    // MARK: - enqueueSubscription
+
+    private func subscriptionPayload(email: String = "a@b.com") -> CreateSubscriptionPayload {
+        CreateSubscriptionPayload(
+            listId: "list-1",
+            profile: ProfilePayload(email: email, anonymousId: "anon-1"),
+            customSource: nil
+        )
+    }
+
+    func testSubscriptionWithoutApiKeyGoesToBuffer() {
+        RequestEnqueuer.enqueueSubscription(payload: subscriptionPayload())
+        let snap = UnattributedBuffer.shared.snapshot()
+        XCTAssertEqual(snap.count, 1)
+        guard case .subscription = snap[0] else { return XCTFail("expected .subscription in buffer") }
+        XCTAssertNil(QueueStore.current())
+    }
+
+    func testSubscriptionWithApiKeyGoesToQueueStore() {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.enqueueSubscription(payload: subscriptionPayload())
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        XCTAssertEqual(QueueStore.current()?.count, 1)
+        guard case .createSubscription = QueueStore.current()?.requests.first?.endpoint else {
+            return XCTFail("expected .createSubscription endpoint in QueueStore")
+        }
+    }
+
+    func testDrainMapsSubscriptionToCreateSubscriptionEndpoint() {
+        RequestEnqueuer.enqueueSubscription(payload: subscriptionPayload())
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "pk-1"))
+        RequestEnqueuer.drainBuffer(apiKey: "pk-1")
+
+        XCTAssertEqual(UnattributedBuffer.shared.snapshot().count, 0)
+        guard case let .createSubscription(apiKey, _) =
+            QueueStore.current()?.requests.first?.endpoint
+        else {
+            return XCTFail("expected .createSubscription endpoint after drain")
+        }
+        XCTAssertEqual(apiKey, "pk-1", "apiKey is stamped at drain")
+    }
+
     // MARK: - enqueueTrackingLinkClicked
 
     func testTrackingLinkClickWithoutApiKeyGoesToBuffer() {

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -210,7 +210,11 @@ final class UnattributedBufferTests: XCTestCase {
                     trackingLink: URL(string: "https://klaviyo.com/tracking/abc")!,
                     clickTime: Date(timeIntervalSince1970: 1_234_567_890),
                     profileInfo: ProfilePayload(anonymousId: "anon-1")
-                )
+                ),
+                .subscription(CreateSubscriptionPayload(
+                    listId: "list-1",
+                    profile: ProfilePayload(email: "a@b.com", anonymousId: "anon-1")
+                ))
             ]
         )
 

--- a/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
+++ b/Tests/KlaviyoCoreTests/UnattributedBufferTests.swift
@@ -190,7 +190,7 @@ final class UnattributedBufferTests: XCTestCase {
         XCTAssertEqual(buffer.snapshot(), [token("2")])
     }
 
-    func testPersistedBufferRoundTripsAllFourCases() throws {
+    func testPersistedBufferRoundTripsAllCases() throws {
         let eventPayload = CreateEventPayload(
             data: CreateEventPayload.Event(name: "Test", anonymousId: "anon-1"))
         let profilePayload = CreateProfilePayload(
@@ -205,7 +205,12 @@ final class UnattributedBufferTests: XCTestCase {
                 .event(eventPayload, .high),
                 agg("agg"),
                 .profile(profilePayload),
-                .pushToken(tokenPayload)
+                .pushToken(tokenPayload),
+                .trackingLinkClick(
+                    trackingLink: URL(string: "https://klaviyo.com/tracking/abc")!,
+                    clickTime: Date(timeIntervalSince1970: 1_234_567_890),
+                    profileInfo: ProfilePayload(anonymousId: "anon-1")
+                )
             ]
         )
 

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -19,6 +19,7 @@ final class ResolveTrackingLinkTests: XCTestCase {
     override func setUpWithError() throws {
         environment = KlaviyoEnvironment.test()
         resetCanonicalCoreStores()
+        UnattributedBuffer.shared.reset()
         klaviyoSwiftEnvironment = KlaviyoSwiftEnvironment.test()
         DeepLinkManager.resetToProduction()
         readQueue = seedTestQueueStore(apiKey: TEST_API_KEY)
@@ -164,6 +165,31 @@ final class ResolveTrackingLinkTests: XCTestCase {
             readQueue(), [request],
             "failed tracking-link resolution enqueues a log request"
         )
+    }
+
+    @MainActor
+    func testPreInitTrackingLinkResolutionFailedBuffers() async throws {
+        // Pre-init (no apiKey in SDKConfigStore): a failed tracking-link resolution must park its
+        // click-log in the durable buffer instead of dropping it via the apiKey-gated
+        // `state.enqueueRequest` (MAGE-1136).
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+        let clickTime = environment.date()
+        let trackingLinkURL = try XCTUnwrap(URL(string: "https://email.klaviyo.com/tracking/link"))
+
+        await store.send(
+            .trackingLinkResolutionFailed(trackingLink: trackingLinkURL, clickTime: clickTime)
+        )
+
+        let (buffered, _) = UnattributedBuffer.shared.drainSnapshot()
+        XCTAssertEqual(buffered.count, 1, "pre-init tracking-link click is buffered, not dropped")
+        guard case let .trackingLinkClick(link, time, _) = buffered.first else {
+            return XCTFail("expected a buffered .trackingLinkClick")
+        }
+        XCTAssertEqual(link, trackingLinkURL)
+        XCTAssertEqual(time, clickTime)
     }
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
@@ -322,6 +322,59 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         XCTAssertEqual(readQueue(), [request])
     }
 
+    @MainActor
+    func testPreInitResetProfileClearsPersistedIdentity() async throws {
+        // Pre-init reset must clear the persisted identity (drop PII, mint a fresh anon) so a reset
+        // issued before initialize() doesn't leave the prior profile in IdentityStore (MAGE-1136).
+        IdentityStore.shared.update(
+            ProfileData(email: "user@email.com", externalId: "ext-123", anonymousId: "anon-old")
+        )
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+
+        _ = await store.send(.resetProfile)
+
+        let identity = IdentityStore.shared.current
+        XCTAssertNil(identity.email, "pre-init reset clears persisted email")
+        XCTAssertNil(identity.externalId, "pre-init reset clears persisted externalId")
+        XCTAssertNotNil(identity.anonymousId)
+        XCTAssertNotEqual(
+            identity.anonymousId, "anon-old", "pre-init reset mints a fresh anonymousId"
+        )
+    }
+
+    @MainActor
+    func testPreInitResetProfileRebuffersPersistedPushToken() async throws {
+        // Parity with post-init reset(preserveTokenData: true): a persisted push token is
+        // re-registered against the freshly minted anon. Pre-init that register routes through the
+        // ungated RequestEnqueuer and lands in the durable buffer (MAGE-1136).
+        IdentityStore.shared.update(ProfileData(email: "user@email.com", anonymousId: "anon-old"))
+        IdentityStore.shared.updatePushToken(
+            PushTokenData(
+                pushToken: "tok-1", pushEnablement: .authorized, pushBackground: .available,
+                deviceData: DeviceMetadata(context: environment.appContextInfo())
+            )
+        )
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+
+        _ = await store.send(.resetProfile)
+
+        let (buffered, _) = UnattributedBuffer.shared.drainSnapshot()
+        let hasTokenRegister = buffered.contains {
+            if case .pushToken = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(
+            hasTokenRegister,
+            "persisted push token is re-registered into the buffer after a pre-init reset"
+        )
+    }
+
     // MARK: - Helpers
 
     /// Builds a fully-initialized, identified `KlaviyoState` for tests that differ only in identifiers.

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -767,12 +767,19 @@ class StateManagementTests: StateManagementTestCase {
         XCTAssertEqual(buffered.count, 1, "pre-init event is buffered, not dropped or queued")
     }
 
+    /// Drives the pre-init → drain-on-init flow shared by the buffered event, aggregate-event, and
+    /// subscription tests (MAGE-1136): buffers a request via `bufferPreInit`, initializes the SDK,
+    /// then asserts the QueueStore persisted `expectedRequest` and the buffer was trimmed.
     @MainActor
-    func testPreInitBufferedEventDrainsIntoQueueOnInit() async throws {
+    private func assertPreInitBufferDrainsIntoQueueOnInit(
+        bufferPreInit: () -> Void,
+        expectedRequest: () throws -> KlaviyoRequest
+    ) async throws {
         resetCanonicalCoreStores()
         UnattributedBuffer.shared.reset()
-        // Buffer an event pre-init (no apiKey known yet).
-        RequestEnqueuer.enqueueEvent(.test)
+
+        // Buffer a request pre-init (no apiKey known yet).
+        bufferPreInit()
         XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
 
         // Record every request the QueueStore ever persists, so the assertion is robust against the
@@ -791,28 +798,38 @@ class StateManagementTests: StateManagementTestCase {
             timeout: TIMEOUT_NANOSECONDS
         )
 
-        let expectedRequest = try KlaviyoRequest(
-            endpoint: .createEvent(
-                TEST_API_KEY,
-                CreateEventPayload(
-                    data: CreateEventPayload.Event(
-                        name: Event.test.metric.name.value,
-                        properties: Event.test.properties,
-                        anonymousId: environment.uuid().uuidString,
-                        time: Event.test.time
-                    )
-                )
-            )
-        )
-        // drainBuffer (run inside .initialize) enqueued the buffered event into the QueueStore for
+        // drainBuffer (run inside .initialize) enqueued the buffered request into the QueueStore for
         // this apiKey (it was persisted at some point), and trimmed the buffer.
+        let request = try expectedRequest()
         XCTAssertTrue(
-            recorded().contains(expectedRequest),
-            "buffered event was drained into the QueueStore at init"
+            recorded().contains(request),
+            "buffered request was drained into the QueueStore at init"
         )
         XCTAssertTrue(
             UnattributedBuffer.shared.drainSnapshot().requests.isEmpty,
             "buffer is trimmed after draining into the queue"
+        )
+    }
+
+    @MainActor
+    func testPreInitBufferedEventDrainsIntoQueueOnInit() async throws {
+        try await assertPreInitBufferDrainsIntoQueueOnInit(
+            bufferPreInit: { RequestEnqueuer.enqueueEvent(.test) },
+            expectedRequest: {
+                try KlaviyoRequest(
+                    endpoint: .createEvent(
+                        TEST_API_KEY,
+                        CreateEventPayload(
+                            data: CreateEventPayload.Event(
+                                name: Event.test.metric.name.value,
+                                properties: Event.test.properties,
+                                anonymousId: environment.uuid().uuidString,
+                                time: Event.test.time
+                            )
+                        )
+                    )
+                )
+            }
         )
     }
 
@@ -835,37 +852,15 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testPreInitAggregateEventDrainsIntoQueueOnInit() async throws {
-        resetCanonicalCoreStores()
-        UnattributedBuffer.shared.reset()
-
         let data = Data()
-        // Buffer an aggregate event pre-init (no apiKey known yet).
-        RequestEnqueuer.enqueueAggregateEvent(data)
-        XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
-
-        // Record every persisted request (robust against the post-init flush lease/dequeue).
-        let recorded = registerRecordingQueueStore(apiKey: TEST_API_KEY)
-
-        let store = TestStore(
-            initialState: KlaviyoState(requestsInFlight: []),
-            reducer: KlaviyoReducer()
+        try await assertPreInitBufferDrainsIntoQueueOnInit(
+            bufferPreInit: { RequestEnqueuer.enqueueAggregateEvent(data) },
+            expectedRequest: {
+                try KlaviyoRequest(
+                    endpoint: .aggregateEvent(TEST_API_KEY, AggregateEventPayload(data))
+                )
+            }
         )
-        store.exhaustivity = .off
-
-        await store.send(.initialize(TEST_API_KEY))
-        await store.receive(
-            .completeInitialization(KlaviyoState(requestsInFlight: [])),
-            timeout: TIMEOUT_NANOSECONDS
-        )
-
-        let request = try KlaviyoRequest(
-            endpoint: .aggregateEvent(TEST_API_KEY, AggregateEventPayload(data))
-        )
-        XCTAssertTrue(
-            recorded().contains(request),
-            "buffered aggregate event drained into the QueueStore at init"
-        )
-        XCTAssertTrue(UnattributedBuffer.shared.drainSnapshot().requests.isEmpty)
     }
 
     @MainActor
@@ -1056,34 +1051,16 @@ class StateManagementTests: StateManagementTestCase {
     func testPreInitSubscriptionDrainsIntoQueueOnInit() async throws {
         // Restores the pre-MAGE-952 "pending subscription replays on init" coverage: a subscribe
         // buffered before initialize() drains into the QueueStore when the SDK initializes (MAGE-1136).
-        resetCanonicalCoreStores()
-        UnattributedBuffer.shared.reset()
-
         let payload = CreateSubscriptionPayload(
             listId: "list-123",
             profile: ProfilePayload(email: "test@example.com", anonymousId: "anon-1")
         )
-        RequestEnqueuer.enqueueSubscription(payload: payload)
-        XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
-
-        let recorded = registerRecordingQueueStore(apiKey: TEST_API_KEY)
-        let store = TestStore(
-            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        try await assertPreInitBufferDrainsIntoQueueOnInit(
+            bufferPreInit: { RequestEnqueuer.enqueueSubscription(payload: payload) },
+            expectedRequest: {
+                KlaviyoRequest(endpoint: .createSubscription(TEST_API_KEY, payload))
+            }
         )
-        store.exhaustivity = .off
-
-        await store.send(.initialize(TEST_API_KEY))
-        await store.receive(
-            .completeInitialization(KlaviyoState(requestsInFlight: [])),
-            timeout: TIMEOUT_NANOSECONDS
-        )
-
-        let request = KlaviyoRequest(endpoint: .createSubscription(TEST_API_KEY, payload))
-        XCTAssertTrue(
-            recorded().contains(request),
-            "buffered subscription drained into the QueueStore at init"
-        )
-        XCTAssertTrue(UnattributedBuffer.shared.drainSnapshot().requests.isEmpty)
     }
 
     @MainActor

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -1028,20 +1028,62 @@ class StateManagementTests: StateManagementTestCase {
     }
 
     @MainActor
-    func testEnqueueSubscriptionUninitializedWarnsAndDoesNotEnqueue() async throws {
-        let initialState = INITILIZING_TEST_STATE()
-        let apiKey = try XCTUnwrap(initialState.apiKey)
-        let readQueue = seedTestQueueStore(apiKey: apiKey)
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+    func testEnqueueSubscriptionUninitializedBuffers() async throws {
+        // Pre-init: a subscribe carrying an identifier buffers its apiKey-free payload in the durable
+        // UnattributedBuffer (drains into the QueueStore at initialize()) instead of the pre-MAGE-1136
+        // warn + drop. Mirrors the initialized path against the canonical persisted identity.
+        IdentityStore.shared.update(ProfileData(email: "test@example.com", anonymousId: "anon-1"))
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
         store.exhaustivity = .off
 
-        let warningExpectation = expectSubscriptionWarning(containing: "initialize")
-
         await store.send(.enqueueSubscription(Subscription.allAvailableMarketing(listId: "list-123")))
-        await fulfillment(of: [warningExpectation], timeout: 1.0)
-        XCTAssertTrue(readQueue().isEmpty, "nothing should be enqueued before initialization")
-        XCTAssertTrue(UnattributedBuffer.shared.drainSnapshot().requests.isEmpty,
-                      "nothing should be buffered for pre-init subscriptions")
+
+        let (buffered, _) = UnattributedBuffer.shared.drainSnapshot()
+        XCTAssertEqual(buffered.count, 1, "pre-init subscription is buffered, not dropped")
+        guard case let .subscription(payload) = buffered.first else {
+            return XCTFail("expected a buffered .subscription")
+        }
+        XCTAssertEqual(payload.data.relationships.list.data.id, "list-123")
+        XCTAssertEqual(
+            payload.data.attributes.profile.data.attributes.email, "test@example.com",
+            "the persisted identity is folded into the buffered subscription payload"
+        )
+    }
+
+    @MainActor
+    func testPreInitSubscriptionDrainsIntoQueueOnInit() async throws {
+        // Restores the pre-MAGE-952 "pending subscription replays on init" coverage: a subscribe
+        // buffered before initialize() drains into the QueueStore when the SDK initializes (MAGE-1136).
+        resetCanonicalCoreStores()
+        UnattributedBuffer.shared.reset()
+
+        let payload = CreateSubscriptionPayload(
+            listId: "list-123",
+            profile: ProfilePayload(email: "test@example.com", anonymousId: "anon-1")
+        )
+        RequestEnqueuer.enqueueSubscription(payload: payload)
+        XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
+
+        let recorded = registerRecordingQueueStore(apiKey: TEST_API_KEY)
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+
+        await store.send(.initialize(TEST_API_KEY))
+        await store.receive(
+            .completeInitialization(KlaviyoState(requestsInFlight: [])),
+            timeout: TIMEOUT_NANOSECONDS
+        )
+
+        let request = KlaviyoRequest(endpoint: .createSubscription(TEST_API_KEY, payload))
+        XCTAssertTrue(
+            recorded().contains(request),
+            "buffered subscription drained into the QueueStore at init"
+        )
+        XCTAssertTrue(UnattributedBuffer.shared.drainSnapshot().requests.isEmpty)
     }
 
     @MainActor


### PR DESCRIPTION
# Description
Restores pre-init durability for the three KlaviyoSwift-routed intents that MAGE-952 left dropped when it removed the in-memory `pendingRequests` machinery: subscriptions, tracking-link click logs, and `resetProfile`. Each now survives a call made before `initialize()`.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview
All three fixes are additive and reuse the existing apiKey-free Model-1 buffer pattern (payload buffered pre-init, apiKey stamped into the endpoint at drain). No changes to `UnattributedBuffer`'s FIFO/cap/coalesce/drain internals.

**1. Tracking-link clicks** (`ac05e085`)
- New `UnattributedRequest.trackingLinkClick` case + `RequestEnqueuer.enqueueTrackingLinkClicked`. The `logTrackingLinkClicked` endpoint is already apiKey-free, so the drain wraps the buffered values directly.
- The reducer's `trackingLinkResolutionFailed` now routes pre-init through `RequestEnqueuer` (identity resolved from the canonical `IdentityStore`) instead of the apiKey-gated `state.enqueueRequest` that silently dropped it. Post-init behavior unchanged.

**2. Subscriptions** (`e90d0dea`)
- `CreateSubscriptionPayload` is already a Core type and is built without an apiKey, so a pre-init subscribe fits Model-1 with **no KlaviyoSwift seam**. Split `buildSubscriptionRequest` into an apiKey-free `buildSubscriptionPayload`; added `UnattributedRequest.subscription` + `RequestEnqueuer.enqueueSubscription` + drain case.
- Reducer `enqueueSubscription` pre-init branch seeds identity from `IdentityStore`, builds the payload, and buffers it. Removes the `warn + drop` and the `MAGE-952 follow-up` TODO.

**3. Pre-init `resetProfile`** (`0a51a3ca`) — no Core changes
- Previously no-oped until initialized, so a reset issued before `completeInitialization` left the prior profile persisted in `IdentityStore`. Now parity with post-init: seed identity, reset (mint fresh anon, drop PII), write the cleared identity through to `IdentityStore` synchronously, and re-register any persisted push token against the new anon via `RequestEnqueuer`.
- The already-buffered old-identity profile still drains at `initialize()` — intended, matching how a post-init queued profile still flushes after a reset.

## Test Plan
`xcodebuild test` on iPhone 17 Pro sim — full `KlaviyoCoreTests` + `KlaviyoSwiftTests` green (335 KlaviyoSwift tests, 0 failures). New/updated coverage:
- `RequestEnqueuerTests` / `UnattributedBufferTests`: routing (buffer vs QueueStore), drain endpoint mapping, and persistence round-trip for both new cases.
- `ResolveTrackingLinkTests`: pre-init failed resolution buffers instead of dropping (post-init unchanged).
- `StateManagementTests`: pre-init subscribe buffers the payload; pending-subscription-replays-on-init restored.
- `StateManagementEnqueueEdgeCaseTests`: pre-init reset clears persisted identity + mints a fresh anon; persisted push token re-registered into the buffer.

## Related Issues/Tickets
Resolves MAGE-1136

Stacked on #707 (`gb/mage-1137-push-token-dedup`) — retarget to the active `rel/*` (or `master` once #707 lands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subscriptions and tracking-link clicks can now be queued before SDK initialization or API-key availability.
  - Buffered requests are automatically processed after initialization while preserving relevant identity and profile information.
  - Pre-initialization profile resets now persist the updated anonymous identity and re-register push tokens.

- **Bug Fixes**
  - Prevented subscriptions and tracking-link clicks from being dropped when initialization or identity resolution has not completed.
  - Improved handling of buffered requests so they retain their associated tracking links, subscription details, and identity data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->