### PR TITLE
fix(KlaviyoSwift): rebind push token on company switch (MAGE-953)

### DIFF
--- a/Sources/KlaviyoCore/Networking/RequestFactory.swift
+++ b/Sources/KlaviyoCore/Networking/RequestFactory.swift
@@ -153,7 +153,8 @@ public enum RequestFactory {
 
     public static func unregisterRequest(
         identity: RequestIdentity,
-        pushToken: String
+        pushToken: String,
+        priority: RequestPriority = .standard
     ) -> KlaviyoRequest {
         let payload = UnregisterPushTokenPayload(
             pushToken: pushToken,
@@ -162,7 +163,7 @@ public enum RequestFactory {
             externalId: identity.externalId,
             anonymousId: identity.anonymousId
         )
-        return KlaviyoRequest(endpoint: .unregisterPushToken(identity.apiKey, payload))
+        return KlaviyoRequest(endpoint: .unregisterPushToken(identity.apiKey, payload), priority: priority)
     }
 
     /// Builds a `PushTokenPayload` with a caller-supplied `ProfilePayload`.

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -206,11 +206,11 @@ struct KlaviyoReducer: ReducerProtocol {
                 }
                 // NOTE: do NOT clear the push token here — the switch must preserve it so the
                 // token can be re-registered under the new company immediately below.
-                if previous.email != nil || previous.phoneNumber != nil || previous.externalId != nil {
-                    // Identified profile: mint a fresh anon and drop PII so `.completeInitialization`
-                    // hydrates a clean identity for the new company.
-                    IdentityStore.shared.update(ProfileData(anonymousId: IdentityStore.shared.mintNewAnonymousId()))
-                }
+                // Give the new company a clean identity: mint a fresh anon and drop any PII so
+                // `.completeInitialization` hydrates it. Unconditional (matches the runtime switch
+                // path's `state.reset()`) so an anonymous-only switch does not carry the old
+                // company's anon into the new one.
+                IdentityStore.shared.update(ProfileData(anonymousId: IdentityStore.shared.mintNewAnonymousId()))
                 // Re-register the preserved token under the new company (identity-only, fresh anon).
                 if let tokenData = IdentityStore.shared.pushToken,
                    let newAnon = IdentityStore.shared.current.anonymousId {

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -166,7 +166,8 @@ struct KlaviyoReducer: ReducerProtocol {
                 guard apiKey != state.apiKey else {
                     return .none
                 }
-                // Since we are moving the token to a new company lets remove the token from the old company first.
+                // Moving the token to a new company: unregister from the old one. Appended (not
+                // front-inserted) so it sends after any already-queued old-company requests.
                 if let apiKey = state.apiKey,
                    let anonymousId = state.anonymousId,
                    let tokenData = state.pushTokenData {
@@ -178,6 +179,7 @@ struct KlaviyoReducer: ReducerProtocol {
                 }
                 state.apiKey = apiKey
                 state.reset()
+                return .task { .flushQueue }
             } else if case .uninitialized = state.initalizationState,
                       let previousApiKey = SDKConfigStore.shared.current.apiKey,
                       previousApiKey != apiKey {
@@ -198,15 +200,30 @@ struct KlaviyoReducer: ReducerProtocol {
                         ),
                         pushToken: tokenData.pushToken
                     )
-                    // Persist synchronously before the wipe below so the unregister survives a
-                    // crash between cold-start company switch and the first flush.
+                    // Appended so it sends after any queued old-company requests; persisted
+                    // synchronously so it survives a crash before the first flush.
                     QueueStore.shared.enqueue(request, persist: .synchronous)
                 }
-                IdentityStore.shared.updatePushToken(nil)
+                // NOTE: do NOT clear the push token here — the switch must preserve it so the
+                // token can be re-registered under the new company immediately below.
                 if previous.email != nil || previous.phoneNumber != nil || previous.externalId != nil {
                     // Identified profile: mint a fresh anon and drop PII so `.completeInitialization`
                     // hydrates a clean identity for the new company.
                     IdentityStore.shared.update(ProfileData(anonymousId: IdentityStore.shared.mintNewAnonymousId()))
+                }
+                // Re-register the preserved token under the new company (identity-only, fresh anon).
+                if let tokenData = IdentityStore.shared.pushToken,
+                   let newAnon = IdentityStore.shared.current.anonymousId {
+                    let request = RequestFactory.tokenRequest(
+                        apiKey: apiKey,
+                        pushToken: tokenData.pushToken,
+                        enablement: tokenData.pushEnablement,
+                        background: tokenData.pushBackground.rawValue,
+                        profile: ProfilePayload(
+                            email: nil, phoneNumber: nil, externalId: nil, anonymousId: newAnon
+                        )
+                    )
+                    QueueStore.shared.enqueue(request)
                 }
             }
             guard case .uninitialized = state.initalizationState else {

--- a/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestFactoryTests.swift
@@ -126,4 +126,15 @@ final class RequestFactoryTests: XCTestCase {
         XCTAssertEqual(payload.data.attributes.backgroundStatus, PushBackground.available.rawValue)
         XCTAssertEqual(payload.data.attributes.profile.data, profile)
     }
+
+    func testUnregisterRequestThreadsPriority() {
+        let identity = RequestIdentity(apiKey: "pk-1", anonymousId: "anon-1")
+        XCTAssertEqual(
+            RequestFactory.unregisterRequest(identity: identity, pushToken: "tok").priority, .standard
+        )
+        XCTAssertEqual(
+            RequestFactory.unregisterRequest(identity: identity, pushToken: "tok", priority: .high).priority,
+            .high
+        )
+    }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -56,6 +56,8 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         _ = await store.send(.initialize(newApiKey)) {
             $0.apiKey = newApiKey
         }
+        // Company switch prompts an immediate flush so the unregister drains promptly.
+        await store.receive(.flushQueue)
         let unregister = mutableState.buildUnregisterRequest(
             apiKey: oldApiKey, anonymousId: store.state.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken
@@ -69,6 +71,157 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         // the token-register (enqueued after the apiKey switch).
         XCTAssertEqual(readQueue(), [unregister, tokenRequest],
                        "both the unregister and register land in the single shared queue")
+        XCTAssertEqual(readQueue().first?.priority, .standard,
+                       "unregister is appended at standard priority, not front-inserted")
+    }
+
+    /// Regression guard: an already-queued old-company register must be sent before the switch
+    /// unregister (i.e. the unregister is appended, not front-inserted).
+    @MainActor
+    func testRuntimeCompanySwitchAppendsUnregisterAfterQueuedOldCompanyRequests() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        let oldApiKey = initialState.apiKey!
+        let newApiKey = "new-api-key"
+        // A register for the OLD company already sitting in the queue (e.g. a token/identity update
+        // waiting for the next flush window).
+        let leftoverRegister = initialState.buildTokenRequest(
+            apiKey: oldApiKey, anonymousId: initialState.anonymousId!,
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement
+        )
+        let readQueue = seedTestQueueStore(initial: [leftoverRegister])
+
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+        _ = await store.send(.initialize(newApiKey)) { $0.apiKey = newApiKey }
+        await store.receive(.flushQueue)
+
+        // Expected order: leftover old-company register → unregister(old) → new-company register.
+        let endpoints = readQueue().map(\.endpoint)
+        XCTAssertEqual(endpoints.count, 3)
+        guard endpoints.count == 3 else { return }
+        guard case let .registerPushToken(key0, _) = endpoints[0], key0 == oldApiKey else {
+            return XCTFail("leftover old-company register must stay first, got \(endpoints[0])")
+        }
+        guard case let .unregisterPushToken(key1, _) = endpoints[1], key1 == oldApiKey else {
+            return XCTFail("unregister must be appended AFTER the leftover register, got \(endpoints[1])")
+        }
+        guard case let .registerPushToken(key2, _) = endpoints[2], key2 == newApiKey else {
+            return XCTFail("new-company register must be last, got \(endpoints[2])")
+        }
+    }
+
+    @MainActor
+    func testColdStartCompanySwitchPreservesAndReregistersToken() async throws {
+        resetCanonicalCoreStores()
+        QueueStore.resetShared()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "old-key"))
+        IdentityStore.shared.update(
+            ProfileData(email: "a@x.com", externalId: "user-A", anonymousId: "anon-A"))
+        let token = PushTokenData(
+            pushToken: "tok-1",
+            pushEnablement: .authorized,
+            pushBackground: .available,
+            deviceData: DeviceMetadata(context: environment.appContextInfo())
+        )
+        IdentityStore.shared.updatePushToken(token)
+        let readQueue = registerRecordingQueueStore()
+
+        let store = TestStore(initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+        await store.send(.initialize("new-key"))
+        await store.receive(
+            .completeInitialization(KlaviyoState(requestsInFlight: [])),
+            timeout: TIMEOUT_NANOSECONDS
+        )
+
+        // Token PRESERVED (regression: today it is cleared).
+        XCTAssertEqual(IdentityStore.shared.pushToken?.pushToken, "tok-1")
+        let endpoints = readQueue().map(\.endpoint)
+        XCTAssertTrue(
+            endpoints.contains { if case .unregisterPushToken = $0 { return true } else { return false } },
+            "old-company unregister enqueued"
+        )
+        XCTAssertTrue(
+            endpoints.contains { if case .registerPushToken = $0 { return true } else { return false } },
+            "token re-registered under the new company"
+        )
+    }
+
+    // MARK: - Company switch without push token
+
+    @MainActor
+    func testRuntimeCompanySwitchWithNoTokenEnqueuesNoTokenRequests() async throws {
+        // An initialized state with NO push token: switching to a new key must not enqueue
+        // an unregister (nothing to unregister) nor a register (no token to register with).
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.pushTokenData = nil
+        let oldApiKey = initialState.apiKey!
+        let newApiKey = "new-api-key-no-token"
+        let readQueue = seedTestQueueStore()
+
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.initialize(newApiKey)) {
+            $0.apiKey = newApiKey
+        }
+
+        let endpoints = readQueue().map(\.endpoint)
+        XCTAssertFalse(
+            endpoints.contains {
+                if case .unregisterPushToken = $0 { return true } else { return false }
+            },
+            "no unregister enqueued when there is no push token"
+        )
+        XCTAssertFalse(
+            endpoints.contains {
+                if case .registerPushToken = $0 { return true } else { return false }
+            },
+            "no register enqueued when there is no push token"
+        )
+    }
+
+    @MainActor
+    func testColdStartCompanySwitchWithNoTokenEnqueuesNoTokenRequests() async throws {
+        // Cold-start company switch: when IdentityStore has no push token, the reducer must
+        // not enqueue an unregister for the old company or a register for the new one.
+        resetCanonicalCoreStores()
+        QueueStore.resetShared()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "old-key"))
+        IdentityStore.shared.update(
+            ProfileData(email: "b@x.com", externalId: "user-B", anonymousId: "anon-B"))
+        // Intentionally: no IdentityStore.shared.updatePushToken call — pushToken stays nil.
+        let readQueue = registerRecordingQueueStore()
+
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []),
+            reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+        await store.send(.initialize("new-key-no-token"))
+        await store.receive(
+            .completeInitialization(KlaviyoState(requestsInFlight: [])),
+            timeout: TIMEOUT_NANOSECONDS
+        )
+
+        XCTAssertEqual(
+            SDKConfigStore.shared.current.apiKey, "new-key-no-token",
+            "apiKey switches to the new company"
+        )
+        let endpoints = readQueue().map(\.endpoint)
+        XCTAssertFalse(
+            endpoints.contains {
+                if case .unregisterPushToken = $0 { return true } else { return false }
+            },
+            "no unregister enqueued when there is no push token"
+        )
+        XCTAssertFalse(
+            endpoints.contains {
+                if case .registerPushToken = $0 { return true } else { return false }
+            },
+            "no register enqueued when there is no push token"
+        )
     }
 
     // MARK: - Send Request

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -11,6 +11,33 @@ import Foundation
 import XCTest
 
 class StateManagementEdgeCaseTests: StateManagementTestCase {
+    private typealias CompanySwitchStore = TestStore<
+        KlaviyoState, KlaviyoAction, KlaviyoState, KlaviyoAction, Void
+    >
+
+    /// Shared cold-start company-switch fixture: resets the canonical Core stores, seeds an
+    /// old-company config + identified profile (and optionally a push token), registers a
+    /// recording queue, and returns the queue reader plus a fresh non-exhaustive `TestStore`.
+    @MainActor
+    private func makeColdStartCompanySwitchFixture(
+        pushToken: PushTokenData? = nil
+    ) -> (readQueue: () -> [KlaviyoRequest], store: CompanySwitchStore) {
+        resetCanonicalCoreStores()
+        QueueStore.resetShared()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "old-key"))
+        IdentityStore.shared.update(
+            ProfileData(email: "a@x.com", externalId: "user-A", anonymousId: "anon-A"))
+        if let pushToken {
+            IdentityStore.shared.updatePushToken(pushToken)
+        }
+        let readQueue = registerRecordingQueueStore()
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+        return (readQueue, store)
+    }
+
     // MARK: - initialization
 
     @MainActor
