### PR TITLE
ci: quote PR number and repo in pr-target-check

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -25,13 +25,13 @@ jobs:
           # If PR doesn't target master, this check doesn't apply — clean up any stale label and pass
           if [[ "$BASE_REF" != "master" ]]; then
             echo "PR targets '$BASE_REF' (not master) — check not required."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
           if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]] || [[ "$HEAD_REF" == dependabot/* ]]; then
             echo "Branch '$HEAD_REF' is allowed to target master."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -41,7 +41,7 @@ jobs:
           TITLE_REGEX='^(ci|chore|docs|rel)(\([^)]*\))?!?:[[:space:]]'
           if [[ "$TITLE_LC" =~ $TITLE_REGEX ]]; then
             echo "PR title '$PR_TITLE' has an allowed conventional-commit prefix — allowed to target master."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -51,7 +51,7 @@ jobs:
 
           if [ -n "$HAS_OVERRIDE" ]; then
             echo "manual-merge label present — bypassing check. This PR will merge directly to master without a release branch."
-            gh pr edit $PR_NUMBER --repo $REPO --remove-label "$LABEL" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
             exit 0
           fi
 
@@ -79,7 +79,7 @@ jobs:
           _Enforced by the \`pr-target-check\` workflow._"
           fi
 
-          gh pr edit $PR_NUMBER --repo $REPO --add-label "$LABEL"
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
 
           echo "Branch '$HEAD_REF' cannot target master directly. Use a rel/*, ci/*, docs/*, or dependabot/* branch, a ci:/chore:/docs:/rel: PR title, or add the manual-merge label to override."
           exit 1


### PR DESCRIPTION
# Description

Quotes `$PR_NUMBER` and `$REPO` in the `pr-target-check` workflow's `gh pr edit` calls, matching `klaviyo-android-sdk`. Noticed while copying this workflow into the three hybrid repos — android's copy had the quoting, this one didn't.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — CI-only change, ships no SDK code.
- [x] I have added sufficient unit/integration tests of my changes.
  - N/A — a GitHub Actions workflow isn't unit-testable. Validation notes under Test Plan.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
  - N/A
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - N/A — no platform code.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - Repo tooling only; nothing ships to consumers.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Drive-by hardening spun out of the hybrid-repo parity work; no ticket.

## Changelog / Code Overview

Five lines, all in `.github/workflows/pr-target-check.yml` — `gh pr edit $PR_NUMBER --repo $REPO` becomes `gh pr edit "$PR_NUMBER" --repo "$REPO"`. No logic change.

Why it's worth doing: unquoted interpolation is subject to word splitting, and the four `--remove-label` calls swallow their own failure via `2>/dev/null || true` — so a malformed invocation fails silently rather than surfacing. The values come from `github.event` and are well-formed in practice, which is why this hasn't bitten us; the fix is cheap insurance.

After this, all four repos running `pr-target-check` have a byte-identical copy of the file.

## Test Plan

- `diff` against `klaviyo-android-sdk`'s copy: identical after the change
- YAML parses; the embedded shell script passes `bash -n`
- the repo's `pre-commit` gate passes on the changed file (Check Yaml, Fix End of Files, Trim Trailing Whitespace)
- This PR does not exercise the changed lines: it's titled `ci:`, so it takes an early-exit path. The label-writing call only runs on a PR that fails the check — see the sibling PRs for that path.

## Related Issues/Tickets

- Spun out of the hybrid-repo parity work: MAGE-1188 (Flutter), MAGE-1189 (React Native), MAGE-1190 (Expo)
- Original workflow: klaviyo/klaviyo-swift-sdk#631 · android port: klaviyo/klaviyo-android-sdk#447

🔗 [View this job in Reca Studio](https://kiosk.klaviyo-dev.com/remote-coding-agent/flow/e7954c3b-654a-4787-83b8-988a77e7846c)
🤖 Generated with Reca


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating release-branch labels on pull requests by ensuring pull request numbers are handled consistently.
  * Branch and title validation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->