### PR TITLE
feat(analytics): per-request token-bucket flush governor (MAGE-791 PoC)

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
+++ b/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
@@ -190,16 +190,17 @@ struct FlushGovernor: Equatable {
         lastRefill = nil
     }
 
-    /// Marks the bucket as frozen from `currentTime` onward, so the time spent offline accrues
-    /// nothing once connectivity returns.
+    /// Restarts accrual from `currentTime`, discarding any time the device spent offline.
     ///
-    /// This must be driven by the connectivity change itself. The freeze branch in
-    /// `refill(currentTime:flushInterval:)` cannot carry it alone: `canSend` refills a throwaway
-    /// copy, and `.sendRequest` is unreachable while offline because `.flushQueue` returns at its
-    /// `flushInterval.isFinite` guard first. Without this call nothing advances `lastRefill` during
-    /// an outage, and the first reading after reconnect would compute elapsed time across the whole
-    /// offline stretch and grant a full burst.
-    mutating func freezeForOffline(currentTime: Date) {
+    /// This must be driven by the **reconnect** edge of the connectivity change. Stamping at the
+    /// start of an outage is not enough: nothing advances `lastRefill` while offline (`canSend`
+    /// refills a throwaway copy, and `.sendRequest` is unreachable because `.flushQueue` returns at
+    /// its `flushInterval.isFinite` guard first), so the first refill after reconnect would treat
+    /// the entire offline stretch as elapsed connected time and fill the bucket to capacity — the
+    /// windfall the freeze exists to prevent.
+    ///
+    /// Only ever moves the timestamp forward, so a backward clock jump cannot manufacture accrual.
+    mutating func resumeAfterOffline(currentTime: Date) {
         if let last = lastRefill {
             if currentTime > last { lastRefill = currentTime }
         } else {

--- a/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
+++ b/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
@@ -1,0 +1,158 @@
+//
+//  FlushGovernor.swift
+//
+//  Demand-adaptive flush governor: a token bucket that paces outbound API
+//  requests instead of flush cycles.
+//
+//  Copyright (c) 2026 Klaviyo
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+import Foundation
+
+/// Tunables for the flush governor.
+///
+/// The refill rate is expressed in **requests per second**, not flushes per second. This is the
+/// central design point: a single flush drains the whole queue one HTTP request at a time (see
+/// `.sendRequest` / `.deQueueCompletedResults`), so pacing flush *cycles* places no bound at all on
+/// the request rate. Pacing requests does.
+enum FlushGovernorConstants {
+    /// Burst allowance, in requests. Tokens accrue while the app is idle up to this ceiling, so a
+    /// burst of activity after a quiet stretch is sent immediately rather than waiting for the next
+    /// flush tick. This is the knob that buys post-idle responsiveness.
+    static let burstCapacity = 20.0
+
+    /// Sustained ceiling on wifi, in requests/second. Well above ordinary app traffic (a handful of
+    /// events per minute) and well below a pathological storm, so normal usage never touches the
+    /// governor while a runaway loop is bounded.
+    static let wifiRefillPerSecond = 2.0
+
+    /// Sustained ceiling on cellular, in requests/second. Lower than wifi for radio/battery cost,
+    /// mirroring the existing tiered flush intervals.
+    static let cellularRefillPerSecond = 1.0
+}
+
+/// A token bucket that paces outbound requests.
+///
+/// One token is spent per HTTP request. Tokens accrue continuously at `refillPerSecond` up to
+/// `capacity`. Because the bucket banks idle time, it absorbs bursts without raising the long-run
+/// average, which is what "demand-adaptive" means here: cadence follows demand over time rather
+/// than a fixed timer.
+///
+/// Refill is computed lazily from elapsed wall-clock time rather than driven by a timer, so the
+/// bucket costs nothing while the app is quiet and needs no scheduling of its own.
+struct FlushGovernor: Equatable {
+    /// Available tokens. Fractional between refills; may go negative when a prioritized request
+    /// overdraws the bucket (see `debitForPrioritizedRequest()`).
+    private(set) var tokens: Double
+
+    /// Timestamp of the last refill computation. `nil` until the first request is considered.
+    private(set) var lastRefill: Date?
+
+    let capacity: Double
+
+    init(
+        capacity: Double = FlushGovernorConstants.burstCapacity,
+        tokens: Double? = nil,
+        lastRefill: Date? = nil
+    ) {
+        self.capacity = capacity
+        // Start full: a cold launch should never be throttled, and the first send goes immediately.
+        self.tokens = tokens ?? capacity
+        self.lastRefill = lastRefill
+    }
+
+    /// Requests/second for the current network tier. Returns `nil` when offline, which freezes the
+    /// bucket — no accrual while we cannot send, so reconnecting does not hand out a windfall
+    /// proportional to time spent offline.
+    ///
+    /// Derived from `flushInterval` so the governor subsumes the existing network tiering rather
+    /// than competing with it.
+    static func refillPerSecond(forFlushInterval flushInterval: Double) -> Double? {
+        guard flushInterval.isFinite, flushInterval > 0 else { return nil }
+        return flushInterval <= StateManagementConstants.wifiFlushInterval
+            ? FlushGovernorConstants.wifiRefillPerSecond
+            : FlushGovernorConstants.cellularRefillPerSecond
+    }
+
+    /// Accrues tokens for time elapsed since the last refill, capped at `capacity`.
+    ///
+    /// A backward clock jump (manual change, NTP correction) must never rewind `lastRefill`,
+    /// otherwise a later reading against the stale timestamp would compute an inflated elapsed
+    /// interval and grant a windfall. The timestamp therefore only ever moves forward.
+    mutating func refill(currentTime: Date, flushInterval: Double) {
+        guard let rate = Self.refillPerSecond(forFlushInterval: flushInterval) else {
+            // Offline: freeze. Still advance the clock so the offline stretch accrues nothing once
+            // connectivity returns.
+            if let last = lastRefill, currentTime > last {
+                lastRefill = currentTime
+            } else if lastRefill == nil {
+                lastRefill = currentTime
+            }
+            return
+        }
+
+        defer {
+            if let last = lastRefill {
+                if currentTime > last { lastRefill = currentTime }
+            } else {
+                lastRefill = currentTime
+            }
+        }
+
+        guard let last = lastRefill else { return }
+        let elapsed = currentTime.timeIntervalSince(last)
+        guard elapsed > 0 else { return }
+        tokens = min(capacity, tokens + elapsed * rate)
+    }
+
+    /// Whether a request may be sent right now, without consuming anything.
+    ///
+    /// Used by the enqueue path to decide whether to flush immediately, so a doomed early flush is
+    /// never scheduled.
+    func canSend(currentTime: Date, flushInterval: Double) -> Bool {
+        var copy = self
+        copy.refill(currentTime: currentTime, flushInterval: flushInterval)
+        return copy.tokens >= 1.0
+    }
+
+    /// Refills, then spends one token if available.
+    ///
+    /// - Returns: `true` when the caller may send. `false` means the bucket is dry and the caller
+    ///   should leave the request queued; the next flush tick retries it.
+    mutating func consume(currentTime: Date, flushInterval: Double) -> Bool {
+        refill(currentTime: currentTime, flushInterval: flushInterval)
+        guard tokens >= 1.0 else { return false }
+        tokens -= 1.0
+        return true
+    }
+
+    /// Spends a token for a prioritized request (opened-push, geofence) that is exempt from the
+    /// gate, allowing the balance to go negative.
+    ///
+    /// Engagement events must never be delayed, but they are still real load on the backend, so
+    /// they are debited rather than waved through for free. Overdrawing simply means ordinary
+    /// traffic waits slightly longer afterwards, which keeps the long-run ceiling honest — a
+    /// meaningful difference from bypassing the bucket entirely.
+    mutating func debitForPrioritizedRequest(currentTime: Date, flushInterval: Double) {
+        refill(currentTime: currentTime, flushInterval: flushInterval)
+        tokens -= 1.0
+    }
+
+    /// Seconds until at least one token is available, or `nil` if the bucket is frozen (offline) and
+    /// will never refill on its own. Reported for diagnostics and to size test expectations.
+    func timeUntilNextToken(flushInterval: Double) -> Double? {
+        if tokens >= 1.0 { return 0 }
+        guard let rate = Self.refillPerSecond(forFlushInterval: flushInterval), rate > 0 else {
+            return nil
+        }
+        return (1.0 - tokens) / rate
+    }
+
+    /// Restores the bucket to a cold-launch state. Called when the API key changes so one company's
+    /// traffic cannot throttle the next.
+    mutating func reset() {
+        tokens = capacity
+        lastRefill = nil
+    }
+}

--- a/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
+++ b/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
@@ -53,6 +53,19 @@ enum FlushGovernorConstants {
     static let cellularRefillPerSecond = 5.0
 }
 
+extension Array {
+    /// Splits the array into the elements matching `predicate` and those that don't, preserving
+    /// relative order within each group.
+    func partitioned(by predicate: (Element) -> Bool) -> (matching: [Element], rest: [Element]) {
+        var matching: [Element] = []
+        var rest: [Element] = []
+        for element in self {
+            if predicate(element) { matching.append(element) } else { rest.append(element) }
+        }
+        return (matching, rest)
+    }
+}
+
 /// A token bucket that paces outbound requests.
 ///
 /// One token is spent per HTTP request. Tokens accrue continuously at `refillPerSecond` up to
@@ -175,5 +188,22 @@ struct FlushGovernor: Equatable {
     mutating func reset() {
         tokens = capacity
         lastRefill = nil
+    }
+
+    /// Marks the bucket as frozen from `currentTime` onward, so the time spent offline accrues
+    /// nothing once connectivity returns.
+    ///
+    /// This must be driven by the connectivity change itself. The freeze branch in
+    /// `refill(currentTime:flushInterval:)` cannot carry it alone: `canSend` refills a throwaway
+    /// copy, and `.sendRequest` is unreachable while offline because `.flushQueue` returns at its
+    /// `flushInterval.isFinite` guard first. Without this call nothing advances `lastRefill` during
+    /// an outage, and the first reading after reconnect would compute elapsed time across the whole
+    /// offline stretch and grant a full burst.
+    mutating func freezeForOffline(currentTime: Date) {
+        if let last = lastRefill {
+            if currentTime > last { lastRefill = currentTime }
+        } else {
+            lastRefill = currentTime
+        }
     }
 }

--- a/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
+++ b/Sources/KlaviyoSwift/StateManagement/FlushGovernor.swift
@@ -16,20 +16,41 @@ import Foundation
 /// central design point: a single flush drains the whole queue one HTTP request at a time (see
 /// `.sendRequest` / `.deQueueCompletedResults`), so pacing flush *cycles* places no bound at all on
 /// the request rate. Pacing requests does.
+/// Sized against the documented client-endpoint rate limits:
+///
+/// | Endpoint | Burst | Steady | Scope |
+/// | --- | --- | --- | --- |
+/// | `POST /client/events` | 350/sec | 3,500/min | account |
+/// | `POST /client/profiles` | 350/sec | 3,500/min | account |
+/// | `POST /client/push-tokens` | 150/sec | 1,400/min | per IP/device |
+///
+/// The per-device push-token limit is the binding constraint, since the event and profile limits
+/// are account-wide and a single device is only ever a small fraction of an account's traffic. The
+/// device budget works out to ~23 requests/second sustained (1,400/min).
+///
+/// Values below hold one device to roughly 40% of that budget, leaving headroom for the several
+/// apps or app instances that can share an IP, and for the account-level limits that this governor
+/// cannot see from a single device.
 enum FlushGovernorConstants {
     /// Burst allowance, in requests. Tokens accrue while the app is idle up to this ceiling, so a
     /// burst of activity after a quiet stretch is sent immediately rather than waiting for the next
     /// flush tick. This is the knob that buys post-idle responsiveness.
-    static let burstCapacity = 20.0
+    ///
+    /// At 50, the opening 10-second window admits `50 + 10*10 = 150` requests — exactly the
+    /// documented per-second burst allowance, so even a full bucket draining at once stays inside
+    /// it while still absorbing a substantial burst instantly.
+    static let burstCapacity = 50.0
 
-    /// Sustained ceiling on wifi, in requests/second. Well above ordinary app traffic (a handful of
-    /// events per minute) and well below a pathological storm, so normal usage never touches the
-    /// governor while a runaway loop is bounded.
-    static let wifiRefillPerSecond = 2.0
+    /// Sustained ceiling on wifi, in requests/second: 600/min, ~43% of the per-device budget.
+    ///
+    /// This is far above ordinary traffic (a handful of events per minute), so normal usage never
+    /// reaches the governor, while a runaway loop is still held to a predictable share of the
+    /// device's allowance instead of being bounded only by network round-trip time.
+    static let wifiRefillPerSecond = 10.0
 
-    /// Sustained ceiling on cellular, in requests/second. Lower than wifi for radio/battery cost,
-    /// mirroring the existing tiered flush intervals.
-    static let cellularRefillPerSecond = 1.0
+    /// Sustained ceiling on cellular, in requests/second: 300/min. Half the wifi rate, for radio
+    /// and battery cost, mirroring the existing tiered flush intervals.
+    static let cellularRefillPerSecond = 5.0
 }
 
 /// A token bucket that paces outbound requests.

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -80,6 +80,15 @@ struct KlaviyoState: Equatable, Codable {
     var flushInterval = StateManagementConstants.wifiFlushInterval
     var retryState = RetryState.retry(StateManagementConstants.initialAttempt)
     var pendingRequests: [PendingRequest] = []
+
+    /// Paces outbound requests (see `FlushGovernor`). Transient — excluded from `CodingKeys` — so
+    /// the bucket starts full on every launch and a cold start is never throttled.
+    var flushGovernor = FlushGovernor()
+
+    /// Ids of queued requests that must never be delayed by the governor (opened-push, geofence).
+    /// These bypass the gate and are debited instead, so they stay instant without escaping the
+    /// long-run ceiling. Transient, and entries are removed as requests complete.
+    var prioritizedRequestIds: Set<String> = []
     var pendingProfile: [Profile.ProfileKey: AnyEncodable]?
 
     enum CodingKeys: CodingKey {

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -498,18 +498,20 @@ struct KlaviyoReducer: ReducerProtocol {
             switch networkStatus {
             case .notReachable:
                 state.flushInterval = Double.infinity
-                // Freeze the bucket now. Nothing else advances `lastRefill` while offline, so
-                // without this the first send after reconnect would accrue tokens for the entire
-                // outage. See `freezeForOffline(currentTime:)`.
-                state.flushGovernor.freezeForOffline(currentTime: environment.date())
                 return EffectPublisher.cancel(ids: [RequestId.self, FlushTimer.self])
                     .concatenate(with: .run { send in
                         await send(.cancelInFlightRequests)
                     })
             case .reachableViaWiFi:
                 state.flushInterval = StateManagementConstants.wifiFlushInterval
+                // Restart accrual from the moment connectivity returns, so the outage itself
+                // grants nothing. This has to happen on the *reconnect* edge: nothing advances
+                // `lastRefill` while offline, so without it the first refill would treat the whole
+                // offline stretch as elapsed connected time and fill the bucket to capacity.
+                state.flushGovernor.resumeAfterOffline(currentTime: environment.date())
             case .reachableViaWWAN:
                 state.flushInterval = StateManagementConstants.cellularFlushInterval
+                state.flushGovernor.resumeAfterOffline(currentTime: environment.date())
             }
             return environment.timer(state.flushInterval)
                 .map { _ in

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -574,9 +574,14 @@ struct KlaviyoReducer: ReducerProtocol {
             // the first event of a burst leave immediately. Under sustained load the bucket is dry,
             // `canSend` is false, and we fall back to the timer — so this cannot become a storm.
             //
+            // Skipped while a flush is already in progress: `.flushQueue` would no-op on its
+            // `flushing` guard anyway, and dispatching one action per enqueued event during a
+            // burst is pure overhead. Events that arrive mid-drain wait for the next timer tick,
+            // which is no worse than today's behavior.
+            //
             // Prioritized engagement events always flush; the governor debits them afterwards
             // rather than gating them, so they stay instant without escaping the ceiling.
-            let governorAllowsSend = state.flushGovernor.canSend(
+            let governorAllowsSend = !state.flushing && state.flushGovernor.canSend(
                 currentTime: environment.date(),
                 flushInterval: state.flushInterval
             )
@@ -601,9 +606,9 @@ struct KlaviyoReducer: ReducerProtocol {
 
             state.enqueueRequest(request: request)
 
-            // Same burst behavior as `.enqueueEvent`: send now if the governor has a token,
-            // otherwise fall back to the timer.
-            return state.flushGovernor.canSend(
+            // Same burst behavior as `.enqueueEvent`: send now if the governor has a token and no
+            // flush is already draining, otherwise fall back to the timer.
+            return !state.flushing && state.flushGovernor.canSend(
                 currentTime: environment.date(),
                 flushInterval: state.flushInterval
             ) ? EffectTask<KlaviyoAction>.task { .flushQueue } : .none

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -176,6 +176,10 @@ struct KlaviyoReducer: ReducerProtocol {
                 }
                 state.apiKey = apiKey
                 state.reset()
+                // Restore cold-launch pacing so the previous company's traffic cannot throttle the
+                // incoming one, and clear stale exemptions along with it.
+                state.flushGovernor.reset()
+                state.prioritizedRequestIds.removeAll()
             }
             guard case .uninitialized = state.initalizationState else {
                 return .none
@@ -390,6 +394,9 @@ struct KlaviyoReducer: ReducerProtocol {
             state.requestsInFlight.removeAll { inflightRequest in
                 completedRequest.id == inflightRequest.id
             }
+            // Stop tracking the prioritized exemption once the request leaves the queue, so the set
+            // cannot grow without bound over a long session.
+            state.prioritizedRequestIds.remove(completedRequest.id)
             state.retryState = RetryState.retry(StateManagementConstants.initialAttempt)
             if state.requestsInFlight.isEmpty {
                 state.flushing = false
@@ -409,6 +416,33 @@ struct KlaviyoReducer: ReducerProtocol {
                 state.flushing = false
                 return .none
             }
+
+            // Pace the send. This is the governor's single gate, and it sits here — per request —
+            // rather than on `.flushQueue`, because one flush drains the whole queue one request at
+            // a time (see `.deQueueCompletedResults` below). Gating the flush cycle would let a
+            // single token authorize an unbounded number of requests; gating here is what actually
+            // bounds the request rate.
+            //
+            // Prioritized engagement events skip the gate and are debited instead, so they are
+            // never delayed but still count against the ceiling.
+            if state.prioritizedRequestIds.contains(request.id) {
+                state.flushGovernor.debitForPrioritizedRequest(
+                    currentTime: environment.date(),
+                    flushInterval: state.flushInterval
+                )
+            } else if !state.flushGovernor.consume(
+                currentTime: environment.date(),
+                flushInterval: state.flushInterval
+            ) {
+                // Bucket is dry: stop draining and leave the remainder queued. `flushing` is
+                // cleared so a later tick can pick the queue back up; the timer publisher is
+                // already running, so no extra scheduling is needed.
+                state.flushing = false
+                state.queue.insert(contentsOf: state.requestsInFlight, at: 0)
+                state.requestsInFlight = []
+                return .none
+            }
+
             let retryState = state.retryState
             var numAttempts = 1
             if case let .retry(attempts) = retryState {
@@ -530,11 +564,25 @@ struct KlaviyoReducer: ReducerProtocol {
             let shouldPrioritize = event.metric.name == ._openedPush || event.metric.isGeofenceEvent
             if shouldPrioritize {
                 state.enqueuePriorityRequest(request: request)
+                state.prioritizedRequestIds.insert(request.id)
             } else {
                 state.enqueueRequest(request: request)
             }
 
-            let baseEffect = shouldPrioritize ? EffectTask<KlaviyoAction>.task { .flushQueue } : .none
+            // Flush as soon as the governor has a token, rather than waiting out the interval.
+            // This is where post-idle latency goes away: tokens banked during a quiet stretch let
+            // the first event of a burst leave immediately. Under sustained load the bucket is dry,
+            // `canSend` is false, and we fall back to the timer — so this cannot become a storm.
+            //
+            // Prioritized engagement events always flush; the governor debits them afterwards
+            // rather than gating them, so they stay instant without escaping the ceiling.
+            let governorAllowsSend = state.flushGovernor.canSend(
+                currentTime: environment.date(),
+                flushInterval: state.flushInterval
+            )
+            let baseEffect = (shouldPrioritize || governorAllowsSend)
+                ? EffectTask<KlaviyoAction>.task { .flushQueue }
+                : .none
             return .merge([
                 baseEffect,
                 .fireAndForget { enrichAndPublishEvent(event) }
@@ -553,7 +601,12 @@ struct KlaviyoReducer: ReducerProtocol {
 
             state.enqueueRequest(request: request)
 
-            return .none
+            // Same burst behavior as `.enqueueEvent`: send now if the governor has a token,
+            // otherwise fall back to the timer.
+            return state.flushGovernor.canSend(
+                currentTime: environment.date(),
+                flushInterval: state.flushInterval
+            ) ? EffectTask<KlaviyoAction>.task { .flushQueue } : .none
 
         case let .enqueueProfile(profile):
             guard case .initialized = state.initalizationState

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -502,16 +502,24 @@ struct KlaviyoReducer: ReducerProtocol {
                     .concatenate(with: .run { send in
                         await send(.cancelInFlightRequests)
                     })
-            case .reachableViaWiFi:
-                state.flushInterval = StateManagementConstants.wifiFlushInterval
-                // Restart accrual from the moment connectivity returns, so the outage itself
-                // grants nothing. This has to happen on the *reconnect* edge: nothing advances
-                // `lastRefill` while offline, so without it the first refill would treat the whole
-                // offline stretch as elapsed connected time and fill the bucket to capacity.
-                state.flushGovernor.resumeAfterOffline(currentTime: environment.date())
-            case .reachableViaWWAN:
-                state.flushInterval = StateManagementConstants.cellularFlushInterval
-                state.flushGovernor.resumeAfterOffline(currentTime: environment.date())
+            case .reachableViaWiFi, .reachableViaWWAN:
+                // Restart accrual only when we are genuinely coming back from offline. Reachability
+                // re-emits a reachable status on wifi<->cellular switches, flag flaps and every
+                // foreground, and stamping `lastRefill` on those would silently discard banked idle
+                // accrual — losing the post-idle burst this governor exists to provide.
+                //
+                // The stamp has to be on this edge rather than `.notReachable`: nothing advances
+                // `lastRefill` while offline, so without it the first refill after an outage would
+                // treat the whole offline stretch as elapsed connected time and fill the bucket.
+                let wasOffline = !state.flushInterval.isFinite
+
+                state.flushInterval = networkStatus == .reachableViaWiFi
+                    ? StateManagementConstants.wifiFlushInterval
+                    : StateManagementConstants.cellularFlushInterval
+
+                if wasOffline {
+                    state.flushGovernor.resumeAfterOffline(currentTime: environment.date())
+                }
             }
             return environment.timer(state.flushInterval)
                 .map { _ in

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -437,9 +437,19 @@ struct KlaviyoReducer: ReducerProtocol {
                 // Bucket is dry: stop draining and leave the remainder queued. `flushing` is
                 // cleared so a later tick can pick the queue back up; the timer publisher is
                 // already running, so no extra scheduling is needed.
+                //
+                // Prioritized requests keep their place at the front. A blind
+                // `insert(at: 0)` would bury an opened-push or geofence request that arrived
+                // mid-drain behind the returning regulars, and it would then be gated with them
+                // instead of sent immediately.
                 state.flushing = false
-                state.queue.insert(contentsOf: state.requestsInFlight, at: 0)
+                let returning = state.requestsInFlight
                 state.requestsInFlight = []
+                let (returningPrioritized, returningRegular) = returning
+                    .partitioned(by: { state.prioritizedRequestIds.contains($0.id) })
+                let (queuedPrioritized, queuedRegular) = state.queue
+                    .partitioned(by: { state.prioritizedRequestIds.contains($0.id) })
+                state.queue = returningPrioritized + queuedPrioritized + returningRegular + queuedRegular
                 return .none
             }
 
@@ -488,6 +498,10 @@ struct KlaviyoReducer: ReducerProtocol {
             switch networkStatus {
             case .notReachable:
                 state.flushInterval = Double.infinity
+                // Freeze the bucket now. Nothing else advances `lastRefill` while offline, so
+                // without this the first send after reconnect would accrue tokens for the entire
+                // outage. See `freezeForOffline(currentTime:)`.
+                state.flushGovernor.freezeForOffline(currentTime: environment.date())
                 return EffectPublisher.cancel(ids: [RequestId.self, FlushTimer.self])
                     .concatenate(with: .run { send in
                         await send(.cancelInFlightRequests)
@@ -579,9 +593,16 @@ struct KlaviyoReducer: ReducerProtocol {
             // burst is pure overhead. Events that arrive mid-drain wait for the next timer tick,
             // which is no worse than today's behavior.
             //
+            // Also skipped during a server-mandated backoff. `.flushQueue` decrements
+            // `retryWithBackoff` by a full `flushInterval` on every call, so dispatching one per
+            // enqueued event would let a handful of events exhaust a `Retry-After` window and
+            // retry early. Only the timer may advance that countdown.
+            //
             // Prioritized engagement events always flush; the governor debits them afterwards
             // rather than gating them, so they stay instant without escaping the ceiling.
-            let governorAllowsSend = !state.flushing && state.flushGovernor.canSend(
+            let inBackoff: Bool
+            if case .retryWithBackoff = state.retryState { inBackoff = true } else { inBackoff = false }
+            let governorAllowsSend = !state.flushing && !inBackoff && state.flushGovernor.canSend(
                 currentTime: environment.date(),
                 flushInterval: state.flushInterval
             )
@@ -606,9 +627,12 @@ struct KlaviyoReducer: ReducerProtocol {
 
             state.enqueueRequest(request: request)
 
-            // Same burst behavior as `.enqueueEvent`: send now if the governor has a token and no
-            // flush is already draining, otherwise fall back to the timer.
-            return !state.flushing && state.flushGovernor.canSend(
+            // Same burst behavior as `.enqueueEvent`: send now if the governor has a token, no
+            // flush is already draining, and no server-mandated backoff is active (see the note
+            // on `.enqueueEvent`); otherwise fall back to the timer.
+            let aggregateInBackoff: Bool
+            if case .retryWithBackoff = state.retryState { aggregateInBackoff = true } else { aggregateInBackoff = false }
+            return !state.flushing && !aggregateInBackoff && state.flushGovernor.canSend(
                 currentTime: environment.date(),
                 flushInterval: state.flushInterval
             ) ? EffectTask<KlaviyoAction>.task { .flushQueue } : .none

--- a/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
+++ b/Tests/KlaviyoSwiftTests/APIRequestErrorHandlingTests.swift
@@ -30,7 +30,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
         // Use 400 (client error) which should dequeue without retry
         environment.klaviyoAPI.send = { _, _ in .failure(.httpError(400, TEST_RETURN_DATA)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request)) {
             $0.flushing = false
@@ -47,7 +49,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.httpError(400, TEST_FAILURE_JSON_INVALID_PHONE_NUMBER.data(using: .utf8)!)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.resetStateAndDequeue(request, [InvalidField.phone]), timeout: TIMEOUT_NANOSECONDS) {
             $0.phoneNumber = nil
@@ -70,7 +74,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.httpError(400, TEST_FAILURE_JSON_INVALID_EMAIL.data(using: .utf8)!)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.resetStateAndDequeue(request, [InvalidField.email]), timeout: TIMEOUT_NANOSECONDS) {
             $0.email = nil
@@ -93,7 +99,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.httpError(400, TEST_FAILURE_JSON_INVALID_PHONE_NUMBER_DIFFERENT_SOURCE_POINTER.data(using: .utf8)!)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.resetStateAndDequeue(request, [InvalidField.phone]), timeout: TIMEOUT_NANOSECONDS) {
             $0.phoneNumber = nil
@@ -119,7 +127,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         environment.klaviyoAPI.send = { _, _ in .success(Data()) }
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.requestsInFlight = []
             $0.flushing = false
@@ -142,7 +152,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.networkError(NSError(domain: "foo", code: NSURLErrorCancelled))) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retry(2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -163,7 +175,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.networkError(NSError(domain: "foo", code: NSURLErrorCancelled))) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retry(2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -187,7 +201,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.networkError(NSError(domain: "foo", code: NSURLErrorCancelled))) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retry(maxRetries + 1)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -210,7 +226,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.internalError("internal error!")) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -232,7 +250,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.internalRequestError(KlaviyoAPIError.internalError("foo"))) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -254,7 +274,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.unknownError(KlaviyoAPIError.internalError("foo"))) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -275,7 +297,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.dataEncodingError(request)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -296,7 +320,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.invalidData) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -317,7 +343,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.rateLimitError(backOff: 30)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 30)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -337,7 +365,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.rateLimitError(backOff: 30)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: 30)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -357,7 +387,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.rateLimitError(backOff: 20)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 4, totalRetryCount: 4, currentBackoff: 20)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -379,7 +411,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.missingOrInvalidResponse(nil)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -400,7 +434,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 500, backOff: 2)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -419,7 +455,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 502, backOff: 2)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -438,7 +476,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 503, backOff: 2)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -457,7 +497,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 504, backOff: 2)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -477,7 +519,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
         // 501 is in the retryable 5xx range (see KlaviyoAPITests.testNotImplemented501IsRetriedAsServerError)
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 501, backOff: 2)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 2)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -497,7 +541,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
 
         environment.klaviyoAPI.send = { _, _ in .failure(.serverError(statusCode: 502, backOff: 4)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.requestFailed(request, .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 4)), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false
@@ -517,7 +563,9 @@ class APIRequestErrorHandlingTests: XCTestCase {
         // 404 should dequeue without retry (client error, not server error)
         environment.klaviyoAPI.send = { _, _ in .failure(.httpError(404, TEST_RETURN_DATA)) }
 
-        _ = await store.send(.sendRequest)
+        _ = await store.send(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request), timeout: TIMEOUT_NANOSECONDS) {
             $0.flushing = false

--- a/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
+++ b/Tests/KlaviyoSwiftTests/AttemptNumberTests.swift
@@ -26,6 +26,7 @@ final class AttemptNumberTests: XCTestCase {
         store.exhaustivity = .off // We only care about the sendRequest action.
 
         // Trigger sendRequest which should invoke our mock API.
+        // Exhaustivity is off above, so the governor mutation needs no expectation here.
         await store.send(.sendRequest)
 
         XCTAssertEqual(capturedAttempt, 1, "The first request should have an attempt number of 1")

--- a/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
+++ b/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
@@ -36,8 +36,10 @@ final class FlushGovernorTests: XCTestCase {
         var governor = FlushGovernor(capacity: 2, tokens: 0, lastRefill: t0)
         XCTAssertFalse(governor.consume(currentTime: t0, flushInterval: wifi))
 
-        // wifi refills at 2 req/s, so half a second buys exactly one token.
-        let later = t0.addingTimeInterval(0.5)
+        // Derive the wait from the configured rate so retuning the constants cannot silently
+        // invalidate this test.
+        let oneTokenWait = 1.0 / FlushGovernorConstants.wifiRefillPerSecond
+        let later = t0.addingTimeInterval(oneTokenWait)
         XCTAssertTrue(governor.consume(currentTime: later, flushInterval: wifi))
     }
 
@@ -55,9 +57,16 @@ final class FlushGovernorTests: XCTestCase {
         onWifi.refill(currentTime: after10s, flushInterval: wifi)
         onCell.refill(currentTime: after10s, flushInterval: cell)
 
-        XCTAssertEqual(onWifi.tokens, 20, accuracy: 0.0001) // 2/s * 10s, capped
-        XCTAssertEqual(onCell.tokens, 10, accuracy: 0.0001) // 1/s * 10s
-        XCTAssertGreaterThan(onWifi.tokens, onCell.tokens)
+        let expectedWifi = min(20.0, FlushGovernorConstants.wifiRefillPerSecond * 10)
+        let expectedCell = min(20.0, FlushGovernorConstants.cellularRefillPerSecond * 10)
+        XCTAssertEqual(onWifi.tokens, expectedWifi, accuracy: 0.0001)
+        XCTAssertEqual(onCell.tokens, expectedCell, accuracy: 0.0001)
+        // The tier relationship is the invariant worth pinning: cellular must never accrue
+        // faster than wifi.
+        XCTAssertLessThanOrEqual(
+            FlushGovernorConstants.cellularRefillPerSecond,
+            FlushGovernorConstants.wifiRefillPerSecond
+        )
     }
 
     func test_bucketIsFrozenWhileOfflineSoReconnectGrantsNoWindfall() {
@@ -76,7 +85,11 @@ final class FlushGovernorTests: XCTestCase {
 
         // A real (forward) reading one second on should yield one second of accrual, not 301s.
         governor.refill(currentTime: t0.addingTimeInterval(1), flushInterval: wifi)
-        XCTAssertEqual(governor.tokens, 2, accuracy: 0.0001)
+        XCTAssertEqual(
+            governor.tokens,
+            FlushGovernorConstants.wifiRefillPerSecond,
+            accuracy: 0.0001
+        )
     }
 
     func test_prioritizedRequestIsDebitedAndMayOverdraw() {
@@ -96,8 +109,16 @@ final class FlushGovernorTests: XCTestCase {
 
     func test_timeUntilNextTokenTracksTier() {
         let drained = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
-        XCTAssertEqual(drained.timeUntilNextToken(flushInterval: wifi) ?? -1, 0.5, accuracy: 0.0001)
-        XCTAssertEqual(drained.timeUntilNextToken(flushInterval: cell) ?? -1, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            drained.timeUntilNextToken(flushInterval: wifi) ?? -1,
+            1.0 / FlushGovernorConstants.wifiRefillPerSecond,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            drained.timeUntilNextToken(flushInterval: cell) ?? -1,
+            1.0 / FlushGovernorConstants.cellularRefillPerSecond,
+            accuracy: 0.0001
+        )
         XCTAssertNil(drained.timeUntilNextToken(flushInterval: .infinity))
     }
 }
@@ -310,23 +331,30 @@ final class FlushGovernorSimulationTests: XCTestCase {
 
     // MARK: Scenario 4 — fewer 429s against a real rate limit
 
-    func test_sustainedStorm_againstRateLimit_governorAvoids429s() {
+    func test_sustainedStorm_againstRealPushTokenLimit_neitherIsRateLimited() {
         let arrivals = stride(from: 0.05, through: 30.0, by: 0.05).map { $0 }
-        // Backend admits 30 requests / 10s.
-        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true, serverLimit: 30)
-        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false, serverLimit: 30)
-        report("4 - storm vs 30 req/10s limit",
+        // The real binding constraint: POST /client/push-tokens allows 150 req/sec burst and
+        // 1,400/min steady, applied per IP/device. Expressed in the 10s window the model uses,
+        // the steady budget is ~233 requests.
+        let pushTokenBudgetPer10s = 233
+        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true,
+                                serverLimit: pushTokenBudgetPer10s)
+        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false,
+                              serverLimit: pushTokenBudgetPer10s)
+        report("4 - storm vs real per-device budget (233 req/10s)",
                [("governor", governor), ("legacy", legacy)])
 
-        // This is the claim PR #622 could not substantiate for iOS, and it does hold once the gate
-        // is per-request: pacing cuts 429s by roughly an order of magnitude.
-        XCTAssertLessThan(governor.rateLimited, legacy.rateLimited)
-
-        // Not zero, and that is a genuine tuning finding rather than a bug. `burstCapacity` (20)
-        // plus 2 req/s means the opening 10s window can admit ~40 requests against a 30/10s limit,
-        // so the initial burst overshoots before pacing takes hold. Sizing the burst allowance to
-        // the real backend limit is exactly the open question this PoC exists to expose; it needs
-        // the actual server-side numbers to settle.
-        XCTAssertLessThanOrEqual(governor.rateLimited, legacy.rateLimited / 5)
+        // The honest result once real limits are used: a single device does not breach the
+        // per-device push-token budget even without a governor, because the queue is capped at 200
+        // and requests drain serially. So there are no 429s to prevent here.
+        //
+        // This is worth stating plainly: the "fewer 429s" argument for a client-side ceiling does
+        // not survive contact with the documented limits. The governor's defensible benefit is
+        // post-idle burst latency (scenario 1) plus a predictable share of the device budget
+        // (scenario 3), not 429 avoidance.
+        XCTAssertEqual(legacy.rateLimited, 0)
+        XCTAssertEqual(governor.rateLimited, 0)
+        XCTAssertEqual(governor.delivered, arrivals.count)
+        XCTAssertEqual(legacy.delivered, arrivals.count)
     }
 }

--- a/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
+++ b/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
@@ -77,6 +77,37 @@ final class FlushGovernorTests: XCTestCase {
         XCTAssertNil(FlushGovernor.refillPerSecond(forFlushInterval: .infinity))
     }
 
+    /// The offline freeze has to be driven by the connectivity change, because nothing on the send
+    /// path reaches it while offline: `canSend` refills a copy and `.sendRequest` is unreachable.
+    /// This exercises `freezeForOffline` and then a real post-reconnect refill, which is what the
+    /// production sequence actually does.
+    func test_freezeForOffline_thenReconnect_accruesOnlyPostReconnectTime() {
+        var governor = FlushGovernor(capacity: 50, tokens: 0, lastRefill: t0)
+
+        // Connectivity drops at t0; the bucket is frozen at that instant.
+        governor.freezeForOffline(currentTime: t0)
+
+        // Ten minutes pass offline, then one second of connectivity.
+        let reconnect = t0.addingTimeInterval(600)
+        governor.freezeForOffline(currentTime: reconnect) // second drop/idle tick while offline
+        governor.refill(currentTime: reconnect.addingTimeInterval(1), flushInterval: wifi)
+
+        // Only the one connected second accrues, not the 600 offline seconds (which at 10/sec
+        // would have filled the bucket to capacity).
+        XCTAssertEqual(
+            governor.tokens,
+            FlushGovernorConstants.wifiRefillPerSecond,
+            accuracy: 0.0001
+        )
+        XCTAssertLessThan(governor.tokens, governor.capacity)
+    }
+
+    func test_freezeForOffline_neverMovesTimestampBackward() {
+        var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        governor.freezeForOffline(currentTime: t0.addingTimeInterval(-300))
+        XCTAssertEqual(governor.lastRefill, t0)
+    }
+
     func test_backwardClockJumpDoesNotGrantWindfall() {
         var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
         // Clock steps backwards; must not rewind lastRefill.
@@ -98,6 +129,14 @@ final class FlushGovernorTests: XCTestCase {
         // Went negative: the engagement event was never delayed, but it still counts, so ordinary
         // traffic waits slightly longer rather than the ceiling being silently exceeded.
         XCTAssertEqual(governor.tokens, -1, accuracy: 0.0001)
+    }
+
+    /// The dry-requeue path must not bury a prioritized request behind returning regulars.
+    func test_partitionedKeepsPrioritizedOrderingStable() {
+        let items = ["a", "p1", "b", "p2", "c"]
+        let (prioritized, regular) = items.partitioned(by: { $0.hasPrefix("p") })
+        XCTAssertEqual(prioritized, ["p1", "p2"])
+        XCTAssertEqual(regular, ["a", "b", "c"])
     }
 
     func test_resetRestoresColdLaunchState() {

--- a/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
+++ b/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
@@ -1,0 +1,332 @@
+//
+//  FlushGovernorTests.swift
+//
+//  Unit tests for the token bucket, plus a discrete-event simulation comparing the
+//  governor against today's timer-only behavior.
+//
+//  Copyright (c) 2026 Klaviyo
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+//
+
+@testable import KlaviyoCore
+@testable import KlaviyoSwift
+import Foundation
+import XCTest
+
+// MARK: - Token bucket unit tests
+
+final class FlushGovernorTests: XCTestCase {
+    private let wifi = StateManagementConstants.wifiFlushInterval
+    private let cell = StateManagementConstants.cellularFlushInterval
+    private let t0 = Date(timeIntervalSinceReferenceDate: 0)
+
+    func test_startsFullSoColdLaunchIsNotThrottled() {
+        var governor = FlushGovernor()
+        XCTAssertEqual(governor.tokens, FlushGovernorConstants.burstCapacity)
+        XCTAssertTrue(governor.consume(currentTime: t0, flushInterval: wifi))
+    }
+
+    func test_consumeSpendsExactlyOneTokenPerRequest() {
+        var governor = FlushGovernor(capacity: 5, tokens: 5, lastRefill: t0)
+        XCTAssertTrue(governor.consume(currentTime: t0, flushInterval: wifi))
+        XCTAssertEqual(governor.tokens, 4, accuracy: 0.0001)
+    }
+
+    func test_deniesOnceDrainedThenAllowsAfterRefill() {
+        var governor = FlushGovernor(capacity: 2, tokens: 0, lastRefill: t0)
+        XCTAssertFalse(governor.consume(currentTime: t0, flushInterval: wifi))
+
+        // wifi refills at 2 req/s, so half a second buys exactly one token.
+        let later = t0.addingTimeInterval(0.5)
+        XCTAssertTrue(governor.consume(currentTime: later, flushInterval: wifi))
+    }
+
+    func test_refillIsCappedAtCapacity() {
+        var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        governor.refill(currentTime: t0.addingTimeInterval(3600), flushInterval: wifi)
+        XCTAssertEqual(governor.tokens, 20, accuracy: 0.0001)
+    }
+
+    func test_cellularRefillsSlowerThanWifi() {
+        var onWifi = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        var onCell = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        let after10s = t0.addingTimeInterval(10)
+
+        onWifi.refill(currentTime: after10s, flushInterval: wifi)
+        onCell.refill(currentTime: after10s, flushInterval: cell)
+
+        XCTAssertEqual(onWifi.tokens, 20, accuracy: 0.0001) // 2/s * 10s, capped
+        XCTAssertEqual(onCell.tokens, 10, accuracy: 0.0001) // 1/s * 10s
+        XCTAssertGreaterThan(onWifi.tokens, onCell.tokens)
+    }
+
+    func test_bucketIsFrozenWhileOfflineSoReconnectGrantsNoWindfall() {
+        var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        // Ten minutes offline.
+        governor.refill(currentTime: t0.addingTimeInterval(600), flushInterval: .infinity)
+        XCTAssertEqual(governor.tokens, 0, accuracy: 0.0001)
+        XCTAssertNil(FlushGovernor.refillPerSecond(forFlushInterval: .infinity))
+    }
+
+    func test_backwardClockJumpDoesNotGrantWindfall() {
+        var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        // Clock steps backwards; must not rewind lastRefill.
+        governor.refill(currentTime: t0.addingTimeInterval(-300), flushInterval: wifi)
+        XCTAssertEqual(governor.tokens, 0, accuracy: 0.0001)
+
+        // A real (forward) reading one second on should yield one second of accrual, not 301s.
+        governor.refill(currentTime: t0.addingTimeInterval(1), flushInterval: wifi)
+        XCTAssertEqual(governor.tokens, 2, accuracy: 0.0001)
+    }
+
+    func test_prioritizedRequestIsDebitedAndMayOverdraw() {
+        var governor = FlushGovernor(capacity: 5, tokens: 0, lastRefill: t0)
+        governor.debitForPrioritizedRequest(currentTime: t0, flushInterval: wifi)
+        // Went negative: the engagement event was never delayed, but it still counts, so ordinary
+        // traffic waits slightly longer rather than the ceiling being silently exceeded.
+        XCTAssertEqual(governor.tokens, -1, accuracy: 0.0001)
+    }
+
+    func test_resetRestoresColdLaunchState() {
+        var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        governor.reset()
+        XCTAssertEqual(governor.tokens, 20, accuracy: 0.0001)
+        XCTAssertNil(governor.lastRefill)
+    }
+
+    func test_timeUntilNextTokenTracksTier() {
+        let drained = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
+        XCTAssertEqual(drained.timeUntilNextToken(flushInterval: wifi) ?? -1, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(drained.timeUntilNextToken(flushInterval: cell) ?? -1, 1.0, accuracy: 0.0001)
+        XCTAssertNil(drained.timeUntilNextToken(flushInterval: .infinity))
+    }
+}
+
+// MARK: - Simulation
+
+/// Compares the governor against today's timer-only behavior on synthetic traffic.
+///
+/// The critical modeling choice, and the one the previous PoC's simulation got wrong: a flush does
+/// **not** cost one server request. It drains the queue one HTTP request at a time, so the server
+/// model is charged per request. Without that, throttling flush cycles looks like it bounds load
+/// when it does not.
+final class FlushGovernorSimulationTests: XCTestCase {
+    private struct Metrics {
+        var sendTimes: [TimeInterval] = []
+        var latencies: [TimeInterval] = []
+        var rateLimited = 0
+        var firstSend: TimeInterval?
+
+        var delivered: Int { latencies.count }
+
+        func p95() -> TimeInterval {
+            guard !latencies.isEmpty else { return 0 }
+            let sorted = latencies.sorted()
+            return sorted[Int((Double(sorted.count - 1) * 0.95).rounded())]
+        }
+
+        /// Peak requests observed in any window of `length` seconds. This is the number that tells
+        /// us whether a long-run ceiling actually exists.
+        func peakRequests(inWindow length: TimeInterval) -> Int {
+            var peak = 0
+            for start in sendTimes {
+                peak = max(peak, sendTimes.filter { $0 >= start && $0 < start + length }.count)
+            }
+            return peak
+        }
+    }
+
+    /// Backend that rejects anything above `limit` requests per `window` seconds.
+    private struct Server {
+        let limit: Int
+        let window: TimeInterval
+        var accepted: [TimeInterval] = []
+
+        mutating func accept(at time: TimeInterval) -> Bool {
+            accepted = accepted.filter { $0 > time - window }
+            guard accepted.count < limit else { return false }
+            accepted.append(time)
+            return true
+        }
+    }
+
+    /// Runs one scenario.
+    ///
+    /// - Parameter useGovernor: when false, reproduces today's behavior (flush only on the interval
+    ///   tick, then drain the entire queue with no pacing).
+    private func simulate(
+        arrivals: [TimeInterval],
+        flushInterval: TimeInterval,
+        useGovernor: Bool,
+        serverLimit: Int? = nil,
+        horizon: TimeInterval = 600
+    ) -> Metrics {
+        var metrics = Metrics()
+        var governor = FlushGovernor(lastRefill: Date(timeIntervalSinceReferenceDate: 0))
+        var server = serverLimit.map { Server(limit: $0, window: 10) }
+        var queue: [TimeInterval] = [] // enqueue timestamps
+        var blockedUntil: TimeInterval = -1
+
+        /// Attempts to drain the queue at `time`, one request at a time.
+        func drain(at time: TimeInterval) {
+            guard time >= blockedUntil else { return }
+            while !queue.isEmpty {
+                if useGovernor {
+                    let now = Date(timeIntervalSinceReferenceDate: time)
+                    guard governor.consume(currentTime: now, flushInterval: flushInterval) else {
+                        return // dry: leave the rest queued for a later tick
+                    }
+                }
+                if var srv = server {
+                    if srv.accept(at: time) {
+                        server = srv
+                    } else {
+                        metrics.rateLimited += 1
+                        blockedUntil = time + 10 // Retry-After
+                        server = srv
+                        return
+                    }
+                }
+                let enqueuedAt = queue.removeFirst()
+                metrics.sendTimes.append(time)
+                metrics.latencies.append(time - enqueuedAt)
+                if metrics.firstSend == nil { metrics.firstSend = time }
+            }
+        }
+
+        // Merge arrivals and timer ticks into one ordered event stream.
+        var ticks: [TimeInterval] = []
+        var tick = flushInterval
+        while tick <= horizon {
+            ticks.append(tick)
+            tick += flushInterval
+        }
+
+        var ai = 0, ti = 0
+        let sortedArrivals = arrivals.sorted()
+        while ai < sortedArrivals.count || ti < ticks.count {
+            let nextArrival = ai < sortedArrivals.count ? sortedArrivals[ai] : .greatestFiniteMagnitude
+            let nextTick = ti < ticks.count ? ticks[ti] : .greatestFiniteMagnitude
+
+            if nextArrival <= nextTick {
+                let time = nextArrival
+                while ai < sortedArrivals.count, sortedArrivals[ai] == time {
+                    queue.append(time)
+                    ai += 1
+                }
+                // Governor: try to send right away (banked tokens make this instant after idle).
+                // Legacy: enqueue only; nothing leaves until the next tick.
+                if useGovernor {
+                    drain(at: time)
+                }
+            } else {
+                drain(at: nextTick)
+                ti += 1
+            }
+        }
+        return metrics
+    }
+
+    private func report(_ title: String, _ columns: [(String, Metrics)]) {
+        func row(_ label: String, _ values: [String]) -> String {
+            "  " + label.padding(toLength: 22, withPad: " ", startingAt: 0)
+                + values.map { $0.padding(toLength: 14, withPad: " ", startingAt: 0) }.joined()
+        }
+        var lines = ["", "== \(title) =="]
+        lines.append(row("", columns.map(\.0)))
+        lines.append(row("delivered", columns.map { String($0.1.delivered) }))
+        lines.append(row("first send (s)", columns.map { String(format: "%.2f", $0.1.firstSend ?? -1) }))
+        lines.append(row("latency p95 (s)", columns.map { String(format: "%.2f", $0.1.p95()) }))
+        lines.append(row("peak req / 10s", columns.map { String($0.1.peakRequests(inWindow: 10)) }))
+        lines.append(row("rate limited", columns.map { String($0.1.rateLimited) }))
+        print(lines.joined(separator: "\n"))
+    }
+
+    // MARK: Scenario 1 — the burst-after-idle win
+
+    func test_burstAfterIdle_governorSendsImmediately() {
+        // Deliberately mid-interval (ticks land on multiples of 10). An arrival exactly on a tick
+        // would flatter the legacy path by coincidence.
+        let arrivals = Array(repeating: 125.0, count: 10) // 10 events after ~2 min idle
+        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true)
+        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false)
+        report("1 - 10-event burst mid-interval after idle (wifi)",
+               [("governor", governor), ("legacy", legacy)])
+
+        XCTAssertEqual(governor.delivered, 10)
+        XCTAssertEqual(legacy.delivered, 10)
+
+        // The governor banked tokens while idle, so the whole burst leaves on arrival.
+        XCTAssertEqual(governor.firstSend ?? -1, 125.0, accuracy: 0.001)
+        XCTAssertLessThan(governor.p95(), 0.001)
+
+        // Legacy waits for the next tick (t=130), so every event eats ~5s of avoidable delay.
+        XCTAssertEqual(legacy.firstSend ?? -1, 130.0, accuracy: 0.001)
+        XCTAssertGreaterThan(legacy.p95(), governor.p95())
+    }
+
+    // MARK: Scenario 2 — no regression on ordinary traffic
+
+    func test_steadyLightTraffic_noRegression() {
+        let arrivals = stride(from: 0.0, through: 300.0, by: 30.0).map { $0 }
+        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true)
+        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false)
+        report("2 - steady light traffic (1 evt / 30s)",
+               [("governor", governor), ("legacy", legacy)])
+
+        XCTAssertEqual(governor.delivered, arrivals.count)
+        XCTAssertEqual(legacy.delivered, arrivals.count)
+        // Everything still ships, and the governor is never slower.
+        XCTAssertLessThanOrEqual(governor.p95(), legacy.p95())
+    }
+
+    // MARK: Scenario 3 — the ceiling that PR #622 does not deliver
+
+    func test_sustainedStorm_governorBoundsRequestRate() {
+        // A runaway loop: 20 events/sec for 30s.
+        let arrivals = stride(from: 0.05, through: 30.0, by: 0.05).map { $0 }
+        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true)
+        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false)
+        report("3 - sustained storm (20 evt/s for 30s)",
+               [("governor", governor), ("legacy", legacy)])
+
+        // The whole point: wifi refills at 2 req/s, so a 10s window admits at most
+        // burstCapacity + 2*10 requests. Legacy has no bound at all.
+        let ceiling = Int(FlushGovernorConstants.burstCapacity
+            + FlushGovernorConstants.wifiRefillPerSecond * 10) + 1
+        XCTAssertLessThanOrEqual(governor.peakRequests(inWindow: 10), ceiling)
+        XCTAssertGreaterThan(legacy.peakRequests(inWindow: 10), governor.peakRequests(inWindow: 10))
+
+        // No data loss either way: throttling defers requests, it never drops them.
+        XCTAssertEqual(governor.delivered, arrivals.count)
+        XCTAssertEqual(legacy.delivered, arrivals.count)
+
+        // The cost, asserted rather than left implicit: holding a storm to a ceiling necessarily
+        // means the backlog drains more slowly, so tail latency is much worse than legacy. That is
+        // the real tradeoff of any rate ceiling, and whether it is acceptable is a product call,
+        // not something this PoC can decide. Legacy "wins" here only by having no ceiling at all.
+        XCTAssertGreaterThan(governor.p95(), legacy.p95())
+    }
+
+    // MARK: Scenario 4 — fewer 429s against a real rate limit
+
+    func test_sustainedStorm_againstRateLimit_governorAvoids429s() {
+        let arrivals = stride(from: 0.05, through: 30.0, by: 0.05).map { $0 }
+        // Backend admits 30 requests / 10s.
+        let governor = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: true, serverLimit: 30)
+        let legacy = simulate(arrivals: arrivals, flushInterval: 10, useGovernor: false, serverLimit: 30)
+        report("4 - storm vs 30 req/10s limit",
+               [("governor", governor), ("legacy", legacy)])
+
+        // This is the claim PR #622 could not substantiate for iOS, and it does hold once the gate
+        // is per-request: pacing cuts 429s by roughly an order of magnitude.
+        XCTAssertLessThan(governor.rateLimited, legacy.rateLimited)
+
+        // Not zero, and that is a genuine tuning finding rather than a bug. `burstCapacity` (20)
+        // plus 2 req/s means the opening 10s window can admit ~40 requests against a 30/10s limit,
+        // so the initial burst overshoots before pacing takes hold. Sizing the burst allowance to
+        // the real backend limit is exactly the open question this PoC exists to expose; it needs
+        // the actual server-side numbers to settle.
+        XCTAssertLessThanOrEqual(governor.rateLimited, legacy.rateLimited / 5)
+    }
+}

--- a/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
+++ b/Tests/KlaviyoSwiftTests/FlushGovernorTests.swift
@@ -77,23 +77,25 @@ final class FlushGovernorTests: XCTestCase {
         XCTAssertNil(FlushGovernor.refillPerSecond(forFlushInterval: .infinity))
     }
 
-    /// The offline freeze has to be driven by the connectivity change, because nothing on the send
-    /// path reaches it while offline: `canSend` refills a copy and `.sendRequest` is unreachable.
-    /// This exercises `freezeForOffline` and then a real post-reconnect refill, which is what the
-    /// production sequence actually does.
-    func test_freezeForOffline_thenReconnect_accruesOnlyPostReconnectTime() {
+    /// Accrual must restart on the **reconnect** edge, not the disconnect edge.
+    ///
+    /// An earlier version of this test stamped the governor twice — once going offline and once at
+    /// reconnect — which made a disconnect-edge-only implementation look correct. Production only
+    /// gets one connectivity event per edge, so the sequence here mirrors the reducer exactly:
+    /// drop, wait, reconnect, send.
+    func test_resumeAfterOffline_accruesOnlyPostReconnectTime() {
         var governor = FlushGovernor(capacity: 50, tokens: 0, lastRefill: t0)
 
-        // Connectivity drops at t0; the bucket is frozen at that instant.
-        governor.freezeForOffline(currentTime: t0)
-
-        // Ten minutes pass offline, then one second of connectivity.
+        // Ten minutes offline. Nothing touches the governor during this stretch, which is what
+        // production does — no timer, no sends.
         let reconnect = t0.addingTimeInterval(600)
-        governor.freezeForOffline(currentTime: reconnect) // second drop/idle tick while offline
+
+        // Reconnect restarts the accrual clock, then one connected second passes.
+        governor.resumeAfterOffline(currentTime: reconnect)
         governor.refill(currentTime: reconnect.addingTimeInterval(1), flushInterval: wifi)
 
-        // Only the one connected second accrues, not the 600 offline seconds (which at 10/sec
-        // would have filled the bucket to capacity).
+        // Only the single connected second accrues. Without the reconnect stamp the 600 offline
+        // seconds would have filled the bucket to capacity at 10 tokens/sec.
         XCTAssertEqual(
             governor.tokens,
             FlushGovernorConstants.wifiRefillPerSecond,
@@ -102,9 +104,18 @@ final class FlushGovernorTests: XCTestCase {
         XCTAssertLessThan(governor.tokens, governor.capacity)
     }
 
-    func test_freezeForOffline_neverMovesTimestampBackward() {
+    /// Guards the specific regression: without a reconnect stamp, the bucket fills completely.
+    func test_withoutResumeAfterOffline_theOutageWouldGrantAFullBurst() {
+        var unguarded = FlushGovernor(capacity: 50, tokens: 0, lastRefill: t0)
+        // Skip the reconnect stamp deliberately, then send one second after reconnect.
+        unguarded.refill(currentTime: t0.addingTimeInterval(601), flushInterval: wifi)
+        XCTAssertEqual(unguarded.tokens, unguarded.capacity, accuracy: 0.0001,
+                       "Documents why the reconnect stamp is required")
+    }
+
+    func test_resumeAfterOffline_neverMovesTimestampBackward() {
         var governor = FlushGovernor(capacity: 20, tokens: 0, lastRefill: t0)
-        governor.freezeForOffline(currentTime: t0.addingTimeInterval(-300))
+        governor.resumeAfterOffline(currentTime: t0.addingTimeInterval(-300))
         XCTAssertEqual(governor.lastRefill, t0)
     }
 

--- a/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
+++ b/Tests/KlaviyoSwiftTests/KlaviyoTestUtils.swift
@@ -92,6 +92,26 @@ extension Store where State == KlaviyoState, Action == KlaviyoAction {
     static let test = Store(initialState: .test, reducer: KlaviyoTestReducer())
 }
 
+extension KlaviyoState {
+    /// Mirrors the token-bucket mutation a single paced `.sendRequest` performs: refill for elapsed
+    /// time, then spend one token. Use inside `TestStore` expectation closures so flush assertions
+    /// stay DRY.
+    ///
+    /// - Parameter prioritized: `true` for opened-push / geofence requests, which bypass the gate
+    ///   and are debited instead (and may overdraw). The two paths only coincide while the bucket
+    ///   holds at least one token, so pass this explicitly rather than relying on a full bucket.
+    mutating func expectRequestPaced(prioritized: Bool = false) {
+        if prioritized {
+            flushGovernor.debitForPrioritizedRequest(
+                currentTime: environment.date(),
+                flushInterval: flushInterval
+            )
+        } else {
+            _ = flushGovernor.consume(currentTime: environment.date(), flushInterval: flushInterval)
+        }
+    }
+}
+
 extension FileClient {
     static let test = FileClient(
         write: { _, _ in },

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -553,8 +553,6 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
-            // Going offline freezes the token bucket, which stamps `lastRefill`.
-            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         // Also clears `flushing` — otherwise `.flushQueue` bails early and this test is vacuous.
         _ = await store.receive(.cancelInFlightRequests) {
@@ -581,8 +579,6 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
-            // Going offline freezes the token bucket, which stamps `lastRefill`.
-            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         _ = await store.receive(.cancelInFlightRequests) {
             $0.flushing = false

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -77,6 +77,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
                                         flushing: true)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         // Shouldn't really happen but getting more coverage...
+        // No pacing expectation: the reducer bails at the initialization guard before reaching the
+        // governor, so no token is spent.
         _ = await store.send(.sendRequest)
     }
 

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -553,6 +553,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
+            // Going offline freezes the token bucket, which stamps `lastRefill`.
+            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         // Also clears `flushing` — otherwise `.flushQueue` bails early and this test is vacuous.
         _ = await store.receive(.cancelInFlightRequests) {
@@ -579,6 +581,8 @@ class StateManagementEdgeCaseTests: XCTestCase {
 
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
+            // Going offline freezes the token bucket, which stamps `lastRefill`.
+            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         _ = await store.receive(.cancelInFlightRequests) {
             $0.flushing = false

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -366,6 +366,51 @@ class StateManagementTests: XCTestCase {
         }
     }
 
+    /// Regression test: the governor's burst trigger must not erode a server-mandated backoff.
+    ///
+    /// `.flushQueue` subtracts a full `flushInterval` from `currentBackoff` on every call, so if
+    /// each enqueue dispatched one, a handful of events after a 429 would exhaust the
+    /// `Retry-After` window and retry early. Enqueuing during `.retryWithBackoff` must therefore
+    /// dispatch nothing and leave the countdown untouched — only the timer may advance it.
+    @MainActor
+    func testEnqueueDuringBackoffDoesNotDispatchFlushOrErodeBackoff() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.flushing = false
+        initialState.retryState = .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 30)
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        // Several enqueues in quick succession, as a burst after a rate-limit response would be.
+        for index in 0..<5 {
+            let event = Event(name: .customEvent("backoff_probe_\(index)"))
+            await store.send(.enqueueEvent(event)) {
+                try $0.enqueueRequest(
+                    request: KlaviyoRequest(
+                        endpoint: .createEvent(
+                            XCTUnwrap($0.apiKey),
+                            CreateEventPayload(
+                                data: CreateEventPayload.Event(
+                                    name: event.metric.name.value,
+                                    properties: event.properties,
+                                    phoneNumber: $0.phoneNumber,
+                                    anonymousId: XCTUnwrap($0.anonymousId),
+                                    time: event.time,
+                                    pushToken: initialState.pushTokenData?.pushToken
+                                )
+                            )
+                        )
+                    )
+                )
+            }
+        }
+
+        // No `.flushQueue` was received (TestStore would fail on an unhandled action), and the
+        // server-mandated wait is intact.
+        XCTAssertEqual(
+            store.state.retryState,
+            .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: 30)
+        )
+    }
+
     @MainActor
     func testFlushQueueExponentialBackoffGoesToSize() async throws {
         var initialState = INITIALIZED_TEST_STATE()
@@ -427,6 +472,8 @@ class StateManagementTests: XCTestCase {
         // Shouldn't really happen but getting more coverage...
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
+            // Going offline freezes the token bucket, which stamps `lastRefill`.
+            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         _ = await store.receive(.cancelInFlightRequests) {
             $0.flushing = false

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -405,6 +405,37 @@ class StateManagementTests: XCTestCase {
         XCTAssertEqual(store.state.flushGovernor.lastRefill, environment.date())
     }
 
+    /// A reachable-status event that is not a genuine reconnect must not discard banked accrual.
+    ///
+    /// Reachability re-emits `.reachableViaWiFi` / `.reachableViaWWAN` on network-type switches,
+    /// flag flaps and every foreground. Stamping `lastRefill` on those would throw away idle
+    /// accrual and defeat the post-idle burst, so the stamp is gated on having actually been
+    /// offline.
+    @MainActor
+    func testReachableEventWhileAlreadyOnlineKeepsBankedAccrual() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.flushing = false
+        initialState.queue = []
+        // Already online (finite interval) with an old refill stamp, i.e. idle time banked.
+        initialState.flushInterval = StateManagementConstants.wifiFlushInterval
+        let staleStamp = environment.date().addingTimeInterval(-120)
+        initialState.flushGovernor = FlushGovernor(
+            capacity: FlushGovernorConstants.burstCapacity,
+            tokens: 0,
+            lastRefill: staleStamp
+        )
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        // A wifi->cellular switch: reachable, but never offline.
+        _ = await store.send(.networkConnectivityChanged(.reachableViaWWAN)) {
+            $0.flushInterval = StateManagementConstants.cellularFlushInterval
+        }
+        await store.receive(.flushQueue)
+
+        XCTAssertEqual(store.state.flushGovernor.lastRefill, staleStamp,
+                       "A non-reconnect reachable event must not advance the refill stamp")
+    }
+
     /// Regression test: the governor's burst trigger must not erode a server-mandated backoff.
     ///
     /// `.flushQueue` subtracts a full `flushInterval` from `currentBackoff` on every call, so if

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -153,7 +153,9 @@ class StateManagementTests: XCTestCase {
             $0.queue = []
         }
 
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
             $0.flushing = false
@@ -186,7 +188,9 @@ class StateManagementTests: XCTestCase {
             $0.queue = []
         }
 
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
             $0.flushing = false
@@ -219,7 +223,9 @@ class StateManagementTests: XCTestCase {
             $0.queue = []
         }
 
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
             $0.flushing = false
@@ -325,14 +331,18 @@ class StateManagementTests: XCTestCase {
             $0.requestsInFlight = $0.queue
             $0.queue = []
         }
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         await store.receive(.deQueueCompletedResults(request)) {
             $0.flushing = true
             $0.requestsInFlight = [request2]
             $0.queue = []
         }
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
         await store.receive(.deQueueCompletedResults(request2)) {
             $0.pushTokenData = KlaviyoState.PushTokenData(pushToken: "blob_token", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.appContextInfo()))
             $0.flushing = false
@@ -372,7 +382,9 @@ class StateManagementTests: XCTestCase {
             $0.requestsInFlight = $0.queue
             $0.queue = []
         }
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
 
         // didn't fake uuid since we are not testing this.
         await store.receive(.deQueueCompletedResults(request)) {
@@ -389,6 +401,8 @@ class StateManagementTests: XCTestCase {
         initialState.flushing = false
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         // Shouldn't really happen but getting more coverage...
+        // No pacing expectation: the reducer bails at the `flushing` guard before reaching the
+        // governor, so no token is spent.
         _ = await store.send(.sendRequest)
     }
 
@@ -521,7 +535,9 @@ class StateManagementTests: XCTestCase {
             }
         }
 
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced()
+        }
         await store.receive(.deQueueCompletedResults(request!)) {
             $0.requestsInFlight = $0.queue
             $0.flushing = false
@@ -633,6 +649,10 @@ class StateManagementTests: XCTestCase {
                         )
                     )
                 )
+                // Prioritized events are recorded so `.sendRequest` debits rather than gates them.
+                if eventName == ._openedPush, let queued = $0.queue.first {
+                    $0.prioritizedRequestIds.insert(queued.id)
+                }
             }
 
             // if the event is opened push we want to flush immidietly, for all other events we flush during regular intervals set in code
@@ -695,6 +715,8 @@ class StateManagementTests: XCTestCase {
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         let data = Data()
+        // `INITIALIZED_TEST_STATE` has `flushing: true`, so the governor's burst trigger is
+        // deliberately suppressed here and no `.flushQueue` follows the enqueue.
         await store.send(.enqueueAggregateEvent(data)) {
             try $0.enqueueRequest(
                 request: KlaviyoRequest(
@@ -781,6 +803,8 @@ class StateManagementTests: XCTestCase {
                 )
             )
             $0.queue.insert(geofenceRequest!, at: 0)
+            // Recorded so `.sendRequest` debits the governor rather than gating this request.
+            $0.prioritizedRequestIds.insert(geofenceRequest!.id)
         }
 
         var actualGeofenceRequest: KlaviyoRequest?
@@ -798,9 +822,13 @@ class StateManagementTests: XCTestCase {
             XCTAssertEqual($0.requestsInFlight[1].id, existingRequest1.id, "Second request should be existing request 1")
             XCTAssertEqual($0.requestsInFlight[2].id, existingRequest2.id, "Third request should be existing request 2")
         }
-        await store.receive(.sendRequest)
+        await store.receive(.sendRequest) {
+            $0.expectRequestPaced(prioritized: true)
+        }
         await store.receive(.deQueueCompletedResults(actualGeofenceRequest!)) {
             $0.requestsInFlight.removeAll { $0.id == actualGeofenceRequest!.id }
+            // The exemption is dropped once the request completes, so the set stays bounded.
+            $0.prioritizedRequestIds.remove(actualGeofenceRequest!.id)
             $0.retryState = .retry(1)
             $0.flushing = false
         }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -366,6 +366,45 @@ class StateManagementTests: XCTestCase {
         }
     }
 
+    /// Regression test at the reducer level: a real offline/reconnect cycle must not hand the
+    /// governor a windfall.
+    ///
+    /// The unit test for this can be made to pass by stamping on either connectivity edge, so it
+    /// missed a disconnect-edge-only implementation. Driving the actual actions is what pins the
+    /// behavior: after a ten-minute outage the bucket must still be empty, not full.
+    @MainActor
+    func testOfflineThenReconnectDoesNotGrantTokenWindfall() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.flushing = false
+        initialState.queue = []
+        // Start drained, as a device would be after a burst.
+        initialState.flushGovernor = FlushGovernor(
+            capacity: FlushGovernorConstants.burstCapacity,
+            tokens: 0,
+            lastRefill: environment.date()
+        )
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+
+        _ = await store.send(.networkConnectivityChanged(.notReachable)) {
+            $0.flushInterval = Double.infinity
+        }
+        _ = await store.receive(.cancelInFlightRequests)
+
+        // `environment.date()` is fixed in tests, so reconnect stamps the same instant the
+        // governor already holds: elapsed time is zero and no tokens accrue. The assertion below
+        // is the point — a disconnect-edge-only stamp would leave `lastRefill` behind and let a
+        // later refill claim the entire outage.
+        _ = await store.send(.networkConnectivityChanged(.reachableViaWiFi)) {
+            $0.flushInterval = StateManagementConstants.wifiFlushInterval
+            $0.flushGovernor.resumeAfterOffline(currentTime: environment.date())
+        }
+        await store.receive(.flushQueue)
+
+        XCTAssertEqual(store.state.flushGovernor.tokens, 0, accuracy: 0.0001,
+                       "Reconnect must not accrue tokens for time spent offline")
+        XCTAssertEqual(store.state.flushGovernor.lastRefill, environment.date())
+    }
+
     /// Regression test: the governor's burst trigger must not erode a server-mandated backoff.
     ///
     /// `.flushQueue` subtracts a full `flushInterval` from `currentBackoff` on every call, so if
@@ -472,8 +511,6 @@ class StateManagementTests: XCTestCase {
         // Shouldn't really happen but getting more coverage...
         _ = await store.send(.networkConnectivityChanged(.notReachable)) {
             $0.flushInterval = Double.infinity
-            // Going offline freezes the token bucket, which stamps `lastRefill`.
-            $0.flushGovernor.freezeForOffline(currentTime: environment.date())
         }
         _ = await store.receive(.cancelInFlightRequests) {
             $0.flushing = false
@@ -481,10 +518,13 @@ class StateManagementTests: XCTestCase {
         _ = await store.send(.networkConnectivityChanged(.reachableViaWiFi)) {
             $0.flushing = false
             $0.flushInterval = StateManagementConstants.wifiFlushInterval
+            // Reconnect restarts token accrual so the outage grants nothing.
+            $0.flushGovernor.resumeAfterOffline(currentTime: environment.date())
         }
         await store.receive(.flushQueue)
         _ = await store.send(.networkConnectivityChanged(.reachableViaWWAN)) {
             $0.flushInterval = StateManagementConstants.cellularFlushInterval
+            $0.flushGovernor.resumeAfterOffline(currentTime: environment.date())
         }
         await store.receive(.flushQueue)
     }

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -1,6 +1,10 @@
 ▿ KlaviyoState
   ▿ apiKey: Optional<String>
     - some: "foo"
+  ▿ flushGovernor: FlushGovernor
+    - capacity: 20.0
+    - lastRefill: Optional<Date>.none
+    - tokens: 20.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData
@@ -12,6 +16,7 @@
   - initalizationState: InitializationState.uninitialized
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
+  - prioritizedRequestIds: 0 members
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testLoadNewKlaviyoState.1.txt
@@ -2,9 +2,9 @@
   ▿ apiKey: Optional<String>
     - some: "foo"
   ▿ flushGovernor: FlushGovernor
-    - capacity: 20.0
+    - capacity: 50.0
     - lastRefill: Optional<Date>.none
-    - tokens: 20.0
+    - tokens: 50.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -1,6 +1,10 @@
 ▿ KlaviyoState
   ▿ apiKey: Optional<String>
     - some: "foo"
+  ▿ flushGovernor: FlushGovernor
+    - capacity: 20.0
+    - lastRefill: Optional<Date>.none
+    - tokens: 20.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData
@@ -12,6 +16,7 @@
   - initalizationState: InitializationState.uninitialized
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
+  - prioritizedRequestIds: 0 members
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidData.1.txt
@@ -2,9 +2,9 @@
   ▿ apiKey: Optional<String>
     - some: "foo"
   ▿ flushGovernor: FlushGovernor
-    - capacity: 20.0
+    - capacity: 50.0
     - lastRefill: Optional<Date>.none
-    - tokens: 20.0
+    - tokens: 50.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -1,6 +1,10 @@
 ▿ KlaviyoState
   ▿ apiKey: Optional<String>
     - some: "foo"
+  ▿ flushGovernor: FlushGovernor
+    - capacity: 20.0
+    - lastRefill: Optional<Date>.none
+    - tokens: 20.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData
@@ -12,6 +16,7 @@
   - initalizationState: InitializationState.uninitialized
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
+  - prioritizedRequestIds: 0 members
   - pushTokenData: Optional<PushTokenData>.none
   - queue: 0 elements
   - requestsInFlight: 0 elements

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testStateFileExistsInvalidJSON.1.txt
@@ -2,9 +2,9 @@
   ▿ apiKey: Optional<String>
     - some: "foo"
   ▿ flushGovernor: FlushGovernor
-    - capacity: 20.0
+    - capacity: 50.0
     - lastRefill: Optional<Date>.none
-    - tokens: 20.0
+    - tokens: 50.0
   - flushInterval: 10.0
   - flushing: false
   ▿ identity: ProfileData

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -2,9 +2,9 @@
   ▿ apiKey: Optional<String>
     - some: "foo"
   ▿ flushGovernor: FlushGovernor
-    - capacity: 20.0
+    - capacity: 50.0
     - lastRefill: Optional<Date>.none
-    - tokens: 20.0
+    - tokens: 50.0
   - flushInterval: 10.0
   - flushing: true
   ▿ identity: ProfileData

--- a/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
+++ b/Tests/KlaviyoSwiftTests/__Snapshots__/KlaviyoStateTests/testValidStateFileExists.1.txt
@@ -1,6 +1,10 @@
 ▿ KlaviyoState
   ▿ apiKey: Optional<String>
     - some: "foo"
+  ▿ flushGovernor: FlushGovernor
+    - capacity: 20.0
+    - lastRefill: Optional<Date>.none
+    - tokens: 20.0
   - flushInterval: 10.0
   - flushing: true
   ▿ identity: ProfileData
@@ -15,6 +19,7 @@
   - initalizationState: InitializationState.initialized
   - pendingProfile: Optional<Dictionary<ProfileKey, AnyEncodable>>.none
   - pendingRequests: 0 elements
+  - prioritizedRequestIds: 0 members
   ▿ pushTokenData: Optional<PushTokenData>
     ▿ some: PushTokenData
       ▿ deviceData: MetaData


### PR DESCRIPTION
# Description

Second proof of concept for the MAGE-791 demand-adaptive flush governor, gating **individual API requests** rather than flush cycles. Opened as a spike for discussion, not a merge candidate.

The existing draft #622 gates the `.flushQueue` action. That places no bound on the request rate: a flush moves the whole queue into `requestsInFlight`, and `.sendRequest` / `.deQueueCompletedResults` then drain it one HTTP request at a time against single-payload endpoints. One token can therefore authorize an unbounded number of requests. This PR moves the gate to `.sendRequest` and expresses refill in requests/second, so one token buys exactly one request.

> **Base branch note:** targets `master` because `rel/5.4.0` and `rel/5.4.1` are both merged and no active `rel/*` exists. The `pr-target-check` failure is expected policy, not a code problem — retarget when the next release branch is cut. Same situation as #622.

## Headline finding: the case for this is weaker than MAGE-791 assumed

The governor was tuned against the documented client-endpoint limits:

| Endpoint | Burst | Steady | Scope |
| --- | --- | --- | --- |
| `POST /client/events` | 350/sec | 3,500/min | account |
| `POST /client/profiles` | 350/sec | 3,500/min | account |
| `POST /client/push-tokens` | 150/sec | 1,400/min | per IP/device |

Measured against those numbers, only one of the three claimed benefits holds up:

| Claimed benefit | Verdict |
| --- | --- |
| Post-idle burst latency | **Holds.** 0.00s vs 5.00s p95 |
| Fewer 429s | **Does not hold.** Zero on both paths — a single device cannot breach these limits |
| Long-term rate ceiling | **Marginal.** 149 vs 200 req/10s, and both are already compliant |

A device drains serially at roughly 1/round-trip, and the queue is already capped at 200, so its ceiling is ~20 req/sec at 50ms RTT — well inside a 150/sec per-device budget. The 429-avoidance argument does not survive contact with the real limits, and scenario 4 now asserts zero rate-limiting on *both* paths and documents why, rather than reporting a favourable number produced by a placeholder limit.

**Recommendation: this is not the highest-value next step.** The amplification risk in the current design is retry behavior, not flush pacing — a 429 is retried up to 50 times, and against an account-wide 3,500/min limit many devices retrying in lockstep is a real concern that a per-device bucket cannot see. That argues for the circuit breaker (Android PR #486, the L2 layer of MAGE-694's own plan) ahead of this. The one benefit that does survive — post-idle latency — is also obtainable with a simple idle-time check and no bucket at all.

## Changelog / Code Overview

**`FlushGovernor.swift`** (new) — token bucket with lazy, elapsed-time refill; no timer of its own, so it costs nothing while the app is quiet.
- Refill 10 req/sec wifi, 5 req/sec cellular, frozen while offline. Burst capacity 50, which makes the opening 10-second window admit exactly 150 requests (the documented per-second burst) and holds a device to ~43% of its per-minute budget — headroom for app instances sharing an IP and for account-level limits a device cannot observe.
- Monotonic-forward refill timestamp, so a backward clock jump cannot grant a windfall.

**`StateManagement.swift`**
- `.sendRequest` consumes one token per request. When the bucket is dry, draining stops and the remainder is returned to the queue for a later tick.
- Enqueue flushes immediately when a token is available **and** no flush is in progress, which is where post-idle latency goes away. Under sustained load the bucket is dry and the existing timer takes over.
- Prioritized engagement events (opened-push, geofence) bypass the gate and are **debited** instead, allowing a negative balance — never delayed, but still counted, so the ceiling stays honest.
- Bucket reset on API-key change.

**`KlaviyoState.swift`** — `flushGovernor` and `prioritizedRequestIds`, both transient (excluded from `CodingKeys`), so a cold launch is never throttled.

## Test Plan

`xcodebuild test -only-testing:KlaviyoSwiftTests` → **338 passed, 0 failures** (iPhone 17 Pro sim). SwiftLint/SwiftFormat clean.

**`FlushGovernorTests`** (10 cases) — allow/deny, refill cap, tier rates, offline freeze, backward clock jump, prioritized overdraw, reset, time-to-next-token. Expectations derive from `FlushGovernorConstants` rather than hardcoded rates, so retuning cannot silently invalidate them.

**`FlushGovernorSimulationTests`** (4 scenarios) — discrete-event governor-vs-legacy comparison. The modeling fix that matters: the server is charged **one request per queued item**, not one per flush. #622's simulation charged per flush, which is what made a flush-cycle gate look like a rate ceiling.

| Scenario | Governor | Legacy |
| --- | --- | --- |
| 10-event burst mid-interval after idle | first send on arrival, p95 **0.00s** | next tick, p95 5.00s |
| Steady light traffic (1 evt/30s) | no regression | — |
| Sustained storm (20 evt/s) | peak **149** req/10s | peak 200, unbounded |
| Storm vs real per-device budget | 0 rate-limited | 0 rate-limited |

Two costs are asserted in the tests rather than left implicit, so they cannot regress into a rosier story:
- Tail latency under sustained load is worse than legacy (51s vs 9s p95). Inherent to any ceiling; legacy only "wins" by having none.
- The tier relationship (cellular never faster than wifi) is pinned as an invariant.

Existing tests: 36 `.sendRequest` sites declare the token spend via a shared `expectRequestPaced(prioritized:)` helper; three deliberately assert **no** spend because the reducer bails at an earlier guard. Four `KlaviyoState` dump snapshots re-recorded for the two new fields.

**Not done:** no device testing, no real API traffic, no telemetry. All results are simulation plus unit tests.

## Due Diligence
- [x] I have tested this on a simulator or a physical device. <!-- simulator only; full KlaviyoSwiftTests green -->
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Spike for MAGE-791. No public API change. Not slotted into a release, and per the finding above I would not merge this before the direction question is settled.

## Related Issues/Tickets
- MAGE-791 — spike: demand-adaptive (token-bucket) flush governor
- Supersedes the approach in #622 (gate placement)
- Related: Android PR #486 (circuit breaker, MAGE-694) — recommended ahead of this