@@ -113,22 +140,13 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testColdStartCompanySwitchPreservesAndReregistersToken() async throws {
-        resetCanonicalCoreStores()
-        QueueStore.resetShared()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "old-key"))
-        IdentityStore.shared.update(
-            ProfileData(email: "a@x.com", externalId: "user-A", anonymousId: "anon-A"))
         let token = PushTokenData(
             pushToken: "tok-1",
             pushEnablement: .authorized,
             pushBackground: .available,
             deviceData: DeviceMetadata(context: environment.appContextInfo())
         )
-        IdentityStore.shared.updatePushToken(token)
-        let readQueue = registerRecordingQueueStore()
-
-        let store = TestStore(initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer())
-        store.exhaustivity = .off
+        let (readQueue, store) = makeColdStartCompanySwitchFixture(pushToken: token)
         await store.send(.initialize("new-key"))
         await store.receive(
             .completeInitialization(KlaviyoState(requestsInFlight: [])),
@@ -186,19 +204,8 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
     func testColdStartCompanySwitchWithNoTokenEnqueuesNoTokenRequests() async throws {
         // Cold-start company switch: when IdentityStore has no push token, the reducer must
         // not enqueue an unregister for the old company or a register for the new one.
-        resetCanonicalCoreStores()
-        QueueStore.resetShared()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "old-key"))
-        IdentityStore.shared.update(
-            ProfileData(email: "b@x.com", externalId: "user-B", anonymousId: "anon-B"))
-        // Intentionally: no IdentityStore.shared.updatePushToken call — pushToken stays nil.
-        let readQueue = registerRecordingQueueStore()
-
-        let store = TestStore(
-            initialState: KlaviyoState(requestsInFlight: []),
-            reducer: KlaviyoReducer()
-        )
-        store.exhaustivity = .off
+        // No push token passed — pushToken stays nil.
+        let (readQueue, store) = makeColdStartCompanySwitchFixture()
         await store.send(.initialize("new-key-no-token"))
         await store.receive(
             .completeInitialization(KlaviyoState(requestsInFlight: [])),


### PR DESCRIPTION
# Description

On a company (apiKey) switch, promptly move the device push token off the old company and re-register it under the new one — on the single consolidated queue (MAGE-1192). Fixes the cold-start bug where the token was cleared and never re-registered (MAGE-953).

**Rebased onto `feat/modularization-2`** now that MAGE-1192 (#719) has merged, so the diff is just the MAGE-953 changes.

## Why / approach

Identity and apiKey keep flowing through the `KlaviyoState` projection + the write-through `defer`; the only genuinely-new behavior is on the queue. The full "move the switch off `state`" is deferred to MAGE-904 (which deletes the reducer).

Each request self-tags its apiKey, so the single-queue flush delivers unregister → old company and re-register → new company.

## Ordering (Cursor Bugbot fix)

The switch unregister is **appended at standard priority, not front-inserted**. The flush is strictly sequential FIFO, so front-inserting (`.high`) would send the unregister first and any old-company register still queued second — re-binding the token to the old company right after we removed it. Appending places the unregister after all old-company requests, so the final order is `register(old) → unregister(old) → register(new)` and the token ends up only on the new company. Promptness comes from `return .task { .flushQueue }`, not from priority — the two are independent. This restores master's ordering (master also appended) while adding the prompt flush.

## Changelog / Code Overview

- **Runtime switch** (`.initialize` while `.initialized`): old-company unregister is appended (standard priority); `state.reset()` re-registers the token to the new key; the block returns `.task { .flushQueue }` for a prompt flush.
- **Cold-start switch** (`.initialize` while `.uninitialized`, stored apiKey differs): the token is now **preserved** (removed the `updatePushToken(nil)` clear); the unregister is appended + persisted synchronously; a re-register of the preserved token under the new company (new anon, identity-only) is enqueued after the identity reset.
- `RequestFactory.unregisterRequest` gains an additive `priority: RequestPriority = .standard` parameter (backwards-compatible).

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release. (iOS modularization line.)

## Test Plan

`StateManagementEdgeCaseTests`:
- `testInitializeAfterInitialized` — runtime switch: unregister + register land in the queue in order; `.flushQueue` received; unregister is appended at `.standard` priority.
- `testRuntimeCompanySwitchAppendsUnregisterAfterQueuedOldCompanyRequests` — regression guard: with an old-company register pre-seeded, the final order is `[register(old), unregister(old), register(new)]`.
- `testColdStartCompanySwitchPreservesAndReregistersToken` — cold-start: token preserved (regression), unregister + re-register enqueued.
- `testRuntimeCompanySwitchWithNoTokenEnqueuesNoTokenRequests` / `testColdStartCompanySwitchWithNoTokenEnqueuesNoTokenRequests` — no token → no unregister/register; config/identity still switch.
- `RequestFactoryTests.testUnregisterRequestThreadsPriority`.

Full suite: KlaviyoSwiftTests + KlaviyoCoreTests green.

## Related Issues/Tickets

- [MAGE-953](https://linear.app/klaviyo/issue/MAGE-953)
- Builds on [MAGE-1192](https://linear.app/klaviyo/issue/MAGE-1192) (#719, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved company switching by flushing queued requests immediately when appropriate.
  - Preserved push tokens during cold-start company switches and re-registered them for the new company.
  - Ensured previous-company unregister requests are queued reliably without losing existing token data.
  - Applied standard priority to unregister requests by default while preserving explicitly assigned priorities.
  - Improved request ordering during company transitions for more reliable registration and unregistration processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->