### PR TITLE
refactor(KlaviyoSwift): route the post-init public API through the ungated Core path (MAGE-1196)

### DIFF
--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -65,7 +65,12 @@ extension KlaviyoState {
         // if we have push data and we are switching emails
         // we want to associate the token with the new email.
         if let pushTokenData = pushTokenData {
-            self.pushTokenData = nil
+            // Do NOT nil `self.pushTokenData` here: the request below is built from the captured
+            // value, and the reducer's write-through `defer` would otherwise persist nil into
+            // IdentityStore — wiping the canonical/persisted token until the register completes (a
+            // crash in that window loses the token on disk, and concurrent reads see nil). This is
+            // a token re-registration, not an unregister, so the token stays; deQueueCompletedResults
+            // reconfirms it from the response. (MAGE-1196)
             let request = resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -65,12 +65,6 @@ extension KlaviyoState {
         // if we have push data and we are switching emails
         // we want to associate the token with the new email.
         if let pushTokenData = pushTokenData {
-            // Do NOT nil `self.pushTokenData` here: the request below is built from the captured
-            // value, and the reducer's write-through `defer` would otherwise persist nil into
-            // IdentityStore — wiping the canonical/persisted token until the register completes (a
-            // crash in that window loses the token on disk, and concurrent reads see nil). This is
-            // a token re-registration, not an unregister, so the token stays; deQueueCompletedResults
-            // reconfirms it from the response. (MAGE-1196)
             let request = resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState+RequestBuilding.swift
@@ -57,14 +57,14 @@ extension KlaviyoState {
     }
 
     mutating func enqueueProfileOrTokenRequest() {
-        guard let apiKey = apiKey,
-              let anonymousId = anonymousId else {
+        guard let apiKey,
+              let anonymousId else {
             environment.emitDeveloperWarning("SDK internal error")
             return
         }
         // if we have push data and we are switching emails
         // we want to associate the token with the new email.
-        if let pushTokenData = pushTokenData {
+        if let pushTokenData {
             let request = resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,
@@ -86,7 +86,7 @@ extension KlaviyoState {
     }
 
     mutating func updateRequestAndStateWithPendingProfile(profile: CreateProfilePayload) -> CreateProfilePayload {
-        guard let pendingProfile = pendingProfile else {
+        guard let pendingProfile else {
             return profile
         }
         let updatedProfile = Profile.updateProfileWithProperties(dict: pendingProfile)

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -142,8 +142,8 @@ struct KlaviyoState: Equatable {
         pushTokenData = nil
         if preserveTokenData {
             pushTokenData = previousPushTokenData
-            if let apiKey = apiKey,
-               let anonymousId = anonymousId,
+            if let apiKey,
+               let anonymousId,
                let tokenData = previousPushTokenData {
                 let profile = ProfilePayload(Profile(), anonymousId: anonymousId)
                 let request = RequestFactory.tokenRequest(

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -157,21 +157,6 @@ struct KlaviyoState: Equatable {
             }
         }
     }
-
-    func shouldSendTokenUpdate(newToken: String, enablement: PushEnablement) -> Bool {
-        guard let pushTokenData = pushTokenData else {
-            return true
-        }
-        let currentDeviceMetadata = DeviceMetadata(context: environment.appContextInfo())
-        let newPushTokenData = PushTokenData(
-            pushToken: newToken,
-            pushEnablement: enablement,
-            pushBackground: environment.getBackgroundSetting(),
-            deviceData: currentDeviceMetadata
-        )
-
-        return pushTokenData != newPushTokenData
-    }
 }
 
 // MARK: Klaviyo state persistence

--- a/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
+++ b/Sources/KlaviyoSwift/StateManagement/KlaviyoState.swift
@@ -97,27 +97,6 @@ struct KlaviyoState: Equatable {
         QueueStore.shared.enqueue(request)
     }
 
-    mutating func updateEmail(email: String) {
-        if email.isNotEmptyOrSame(as: self.email, identifier: "email") {
-            self.email = email.trimWhiteSpaceOrReturnNilIfEmpty()
-            enqueueProfileOrTokenRequest()
-        }
-    }
-
-    mutating func updateExternalId(externalId: String) {
-        if externalId.isNotEmptyOrSame(as: self.externalId, identifier: "external Id") {
-            self.externalId = externalId.trimWhiteSpaceOrReturnNilIfEmpty()
-            enqueueProfileOrTokenRequest()
-        }
-    }
-
-    mutating func updatePhoneNumber(phoneNumber: String) {
-        if phoneNumber.isNotEmptyOrSame(as: self.phoneNumber, identifier: "phone number") {
-            self.phoneNumber = phoneNumber.trimWhiteSpaceOrReturnNilIfEmpty()
-            enqueueProfileOrTokenRequest()
-        }
-    }
-
     func requestIdentity(apiKey: String, anonymousId: String) -> RequestIdentity {
         RequestIdentity(
             apiKey: apiKey,

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -279,29 +279,28 @@ struct KlaviyoReducer: ReducerProtocol {
             .merge(with: environment.lifecycleEventsWithReachability().map(\.transformToKlaviyoAction).eraseToEffect())
 
         case let .setEmail(email):
-            guard case .initialized = state.initalizationState else {
-                setPreInitIdentifier(&state) { $0.email = email.trimWhiteSpaceOrReturnNilIfEmpty() }
+            guard email.isNotEmptyOrSame(as: IdentityStore.shared.current.email, identifier: "email") else {
                 return .none
             }
-            state.updateEmail(email: email)
+            applyIdentifierChange(&state) { $0.email = email.trimWhiteSpaceOrReturnNilIfEmpty() }
             return .none
 
         case let .setPhoneNumber(phoneNumber):
-            guard case .initialized = state.initalizationState else {
-                setPreInitIdentifier(&state) {
-                    $0.phoneNumber = phoneNumber.trimWhiteSpaceOrReturnNilIfEmpty()
-                }
+            guard phoneNumber.isNotEmptyOrSame(
+                as: IdentityStore.shared.current.phoneNumber, identifier: "phone number"
+            ) else {
                 return .none
             }
-            state.updatePhoneNumber(phoneNumber: phoneNumber)
+            applyIdentifierChange(&state) { $0.phoneNumber = phoneNumber.trimWhiteSpaceOrReturnNilIfEmpty() }
             return .none
 
         case let .setExternalId(externalId):
-            guard case .initialized = state.initalizationState else {
-                setPreInitIdentifier(&state) { $0.externalId = externalId.trimWhiteSpaceOrReturnNilIfEmpty() }
+            guard externalId.isNotEmptyOrSame(
+                as: IdentityStore.shared.current.externalId, identifier: "external id"
+            ) else {
                 return .none
             }
-            state.updateExternalId(externalId: externalId)
+            applyIdentifierChange(&state) { $0.externalId = externalId.trimWhiteSpaceOrReturnNilIfEmpty() }
             return .none
 
         case let .setAutomaticPushToken(pushToken, enablement):
@@ -314,36 +313,32 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
         case let .setPushToken(pushToken, enablement):
-            guard case .initialized = state.initalizationState,
-                  let apiKey = state.apiKey,
-                  let anonymousId = state.anonymousId
-            else {
-                // Persist the token as canonical device state so a later pre-init identity change
-                // reads it and rebinds; that rebind buffers a fresh `.pushToken` registration, which
-                // coalesces this standalone one away.
-                IdentityStore.shared.updatePushToken(PushTokenData(
-                    pushToken: pushToken,
-                    pushEnablement: enablement,
-                    pushBackground: environment.getBackgroundSetting(),
-                    deviceData: DeviceMetadata(context: environment.appContextInfo())
-                ))
-                RequestEnqueuer.enqueuePushToken(pushToken, enablement: enablement)
-                return .none
-            }
-            if !state.shouldSendTokenUpdate(newToken: pushToken, enablement: enablement) {
-                return .none
-            }
-
-            let request = state.resolvedTokenRequest(
-                apiKey: apiKey,
-                anonymousId: anonymousId,
-                pushToken: pushToken,
-                enablement: enablement
+            let newTokenData = PushTokenData(
+                pushToken: pushToken, pushEnablement: enablement,
+                pushBackground: environment.getBackgroundSetting(),
+                deviceData: DeviceMetadata(context: environment.appContextInfo())
             )
-            state.enqueueRequest(request: request)
+            // Dedup against the canonical token (parity with shouldSendTokenUpdate).
+            guard IdentityStore.shared.pushToken != newTokenData else { return .none }
+            IdentityStore.shared.updatePushToken(newTokenData)
+            guard let anonymousId = IdentityStore.shared.current.anonymousId else {
+                environment.emitDeveloperWarning("SDK internal error: missing anonymousId")
+                return .none
+            }
+            if let apiKey = SDKConfigStore.shared.current.apiKey {
+                // Post-init: fold + consume any pending profile into the registration.
+                state.identity = IdentityStore.shared.current
+                let request = state.resolvedTokenRequest(
+                    apiKey: apiKey, anonymousId: anonymousId, pushToken: pushToken, enablement: enablement
+                )
+                state.enqueueRequest(request: request)
+            } else {
+                RequestEnqueuer.enqueuePushToken(pushToken, enablement: enablement) // pre-init buffer
+            }
             return .none
 
         case let .setPushEnablement(enablement):
+            // TODO(MAGE-1197): read the token from IdentityStore, not state.pushTokenData
             guard let pushToken = state.pushTokenData?.pushToken else {
                 return .none
             }
@@ -556,203 +551,104 @@ struct KlaviyoReducer: ReducerProtocol {
             state.requestsInFlight = []
             return .none
 
-        case var .enqueueEvent(event):
-            guard case .initialized = state.initalizationState,
-                  let apiKey = state.apiKey,
-                  let anonymousId = state.anonymousId
-            else {
-                RequestEnqueuer.enqueueEvent(event)
-                return .none
-            }
-
-            event = event.updateEventWithIdentifiers(
-                email: state.email,
-                phoneNumber: state.phoneNumber,
-                externalId: state.externalId,
-                pushToken: state.pushTokenData?.pushToken
-            )
-
-            let request = RequestFactory.eventRequest(
-                identity: state.requestIdentity(apiKey: apiKey, anonymousId: anonymousId),
-                event: event,
-                pushToken: state.pushTokenData?.pushToken
-            )
-
-            /*
-             High-priority requests (e.g. opened-push, geofence events) are front-inserted (inside
-             `QueueStore.enqueue`, keyed on `request.priority`) and trigger an immediate flush so
-             that user engagement events are not delayed. All other requests are appended and
-             flushed on the regular intervals defined in `StateManagementConstants`.
-             */
-            let shouldPrioritize = request.priority == .high
-            state.enqueueRequest(request: request)
-
-            let baseEffect = shouldPrioritize ? EffectTask<KlaviyoAction>.task { .flushQueue } : .none
-            return .merge([
-                baseEffect,
-                .fireAndForget { enrichAndPublishEvent(event) }
-            ])
+        case let .enqueueEvent(event):
+            RequestEnqueuer.enqueueEvent(event)
+            // Post-init only, matching today: publish to the EventBus (drives event-triggered in-app
+            // forms via KlaviyoForms' ProfileEventObserver) and prompt-flush high-priority events.
+            // Pre-init there is no forms observer and the flush engine no-ops, so gate on init state.
+            guard case .initialized = state.initalizationState else { return .none }
+            // `.fireAndForget` keeps publish async and reentrancy-safe, matching the pre-cutover
+            // semantics: an EventBus subscriber cannot dispatch back into the store synchronously.
+            let publish = EffectTask<KlaviyoAction>.fireAndForget { enrichAndPublishEvent(event) }
+            return event.priority == .high ? .merge([.task { .flushQueue }, publish]) : publish
 
         case let .enqueueAggregateEvent(payload):
-            guard case .initialized = state.initalizationState,
-                  let apiKey = state.apiKey
-            else {
-                RequestEnqueuer.enqueueAggregateEvent(payload)
-                return .none
-            }
-
-            let endpoint = KlaviyoEndpoint.aggregateEvent(apiKey, payload)
-            let request = KlaviyoRequest(endpoint: endpoint)
-
-            state.enqueueRequest(request: request)
-
+            RequestEnqueuer.enqueueAggregateEvent(payload)
             return .none
 
         case let .enqueueProfile(profile):
-            guard case .initialized = state.initalizationState
-            else {
-                // Pre-init: mirror the initialized path against the canonical persisted identity.
-                // Seed `state.identity` from `IdentityStore` so we fold onto (not clobber) the
-                // stored profile, run the SAME identifier-change reset, then push synchronously
-                // so the merged identity is durable before the profile sync is buffered.
-                state.identity = IdentityStore.shared.current
-                // Read before the reset below — the token lives in IdentityStore, not pre-init state.
-                let tokenData = IdentityStore.shared.pushToken
-                let preInitCurrentIds = [state.email, state.phoneNumber, state.externalId]
-                let preInitIncomingIds = [profile.email, profile.phoneNumber, profile.externalId].map {
-                    $0?.trimWhiteSpaceOrReturnNilIfEmpty()
-                }
-                // Identifier change on an already-identified profile → mint a fresh anonymousId and
-                // drop prior PII, so a set(profile:) with different identifiers before initialize()
-                // on a later launch does not reuse the previous user's anonymousId (which would
-                // merge two people onto one profile). Mirrors the initialized branch below.
-                if state.isIdentified, preInitCurrentIds != preInitIncomingIds {
-                    state.reset(preserveTokenData: false)
-                }
-                state.updateStateWithProfile(profile: profile)
-                IdentityStore.shared.update(state.identity)
-                guard let anonymousId = state.anonymousId else { return .none }
-                // Build the full payload exactly as the initialized path does, so structured
-                // attributes (name/title/organization/image/location) survive the pre-init buffer
-                // and sync completely after initialize() (MAGE-1141).
-                let profilePayload = state.profilePayload(from: profile, anonymousId: anonymousId)
-                RequestEnqueuer.enqueueProfile(payload: CreateProfilePayload(data: profilePayload))
-                if let tokenData {
-                    // Re-register the token against the new identity as a SEPARATE call. Keeping the
-                    // profile in its own `.profile` buffer entry means a later token callback (e.g. an
-                    // async automatic APNs fire) can't clobber the profile's structured attributes via
-                    // push-token coalescing. The identity-only registration coalesces to the current
-                    // identity, which the update above just set to the new one.
-                    RequestEnqueuer.enqueuePushToken(tokenData.pushToken, enablement: tokenData.pushEnablement)
-                }
-                return .none
-            }
-
-            let pushTokenData = state.pushTokenData
+            // Unified init-state-agnostic path: seed identity from the canonical IdentityStore so
+            // we fold onto (not clobber) the stored profile, run the identifier-change reset, write
+            // the merged identity back, then delegate to RequestEnqueuer. The write-through `defer`
+            // runs too late for RequestEnqueuer to read the new identity, so we update explicitly.
+            state.identity = IdentityStore.shared.current
+            // Read the token BEFORE any reset — IdentityStore holds the canonical token.
+            let tokenData = IdentityStore.shared.pushToken
             let currentIds = [state.email, state.phoneNumber, state.externalId]
             let incomingIds = [profile.email, profile.phoneNumber, profile.externalId].map {
                 // Normalize with the same trimming used by updateStateWithProfile
                 // so whitespace-padded inputs match their stored counterparts.
                 $0?.trimWhiteSpaceOrReturnNilIfEmpty()
             }
-
             let identifiersChanged = currentIds != incomingIds
-
-            // Only reset if the incoming profile has different identifiers.
-            // Anonymous ID is the lowest-order identifier, so there's no reason
-            // to regenerate it when higher-order identifiers haven't changed.
-            // Resetting with the same identifiers causes unnecessary anonymous ID
-            // churn, which triggers spurious push-token API requests.
+            // Identifier change on an already-identified profile → mint a fresh anonymousId and
+            // drop prior PII, so a set(profile:) with different identifiers does not reuse the
+            // previous user's anonymousId (which would merge two people onto one profile).
             // resetProfile() remains available for explicitly clobbering all state.
             if state.isIdentified, identifiersChanged {
                 state.reset(preserveTokenData: false)
             }
             state.updateStateWithProfile(profile: profile)
-
+            // Push the merged identity synchronously so RequestEnqueuer reads it before enqueueing.
+            IdentityStore.shared.update(state.identity)
             // Skip the API call entirely when there is nothing new to sync:
             // identifiers are unchanged, the profile carries no extra attributes,
             // and no profile properties are queued up via setProfileProperty.
             if !identifiersChanged, !profile.hasNonIdentifierData, state.pendingProfile == nil {
                 return .none
             }
-
-            guard let anonymousId = state.anonymousId,
-                  let apiKey = state.apiKey
-            else {
-                return .none
-            }
+            guard let anonymousId = state.anonymousId else { return .none }
+            // Build the full payload so structured attributes (name/title/organization/image/location)
+            // survive the buffer and sync completely after initialize() (MAGE-1141).
             let profilePayload = state.profilePayload(from: profile, anonymousId: anonymousId)
-
-            let request: KlaviyoRequest
-            if let tokenData = pushTokenData {
-                request = RequestFactory.tokenRequest(
-                    apiKey: apiKey,
-                    pushToken: tokenData.pushToken,
-                    enablement: tokenData.pushEnablement,
-                    background: tokenData.pushBackground.rawValue,
-                    profile: profilePayload
-                )
-            } else {
-                request = RequestFactory.profileRequest(
-                    apiKey: apiKey,
-                    payload: CreateProfilePayload(data: profilePayload)
-                )
+            RequestEnqueuer.enqueueProfile(payload: CreateProfilePayload(data: profilePayload))
+            if let tokenData {
+                // Re-register the token as a SEPARATE, identity-only request (built from the current
+                // identity, no structured attributes), enqueued after the createProfile above. Because
+                // it carries no attributes, it can't overwrite the profile attributes just sent, and
+                // FIFO ordering keeps the profile ahead of the registration.
+                RequestEnqueuer.enqueuePushToken(tokenData.pushToken, enablement: tokenData.pushEnablement)
             }
-            state.enqueueRequest(request: request)
-
             return .none
 
         case let .enqueueSubscription(subscription):
-            guard case .initialized = state.initalizationState,
-                  let apiKey = state.apiKey,
-                  let anonymousId = state.anonymousId
+            // Seed identity from the canonical store (both pre- and post-init). The ungated
+            // `RequestEnqueuer` routes to `QueueStore` when an apiKey is present, or buffers
+            // durably in `UnattributedBuffer` pre-init so a subscribe is never silently dropped.
+            state.identity = IdentityStore.shared.current
+            // Defensive: `IdentityStore` auto-mints an `anonymousId` on first access, so `nil`
+            // is unreachable in practice — mirroring the note in `RequestEnqueuer.swift`.
+            guard let anonymousId = state.anonymousId,
+                  let payload = state.buildSubscriptionPayload(
+                      anonymousId: anonymousId, subscription: subscription
+                  )
             else {
-                // Pre-init: seed identity from the canonical store, build the apiKey-free payload, and
-                // buffer it via the ungated `RequestEnqueuer` so a pre-init subscribe survives (MAGE-1136).
-                state.identity = IdentityStore.shared.current
-                guard let anonymousId = state.anonymousId,
-                      let payload = state.buildSubscriptionPayload(
-                          anonymousId: anonymousId, subscription: subscription
-                      )
-                else {
-                    return .none
-                }
-                RequestEnqueuer.enqueueSubscription(payload: payload)
                 return .none
             }
-
-            guard let request = state.buildSubscriptionRequest(
-                apiKey: apiKey,
-                anonymousId: anonymousId,
-                subscription: subscription
-            ) else {
-                return .none
-            }
-            state.enqueueRequest(request: request)
-
+            RequestEnqueuer.enqueueSubscription(payload: payload)
             return .none
 
         case .resetProfile:
-            guard case .initialized = state.initalizationState
-            else {
-                // Pre-init reset, mirroring the post-init path. Persist the reset identity to
-                // `IdentityStore` synchronously before the re-register below: the write-through
-                // `defer` runs too late for `RequestEnqueuer` to read the new anon.
-                // `preserveTokenData: false` skips reset's apiKey-gated re-register; we use the
-                // ungated `RequestEnqueuer` instead. A profile buffered under the old identity
-                // still drains at init (MAGE-1136).
-                state.identity = IdentityStore.shared.current
-                let tokenData = IdentityStore.shared.pushToken
-                state.reset(preserveTokenData: false)
-                IdentityStore.shared.update(state.identity)
-                if let tokenData = tokenData {
-                    RequestEnqueuer.enqueuePushToken(
-                        tokenData.pushToken, enablement: tokenData.pushEnablement
-                    )
-                }
-                return .none
+            // Unified reset: mint a fresh anonymous id, drop all PII, and re-register the
+            // preserved push token under the new identity via the ungated `RequestEnqueuer`.
+            // The explicit `IdentityStore.shared.update` before the re-register ensures the
+            // enqueuer reads the post-reset identity; the write-through `defer` would fire too
+            // late for `RequestEnqueuer` to observe the new anon.
+            // `preserveTokenData: false` skips `reset`'s own apiKey-gated re-register so we
+            // avoid a duplicate enqueue. A profile buffered under the old identity still drains
+            // at init (MAGE-1136).
+            state.identity = IdentityStore.shared.current
+            let tokenData = IdentityStore.shared.pushToken
+            state.reset(preserveTokenData: false)
+            // Restore the token on state so the write-through `defer` observes no token change and
+            // does NOT call `IdentityStore.shared.updatePushToken(nil)`. The canonical push token is
+            // preserved in `IdentityStore`; the re-register below re-associates it with the new
+            // anonymous identity. Without this restore the defer would transiently clear the token.
+            state.pushTokenData = tokenData
+            IdentityStore.shared.update(state.identity)
+            if let tokenData {
+                RequestEnqueuer.enqueuePushToken(tokenData.pushToken, enablement: tokenData.pushEnablement)
             }
-            state.reset()
             return .none
 
         case let .setProfileProperty(key, value):
@@ -808,61 +704,64 @@ struct KlaviyoReducer: ReducerProtocol {
             }
 
         case let .trackingLinkResolutionFailed(trackingLink, clickTime):
-            // In the reducer only because it's a TCA action whose post-init path reads identity
-            // from `state`. Once the flush engine becomes a Core actor queue and this reducer is
-            // retired, the case folds into `TrackingLinkManager`, which reads identity from the
-            // canonical stores and enqueues directly.
-            guard case .initialized = state.initalizationState, state.apiKey != nil else {
-                // Pre-init: buffer via the ungated `RequestEnqueuer` instead of the apiKey-gated
-                // `state.enqueueRequest`, which would drop the click (MAGE-1136).
-                RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
-                return .none
-            }
-            let profileInfo = ProfilePayload(
-                email: state.email,
-                phoneNumber: state.phoneNumber,
-                externalId: state.externalId,
-                anonymousId: state.anonymousId ?? ""
-            )
-
-            let request = KlaviyoRequest(
-                endpoint: .logTrackingLinkClicked(
-                    trackingLink: trackingLink,
-                    clickTime: clickTime,
-                    profileInfo: profileInfo
-                )
-            )
-            state.enqueueRequest(request: request)
-
+            // Identity is resolved inside `RequestEnqueuer.enqueueTrackingLinkClicked` from the
+            // canonical `IdentityStore`. The ungated enqueuer routes to `QueueStore` when an apiKey
+            // is present, or buffers durably pre-init (MAGE-1136). Once the flush engine becomes a
+            // Core actor the case will fold into `TrackingLinkManager` entirely.
+            RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
             return .none
         }
     }
 
-    /// Applies a pre-init identity-setter (`setEmail`/`setPhoneNumber`/`setExternalId`) and buffers
-    /// a profile sync.
+    /// Applies an identifier change (`setEmail`/`setPhoneNumber`/`setExternalId`) against the
+    /// canonical `IdentityStore`, then enqueues the follow-up sync request:
+    /// - **Post-init + token present:** enqueues a token re-association request via
+    ///   `state.enqueueRequest` (→ `QueueStore.shared`), folding any pending profile.
+    /// - **Pre-init or no token:** enqueues a profile via the ungated `RequestEnqueuer`,
+    ///   folding any pending profile.
     ///
-    /// The just-set identifier must reach `IdentityStore` BEFORE `RequestEnqueuer.enqueueProfile`
-    /// reads it: the reducer's write-through `defer` fires only at RETURN, which is too late.
-    /// So we push identity synchronously here. Crucially we seed the FULL `state.identity` from
-    /// `IdentityStore.current` first (minting the anonymousId on first access) so the setter FOLDS
-    /// onto the persisted identity — `IdentityStore.update` replaces wholesale, so seeding only the
-    /// anonymousId would clobber the other persisted identifiers with `nil` from a fresh pre-init `state`.
-    /// Mirrors the pre-init `set(profile:)` path.
-    private func setPreInitIdentifier(
+    /// Seeds the FULL identity from `IdentityStore` first so the setter folds onto the persisted
+    /// profile (update replaces wholesale).
+    private func applyIdentifierChange(
         _ state: inout KlaviyoState,
         _ apply: (inout KlaviyoState) -> Void
     ) {
         state.identity = IdentityStore.shared.current
         apply(&state)
         IdentityStore.shared.update(state.identity)
+        // Note: `state.pushTokenData` is NOT cleared here. The token is now canonical in
+        // `IdentityStore` — clearing it from state was only necessary in the old
+        // per-setter code path. The `state.pushTokenData` field is written through by the
+        // reducer's defer block whenever `IdentityStore.shared.updatePushToken` is called.
         guard let anonymousId = state.anonymousId else { return }
-        let payload = CreateProfilePayload(data: ProfilePayload(
-            email: state.email,
-            phoneNumber: state.phoneNumber,
-            externalId: state.externalId,
-            anonymousId: anonymousId
-        ))
-        RequestEnqueuer.enqueueProfile(payload: payload)
+
+        if let apiKey = SDKConfigStore.shared.current.apiKey,
+           let tokenData = IdentityStore.shared.pushToken {
+            // Post-init token re-association: fold + consume any pending profile into the token
+            // request's profile (as the legacy resolvedTokenRequest did), then enqueue.
+            let request = state.resolvedTokenRequest(
+                apiKey: apiKey,
+                anonymousId: anonymousId,
+                pushToken: tokenData.pushToken,
+                enablement: tokenData.pushEnablement
+            )
+            state.enqueueRequest(request: request) // already targets QueueStore.shared
+        } else {
+            // Pre-init (no apiKey → buffer) or post-init with no token: enqueue a profile via the
+            // ungated RequestEnqueuer, folding any pending profile. Matches the legacy
+            // setPreInitIdentifier.
+            // Pass an empty Profile(): `profilePayload(from:anonymousId:)` sources all identifiers
+            // from `state` directly — the Profile argument carries no structured attributes that
+            // would override state, so constructing it with the current identifier values is
+            // redundant.
+            let payload = CreateProfilePayload(data: state.profilePayload(
+                from: Profile(),
+                anonymousId: anonymousId
+            ))
+            RequestEnqueuer.enqueueProfile(
+                payload: state.updateRequestAndStateWithPendingProfile(profile: payload)
+            )
+        }
     }
 }
 

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -166,8 +166,6 @@ struct KlaviyoReducer: ReducerProtocol {
                 guard apiKey != state.apiKey else {
                     return .none
                 }
-                // Moving the token to a new company: unregister from the old one. Appended (not
-                // front-inserted) so it sends after any already-queued old-company requests.
                 if let apiKey = state.apiKey,
                    let anonymousId = state.anonymousId,
                    let tokenData = state.pushTokenData {
@@ -320,12 +318,18 @@ struct KlaviyoReducer: ReducerProtocol {
             )
             // Dedup against the canonical token (parity with shouldSendTokenUpdate).
             guard IdentityStore.shared.pushToken != newTokenData else { return .none }
-            IdentityStore.shared.updatePushToken(newTokenData)
+            // Write-through: assign the projection and let the reducer's `defer` persist it to
+            // IdentityStore. Writing IdentityStore directly would leave `state.pushTokenData` stale
+            // for other state readers (the company-switch unregister) until a register drains (MAGE-1196).
+            state.pushTokenData = newTokenData
             guard let anonymousId = IdentityStore.shared.current.anonymousId else {
                 environment.emitDeveloperWarning("SDK internal error: missing anonymousId")
                 return .none
             }
-            if let apiKey = SDKConfigStore.shared.current.apiKey {
+            // Gate on `state.apiKey` to match `state.enqueueRequest`: `SDKConfigStore` can hold a
+            // persisted apiKey before `.initialize` sets `state.apiKey` (warm start), and enqueuing
+            // then would be dropped. Pre-init falls through to the durable buffer instead (MAGE-1196).
+            if let apiKey = state.apiKey {
                 // Post-init: fold + consume any pending profile into the registration.
                 state.identity = IdentityStore.shared.current
                 let request = state.resolvedTokenRequest(
@@ -338,8 +342,11 @@ struct KlaviyoReducer: ReducerProtocol {
             return .none
 
         case let .setPushEnablement(enablement):
-            // TODO(MAGE-1197): read the token from IdentityStore, not state.pushTokenData
-            guard let pushToken = state.pushTokenData?.pushToken else {
+            // Read the token from the canonical IdentityStore, not the `state` projection.
+            // setPushToken writes IdentityStore eagerly but leaves state.pushTokenData stale until
+            // the register drains, so reading state here could forward — and re-register — a stale
+            // token, clobbering the canonical store back to it (MAGE-1196).
+            guard let pushToken = IdentityStore.shared.pushToken?.pushToken else {
                 return .none
             }
 
@@ -735,7 +742,10 @@ struct KlaviyoReducer: ReducerProtocol {
         // reducer's defer block whenever `IdentityStore.shared.updatePushToken` is called.
         guard let anonymousId = state.anonymousId else { return }
 
-        if let apiKey = SDKConfigStore.shared.current.apiKey,
+        // Gate on `state.apiKey` (not `SDKConfigStore`) to match `state.enqueueRequest`: a warm-start
+        // apiKey persisted in `SDKConfigStore` before `.initialize` would otherwise take this branch
+        // and be dropped. Pre-init falls through to the buffered `RequestEnqueuer` path (MAGE-1196).
+        if let apiKey = state.apiKey,
            let tokenData = IdentityStore.shared.pushToken {
             // Post-init token re-association: fold + consume any pending profile into the token
             // request's profile (as the legacy resolvedTokenRequest did), then enqueue.

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -329,7 +329,8 @@ struct KlaviyoReducer: ReducerProtocol {
             }
             // Gate on `state.apiKey` to match `state.enqueueRequest`: `SDKConfigStore` can hold a
             // persisted apiKey before `.initialize` sets `state.apiKey` (warm start), and enqueuing
-            // then would be dropped. Pre-init falls through to the durable buffer instead.
+            // via `enqueueRequest` then would be dropped. The else branch re-gates on
+            // `SDKConfigStore`, so a warm-start token still reaches `QueueStore` (not the buffer).
             if let apiKey = state.apiKey {
                 // Post-init: fold + consume any pending profile into the registration.
                 state.identity = IdentityStore.shared.current
@@ -338,7 +339,8 @@ struct KlaviyoReducer: ReducerProtocol {
                 )
                 state.enqueueRequest(request: request)
             } else {
-                RequestEnqueuer.enqueuePushToken(pushToken, enablement: enablement) // pre-init buffer
+                // Pre-init or warm start: RequestEnqueuer re-gates on SDKConfigStore.
+                RequestEnqueuer.enqueuePushToken(pushToken, enablement: enablement)
             }
             return .none
 
@@ -561,9 +563,19 @@ struct KlaviyoReducer: ReducerProtocol {
             // forms via KlaviyoForms' ProfileEventObserver) and prompt-flush high-priority events.
             // Pre-init there is no forms observer and the flush engine no-ops, so gate on init state.
             guard case .initialized = state.initalizationState else { return .none }
+            // Stamp identifiers onto the published event so the EventBus/KlaviyoJS path carries the
+            // same properties as the outbound request. Read from the canonical stores, matching
+            // `RequestEnqueuer.enqueueEvent`.
+            let identity = IdentityStore.shared.current
+            let publishedEvent = event.updateEventWithIdentifiers(
+                email: identity.email,
+                phoneNumber: identity.phoneNumber,
+                externalId: identity.externalId,
+                pushToken: IdentityStore.shared.pushToken?.pushToken
+            )
             // `.fireAndForget` keeps publish async and reentrancy-safe, matching the pre-cutover
             // semantics: an EventBus subscriber cannot dispatch back into the store synchronously.
-            let publish = EffectTask<KlaviyoAction>.fireAndForget { enrichAndPublishEvent(event) }
+            let publish = EffectTask<KlaviyoAction>.fireAndForget { enrichAndPublishEvent(publishedEvent) }
             return event.priority == .high ? .merge([.task { .flushQueue }, publish]) : publish
 
         case let .enqueueAggregateEvent(payload):
@@ -586,6 +598,7 @@ struct KlaviyoReducer: ReducerProtocol {
             // resetProfile() remains available for explicitly clobbering all state.
             if state.isIdentified, identifiersChanged {
                 state.reset(preserveTokenData: false)
+                state.pushTokenData = tokenData
             }
             state.updateStateWithProfile(profile: profile)
             IdentityStore.shared.update(state.identity)
@@ -712,14 +725,16 @@ struct KlaviyoReducer: ReducerProtocol {
         IdentityStore.shared.update(state.identity)
         guard let anonymousId = state.anonymousId else { return }
 
-        // Identifier change means profile must be re-registered/associated.
-        // Use `apiKey` in state in case of warm start (i.e. initialize has not
-        // finished running in reducer yet) instead of `SDKConfigStore` (which
-        // still at this point relies on the defer write through)
+        // The identifier changed, so re-register the profile under the new identity. Two paths,
+        // and both fold in + consume any staged `pendingProfile` so those properties ship now
+        // instead of waiting for a later flush. (This is the one behavior change from the legacy
+        // `setPreInitIdentifier`, which left `pendingProfile` staged.)
+        //
+        // Gate on `state.apiKey`, not `SDKConfigStore`: on a warm start `initialize` may not have
+        // run through the reducer yet, so `state.apiKey` is the source of truth for "post-init".
         if let apiKey = state.apiKey,
            let tokenData = IdentityStore.shared.pushToken {
-            // Post-init token re-association: fold + consume any pending profile into the token
-            // request's profile, then enqueue.
+            // Post-init with a token: re-associate the token to the new identity.
             let request = state.resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,
@@ -728,13 +743,10 @@ struct KlaviyoReducer: ReducerProtocol {
             )
             state.enqueueRequest(request: request) // already targets QueueStore.shared
         } else {
-            // Pre-init (no apiKey → buffer) or post-init with no token: enqueue a profile via the
-            // ungated RequestEnqueuer, folding any pending profile. Matches the legacy
-            // setPreInitIdentifier.
-            // Pass an empty Profile(): `profilePayload(from:anonymousId:)` sources all identifiers
-            // from `state` directly — the Profile argument carries no structured attributes that
-            // would override state, so constructing it with the current identifier values is
-            // redundant.
+            // Pre-init or post-init with no token: send a profile via the ungated RequestEnqueuer
+            // (pre-init, this lands in the durable buffer). Empty `Profile()` is intentional —
+            // `profilePayload(from:anonymousId:)` reads every identifier straight from `state`,
+            // at this point, so the argument would only carry redundant values.
             let payload = CreateProfilePayload(data: state.profilePayload(
                 from: Profile(),
                 anonymousId: anonymousId

--- a/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
+++ b/Sources/KlaviyoSwift/StateManagement/StateManagement.swift
@@ -316,11 +316,12 @@ struct KlaviyoReducer: ReducerProtocol {
                 pushBackground: environment.getBackgroundSetting(),
                 deviceData: DeviceMetadata(context: environment.appContextInfo())
             )
-            // Dedup against the canonical token (parity with shouldSendTokenUpdate).
+            // Dedup against the canonical token: skip when token + enablement + background +
+            // device metadata all match.
             guard IdentityStore.shared.pushToken != newTokenData else { return .none }
             // Write-through: assign the projection and let the reducer's `defer` persist it to
-            // IdentityStore. Writing IdentityStore directly would leave `state.pushTokenData` stale
-            // for other state readers (the company-switch unregister) until a register drains (MAGE-1196).
+            // IdentityStore. Still the load-bearing write method until KlaviyoState and reducer
+            // fully go away.
             state.pushTokenData = newTokenData
             guard let anonymousId = IdentityStore.shared.current.anonymousId else {
                 environment.emitDeveloperWarning("SDK internal error: missing anonymousId")
@@ -328,7 +329,7 @@ struct KlaviyoReducer: ReducerProtocol {
             }
             // Gate on `state.apiKey` to match `state.enqueueRequest`: `SDKConfigStore` can hold a
             // persisted apiKey before `.initialize` sets `state.apiKey` (warm start), and enqueuing
-            // then would be dropped. Pre-init falls through to the durable buffer instead (MAGE-1196).
+            // then would be dropped. Pre-init falls through to the durable buffer instead.
             if let apiKey = state.apiKey {
                 // Post-init: fold + consume any pending profile into the registration.
                 state.identity = IdentityStore.shared.current
@@ -342,10 +343,6 @@ struct KlaviyoReducer: ReducerProtocol {
             return .none
 
         case let .setPushEnablement(enablement):
-            // Read the token from the canonical IdentityStore, not the `state` projection.
-            // setPushToken writes IdentityStore eagerly but leaves state.pushTokenData stale until
-            // the register drains, so reading state here could forward — and re-register — a stale
-            // token, clobbering the canonical store back to it (MAGE-1196).
             guard let pushToken = IdentityStore.shared.pushToken?.pushToken else {
                 return .none
             }
@@ -574,12 +571,7 @@ struct KlaviyoReducer: ReducerProtocol {
             return .none
 
         case let .enqueueProfile(profile):
-            // Unified init-state-agnostic path: seed identity from the canonical IdentityStore so
-            // we fold onto (not clobber) the stored profile, run the identifier-change reset, write
-            // the merged identity back, then delegate to RequestEnqueuer. The write-through `defer`
-            // runs too late for RequestEnqueuer to read the new identity, so we update explicitly.
             state.identity = IdentityStore.shared.current
-            // Read the token BEFORE any reset — IdentityStore holds the canonical token.
             let tokenData = IdentityStore.shared.pushToken
             let currentIds = [state.email, state.phoneNumber, state.externalId]
             let incomingIds = [profile.email, profile.phoneNumber, profile.externalId].map {
@@ -596,7 +588,6 @@ struct KlaviyoReducer: ReducerProtocol {
                 state.reset(preserveTokenData: false)
             }
             state.updateStateWithProfile(profile: profile)
-            // Push the merged identity synchronously so RequestEnqueuer reads it before enqueueing.
             IdentityStore.shared.update(state.identity)
             // Skip the API call entirely when there is nothing new to sync:
             // identifiers are unchanged, the profile carries no extra attributes,
@@ -605,8 +596,6 @@ struct KlaviyoReducer: ReducerProtocol {
                 return .none
             }
             guard let anonymousId = state.anonymousId else { return .none }
-            // Build the full payload so structured attributes (name/title/organization/image/location)
-            // survive the buffer and sync completely after initialize() (MAGE-1141).
             let profilePayload = state.profilePayload(from: profile, anonymousId: anonymousId)
             RequestEnqueuer.enqueueProfile(payload: CreateProfilePayload(data: profilePayload))
             if let tokenData {
@@ -619,12 +608,7 @@ struct KlaviyoReducer: ReducerProtocol {
             return .none
 
         case let .enqueueSubscription(subscription):
-            // Seed identity from the canonical store (both pre- and post-init). The ungated
-            // `RequestEnqueuer` routes to `QueueStore` when an apiKey is present, or buffers
-            // durably in `UnattributedBuffer` pre-init so a subscribe is never silently dropped.
             state.identity = IdentityStore.shared.current
-            // Defensive: `IdentityStore` auto-mints an `anonymousId` on first access, so `nil`
-            // is unreachable in practice — mirroring the note in `RequestEnqueuer.swift`.
             guard let anonymousId = state.anonymousId,
                   let payload = state.buildSubscriptionPayload(
                       anonymousId: anonymousId, subscription: subscription
@@ -636,21 +620,11 @@ struct KlaviyoReducer: ReducerProtocol {
             return .none
 
         case .resetProfile:
-            // Unified reset: mint a fresh anonymous id, drop all PII, and re-register the
-            // preserved push token under the new identity via the ungated `RequestEnqueuer`.
-            // The explicit `IdentityStore.shared.update` before the re-register ensures the
-            // enqueuer reads the post-reset identity; the write-through `defer` would fire too
-            // late for `RequestEnqueuer` to observe the new anon.
-            // `preserveTokenData: false` skips `reset`'s own apiKey-gated re-register so we
-            // avoid a duplicate enqueue. A profile buffered under the old identity still drains
-            // at init (MAGE-1136).
+            // Seed from canonical so `reset` sees the real identity (mint decision + write-back below);
+            // the projection can be stale/empty pre-init. Goes away with KlaviyoState eventually.
             state.identity = IdentityStore.shared.current
             let tokenData = IdentityStore.shared.pushToken
             state.reset(preserveTokenData: false)
-            // Restore the token on state so the write-through `defer` observes no token change and
-            // does NOT call `IdentityStore.shared.updatePushToken(nil)`. The canonical push token is
-            // preserved in `IdentityStore`; the re-register below re-associates it with the new
-            // anonymous identity. Without this restore the defer would transiently clear the token.
             state.pushTokenData = tokenData
             IdentityStore.shared.update(state.identity)
             if let tokenData {
@@ -713,8 +687,8 @@ struct KlaviyoReducer: ReducerProtocol {
         case let .trackingLinkResolutionFailed(trackingLink, clickTime):
             // Identity is resolved inside `RequestEnqueuer.enqueueTrackingLinkClicked` from the
             // canonical `IdentityStore`. The ungated enqueuer routes to `QueueStore` when an apiKey
-            // is present, or buffers durably pre-init (MAGE-1136). Once the flush engine becomes a
-            // Core actor the case will fold into `TrackingLinkManager` entirely.
+            // is present, or buffers durably pre-init. Once the flush engine becomes a Core actor
+            // the case will fold into `TrackingLinkManager` entirely.
             RequestEnqueuer.enqueueTrackingLinkClicked(trackingLink: trackingLink, clickTime: clickTime)
             return .none
         }
@@ -736,19 +710,16 @@ struct KlaviyoReducer: ReducerProtocol {
         state.identity = IdentityStore.shared.current
         apply(&state)
         IdentityStore.shared.update(state.identity)
-        // Note: `state.pushTokenData` is NOT cleared here. The token is now canonical in
-        // `IdentityStore` — clearing it from state was only necessary in the old
-        // per-setter code path. The `state.pushTokenData` field is written through by the
-        // reducer's defer block whenever `IdentityStore.shared.updatePushToken` is called.
         guard let anonymousId = state.anonymousId else { return }
 
-        // Gate on `state.apiKey` (not `SDKConfigStore`) to match `state.enqueueRequest`: a warm-start
-        // apiKey persisted in `SDKConfigStore` before `.initialize` would otherwise take this branch
-        // and be dropped. Pre-init falls through to the buffered `RequestEnqueuer` path (MAGE-1196).
+        // Identifier change means profile must be re-registered/associated.
+        // Use `apiKey` in state in case of warm start (i.e. initialize has not
+        // finished running in reducer yet) instead of `SDKConfigStore` (which
+        // still at this point relies on the defer write through)
         if let apiKey = state.apiKey,
            let tokenData = IdentityStore.shared.pushToken {
             // Post-init token re-association: fold + consume any pending profile into the token
-            // request's profile (as the legacy resolvedTokenRequest did), then enqueue.
+            // request's profile, then enqueue.
             let request = state.resolvedTokenRequest(
                 apiKey: apiKey,
                 anonymousId: anonymousId,

--- a/Tests/KlaviyoCoreTests/QueueStoreRestoreTests.swift
+++ b/Tests/KlaviyoCoreTests/QueueStoreRestoreTests.swift
@@ -82,7 +82,7 @@ final class QueueStoreRestoreTests: XCTestCase {
 
     /// `restore` prepends the legacy backlog AHEAD of whatever is already queued rather than
     /// replacing it wholesale, so a request that raced into the queue during the init window
-    /// (MAGE-952) survives migration instead of being wiped.
+    /// survives migration instead of being wiped.
     func testRestorePrependsLegacyAheadOfExistingRequests() throws {
         let diskIO = SpyDiskIO([request("a"), request("b")])
         let scheduler = ManualPersistScheduler()

--- a/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestEnqueuerTests.swift
@@ -38,7 +38,7 @@ final class RequestEnqueuerTests: XCTestCase {
 
     func testEventWithoutApiKeyGoesToBuffer() {
         // no apiKey set
-        // IdentityStore mints anonymousId on first access (MAGE-894 single minter), so it is always
+        // IdentityStore mints anonymousId on first access (single minter), so it is always
         // non-nil here — the anonymousId guard in RequestEnqueuer is defensive, never reached.
         XCTAssertNotNil(IdentityStore.shared.current.anonymousId)
         RequestEnqueuer.enqueueEvent(Event(name: .customEvent("X")))
@@ -82,7 +82,7 @@ final class RequestEnqueuerTests: XCTestCase {
 
     func testProfileWithoutApiKeyBuffersFullPayload() {
         // The caller supplies a fully-built payload, so structured attributes survive into the
-        // durable buffer (MAGE-1141).
+        // durable buffer.
         let payload = CreateProfilePayload(data: ProfilePayload(
             email: "ada@example.com", firstName: "Ada", anonymousId: "anon-1"
         ))
@@ -158,7 +158,7 @@ final class RequestEnqueuerTests: XCTestCase {
     func testRepeatedPushTokenWithoutApiKeyCoalescesToLatest() {
         // Models repeated pre-init fires (e.g. multiple automatic APNs callbacks before
         // `initialize()`) — only the latest token should survive in the buffer, not one entry
-        // per fire, so drain doesn't send N redundant register calls (MAGE-1137).
+        // per fire, so drain doesn't send N redundant register calls.
         RequestEnqueuer.enqueuePushToken("token-1", enablement: .authorized)
         RequestEnqueuer.enqueuePushToken("token-2", enablement: .authorized)
         RequestEnqueuer.enqueuePushToken("token-3", enablement: .authorized)
@@ -217,7 +217,7 @@ final class RequestEnqueuerTests: XCTestCase {
 
     func testTrackingLinkClickWithoutApiKeyGoesToBuffer() {
         // A universal-link click that fails destination resolution before initialize() must park
-        // its click-log in the durable buffer instead of being dropped (MAGE-1136).
+        // its click-log in the durable buffer instead of being dropped.
         RequestEnqueuer.enqueueTrackingLinkClicked(
             trackingLink: trackingLinkURL, clickTime: environment.date()
         )

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -176,7 +176,7 @@ final class ResolveTrackingLinkTests: XCTestCase {
     func testPreInitTrackingLinkResolutionFailedBuffers() async throws {
         // Pre-init (no apiKey in SDKConfigStore): a failed tracking-link resolution must park its
         // click-log in the durable buffer instead of dropping it via the apiKey-gated
-        // `state.enqueueRequest` (MAGE-1136).
+        // `state.enqueueRequest`.
         let store = TestStore(
             initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
         )

--- a/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
+++ b/Tests/KlaviyoSwiftTests/ResolveTrackingLinkTests.swift
@@ -128,6 +128,9 @@ final class ResolveTrackingLinkTests: XCTestCase {
     func testResolveTrackingLinkDestinationWithError() async throws {
         // Given
         let initialState = INITIALIZED_TEST_STATE()
+        // Seed the canonical stores so `RequestEnqueuer.enqueueTrackingLinkClicked` routes to
+        // `QueueStore` (apiKey present) and reads identity matching `initialState` (no PII, just anon).
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
         let clickTime = Date(timeIntervalSince1970: 1_735_707_600)
@@ -149,15 +152,17 @@ final class ResolveTrackingLinkTests: XCTestCase {
         await store.receive(
             .trackingLinkResolutionFailed(trackingLink: trackingLinkURL, clickTime: clickTime)
         )
+        // Identity in `IdentityStore` after reset: no PII, anonymousId = test UUID — matches `initialState`.
+        let anonymousId = try XCTUnwrap(IdentityStore.shared.current.anonymousId)
         let request = KlaviyoRequest(
             endpoint: .logTrackingLinkClicked(
                 trackingLink: trackingLinkURL,
                 clickTime: clickTime,
                 profileInfo: ProfilePayload(
-                    email: initialState.email,
-                    phoneNumber: initialState.phoneNumber,
-                    externalId: initialState.externalId,
-                    anonymousId: initialState.anonymousId ?? ""
+                    email: IdentityStore.shared.current.email,
+                    phoneNumber: IdentityStore.shared.current.phoneNumber,
+                    externalId: IdentityStore.shared.current.externalId,
+                    anonymousId: anonymousId
                 )
             )
         )
@@ -196,6 +201,9 @@ final class ResolveTrackingLinkTests: XCTestCase {
     func testResolveTrackingLinkDecodingError() async throws {
         // Given
         let initialState = INITIALIZED_TEST_STATE()
+        // Seed the canonical stores so `RequestEnqueuer.enqueueTrackingLinkClicked` routes to
+        // `QueueStore` (apiKey present) and reads identity matching `initialState` (no PII, just anon).
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
         let clickTime = Date(timeIntervalSince1970: 1_735_707_600)
@@ -214,15 +222,17 @@ final class ResolveTrackingLinkTests: XCTestCase {
         await store.receive(
             .trackingLinkResolutionFailed(trackingLink: trackingLinkURL, clickTime: clickTime)
         )
+        // Identity in `IdentityStore` after reset: no PII, anonymousId = test UUID — matches `initialState`.
+        let anonymousId = try XCTUnwrap(IdentityStore.shared.current.anonymousId)
         let request = KlaviyoRequest(
             endpoint: .logTrackingLinkClicked(
                 trackingLink: trackingLinkURL,
                 clickTime: clickTime,
                 profileInfo: ProfilePayload(
-                    email: initialState.email,
-                    phoneNumber: initialState.phoneNumber,
-                    externalId: initialState.externalId,
-                    anonymousId: initialState.anonymousId ?? ""
+                    email: IdentityStore.shared.current.email,
+                    phoneNumber: IdentityStore.shared.current.phoneNumber,
+                    externalId: IdentityStore.shared.current.externalId,
+                    anonymousId: anonymousId
                 )
             )
         )

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -515,7 +515,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
                                         initalizationState: .uninitialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData
 
         _ = await store.send(.setPushToken("blob_token", .authorized))
         XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
@@ -548,7 +548,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData
 
         _ = await store.send(.setPushToken("blob_token", .authorized))
         XCTAssertEqual(readQueue().count, 1)
@@ -741,7 +741,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
             flushing: false
         )
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData
 
         // Impossible case really but we want coverage on it. Missing apiKey → the token routes to
         // the durable UnattributedBuffer rather than being parked in state.

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -38,6 +38,22 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         return (readQueue, store)
     }
 
+    /// Returns a non-exhaustive `TestStore` seeded with a minimal initialized state and the
+    /// canonical `SDKConfigStore`. Use for identifier-setter tests that only need a live,
+    /// initialized store to send actions against.
+    @MainActor
+    private func makeInitializedIdentifierStore(apiKey: String = "fake-key") -> CompanySwitchStore {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+        let store = TestStore(
+            initialState: KlaviyoState(
+                apiKey: apiKey, requestsInFlight: [], initalizationState: .initialized, flushing: false
+            ),
+            reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+        return store
+    }
+
     // MARK: - initialization
 
     @MainActor
@@ -325,14 +341,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         // Under the canonical-store model, IdentityStore auto-mints an anonymousId on first access,
         // so "missing anonymousId" is no longer a reachable production state. The test intent is
         // preserved: the email is still persisted to the canonical IdentityStore.
-        let apiKey = "fake-key"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
-        let initialState = KlaviyoState(apiKey: apiKey,
-                                        requestsInFlight: [],
-                                        initalizationState: .initialized,
-                                        flushing: false)
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
+        let store = makeInitializedIdentifierStore()
 
         _ = await store.send(.setEmail("test@blob.com"))
 
@@ -361,14 +370,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
     @MainActor
     func testSetEmailWithTrailingWhiteSpace() async throws {
         // Trailing whitespace must be trimmed; the canonical store must receive the trimmed value.
-        let apiKey = "fake-key"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
-        let initialState = KlaviyoState(apiKey: apiKey,
-                                        requestsInFlight: [],
-                                        initalizationState: .initialized,
-                                        flushing: false)
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
+        let store = makeInitializedIdentifierStore()
 
         _ = await store.send(.setEmail("test@blob.com        "))
 
@@ -403,14 +405,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
         // Under the canonical-store model, IdentityStore auto-mints an anonymousId on first access,
         // so "missing anonymousId" is no longer a reachable production state. The test intent is
         // preserved: the externalId is still persisted to the canonical IdentityStore.
-        let apiKey = "fake-key"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
-        let initialState = KlaviyoState(apiKey: apiKey,
-                                        requestsInFlight: [],
-                                        initalizationState: .initialized,
-                                        flushing: false)
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
+        let store = makeInitializedIdentifierStore()
 
         _ = await store.send(.setExternalId("external-blob-id"))
 
@@ -439,14 +434,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
     @MainActor
     func testSetExternalIdWithTrailingWhiteSpace() async throws {
         // Trailing whitespace must be trimmed; the canonical store must receive the trimmed value.
-        let apiKey = "fake-key"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
-        let initialState = KlaviyoState(apiKey: apiKey,
-                                        requestsInFlight: [],
-                                        initalizationState: .initialized,
-                                        flushing: false)
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
+        let store = makeInitializedIdentifierStore()
 
         _ = await store.send(.setExternalId("external-blob-id        "))
 
@@ -527,6 +515,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
                                         initalizationState: .uninitialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
 
         _ = await store.send(.setPushToken("blob_token", .authorized))
         XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
@@ -549,17 +538,20 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetPushTokenWithMissingAnonymousId() async throws {
+        // state.apiKey is set, so the token routes to QueueStore (state.apiKey gates enqueue).
+        // anonymousId is minted on first IdentityStore access, so "missing" is defensive coverage.
         let apiKey = "fake-key"
         let initialState = KlaviyoState(apiKey: apiKey,
                                         requestsInFlight: [],
                                         initalizationState: .initialized,
                                         flushing: false)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+        let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
 
-        // Impossible case really but we want coverage. With no apiKey in SDKConfigStore the token
-        // routes to the durable UnattributedBuffer rather than being parked in state.
         _ = await store.send(.setPushToken("blob_token", .authorized))
-        XCTAssertEqual(UnattributedBuffer.shared.drainSnapshot().requests.count, 1)
+        XCTAssertEqual(readQueue().count, 1)
     }
 
     // MARK: - Stop
@@ -749,6 +741,7 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
             flushing: false
         )
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off // setPushToken now write-throughs state.pushTokenData (MAGE-1196)
 
         // Impossible case really but we want coverage on it. Missing apiKey → the token routes to
         // the durable UnattributedBuffer rather than being parked in state.

--- a/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEdgeCaseTests.swift
@@ -322,16 +322,24 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetEmailMissingAnonymousIdStillSetsEmail() async throws {
+        // Under the canonical-store model, IdentityStore auto-mints an anonymousId on first access,
+        // so "missing anonymousId" is no longer a reachable production state. The test intent is
+        // preserved: the email is still persisted to the canonical IdentityStore.
         let apiKey = "fake-key"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
         let initialState = KlaviyoState(apiKey: apiKey,
                                         requestsInFlight: [],
                                         initalizationState: .initialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
 
-        _ = await store.send(.setEmail("test@blob.com")) {
-            $0.email = "test@blob.com"
-        }
+        _ = await store.send(.setEmail("test@blob.com"))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.email, "test@blob.com",
+            "setEmail persists the identifier to the canonical store even without a prior anonymousId"
+        )
     }
 
     @MainActor
@@ -352,15 +360,22 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetEmailWithTrailingWhiteSpace() async throws {
+        // Trailing whitespace must be trimmed; the canonical store must receive the trimmed value.
         let apiKey = "fake-key"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
         let initialState = KlaviyoState(apiKey: apiKey,
                                         requestsInFlight: [],
                                         initalizationState: .initialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        _ = await store.send(.setEmail("test@blob.com        ")) {
-            $0.email = "test@blob.com"
-        }
+        store.exhaustivity = .off
+
+        _ = await store.send(.setEmail("test@blob.com        "))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.email, "test@blob.com",
+            "trailing whitespace is trimmed before persisting to the canonical store"
+        )
     }
 
     // MARK: - Set External Id
@@ -385,16 +400,24 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetExternalIdMissingAnonymousIdStillSetsExternalId() async throws {
+        // Under the canonical-store model, IdentityStore auto-mints an anonymousId on first access,
+        // so "missing anonymousId" is no longer a reachable production state. The test intent is
+        // preserved: the externalId is still persisted to the canonical IdentityStore.
         let apiKey = "fake-key"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
         let initialState = KlaviyoState(apiKey: apiKey,
                                         requestsInFlight: [],
                                         initalizationState: .initialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
 
-        _ = await store.send(.setExternalId("external-blob-id")) {
-            $0.externalId = "external-blob-id"
-        }
+        _ = await store.send(.setExternalId("external-blob-id"))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.externalId, "external-blob-id",
+            "setExternalId persists the identifier to the canonical store even without a prior anonymousId"
+        )
     }
 
     @MainActor
@@ -415,15 +438,22 @@ class StateManagementEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetExternalIdWithTrailingWhiteSpace() async throws {
+        // Trailing whitespace must be trimmed; the canonical store must receive the trimmed value.
         let apiKey = "fake-key"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
         let initialState = KlaviyoState(apiKey: apiKey,
                                         requestsInFlight: [],
                                         initalizationState: .initialized,
                                         flushing: false)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        _ = await store.send(.setExternalId("external-blob-id        ")) {
-            $0.externalId = "external-blob-id"
-        }
+        store.exhaustivity = .off
+
+        _ = await store.send(.setExternalId("external-blob-id        "))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.externalId, "external-blob-id",
+            "trailing whitespace is trimmed before persisting to the canonical store"
+        )
     }
 
     // MARK: - Set Phone number

--- a/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
@@ -66,7 +66,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
 
         // A pre-init profile carrying structured attributes (name/title/org/location/image) must
         // reach the durable buffer in full, so it syncs completely after initialize() — parity
-        // with the initialized path, closing the MAGE-952 regression (MAGE-1141).
+        // with the initialized path, closing the earlier pre-init attribute-dropping regression.
         let profile = Profile(
             email: "ada@example.com",
             firstName: "Ada",
@@ -104,7 +104,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let store = TestStore(initialState: .init(), reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        // The buffer now carries the full payload (MAGE-1141), so a pre-init profile — including one
+        // The buffer now carries the full payload, so a pre-init profile — including one
         // with structured attributes — no longer emits the dropped-attribute developer warning.
         _ = await store.send(.enqueueProfile(Profile(email: "a@b.com", firstName: "Ada")))
         _ = await store.send(.enqueueProfile(Profile(email: "c@d.com", properties: ["plan": "free"])))
@@ -116,10 +116,12 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     }
 
     @MainActor
-    func testSetProfileWithEmptyStringIdentifiers() async throws {
-        // Empty-string identifiers are trimmed to nil, which differs from the stored identifiers,
-        // so reset() fires and TWO requests are enqueued: a createProfile + an identity-only
-        // registerPushToken (canonical-store contract, MAGE-1196).
+    func testSetProfileClearingIdentifiersResetsToAnonymous() async throws {
+        // Empty identifiers normalize to nil, which differs from the stored non-nil identifiers, so
+        // set(profile:) reads this as clearing an identified profile: reset() fires (mint a fresh
+        // anon, drop PII) and TWO requests are enqueued: a createProfile + an identity-only
+        // registerPushToken (canonical-store contract). Note this differs from the singular setters
+        // (setEmail/etc.), where an empty string is ignored and nothing is sent.
         let initialState = identifiedState(email: "foo@bar.com", phoneNumber: "99999999", externalId: "12345")
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
         IdentityStore.shared.update(initialState.identity)
@@ -177,7 +179,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testSetProfileDifferentIdentifiersResetsState() async throws {
         // When setProfile is called with different identifiers, reset() SHOULD fire,
         // regenerating the anonymousId. TWO requests are enqueued: a createProfile (with the new
-        // identifiers) and an identity-only registerPushToken (canonical-store contract, MAGE-1196).
+        // identifiers) and an identity-only registerPushToken (canonical-store contract).
         let initialState = identifiedState(
             email: "old@email.com",
             phoneNumber: "+11111111111",
@@ -224,7 +226,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testSetProfileSameIdentifiersDifferentAttributesStillUpdates() async throws {
         // Same identifiers but different non-identifier attributes (e.g. firstName) —
         // should NOT reset, but attributes should still be sent in the profile request.
-        // No token → only a createProfile request is enqueued (canonical-store contract, MAGE-1196).
+        // No token → only a createProfile request is enqueued.
         let initialState = KlaviyoState(
             apiKey: TEST_API_KEY,
             email: "same@email.com",
@@ -261,7 +263,6 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testSetProfilePartialIdentifierMatchStillResets() async throws {
         // If only one identifier changes (e.g. email changes, phone stays same),
         // reset should still fire. TWO requests: createProfile + identity-only registerPushToken
-        // (canonical-store contract, MAGE-1196).
         let initialState = identifiedState(email: "old@email.com", phoneNumber: "+15555555555")
         SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
         IdentityStore.shared.update(initialState.identity)
@@ -300,7 +301,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testSetProfileNilIdentifiersTriggersResetWhenStateHasIdentifiers() async throws {
         // All-nil incoming identifiers differ from non-nil state identifiers,
         // so reset fires — preserving the old "clobbering" setProfile behavior.
-        // TWO requests: createProfile + identity-only registerPushToken (MAGE-1196).
+        // TWO requests: createProfile + identity-only registerPushToken.
         let initialState = identifiedState(
             email: "existing@email.com",
             phoneNumber: "+15555555555",
@@ -344,7 +345,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testResetProfileStillClobbersAllState() async throws {
         // resetProfile() always clobbers all state (identifiers cleared, fresh anon minted),
         // then re-registers the preserved push token via an identity-only registerPushToken request
-        // (canonical-store contract: token lives in IdentityStore, not state, MAGE-1196).
+        // (canonical-store contract: token lives in IdentityStore, not state).
         let initialState = identifiedState(
             email: "user@email.com",
             phoneNumber: "+15555555555",
@@ -376,7 +377,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     @MainActor
     func testPreInitResetProfileClearsPersistedIdentity() async throws {
         // Pre-init reset must clear the persisted identity (drop PII, mint a fresh anon) so a reset
-        // issued before initialize() doesn't leave the prior profile in IdentityStore (MAGE-1136).
+        // issued before initialize() doesn't leave the prior profile in IdentityStore.
         IdentityStore.shared.update(
             ProfileData(email: "user@email.com", externalId: "ext-123", anonymousId: "anon-old")
         )
@@ -400,7 +401,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     func testPreInitResetProfileRebuffersPersistedPushToken() async throws {
         // Parity with post-init reset(preserveTokenData: true): a persisted push token is
         // re-registered against the freshly minted anon. Pre-init that register routes through the
-        // ungated RequestEnqueuer and lands in the durable buffer (MAGE-1136).
+        // ungated RequestEnqueuer and lands in the durable buffer.
         IdentityStore.shared.update(ProfileData(email: "user@email.com", anonymousId: "anon-old"))
         IdentityStore.shared.updatePushToken(
             PushTokenData(

--- a/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
@@ -144,13 +144,9 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let profileRequest = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        let tokenPayload = RequestFactory.tokenPayload(
-            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
-            pushToken: initialState.pushTokenData!.pushToken,
-            enablement: initialState.pushTokenData!.pushEnablement,
-            background: environment.getBackgroundSetting()
+        let tokenRequest = expectedIdentityOnlyTokenRequest(
+            anonymousId: newAnon, tokenData: initialState.pushTokenData!
         )
-        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
         XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
@@ -214,18 +210,13 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let profileRequest = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        let tokenPayload = RequestFactory.tokenPayload(
-            identity: PayloadIdentity(
-                anonymousId: newAnon,
-                email: "new@email.com",
-                phoneNumber: "+12222222222",
-                externalId: "new-ext"
-            ),
-            pushToken: initialState.pushTokenData!.pushToken,
-            enablement: initialState.pushTokenData!.pushEnablement,
-            background: environment.getBackgroundSetting()
+        let tokenRequest = expectedIdentityOnlyTokenRequest(
+            anonymousId: newAnon,
+            email: "new@email.com",
+            phoneNumber: "+12222222222",
+            externalId: "new-ext",
+            tokenData: initialState.pushTokenData!
         )
-        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
         XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
@@ -296,18 +287,12 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let profileRequest = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        let tokenPayload = RequestFactory.tokenPayload(
-            identity: PayloadIdentity(
-                anonymousId: newAnon,
-                email: "different@email.com",
-                phoneNumber: "+15555555555",
-                externalId: nil
-            ),
-            pushToken: initialState.pushTokenData!.pushToken,
-            enablement: initialState.pushTokenData!.pushEnablement,
-            background: environment.getBackgroundSetting()
+        let tokenRequest = expectedIdentityOnlyTokenRequest(
+            anonymousId: newAnon,
+            email: "different@email.com",
+            phoneNumber: "+15555555555",
+            tokenData: initialState.pushTokenData!
         )
-        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
         XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
@@ -349,13 +334,9 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let profileRequest = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        let tokenPayload = RequestFactory.tokenPayload(
-            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
-            pushToken: initialState.pushTokenData!.pushToken,
-            enablement: initialState.pushTokenData!.pushEnablement,
-            background: environment.getBackgroundSetting()
+        let tokenRequest = expectedIdentityOnlyTokenRequest(
+            anonymousId: newAnon, tokenData: initialState.pushTokenData!
         )
-        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
         XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
@@ -386,13 +367,9 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         // ONE request: identity-only registerPushToken under the fresh anon (no profile request
         // for resetProfile — only the token re-register is needed to rebind under new identity).
         let newAnon = store.state.anonymousId!
-        let tokenPayload = RequestFactory.tokenPayload(
-            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
-            pushToken: initialState.pushTokenData!.pushToken,
-            enablement: initialState.pushTokenData!.pushEnablement,
-            background: environment.getBackgroundSetting()
+        let tokenRequest = expectedIdentityOnlyTokenRequest(
+            anonymousId: newAnon, tokenData: initialState.pushTokenData!
         )
-        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
         XCTAssertEqual(readQueue().map(\.endpoint), [tokenRequest].map(\.endpoint))
     }
 
@@ -450,6 +427,27 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Builds the identity-only `registerPushToken` request expected after a reset / identifier
+    /// change. Avoids repeating the `RequestFactory.tokenPayload` + `KlaviyoRequest` boilerplate
+    /// across tests that differ only in the identity values.
+    private func expectedIdentityOnlyTokenRequest(
+        anonymousId: String,
+        email: String? = nil,
+        phoneNumber: String? = nil,
+        externalId: String? = nil,
+        tokenData: PushTokenData
+    ) -> KlaviyoRequest {
+        let payload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(
+                anonymousId: anonymousId, email: email, phoneNumber: phoneNumber, externalId: externalId
+            ),
+            pushToken: tokenData.pushToken,
+            enablement: tokenData.pushEnablement,
+            background: environment.getBackgroundSetting()
+        )
+        return KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, payload))
+    }
 
     /// Builds a fully-initialized, identified `KlaviyoState` for tests that differ only in identifiers.
     private func identifiedState(

--- a/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
@@ -223,6 +223,32 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     }
 
     @MainActor
+    func testSetProfileWithChangedIdentifiersPreservesCanonicalPushToken() async throws {
+        // set(profile:) with different identifiers on an identified user fires
+        // reset(preserveTokenData: false), which nils state.pushTokenData. The projection must be
+        // restored so the reducer's write-through defer doesn't persist nil into IdentityStore and
+        // wipe the canonical push token (same defect class as resetProfile / the flush-safety fix).
+        let initialState = identifiedState(email: "old@email.com")
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
+        seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.enqueueProfile(Profile(email: "new@email.com")))
+
+        XCTAssertNotNil(
+            IdentityStore.shared.pushToken,
+            "set(profile:) with changed identifiers must not clear the canonical push token"
+        )
+        XCTAssertEqual(
+            IdentityStore.shared.pushToken?.pushToken, initialState.pushTokenData?.pushToken,
+            "the preserved token must match the pre-change token"
+        )
+    }
+
+    @MainActor
     func testSetProfileSameIdentifiersDifferentAttributesStillUpdates() async throws {
         // Same identifiers but different non-identifier attributes (e.g. firstName) —
         // should NOT reset, but attributes should still be sent in the profile request.
@@ -256,7 +282,7 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let request = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        XCTAssertEqual(readQueue().map(\.endpoint), [request].map(\.endpoint))
+        XCTAssertEqual(readQueue(), [request])
     }
 
     @MainActor
@@ -538,6 +564,39 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         XCTAssertEqual(stored.phoneNumber, "+15555550100", "pre-init setEmail must not wipe the persisted phone")
         XCTAssertEqual(stored.externalId, "ext-1", "pre-init setEmail must not wipe the persisted externalId")
         XCTAssertEqual(stored.anonymousId, anon)
+    }
+
+    /// A pre-init identifier setter folds AND consumes any staged `pendingProfile` into its buffered
+    /// profile request — unlike the pre-init `set(profile:)` path, which leaves the property staged
+    /// (see `testEnqueueProfilePayloadParityWithLegacyBuilder`). Pins the `applyIdentifierChange`
+    /// fold+consume behavior that diverges from the legacy `setPreInitIdentifier`.
+    @MainActor
+    func testPreInitSetProfilePropertyThenSetEmailShipsPropertyInBufferedProfile() async throws {
+        IdentityStore.shared.update(ProfileData(anonymousId: "stable-anon"))
+
+        let store = TestStore(initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        let key = Profile.ProfileKey.custom(customKey: "loyalty_tier")
+        _ = await store.send(.setProfileProperty(key, "gold"))
+        _ = await store.send(.setEmail("new@user.com"))
+
+        // The staged property is consumed onto the buffered profile request, not left pending.
+        XCTAssertNil(store.state.pendingProfile, "setEmail must consume the staged pendingProfile")
+
+        let profiles: [CreateProfilePayload] = UnattributedBuffer.shared.drainSnapshot().requests
+            .compactMap {
+                if case let .profile(payload) = $0 { return payload }
+                return nil
+            }
+        guard let payload = profiles.last else {
+            return XCTFail("expected a buffered profile request carrying the staged property")
+        }
+        let customProps = payload.data.attributes.properties.value as? [String: Any]
+        XCTAssertEqual(
+            customProps?["loyalty_tier"] as? String, "gold",
+            "the staged property must ship in the buffered profile request built by setEmail"
+        )
     }
 }
 

--- a/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementEnqueueEdgeCaseTests.swift
@@ -117,25 +117,41 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
 
     @MainActor
     func testSetProfileWithEmptyStringIdentifiers() async throws {
+        // Empty-string identifiers are trimmed to nil, which differs from the stored identifiers,
+        // so reset() fires and TWO requests are enqueued: a createProfile + an identity-only
+        // registerPushToken (canonical-store contract, MAGE-1196).
         let initialState = identifiedState(email: "foo@bar.com", phoneNumber: "99999999", externalId: "12345")
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
 
         _ = await store.send(.enqueueProfile(Profile(email: "", phoneNumber: "", externalId: ""))) {
-            $0.email = nil // since we reset state
-            $0.phoneNumber = nil // since we reset state
-            $0.externalId = nil // since we reset state
-            $0.pushTokenData = nil
+            // reset() fires → all identifiers cleared on state
+            $0.email = nil
+            $0.phoneNumber = nil
+            $0.externalId = nil
         }
-        // reset fires with preserveTokenData: false, but the captured pushTokenData is used
-        // to build a token request in the reducer before the reset clears state.
-        let request = expectedTokenRequest(
-            apiKey: TEST_API_KEY,
-            tokenData: initialState.pushTokenData!,
-            profile: Profile(email: nil, phoneNumber: nil, externalId: nil),
-            anonymousId: store.state.anonymousId!
+        // TWO requests: profile (all-nil identifiers, post-reset anon) + token re-register
+        // (identity-only payload with the new anon and all-nil identifiers).
+        let newAnon = store.state.anonymousId!
+        let profilePayload = ProfilePayload(
+            Profile(email: nil, phoneNumber: nil, externalId: nil),
+            anonymousId: newAnon
         )
-        XCTAssertEqual(readQueue(), [request])
+        let profileRequest = KlaviyoRequest(
+            endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
+        )
+        let tokenPayload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement,
+            background: environment.getBackgroundSetting()
+        )
+        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
+        XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
     // MARK: - enqueueProfile: conditional reset (push-token storm fix)
@@ -164,13 +180,16 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
     @MainActor
     func testSetProfileDifferentIdentifiersResetsState() async throws {
         // When setProfile is called with different identifiers, reset() SHOULD fire,
-        // regenerating the anonymousId and clearing pushTokenData.
+        // regenerating the anonymousId. TWO requests are enqueued: a createProfile (with the new
+        // identifiers) and an identity-only registerPushToken (canonical-store contract, MAGE-1196).
         let initialState = identifiedState(
             email: "old@email.com",
             phoneNumber: "+11111111111",
             externalId: "old-ext"
         )
-
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -182,23 +201,39 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
             $0.email = "new@email.com"
             $0.phoneNumber = "+12222222222"
             $0.externalId = "new-ext"
-            // pushTokenData cleared by reset
-            $0.pushTokenData = nil
         }
-        // Since pushTokenData existed before reset, the reducer uses it to build a token request.
-        let request = expectedTokenRequest(
-            apiKey: TEST_API_KEY,
-            tokenData: initialState.pushTokenData!,
-            profile: Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext"),
-            anonymousId: store.state.anonymousId!
+        // TWO requests: profile (new identifiers, post-reset anon) + identity-only token re-register.
+        let newAnon = store.state.anonymousId!
+        let profilePayload = ProfilePayload(
+            Profile(email: "new@email.com", phoneNumber: "+12222222222", externalId: "new-ext"),
+            email: "new@email.com",
+            phoneNumber: "+12222222222",
+            externalId: "new-ext",
+            anonymousId: newAnon
         )
-        XCTAssertEqual(readQueue(), [request])
+        let profileRequest = KlaviyoRequest(
+            endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
+        )
+        let tokenPayload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(
+                anonymousId: newAnon,
+                email: "new@email.com",
+                phoneNumber: "+12222222222",
+                externalId: "new-ext"
+            ),
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement,
+            background: environment.getBackgroundSetting()
+        )
+        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
+        XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
     @MainActor
     func testSetProfileSameIdentifiersDifferentAttributesStillUpdates() async throws {
         // Same identifiers but different non-identifier attributes (e.g. firstName) —
         // should NOT reset, but attributes should still be sent in the profile request.
+        // No token → only a createProfile request is enqueued (canonical-store contract, MAGE-1196).
         let initialState = KlaviyoState(
             apiKey: TEST_API_KEY,
             email: "same@email.com",
@@ -207,12 +242,14 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
             initalizationState: .initialized,
             flushing: true
         )
-
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(nil)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        // No pushTokenData → a createProfile request is generated instead of registerPushToken
+        // No pushTokenData → a createProfile request is generated instead of registerPushToken.
         let profile = Profile(email: "same@email.com", firstName: "NewName")
         _ = await store.send(.enqueueProfile(profile))
         // A createProfile request should be enqueued with the updated attributes.
@@ -226,47 +263,67 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         let request = KlaviyoRequest(
             endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
         )
-        XCTAssertEqual(readQueue(), [request])
+        XCTAssertEqual(readQueue().map(\.endpoint), [request].map(\.endpoint))
     }
 
     @MainActor
     func testSetProfilePartialIdentifierMatchStillResets() async throws {
         // If only one identifier changes (e.g. email changes, phone stays same),
-        // reset should still fire.
+        // reset should still fire. TWO requests: createProfile + identity-only registerPushToken
+        // (canonical-store contract, MAGE-1196).
         let initialState = identifiedState(email: "old@email.com", phoneNumber: "+15555555555")
-
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        // Email changes, phone stays the same → identifiersChanged = true
+        // Email changes, phone stays the same → identifiersChanged = true → reset() fires
         _ = await store.send(
             .enqueueProfile(Profile(email: "different@email.com", phoneNumber: "+15555555555"))
         ) {
-            // reset() fires
             $0.email = "different@email.com"
             $0.phoneNumber = "+15555555555"
-            $0.pushTokenData = nil
         }
-        let request = expectedTokenRequest(
-            apiKey: TEST_API_KEY,
-            tokenData: initialState.pushTokenData!,
-            profile: Profile(email: "different@email.com", phoneNumber: "+15555555555"),
-            anonymousId: store.state.anonymousId!
+        let newAnon = store.state.anonymousId!
+        let profilePayload = ProfilePayload(
+            Profile(email: "different@email.com", phoneNumber: "+15555555555"),
+            email: "different@email.com",
+            phoneNumber: "+15555555555",
+            anonymousId: newAnon
         )
-        XCTAssertEqual(readQueue(), [request])
+        let profileRequest = KlaviyoRequest(
+            endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
+        )
+        let tokenPayload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(
+                anonymousId: newAnon,
+                email: "different@email.com",
+                phoneNumber: "+15555555555",
+                externalId: nil
+            ),
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement,
+            background: environment.getBackgroundSetting()
+        )
+        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
+        XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
     @MainActor
     func testSetProfileNilIdentifiersTriggersResetWhenStateHasIdentifiers() async throws {
         // All-nil incoming identifiers differ from non-nil state identifiers,
         // so reset fires — preserving the old "clobbering" setProfile behavior.
+        // TWO requests: createProfile + identity-only registerPushToken (MAGE-1196).
         let initialState = identifiedState(
             email: "existing@email.com",
             phoneNumber: "+15555555555",
             externalId: "ext-id"
         )
-
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -274,52 +331,69 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
         // Profile with all-nil identifiers → [nil,nil,nil] != [email,phone,extId] → reset fires
         let profile = Profile(firstName: "JustAName")
         _ = await store.send(.enqueueProfile(profile)) {
-            // reset(preserveTokenData: false) fires → identifiers cleared, pushTokenData nil
+            // reset(preserveTokenData: false) fires → identifiers cleared
             $0.email = nil
             $0.phoneNumber = nil
             $0.externalId = nil
-            $0.pushTokenData = nil
         }
-        // pushTokenData existed before reset, so a token request is built with captured data.
-        let request = expectedTokenRequest(
-            apiKey: TEST_API_KEY,
-            tokenData: initialState.pushTokenData!,
-            profile: profile,
-            anonymousId: store.state.anonymousId!
+        // TWO requests: profile (structured attrs carried, all-nil identifiers post-reset) +
+        // identity-only token re-register under the new anon.
+        let newAnon = store.state.anonymousId!
+        let profilePayload = ProfilePayload(
+            profile,
+            email: nil,
+            phoneNumber: nil,
+            externalId: nil,
+            anonymousId: newAnon
         )
-        XCTAssertEqual(readQueue(), [request])
+        let profileRequest = KlaviyoRequest(
+            endpoint: .createProfile(TEST_API_KEY, CreateProfilePayload(data: profilePayload))
+        )
+        let tokenPayload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement,
+            background: environment.getBackgroundSetting()
+        )
+        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
+        XCTAssertEqual(readQueue().map(\.endpoint), [profileRequest, tokenRequest].map(\.endpoint))
     }
 
     @MainActor
     func testResetProfileStillClobbersAllState() async throws {
-        // resetProfile() should always clobber all state, regardless of identifiers.
+        // resetProfile() always clobbers all state (identifiers cleared, fresh anon minted),
+        // then re-registers the preserved push token via an identity-only registerPushToken request
+        // (canonical-store contract: token lives in IdentityStore, not state, MAGE-1196).
         let initialState = identifiedState(
             email: "user@email.com",
             phoneNumber: "+15555555555",
             externalId: "ext-123"
         )
-
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: TEST_API_KEY))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData!)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
         _ = await store.send(.resetProfile) {
-            // reset(preserveTokenData: true) is the default for resetProfile
+            // reset fires → all identifiers cleared, fresh anonymousId minted
             $0.email = nil
             $0.phoneNumber = nil
             $0.externalId = nil
             $0.pendingProfile = nil
-            // pushTokenData is preserved and a new token request is enqueued
-            // anonymousId is regenerated since the profile was identified
-            $0.pushTokenData = initialState.pushTokenData
         }
-        let request = expectedTokenRequest(
-            apiKey: TEST_API_KEY,
-            tokenData: initialState.pushTokenData!,
-            profile: Profile(),
-            anonymousId: store.state.anonymousId!
+        // ONE request: identity-only registerPushToken under the fresh anon (no profile request
+        // for resetProfile — only the token re-register is needed to rebind under new identity).
+        let newAnon = store.state.anonymousId!
+        let tokenPayload = RequestFactory.tokenPayload(
+            identity: PayloadIdentity(anonymousId: newAnon, email: nil, phoneNumber: nil, externalId: nil),
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement,
+            background: environment.getBackgroundSetting()
         )
-        XCTAssertEqual(readQueue(), [request])
+        let tokenRequest = KlaviyoRequest(endpoint: .registerPushToken(TEST_API_KEY, tokenPayload))
+        XCTAssertEqual(readQueue().map(\.endpoint), [tokenRequest].map(\.endpoint))
     }
 
     @MainActor
@@ -401,25 +475,6 @@ class StateManagementEnqueueEdgeCaseTests: StateManagementTestCase {
             requestsInFlight: [],
             initalizationState: .initialized,
             flushing: true
-        )
-    }
-
-    private func expectedTokenRequest(
-        apiKey: String,
-        tokenData: PushTokenData,
-        profile: Profile,
-        anonymousId: String
-    ) -> KlaviyoRequest {
-        KlaviyoRequest(
-            endpoint: .registerPushToken(
-                apiKey,
-                PushTokenPayload(
-                    pushToken: tokenData.pushToken,
-                    enablement: tokenData.pushEnablement.rawValue,
-                    background: tokenData.pushBackground.rawValue,
-                    profile: ProfilePayload(profile, anonymousId: anonymousId)
-                )
-            )
         )
     }
 

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -668,6 +668,36 @@ class StateManagementTests: StateManagementTestCase {
         }
     }
 
+    /// Regression (MAGE-1196): `flushQueue` with a staged `pendingProfile` calls
+    /// `enqueueProfileOrTokenRequest`, which must not leave `state.pushTokenData` nil — otherwise the
+    /// write-through `defer` persists nil into `IdentityStore`, wiping the canonical/persisted token
+    /// until the in-flight register completes (a crash in that window loses the token on disk).
+    @MainActor
+    func testFlushWithPendingProfileKeepsCanonicalToken() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.flushing = false
+        initialState.pendingProfile = [.custom(customKey: "foo"): AnyEncodable("bar")]
+        seedCanonicalStores(from: initialState) // seeds IdentityStore.pushToken = the token
+        _ = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.flushQueue)
+
+        // The flush must not have wiped the canonical token via the write-through defer.
+        XCTAssertEqual(
+            IdentityStore.shared.pushToken?.pushToken, initialState.pushTokenData?.pushToken,
+            "flush with a pending profile must not wipe the canonical push token"
+        )
+
+        // Drain the follow-up effects.
+        guard let request = store.state.requestsInFlight.first else {
+            return XCTFail("expected a request in flight after flushQueue")
+        }
+        await store.receive(.sendRequest)
+        await store.receive(.deQueueCompletedResults(request))
+    }
+
     // MARK: - Test set profile
 
     /// Documents the production `enqueueProfile` payload contract: the unified path builds a

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -126,14 +126,22 @@ class StateManagementTests: StateManagementTestCase {
         // assertions on file shape are needed (KlaviyoState is no longer Codable).
     }
 
+    /// Seeds the canonical Core stores from a `KlaviyoState` snapshot so that
+    /// `RequestEnqueuer` routes to `QueueStore` and reads the correct identity.
+    /// Only use where all three stores are seeded from the same `state` value.
+    @MainActor
+    private func seedCanonicalStores(from state: KlaviyoState) {
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: state.apiKey!))
+        IdentityStore.shared.update(state.identity)
+        IdentityStore.shared.updatePushToken(state.pushTokenData)
+    }
+
     // MARK: - Set Email
 
     @MainActor
     func testSetEmail() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -160,9 +168,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetPhoneNumber() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -189,9 +195,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetExternalId() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -245,9 +249,7 @@ class StateManagementTests: StateManagementTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData?.pushEnablement = .denied
         initialState.flushing = true // keep the queue observable (no drain)
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -314,9 +316,7 @@ class StateManagementTests: StateManagementTestCase {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData?.pushEnablement = .denied
         initialState.flushing = true // keep the queue observable (no drain)
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -332,6 +332,41 @@ class StateManagementTests: StateManagementTestCase {
 
         await store.receive(.setPushToken(initialState.pushTokenData!.pushToken, .authorized))
         XCTAssertEqual(readQueue().map(\.endpoint), [pushTokenRequest].map(\.endpoint))
+    }
+
+    /// Regression (MAGE-1196): after a token rotation, `setPushToken` writes the new token to
+    /// `IdentityStore` but leaves `state.pushTokenData` stale until the register drains. If
+    /// `setPushEnablement` read the stale `state` token it would forward it and clobber the canonical
+    /// store back to the old token. It must read the canonical `IdentityStore` token instead.
+    @MainActor
+    func testSetPushEnablementReadsCanonicalTokenNotStaleState() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        // Simulate the divergence setPushToken(new) creates: state holds the old token, the canonical
+        // store already advanced to the rotated one.
+        let staleToken = "stale-rotated-away-token"
+        let freshToken = "fresh-canonical-token"
+        initialState.pushTokenData = PushTokenData(
+            pushToken: staleToken, pushEnablement: .authorized, pushBackground: .available,
+            deviceData: .init(context: environment.appContextInfo())
+        )
+        initialState.flushing = true // keep the queue observable (no drain)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(PushTokenData(
+            pushToken: freshToken, pushEnablement: .authorized, pushBackground: .available,
+            deviceData: .init(context: environment.appContextInfo())
+        ))
+        _ = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setPushEnablement(.denied))
+
+        // Forwards the CANONICAL (fresh) token, not the stale state token.
+        await store.receive(.setPushToken(freshToken, .denied))
+        // The canonical store keeps the fresh token (not clobbered back to stale), with new enablement.
+        XCTAssertEqual(IdentityStore.shared.pushToken?.pushToken, freshToken)
+        XCTAssertEqual(IdentityStore.shared.pushToken?.pushEnablement, .denied)
     }
 
     // MARK: - flush
@@ -645,9 +680,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testEnqueueProfilePayloadParityWithLegacyBuilder() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -708,9 +741,7 @@ class StateManagementTests: StateManagementTestCase {
         initialState.phoneNumber = "555BLOB"
         // Seed the canonical stores so the unified `enqueueProfile` path reads the same
         // identity the reducer sees (phoneNumber="555BLOB", push token present).
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -755,9 +786,7 @@ class StateManagementTests: StateManagementTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
         // and reads the correct identity when building the token re-association payload.
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -797,9 +826,7 @@ class StateManagementTests: StateManagementTestCase {
         let initialState = INITIALIZED_TEST_STATE()
         // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
         // and reads the correct (whitespace-trimmed) identity when building payloads.
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -879,6 +906,7 @@ class StateManagementTests: StateManagementTestCase {
 
     /// Verifies payload parity for `._openedPush` — the event type whose `updateEventWithIdentifiers`
     /// push_token branch matters most (it injects the token into event properties).
+    @MainActor
     func testOpenedPushEventPayloadParityWithLegacyBuilder() throws {
         let state = INITIALIZED_TEST_STATE()
         IdentityStore.shared.update(state.identity)
@@ -923,9 +951,7 @@ class StateManagementTests: StateManagementTestCase {
         initialState.phoneNumber = "555BLOB"
         // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
         // and reads the correct identity (phone number, push token) when building the payload.
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -1241,9 +1267,7 @@ class StateManagementTests: StateManagementTestCase {
 
         // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
         // and reads the correct identity (push token) when building the geofence event payload.
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
 
         // Add some existing requests to the queue
         let existingRequest1 = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
@@ -1564,9 +1588,7 @@ class StateManagementTests: StateManagementTestCase {
         initialState.flushing = false
         // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
         // and reads the correct identity when building event payloads.
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let existingRequest = initialState.buildProfileRequest(
             apiKey: initialState.apiKey!,
             anonymousId: initialState.anonymousId!
@@ -1807,9 +1829,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetEmailEmptyStringEnqueuesNothing() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -1843,9 +1863,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetPhoneNumberEmptyStringEnqueuesNothing() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -1880,9 +1898,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetExternalIdEmptyStringEnqueuesNothing() async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        IdentityStore.shared.update(initialState.identity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        seedCanonicalStores(from: initialState)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -1984,5 +2000,47 @@ class StateManagementTests: StateManagementTestCase {
                        "pre-init setEmail with a stored token must buffer a .profile, not drop silently")
         XCTAssertEqual(profiles.first?.data.attributes.email, "new@example.com",
                        "buffered profile must carry the updated email")
+    }
+
+    /// Warm-start variant: `SDKConfigStore` holds a persisted apiKey (from a prior launch) but
+    /// `.initialize` has not run this launch, so `state.apiKey` is still nil. The token branch must
+    /// gate on `state.apiKey` (which `enqueueRequest` uses), not the persisted `SDKConfigStore`
+    /// apiKey — otherwise the request is built and silently dropped by the nil-`state.apiKey` guard.
+    /// With the gate, it falls through to `RequestEnqueuer.enqueueProfile`, which — since
+    /// `SDKConfigStore` has the apiKey — routes the profile to the `QueueStore` (not dropped).
+    /// Regression gate for the warm-start drop (MAGE-1196).
+    @MainActor
+    func testSetEmailWarmStartWithStoredTokenEnqueuesProfileToQueue() async throws {
+        resetCanonicalCoreStores()
+        UnattributedBuffer.shared.reset()
+        // Persisted apiKey from a prior launch: present in SDKConfigStore but NOT yet on state.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "persisted-key"))
+        IdentityStore.shared.update(ProfileData(
+            email: "old@example.com", externalId: "user-A", anonymousId: "anon-A"
+        ))
+        IdentityStore.shared.updatePushToken(PushTokenData(
+            pushToken: "tok-warmStart",
+            pushEnablement: .authorized,
+            pushBackground: .available,
+            deviceData: DeviceMetadata(context: environment.appContextInfo())
+        ))
+        let readQueue = seedTestQueueStore()
+
+        // Uninitialized state: state.apiKey is nil even though SDKConfigStore has one.
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+
+        await store.send(.setEmail("new@example.com"))
+
+        // Not dropped: a createProfile carrying the new email lands in the QueueStore.
+        let profiles: [CreateProfilePayload] = readQueue().compactMap {
+            if case let .createProfile(_, payload) = $0.endpoint { return payload }
+            return nil
+        }
+        XCTAssertEqual(profiles.count, 1,
+                       "warm-start setEmail (SDKConfigStore apiKey set, state.apiKey nil) must enqueue a profile, not drop")
+        XCTAssertEqual(profiles.first?.data.attributes.email, "new@example.com")
     }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -131,22 +131,28 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetEmail() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        _ = await store.send(.setEmail("test@blob.com")) {
-            $0.email = "test@blob.com"
-            $0.pushTokenData = nil
-        }
+        _ = await store.send(.setEmail("test@blob.com"))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.email, "test@blob.com",
+            "setEmail writes the identifier through to the canonical store"
+        )
+        // A token exists → identifier change re-associates it (token request), folding no pending profile.
         var expectedState = initialState
         expectedState.email = "test@blob.com"
-        let request = expectedState.buildTokenRequest(
+        let expected = expectedState.buildTokenRequest(
             apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
             enablement: initialState.pushTokenData!.pushEnablement
         )
-        XCTAssertEqual(readQueue(), [request])
+        XCTAssertEqual(readQueue().map(\.endpoint), [expected].map(\.endpoint))
     }
 
     // MARK: Set Phone Number
@@ -154,22 +160,28 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetPhoneNumber() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        _ = await store.send(.setPhoneNumber("+1800555BLOB")) {
-            $0.phoneNumber = "+1800555BLOB"
-            $0.pushTokenData = nil
-        }
+        _ = await store.send(.setPhoneNumber("+1800555BLOB"))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.phoneNumber, "+1800555BLOB",
+            "setPhoneNumber writes the identifier through to the canonical store"
+        )
+        // A token exists → identifier change re-associates it (token request), folding no pending profile.
         var expectedState = initialState
         expectedState.phoneNumber = "+1800555BLOB"
-        let request = expectedState.buildTokenRequest(
+        let expected = expectedState.buildTokenRequest(
             apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
             enablement: initialState.pushTokenData!.pushEnablement
         )
-        XCTAssertEqual(readQueue(), [request])
+        XCTAssertEqual(readQueue().map(\.endpoint), [expected].map(\.endpoint))
     }
 
     // MARK: - Set External Id.
@@ -177,22 +189,28 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testSetExternalId() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        _ = await store.send(.setExternalId("external-blob")) {
-            $0.externalId = "external-blob"
-            $0.pushTokenData = nil
-        }
+        _ = await store.send(.setExternalId("external-blob"))
+
+        XCTAssertEqual(
+            IdentityStore.shared.current.externalId, "external-blob",
+            "setExternalId writes the identifier through to the canonical store"
+        )
+        // A token exists → identifier change re-associates it (token request), folding no pending profile.
         var expectedState = initialState
         expectedState.externalId = "external-blob"
-        let request = expectedState.buildTokenRequest(
+        let expected = expectedState.buildTokenRequest(
             apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
             enablement: initialState.pushTokenData!.pushEnablement
         )
-        XCTAssertEqual(readQueue(), [request])
+        XCTAssertEqual(readQueue().map(\.endpoint), [expected].map(\.endpoint))
     }
 
     // MARK: - Set Push Token
@@ -201,94 +219,81 @@ class StateManagementTests: StateManagementTestCase {
     func testSetPushToken() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData = nil
-        initialState.flushing = false
+        initialState.flushing = true // keep the queue observable (no drain)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(nil)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        let pushTokenRequest = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blobtoken", enablement: .authorized)
         _ = await store.send(.setPushToken("blobtoken", .authorized))
-        XCTAssertEqual(readQueue(), [pushTokenRequest])
 
-        _ = await store.send(.flushQueue) {
-            $0.flushing = true
-            $0.requestsInFlight = [pushTokenRequest]
-        }
-
-        await store.receive(.sendRequest)
-
-        _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
-            $0.flushing = false
-            $0.requestsInFlight = []
-            $0.pushTokenData = PushTokenData(pushToken: "blobtoken", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.appContextInfo()))
-        }
+        XCTAssertEqual(
+            IdentityStore.shared.pushToken?.pushToken, "blobtoken",
+            "token persisted to the canonical store"
+        )
+        let expected = initialState.buildTokenRequest(
+            apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!,
+            pushToken: "blobtoken", enablement: .authorized
+        )
+        XCTAssertEqual(readQueue().map(\.endpoint), [expected].map(\.endpoint))
     }
 
     @MainActor
     func testSetPushTokenEnablementChanged() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData?.pushEnablement = .denied
-        initialState.flushing = false
+        initialState.flushing = true // keep the queue observable (no drain)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        let pushTokenRequest = initialState.buildTokenRequest(
+        _ = await store.send(.setPushToken(initialState.pushTokenData!.pushToken, .authorized))
+
+        XCTAssertEqual(
+            IdentityStore.shared.pushToken?.pushEnablement, .authorized,
+            "updated enablement persisted to the canonical store"
+        )
+        var expectedState = initialState
+        expectedState.pushTokenData?.pushEnablement = .authorized
+        let expected = expectedState.buildTokenRequest(
             apiKey: initialState.apiKey!,
             anonymousId: initialState.anonymousId!,
             pushToken: initialState.pushTokenData!.pushToken,
             enablement: .authorized
         )
-
-        _ = await store.send(.setPushToken(initialState.pushTokenData!.pushToken, .authorized))
-        XCTAssertEqual(readQueue(), [pushTokenRequest])
-
-        _ = await store.send(.flushQueue) {
-            $0.flushing = true
-            $0.requestsInFlight = [pushTokenRequest]
-        }
-
-        await store.receive(.sendRequest)
-
-        _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
-            $0.flushing = false
-            $0.requestsInFlight = []
-            $0.pushTokenData = PushTokenData(
-                pushToken: initialState.pushTokenData!.pushToken,
-                pushEnablement: .authorized,
-                pushBackground: initialState.pushTokenData!.pushBackground,
-                deviceData: initialState.pushTokenData!.deviceData
-            )
-        }
+        XCTAssertEqual(readQueue().map(\.endpoint), [expected].map(\.endpoint))
     }
 
     @MainActor
     func testSetPushTokenMultipleTimes() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData = nil
-        initialState.flushing = false
+        initialState.flushing = true // keep the queue observable (no drain)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(nil)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        let pushTokenRequest = initialState.buildTokenRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!, pushToken: "blobtoken", enablement: .authorized)
+        let pushTokenRequest = initialState.buildTokenRequest(
+            apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!,
+            pushToken: "blobtoken", enablement: .authorized
+        )
 
         _ = await store.send(.setPushToken("blobtoken", .authorized))
-        XCTAssertEqual(readQueue(), [pushTokenRequest])
+        XCTAssertEqual(readQueue().map(\.endpoint), [pushTokenRequest].map(\.endpoint),
+                       "first set enqueues a registration")
 
-        _ = await store.send(.flushQueue) {
-            $0.flushing = true
-            $0.requestsInFlight = [pushTokenRequest]
-        }
-
-        await store.receive(.sendRequest)
-
-        _ = await store.receive(.deQueueCompletedResults(pushTokenRequest)) {
-            $0.flushing = false
-            $0.requestsInFlight = []
-            $0.pushTokenData = PushTokenData(pushToken: "blobtoken", pushEnablement: .authorized, pushBackground: .available, deviceData: .init(context: environment.appContextInfo()))
-        }
+        // Second identical send: dedup via IdentityStore — must enqueue nothing.
         _ = await store.send(.setPushToken("blobtoken", .authorized))
+        XCTAssertEqual(readQueue().map(\.endpoint), [pushTokenRequest].map(\.endpoint),
+                       "second identical set is deduped — queue unchanged")
     }
 
     // MARK: - Set Push Enablement
@@ -297,6 +302,8 @@ class StateManagementTests: StateManagementTestCase {
     func testSetPushEnablementPushTokenIsNil() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData = nil
+        // IdentityStore has no token → setPushEnablement is a no-op.
+        IdentityStore.shared.updatePushToken(nil)
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
         await store.send(.setPushEnablement(.authorized))
@@ -306,6 +313,10 @@ class StateManagementTests: StateManagementTestCase {
     func testSetPushEnablementChanged() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.pushTokenData?.pushEnablement = .denied
+        initialState.flushing = true // keep the queue observable (no drain)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -320,7 +331,7 @@ class StateManagementTests: StateManagementTestCase {
         _ = await store.send(.setPushEnablement(.authorized))
 
         await store.receive(.setPushToken(initialState.pushTokenData!.pushToken, .authorized))
-        XCTAssertEqual(readQueue(), [pushTokenRequest])
+        XCTAssertEqual(readQueue().map(\.endpoint), [pushTokenRequest].map(\.endpoint))
     }
 
     // MARK: - flush
@@ -624,24 +635,129 @@ class StateManagementTests: StateManagementTestCase {
 
     // MARK: - Test set profile
 
+    /// Documents the production `enqueueProfile` payload contract: the unified path builds a
+    /// `CreateProfilePayload` via `state.profilePayload(from:anonymousId:)` WITHOUT folding any
+    /// separately-staged `pendingProfile` property. The staged property stays pending for the next
+    /// flush or setter — this matches the legacy post-init behavior (verified in git at 2c8b50da).
+    ///
+    /// Concretely: a property staged via `setProfileProperty` before a `set(profile:)` call does
+    /// NOT appear in that call's `createProfile` payload. It remains staged for the next flush.
+    @MainActor
+    func testEnqueueProfilePayloadParityWithLegacyBuilder() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        let pendingKey = Profile.ProfileKey.custom(customKey: "pending_key")
+
+        // Stage a profile property via the reducer (this is how pendingProfile gets populated).
+        _ = await store.send(.setProfileProperty(pendingKey, AnyEncodable("pending_val"))) {
+            $0.pendingProfile = [pendingKey: AnyEncodable("pending_val")]
+        }
+
+        // Now send a set(profile:) call with Profile.test (which has email, firstName, etc.).
+        // Production path: `state.profilePayload(from:anonymousId:)` — NO pendingProfile fold.
+        _ = await store.send(.enqueueProfile(Profile.test)) {
+            $0.email = Profile.test.email
+            $0.phoneNumber = Profile.test.phoneNumber
+            $0.externalId = Profile.test.externalId
+            // pendingProfile stays staged — enqueueProfile does NOT consume it.
+        }
+
+        // Extract the createProfile request from the queue.
+        let queued = readQueue()
+        guard let profileRequest = queued.first(where: {
+            if case .createProfile = $0.endpoint { return true } else { return false }
+        }) else {
+            return XCTFail("expected a createProfile request in the queue")
+        }
+        guard case let .createProfile(_, payload) = profileRequest.endpoint else {
+            return XCTFail("unexpected endpoint shape")
+        }
+
+        let attrs = payload.data.attributes
+
+        // Profile.test's OWN attributes are present in the createProfile payload.
+        XCTAssertEqual(attrs.email, Profile.test.email,
+                       "profile email must be present in the createProfile payload")
+        XCTAssertEqual(attrs.firstName, Profile.test.firstName,
+                       "profile firstName must be present in the createProfile payload")
+
+        // The separately-staged pendingProfile property is NOT in this createProfile payload —
+        // it remains staged for the next flush (matching legacy enqueueProfile behavior).
+        let customProps = attrs.properties.value as? [String: Any]
+        XCTAssertNil(
+            customProps?["pending_key"],
+            "staged-only pendingProfile key must NOT appear in the enqueueProfile createProfile payload"
+        )
+
+        // pendingProfile is still staged on state (not consumed by enqueueProfile).
+        XCTAssertNotNil(
+            store.state.pendingProfile,
+            "pendingProfile must remain staged after enqueueProfile (only flush/setter consumes it)"
+        )
+    }
+
     @MainActor
     func testSetProfileWithExistingProperties() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "555BLOB"
-        seedTestQueueStore()
+        // Seed the canonical stores so the unified `enqueueProfile` path reads the same
+        // identity the reducer sees (phoneNumber="555BLOB", push token present).
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
+        // Sending a profile with a different email (identifier change on an identified user) →
+        // the case resets state (clearing phoneNumber + pushTokenData), then re-associates the
+        // token with the new identity via two separate requests: createProfile + registerPushToken.
         _ = await store.send(.enqueueProfile(Profile(email: "foo"))) {
             $0.phoneNumber = nil
             $0.email = "foo"
             $0.pushTokenData = nil
         }
+
+        // Unified path: two separate requests — profile first, then identity-only token
+        // re-association. TokenData was captured pre-reset, so the token itself is preserved.
+        // Read anonymousId from the post-send state: the identifier change triggered
+        // `state.reset(preserveTokenData: false)` which mints a fresh anonymousId, so the
+        // payloads must use the post-reset anonymousId, not the pre-send `initialState` value.
+        let apiKey = initialState.apiKey!
+        let anonymousId = store.state.anonymousId!
+        let profilePayload = CreateProfilePayload(data: ProfilePayload(
+            Profile(email: "foo"), email: "foo", anonymousId: anonymousId
+        ))
+        let tokenPayload = PushTokenPayload(
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement.rawValue,
+            background: initialState.pushTokenData!.pushBackground.rawValue,
+            profile: ProfilePayload(
+                email: "foo", phoneNumber: nil, externalId: nil,
+                properties: [:], anonymousId: anonymousId
+            )
+        )
+        let expected: [KlaviyoRequest] = [
+            KlaviyoRequest(endpoint: .createProfile(apiKey, profilePayload)),
+            KlaviyoRequest(endpoint: .registerPushToken(apiKey, tokenPayload))
+        ]
+        XCTAssertEqual(readQueue(), expected)
     }
 
     @MainActor
     func testSetProfileWithAllProfileIdentifiersAndProperties() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct identity when building the token re-association payload.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -653,65 +769,169 @@ class StateManagementTests: StateManagementTestCase {
             // No reset — state had no prior identifiers (isIdentified = false),
             // so pushTokenData stays on state.
         }
-        let request = KlaviyoRequest(
-            endpoint: .registerPushToken(
-                initialState.apiKey!,
-                PushTokenPayload(
-                    pushToken: initialState.pushTokenData!.pushToken,
-                    enablement: initialState.pushTokenData!.pushEnablement.rawValue,
-                    background: initialState.pushTokenData!.pushBackground.rawValue,
-                    profile: ProfilePayload(
-                        Profile.test,
-                        anonymousId: initialState.anonymousId!
-                    )
-                )
+
+        // Unified Core path: createProfile (with full structured attributes) + identity-only
+        // registerPushToken (no attributes — token re-association only).
+        let apiKey = initialState.apiKey!
+        let anonymousId = initialState.anonymousId!
+        let profilePayload = CreateProfilePayload(data: ProfilePayload(Profile.test, anonymousId: anonymousId))
+        let tokenPayload = PushTokenPayload(
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement.rawValue,
+            background: initialState.pushTokenData!.pushBackground.rawValue,
+            profile: ProfilePayload(
+                email: Profile.test.email, phoneNumber: Profile.test.phoneNumber,
+                externalId: Profile.test.externalId,
+                properties: [:], anonymousId: anonymousId
             )
         )
-        XCTAssertEqual(readQueue(), [request])
+        let expected: [KlaviyoRequest] = [
+            KlaviyoRequest(endpoint: .createProfile(apiKey, profilePayload)),
+            KlaviyoRequest(endpoint: .registerPushToken(apiKey, tokenPayload))
+        ]
+        XCTAssertEqual(readQueue(), expected)
     }
 
     @MainActor
     func testCreateProfileWithTrailingWhitespaceProperties() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct (whitespace-trimmed) identity when building payloads.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
-        _ = await store.send(.enqueueProfile(Profile(email: "foo@blob.com ", phoneNumber: "+19999999999     ", externalId: "abcdefg    "))) {
+        _ = await store.send(
+            .enqueueProfile(Profile(email: "foo@blob.com ", phoneNumber: "+19999999999     ",
+                                    externalId: "abcdefg    "))
+        ) {
             $0.phoneNumber = "+19999999999"
             $0.email = "foo@blob.com"
             $0.externalId = "abcdefg"
-            // No reset — state had no prior identifiers (isIdentified = false),
-            // so pushTokenData stays on state. The reducer builds the request inline
-            // using the captured pushTokenData without clearing it from state.
+            // No reset — state had no prior identifiers (isIdentified = false).
         }
-        let request = KlaviyoRequest(
-            endpoint: .registerPushToken(
-                initialState.apiKey!,
-                PushTokenPayload(
-                    pushToken: initialState.pushTokenData!.pushToken,
-                    enablement: initialState.pushTokenData!.pushEnablement.rawValue,
-                    background: initialState.pushTokenData!.pushBackground.rawValue,
-                    profile: ProfilePayload(
-                        Profile(
-                            email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg"
-                        ),
-                        anonymousId: store.state.anonymousId!
-                    )
-                )
+
+        // Unified Core path: createProfile with trimmed identifiers + identity-only token
+        // re-association. IdentityStore is updated with trimmed values before enqueueing.
+        let apiKey = initialState.apiKey!
+        let anonymousId = store.state.anonymousId!
+        let profilePayload = CreateProfilePayload(data: ProfilePayload(
+            Profile(email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg"),
+            anonymousId: anonymousId
+        ))
+        let tokenPayload = PushTokenPayload(
+            pushToken: initialState.pushTokenData!.pushToken,
+            enablement: initialState.pushTokenData!.pushEnablement.rawValue,
+            background: initialState.pushTokenData!.pushBackground.rawValue,
+            profile: ProfilePayload(
+                email: "foo@blob.com", phoneNumber: "+19999999999", externalId: "abcdefg",
+                properties: [:], anonymousId: anonymousId
             )
         )
-        XCTAssertEqual(readQueue(), [request])
+        let expected: [KlaviyoRequest] = [
+            KlaviyoRequest(endpoint: .createProfile(apiKey, profilePayload)),
+            KlaviyoRequest(endpoint: .registerPushToken(apiKey, tokenPayload))
+        ]
+        XCTAssertEqual(readQueue(), expected)
     }
 
     // MARK: - Test enqueue event
+
+    /// Payload-parity: the Core path (RequestEnqueuer → RequestFactory.eventPayload) must produce
+    /// a structurally identical payload to the legacy reducer path
+    /// (updateEventWithIdentifiers + eventRequest) for an identified profile with a push token.
+    /// Must pass before the cutover proceeds.
+    @MainActor
+    func testEnqueueEventPayloadParityWithLegacyBuilder() throws {
+        let state = INITIALIZED_TEST_STATE()
+        IdentityStore.shared.update(state.identity)
+        IdentityStore.shared.updatePushToken(state.pushTokenData)
+        let event = Event(name: .customEvent("Test"), properties: ["k": "v"])
+
+        // Legacy build (what post-init did today):
+        let enriched = event.updateEventWithIdentifiers(
+            email: state.email, phoneNumber: state.phoneNumber,
+            externalId: state.externalId, pushToken: state.pushTokenData?.pushToken
+        )
+        let legacyPayload = RequestFactory.eventPayload(
+            identity: PayloadIdentity(
+                state.requestIdentity(apiKey: state.apiKey!, anonymousId: state.anonymousId!)),
+            event: enriched, pushToken: state.pushTokenData?.pushToken
+        )
+
+        // Core build (RequestEnqueuer path):
+        let identity = PayloadIdentity(
+            anonymousId: state.anonymousId!, email: state.email,
+            phoneNumber: state.phoneNumber, externalId: state.externalId
+        )
+        let corePayload = RequestFactory.eventPayload(
+            identity: identity, event: event, pushToken: state.pushTokenData?.pushToken
+        )
+
+        XCTAssertEqual(
+            legacyPayload,
+            corePayload,
+            "Core event payload must match the legacy builder"
+        )
+    }
+
+    /// Verifies payload parity for `._openedPush` — the event type whose `updateEventWithIdentifiers`
+    /// push_token branch matters most (it injects the token into event properties).
+    func testOpenedPushEventPayloadParityWithLegacyBuilder() throws {
+        let state = INITIALIZED_TEST_STATE()
+        IdentityStore.shared.update(state.identity)
+        IdentityStore.shared.updatePushToken(state.pushTokenData)
+        let pushToken = try XCTUnwrap(state.pushTokenData?.pushToken)
+        let event = Event(
+            name: ._openedPush,
+            properties: ["push_token": pushToken],
+            priority: .high
+        )
+
+        // Legacy build (what post-init did before the cutover):
+        let enriched = event.updateEventWithIdentifiers(
+            email: state.email, phoneNumber: state.phoneNumber,
+            externalId: state.externalId, pushToken: pushToken
+        )
+        let legacyPayload = RequestFactory.eventPayload(
+            identity: PayloadIdentity(
+                state.requestIdentity(apiKey: state.apiKey!, anonymousId: state.anonymousId!)),
+            event: enriched, pushToken: pushToken
+        )
+
+        // Core build (RequestEnqueuer path):
+        let identity = PayloadIdentity(
+            anonymousId: state.anonymousId!, email: state.email,
+            phoneNumber: state.phoneNumber, externalId: state.externalId
+        )
+        let corePayload = RequestFactory.eventPayload(
+            identity: identity, event: event, pushToken: pushToken
+        )
+
+        XCTAssertEqual(
+            legacyPayload,
+            corePayload,
+            "Core _openedPush event payload must match the legacy builder (push_token branch parity)"
+        )
+    }
 
     @MainActor
     func testEnqueueEvents() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "555BLOB"
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct identity (phone number, push token) when building the payload.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
+
+        let apiKey = try XCTUnwrap(initialState.apiKey)
+        let anonymousId = try XCTUnwrap(initialState.anonymousId)
 
         for eventName in Event.EventName.allCases {
             // High-priority events use the package init so that priority flows onto the request.
@@ -724,20 +944,16 @@ class StateManagementTests: StateManagementTestCase {
                 )
                 : Event(name: eventName, properties: ["push_token": initialState.pushTokenData!.pushToken])
             let expectedPriority: RequestPriority = isHighPriority ? .high : .standard
-            let request = try KlaviyoRequest(
-                endpoint: .createEvent(
-                    XCTUnwrap(store.state.apiKey),
-                    CreateEventPayload(
-                        data: CreateEventPayload.Event(
-                            name: eventName.value,
-                            properties: event.properties,
-                            phoneNumber: store.state.phoneNumber,
-                            anonymousId: initialState.anonymousId!,
-                            time: event.time,
-                            pushToken: initialState.pushTokenData!.pushToken
-                        )
-                    )
-                ),
+            // Build the expected request via the Core path so this assertion tracks what
+            // RequestEnqueuer actually sends (identity read from IdentityStore above).
+            let identity = PayloadIdentity(
+                anonymousId: anonymousId, email: initialState.email,
+                phoneNumber: initialState.phoneNumber, externalId: initialState.externalId
+            )
+            let request = KlaviyoRequest(
+                endpoint: .createEvent(apiKey, RequestFactory.eventPayload(
+                    identity: identity, event: event, pushToken: initialState.pushTokenData?.pushToken
+                )),
                 priority: expectedPriority
             )
             await store.send(.enqueueEvent(event))
@@ -755,13 +971,17 @@ class StateManagementTests: StateManagementTestCase {
     func testPreInitEventRoutesToUnattributedBuffer() async throws {
         resetCanonicalCoreStores()
         UnattributedBuffer.shared.reset() // no apiKey set → buffer path
+        // Exhaustive: any spurious `.flushQueue` or publish-triggered action would fail this test.
         let store = TestStore(
             initialState: KlaviyoState(requestsInFlight: []),
             reducer: KlaviyoReducer()
         )
-        store.exhaustivity = .off
+        // exhaustivity = .on (default) — pre-init enqueueEvent must return .none (no downstream
+        // actions). If enrichAndPublishEvent fires or .flushQueue is emitted pre-init, the store
+        // will receive an unexpected action and XCTest will report a failure.
 
         await store.send(.enqueueEvent(.test))
+        // No `store.receive(...)` call — verifies that no further actions were produced.
 
         let (buffered, _) = UnattributedBuffer.shared.drainSnapshot()
         XCTAssertEqual(buffered.count, 1, "pre-init event is buffered, not dropped or queued")
@@ -987,6 +1207,8 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testEnqueueAggregateEvent() async throws {
         let initialState = INITIALIZED_TEST_STATE()
+        // Seed SDKConfigStore so RequestEnqueuer routes to QueueStore (not UnattributedBuffer).
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
@@ -1016,6 +1238,12 @@ class StateManagementTests: StateManagementTestCase {
     func testPrioritizedEventsAreInsertedAtFrontOfQueue() async throws {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.flushing = false
+
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct identity (push token) when building the geofence event payload.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
 
         // Add some existing requests to the queue
         let existingRequest1 = initialState.buildProfileRequest(apiKey: initialState.apiKey!, anonymousId: initialState.anonymousId!)
@@ -1105,6 +1333,8 @@ class StateManagementTests: StateManagementTestCase {
 
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+        IdentityStore.shared.update(initialState.identity)
         let subscription = Subscription.allAvailableMarketing(listId: "list-123")
         let request = expectedSubscriptionRequest(
             apiKey: apiKey,
@@ -1126,6 +1356,8 @@ class StateManagementTests: StateManagementTestCase {
 
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+        IdentityStore.shared.update(initialState.identity)
         let subscription = Subscription(
             listId: "list-123",
             channels: .init(email: .marketing, sms: .marketing)
@@ -1214,8 +1446,15 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testEnqueueSubscriptionMissingIdentifiersDoesNotEnqueue() async throws {
+        // Explicitly seed IdentityStore with the test identity (anonymousId only, no email/phone/externalId).
+        // `state.identity = IdentityStore.shared.current` in the reducer reads it back unchanged,
+        // so `buildSubscriptionPayload` sees no identifiers, warns, and returns nil → no enqueue.
         let expectation = expectSubscriptionWarning(containing: "at least one identifier")
         let initialState = INITIALIZED_TEST_STATE()
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
+        // Seed IdentityStore to match initialState (anonymousId only) so the reducer's identity
+        // seed is a no-op in exhaustive mode and the no-identifiers guard fires as intended.
+        IdentityStore.shared.update(initialState.identity)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -1231,6 +1470,8 @@ class StateManagementTests: StateManagementTestCase {
 
         let apiKey = try XCTUnwrap(initialState.apiKey)
         let anonymousId = try XCTUnwrap(initialState.anonymousId)
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: apiKey))
+        IdentityStore.shared.update(initialState.identity)
         let subscription = Subscription.allAvailableMarketing(listId: "list-123")
         let request = expectedSubscriptionRequest(
             apiKey: apiKey,
@@ -1246,9 +1487,15 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testEnqueueSubscriptionEmptyChannelsDoesNotEnqueue() async throws {
+        // Empty channels (`SubscriptionChannels()`) fails the `mappedChannels` guard before any
+        // identifier check — `buildSubscriptionPayload` warns "none were enabled" and returns nil.
+        // Seed IdentityStore to match state so `state.identity = IdentityStore.shared.current`
+        // is a no-op (avoids a spurious TCA state-mutation in exhaustive mode).
         let expectation = expectSubscriptionWarning(containing: "none were enabled")
         var initialState = INITIALIZED_TEST_STATE()
         initialState.email = "test@example.com"
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
+        IdentityStore.shared.update(initialState.identity)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -1259,9 +1506,14 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testEnqueueSubscriptionEmailChannelWithoutEmailDoesNotEnqueue() async throws {
+        // An email-channel subscription without an email set → `buildSubscriptionPayload` warns
+        // "requires an email" and returns nil → no enqueue. Seed IdentityStore to match state
+        // (phone only, no email) so the identity seed is a no-op in exhaustive mode.
         let expectation = expectSubscriptionWarning(containing: "requires an email")
         var initialState = INITIALIZED_TEST_STATE()
         initialState.phoneNumber = "+15005550006"
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
+        IdentityStore.shared.update(initialState.identity)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -1272,9 +1524,14 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testEnqueueSubscriptionPhoneChannelWithoutPhoneDoesNotEnqueue() async throws {
+        // An SMS-channel subscription without a phone set → `buildSubscriptionPayload` warns
+        // "requires a phone number" and returns nil → no enqueue. Seed IdentityStore to match
+        // state (email only, no phone) so the identity seed is a no-op in exhaustive mode.
         let expectation = expectSubscriptionWarning(containing: "requires a phone number")
         var initialState = INITIALIZED_TEST_STATE()
         initialState.email = "test@example.com"
+        try SDKConfigStore.shared.update(KlaviyoConfig(apiKey: XCTUnwrap(initialState.apiKey)))
+        IdentityStore.shared.update(initialState.identity)
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
 
@@ -1298,12 +1555,18 @@ class StateManagementTests: StateManagementTestCase {
     }
 
     /// Builds a non-flushing store seeded with a single standard-priority queued request,
-    /// so front-insertion (high priority) vs. append (standard) is observable. Returns the
-    /// store together with the seeded request for identity assertions.
+    /// so front-insertion (high priority) vs. append (standard) is observable. Seeds the Core
+    /// stores so RequestEnqueuer routes to QueueStore and reads the correct identity.
+    /// Returns the store together with the seeded request for identity assertions.
     @MainActor
     private func makePriorityTestStore() -> PriorityTestScaffold {
         var initialState = INITIALIZED_TEST_STATE()
         initialState.flushing = false
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct identity when building event payloads.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
         let existingRequest = initialState.buildProfileRequest(
             apiKey: initialState.apiKey!,
             anonymousId: initialState.anonymousId!
@@ -1436,6 +1699,11 @@ class StateManagementTests: StateManagementTestCase {
         var seeded = INITIALIZED_TEST_STATE()
         seeded.email = "old@klaviyo.com"
         seeded.anonymousId = "anon-before"
+        // Seed Core stores so RequestEnqueuer routes to QueueStore (not UnattributedBuffer)
+        // and reads the correct identity when re-registering the token after reset.
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: seeded.apiKey!))
+        IdentityStore.shared.updatePushToken(seeded.pushTokenData)
+        let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: seeded, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
@@ -1446,6 +1714,23 @@ class StateManagementTests: StateManagementTestCase {
         XCTAssertNotEqual(
             IdentityStore.shared.current.anonymousId, "anon-before",
             "reset of an identified profile mints a fresh anonymousId via IdentityStore"
+        )
+
+        // Token must be re-registered under the new anonymous identity via the ungated
+        // RequestEnqueuer (not the apiKey-gated state.enqueueRequest).
+        let queued = readQueue()
+        XCTAssertEqual(queued.count, 1, "reset enqueues exactly one token re-register")
+        guard case let .registerPushToken(apiKey, payload) = queued.first?.endpoint else {
+            XCTFail("expected a registerPushToken request in the queue after reset")
+            return
+        }
+        XCTAssertEqual(apiKey, seeded.apiKey!, "token re-register uses the current apiKey")
+        XCTAssertEqual(payload.data.attributes.token, seeded.pushTokenData!.pushToken,
+                       "preserved push token is re-registered")
+        XCTAssertEqual(
+            payload.data.attributes.profile.data.attributes.anonymousId,
+            IdentityStore.shared.current.anonymousId,
+            "token re-register uses the post-reset (fresh) anonymousId"
         )
     }
 
@@ -1512,5 +1797,192 @@ class StateManagementTests: StateManagementTestCase {
             .completeInitialization(KlaviyoState(requestsInFlight: [])),
             timeout: TIMEOUT_NANOSECONDS
         )
+    }
+
+    // MARK: - Empty / unchanged setter short-circuit (regression gate for MAGE-1196)
+
+    /// `setEmail("")` post-init must enqueue nothing and leave the queue empty.
+    /// The guard mirrors the legacy `isNotEmptyOrSame` check that was present in the old
+    /// per-setter paths.
+    @MainActor
+    func testSetEmailEmptyStringEnqueuesNothing() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setEmail(""))
+
+        XCTAssertTrue(readQueue().isEmpty, "setEmail(\"\") must not enqueue any request")
+    }
+
+    /// `setEmail(currentEmail)` post-init must enqueue nothing (unchanged guard).
+    @MainActor
+    func testSetEmailUnchangedEnqueuesNothing() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.email = "same@example.com"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        let seededIdentity = ProfileData(
+            email: "same@example.com", anonymousId: initialState.anonymousId
+        )
+        IdentityStore.shared.update(seededIdentity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setEmail("same@example.com"))
+
+        XCTAssertTrue(readQueue().isEmpty, "setEmail with the current value must not enqueue any request")
+    }
+
+    /// `setPhoneNumber("")` post-init must enqueue nothing.
+    @MainActor
+    func testSetPhoneNumberEmptyStringEnqueuesNothing() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setPhoneNumber(""))
+
+        XCTAssertTrue(readQueue().isEmpty, "setPhoneNumber(\"\") must not enqueue any request")
+    }
+
+    /// `setPhoneNumber(currentPhoneNumber)` post-init must enqueue nothing.
+    @MainActor
+    func testSetPhoneNumberUnchangedEnqueuesNothing() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.phoneNumber = "+18005551234"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        let seededIdentity = ProfileData(
+            phoneNumber: "+18005551234", anonymousId: initialState.anonymousId
+        )
+        IdentityStore.shared.update(seededIdentity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setPhoneNumber("+18005551234"))
+
+        XCTAssertTrue(readQueue().isEmpty,
+                      "setPhoneNumber with the current value must not enqueue any request")
+    }
+
+    /// `setExternalId("")` post-init must enqueue nothing.
+    @MainActor
+    func testSetExternalIdEmptyStringEnqueuesNothing() async throws {
+        let initialState = INITIALIZED_TEST_STATE()
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        IdentityStore.shared.update(initialState.identity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setExternalId(""))
+
+        XCTAssertTrue(readQueue().isEmpty, "setExternalId(\"\") must not enqueue any request")
+    }
+
+    /// `setExternalId(currentExternalId)` post-init must enqueue nothing.
+    @MainActor
+    func testSetExternalIdUnchangedEnqueuesNothing() async throws {
+        var initialState = INITIALIZED_TEST_STATE()
+        initialState.externalId = "user-42"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+        let seededIdentity = ProfileData(
+            externalId: "user-42", anonymousId: initialState.anonymousId
+        )
+        IdentityStore.shared.update(seededIdentity)
+        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        let readQueue = seedTestQueueStore()
+        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.setExternalId("user-42"))
+
+        XCTAssertTrue(readQueue().isEmpty,
+                      "setExternalId with the current value must not enqueue any request")
+    }
+
+    // MARK: - resetProfile preserves canonical push token in IdentityStore (regression gate for MAGE-1196)
+
+    /// `resetProfile` must NOT transiently clear `IdentityStore.pushToken`. The base
+    /// `state.reset(preserveTokenData: false)` sets `state.pushTokenData = nil`, which would cause
+    /// the write-through `defer` to call `IdentityStore.shared.updatePushToken(nil)`. The fix
+    /// restores `state.pushTokenData` to the captured token before returning so the defer is a no-op.
+    @MainActor
+    func testResetProfilePreservesCanonicalPushToken() async throws {
+        var seeded = INITIALIZED_TEST_STATE()
+        seeded.email = "old@klaviyo.com"
+        seeded.anonymousId = "anon-before"
+        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: seeded.apiKey!))
+        IdentityStore.shared.update(ProfileData(email: "old@klaviyo.com", anonymousId: "anon-before"))
+        IdentityStore.shared.updatePushToken(seeded.pushTokenData)
+        seedTestQueueStore()
+        let store = TestStore(initialState: seeded, reducer: KlaviyoReducer())
+        store.exhaustivity = .off
+
+        _ = await store.send(.resetProfile)
+
+        XCTAssertNotNil(
+            IdentityStore.shared.pushToken,
+            "resetProfile must not clear the canonical push token in IdentityStore"
+        )
+        XCTAssertEqual(
+            IdentityStore.shared.pushToken?.pushToken, seeded.pushTokenData?.pushToken,
+            "the preserved token must match the pre-reset token"
+        )
+    }
+
+    // MARK: - Pre-init identifier change with stored token (regression gate for MAGE-1196)
+
+    /// When an app calls `setEmail` before `initialize()` and a push token is already stored in
+    /// `IdentityStore`, the token branch inside `applyIdentifierChange` must be gated on
+    /// `apiKey`-present. Without the gate, the branch builds a token request with an empty apiKey,
+    /// `enqueueRequest` drops it (nil-apiKey guard), and the profile update is **silently lost**.
+    /// The expected behavior — matching the legacy `setPreInitIdentifier` — is to fall through to
+    /// the profile branch and buffer a `.profile` entry in `UnattributedBuffer`.
+    @MainActor
+    func testSetEmailPreInitWithStoredTokenBuffersProfile() async throws {
+        // Arrange: uninitialized state (no apiKey), identity with anonymousId, and a stored token.
+        resetCanonicalCoreStores()
+        UnattributedBuffer.shared.reset()
+        IdentityStore.shared.update(ProfileData(
+            email: "old@example.com", externalId: "user-A", anonymousId: "anon-A"
+        ))
+        IdentityStore.shared.updatePushToken(PushTokenData(
+            pushToken: "tok-preInit",
+            pushEnablement: .authorized,
+            pushBackground: .available,
+            deviceData: DeviceMetadata(context: environment.appContextInfo())
+        ))
+
+        let store = TestStore(
+            initialState: KlaviyoState(requestsInFlight: []), reducer: KlaviyoReducer()
+        )
+        store.exhaustivity = .off
+
+        // Act: change email while still pre-init (no apiKey set).
+        await store.send(.setEmail("new@example.com"))
+
+        // Assert: a `.profile` entry carrying the new email must be in the buffer.
+        let snap = UnattributedBuffer.shared.drainSnapshot().requests
+        let profiles: [CreateProfilePayload] = snap.compactMap {
+            if case let .profile(payload) = $0 { return payload }
+            return nil
+        }
+        XCTAssertEqual(profiles.count, 1,
+                       "pre-init setEmail with a stored token must buffer a .profile, not drop silently")
+        XCTAssertEqual(profiles.first?.data.attributes.email, "new@example.com",
+                       "buffered profile must carry the updated email")
     }
 }

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -782,7 +782,6 @@ class StateManagementTests: StateManagementTestCase {
         _ = await store.send(.enqueueProfile(Profile(email: "foo"))) {
             $0.phoneNumber = nil
             $0.email = "foo"
-            $0.pushTokenData = nil
         }
 
         // Unified path: two separate requests — profile first, then identity-only token

--- a/Tests/KlaviyoSwiftTests/StateManagementTests.swift
+++ b/Tests/KlaviyoSwiftTests/StateManagementTests.swift
@@ -334,7 +334,7 @@ class StateManagementTests: StateManagementTestCase {
         XCTAssertEqual(readQueue().map(\.endpoint), [pushTokenRequest].map(\.endpoint))
     }
 
-    /// Regression (MAGE-1196): after a token rotation, `setPushToken` writes the new token to
+    /// Regression: after a token rotation, `setPushToken` writes the new token to
     /// `IdentityStore` but leaves `state.pushTokenData` stale until the register drains. If
     /// `setPushEnablement` read the stale `state` token it would forward it and clobber the canonical
     /// store back to the old token. It must read the canonical `IdentityStore` token instead.
@@ -668,7 +668,7 @@ class StateManagementTests: StateManagementTestCase {
         }
     }
 
-    /// Regression (MAGE-1196): `flushQueue` with a staged `pendingProfile` calls
+    /// Regression: `flushQueue` with a staged `pendingProfile` calls
     /// `enqueueProfileOrTokenRequest`, which must not leave `state.pushTokenData` nil — otherwise the
     /// write-through `defer` persists nil into `IdentityStore`, wiping the canonical/persisted token
     /// until the in-flight register completes (a crash in that window loses the token on disk).
@@ -1044,7 +1044,7 @@ class StateManagementTests: StateManagementTestCase {
     }
 
     /// Drives the pre-init → drain-on-init flow shared by the buffered event, aggregate-event, and
-    /// subscription tests (MAGE-1136): buffers a request via `bufferPreInit`, initializes the SDK,
+    /// subscription tests: buffers a request via `bufferPreInit`, initializes the SDK,
     /// then asserts the QueueStore persisted `expectedRequest` and the buffer was trimmed.
     @MainActor
     private func assertPreInitBufferDrainsIntoQueueOnInit(
@@ -1460,7 +1460,7 @@ class StateManagementTests: StateManagementTestCase {
     @MainActor
     func testEnqueueSubscriptionUninitializedBuffers() async throws {
         // Pre-init: a subscribe carrying an identifier buffers its apiKey-free payload in the durable
-        // UnattributedBuffer (drains into the QueueStore at initialize()) instead of the pre-MAGE-1136
+        // UnattributedBuffer (drains into the QueueStore at initialize()) instead of the earlier
         // warn + drop. Mirrors the initialized path against the canonical persisted identity.
         IdentityStore.shared.update(ProfileData(email: "test@example.com", anonymousId: "anon-1"))
         let store = TestStore(
@@ -1484,8 +1484,8 @@ class StateManagementTests: StateManagementTestCase {
 
     @MainActor
     func testPreInitSubscriptionDrainsIntoQueueOnInit() async throws {
-        // Restores the pre-MAGE-952 "pending subscription replays on init" coverage: a subscribe
-        // buffered before initialize() drains into the QueueStore when the SDK initializes (MAGE-1136).
+        // Restores the earlier "pending subscription replays on init" coverage: a subscribe
+        // buffered before initialize() drains into the QueueStore when the SDK initializes.
         let payload = CreateSubscriptionPayload(
             listId: "list-123",
             profile: ProfilePayload(email: "test@example.com", anonymousId: "anon-1")
@@ -1851,115 +1851,64 @@ class StateManagementTests: StateManagementTestCase {
         )
     }
 
-    // MARK: - Empty / unchanged setter short-circuit (regression gate for MAGE-1196)
+    // MARK: - Empty / unchanged setter short-circuit (regression gate)
 
-    /// `setEmail("")` post-init must enqueue nothing and leave the queue empty.
-    /// The guard mirrors the legacy `isNotEmptyOrSame` check that was present in the old
-    /// per-setter paths.
+    private enum IdentifierField { case email, phone, externalId }
+
+    /// Sends the setter for `field` with `value` and asserts nothing is enqueued.
+    /// `seedStored == true` seeds `value` as the canonical identifier first (exercises the
+    /// "unchanged" guard); `false` leaves it unset (exercises the "empty string" short-circuit).
     @MainActor
-    func testSetEmailEmptyStringEnqueuesNothing() async throws {
+    private func assertSetterEnqueuesNothing(
+        field: IdentifierField,
+        value: String,
+        seedStored: Bool
+    ) async throws {
         let initialState = INITIALIZED_TEST_STATE()
-        seedCanonicalStores(from: initialState)
+        if seedStored {
+            SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
+            var identity = ProfileData(anonymousId: initialState.anonymousId)
+            switch field {
+            case .email: identity.email = value
+            case .phone: identity.phoneNumber = value
+            case .externalId: identity.externalId = value
+            }
+            IdentityStore.shared.update(identity)
+            IdentityStore.shared.updatePushToken(initialState.pushTokenData)
+        } else {
+            seedCanonicalStores(from: initialState)
+        }
         let readQueue = seedTestQueueStore()
         let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
         store.exhaustivity = .off
 
-        _ = await store.send(.setEmail(""))
+        let action: KlaviyoAction
+        switch field {
+        case .email: action = .setEmail(value)
+        case .phone: action = .setPhoneNumber(value)
+        case .externalId: action = .setExternalId(value)
+        }
+        _ = await store.send(action)
 
-        XCTAssertTrue(readQueue().isEmpty, "setEmail(\"\") must not enqueue any request")
+        XCTAssertTrue(readQueue().isEmpty, "\(action) must not enqueue any request")
     }
 
-    /// `setEmail(currentEmail)` post-init must enqueue nothing (unchanged guard).
+    /// The singular identifier setters must enqueue nothing when handed an empty string or the value
+    /// already stored — the `isNotEmptyOrSame` guard the old per-setter paths applied. Covers all
+    /// three fields × {empty, unchanged}.
     @MainActor
-    func testSetEmailUnchangedEnqueuesNothing() async throws {
-        var initialState = INITIALIZED_TEST_STATE()
-        initialState.email = "same@example.com"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        let seededIdentity = ProfileData(
-            email: "same@example.com", anonymousId: initialState.anonymousId
-        )
-        IdentityStore.shared.update(seededIdentity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
-        let readQueue = seedTestQueueStore()
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
-
-        _ = await store.send(.setEmail("same@example.com"))
-
-        XCTAssertTrue(readQueue().isEmpty, "setEmail with the current value must not enqueue any request")
+    func testIdentifierSettersShortCircuitOnEmptyOrUnchanged() async throws {
+        // Empty string → short-circuits before any comparison, regardless of the stored value.
+        try await assertSetterEnqueuesNothing(field: .email, value: "", seedStored: false)
+        try await assertSetterEnqueuesNothing(field: .phone, value: "", seedStored: false)
+        try await assertSetterEnqueuesNothing(field: .externalId, value: "", seedStored: false)
+        // Unchanged value → guard compares against the stored identifier and short-circuits.
+        try await assertSetterEnqueuesNothing(field: .email, value: "same@example.com", seedStored: true)
+        try await assertSetterEnqueuesNothing(field: .phone, value: "+18005551234", seedStored: true)
+        try await assertSetterEnqueuesNothing(field: .externalId, value: "user-42", seedStored: true)
     }
 
-    /// `setPhoneNumber("")` post-init must enqueue nothing.
-    @MainActor
-    func testSetPhoneNumberEmptyStringEnqueuesNothing() async throws {
-        let initialState = INITIALIZED_TEST_STATE()
-        seedCanonicalStores(from: initialState)
-        let readQueue = seedTestQueueStore()
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
-
-        _ = await store.send(.setPhoneNumber(""))
-
-        XCTAssertTrue(readQueue().isEmpty, "setPhoneNumber(\"\") must not enqueue any request")
-    }
-
-    /// `setPhoneNumber(currentPhoneNumber)` post-init must enqueue nothing.
-    @MainActor
-    func testSetPhoneNumberUnchangedEnqueuesNothing() async throws {
-        var initialState = INITIALIZED_TEST_STATE()
-        initialState.phoneNumber = "+18005551234"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        let seededIdentity = ProfileData(
-            phoneNumber: "+18005551234", anonymousId: initialState.anonymousId
-        )
-        IdentityStore.shared.update(seededIdentity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
-        let readQueue = seedTestQueueStore()
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
-
-        _ = await store.send(.setPhoneNumber("+18005551234"))
-
-        XCTAssertTrue(readQueue().isEmpty,
-                      "setPhoneNumber with the current value must not enqueue any request")
-    }
-
-    /// `setExternalId("")` post-init must enqueue nothing.
-    @MainActor
-    func testSetExternalIdEmptyStringEnqueuesNothing() async throws {
-        let initialState = INITIALIZED_TEST_STATE()
-        seedCanonicalStores(from: initialState)
-        let readQueue = seedTestQueueStore()
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
-
-        _ = await store.send(.setExternalId(""))
-
-        XCTAssertTrue(readQueue().isEmpty, "setExternalId(\"\") must not enqueue any request")
-    }
-
-    /// `setExternalId(currentExternalId)` post-init must enqueue nothing.
-    @MainActor
-    func testSetExternalIdUnchangedEnqueuesNothing() async throws {
-        var initialState = INITIALIZED_TEST_STATE()
-        initialState.externalId = "user-42"
-        SDKConfigStore.shared.update(KlaviyoConfig(apiKey: initialState.apiKey!))
-        let seededIdentity = ProfileData(
-            externalId: "user-42", anonymousId: initialState.anonymousId
-        )
-        IdentityStore.shared.update(seededIdentity)
-        IdentityStore.shared.updatePushToken(initialState.pushTokenData)
-        let readQueue = seedTestQueueStore()
-        let store = TestStore(initialState: initialState, reducer: KlaviyoReducer())
-        store.exhaustivity = .off
-
-        _ = await store.send(.setExternalId("user-42"))
-
-        XCTAssertTrue(readQueue().isEmpty,
-                      "setExternalId with the current value must not enqueue any request")
-    }
-
-    // MARK: - resetProfile preserves canonical push token in IdentityStore (regression gate for MAGE-1196)
+    // MARK: - resetProfile preserves canonical push token in IdentityStore (regression gate)
 
     /// `resetProfile` must NOT transiently clear `IdentityStore.pushToken`. The base
     /// `state.reset(preserveTokenData: false)` sets `state.pushTokenData = nil`, which would cause
@@ -1989,7 +1938,7 @@ class StateManagementTests: StateManagementTestCase {
         )
     }
 
-    // MARK: - Pre-init identifier change with stored token (regression gate for MAGE-1196)
+    // MARK: - Pre-init identifier change with stored token (regression gate)
 
     /// When an app calls `setEmail` before `initialize()` and a push token is already stored in
     /// `IdentityStore`, the token branch inside `applyIdentifierChange` must be gated on
@@ -2038,7 +1987,7 @@ class StateManagementTests: StateManagementTestCase {
     /// apiKey — otherwise the request is built and silently dropped by the nil-`state.apiKey` guard.
     /// With the gate, it falls through to `RequestEnqueuer.enqueueProfile`, which — since
     /// `SDKConfigStore` has the apiKey — routes the profile to the `QueueStore` (not dropped).
-    /// Regression gate for the warm-start drop (MAGE-1196).
+    /// Regression gate for the warm-start drop.
     @MainActor
     func testSetEmailWarmStartWithStoredTokenEnqueuesProfileToQueue() async throws {
         resetCanonicalCoreStores()


### PR DESCRIPTION
# Description

Route the post-init public API of the KlaviyoSwift TCA reducer through the ungated KlaviyoCore path — writing identity to the canonical `IdentityStore` and enqueuing via `RequestEnqueuer` (→ `QueueStore`) — instead of mutating the `KlaviyoState` projection and relying on the write-through `defer`. This strips request-building/identity ownership out of `StateManagement.swift`, a prerequisite for retiring the reducer + vendored TCA in **MAGE-904**.

**Rebased onto `feat/modularization-2`** now that MAGE-953 (#720) has merged — the diff is just the MAGE-1196 changes. Sub-issue of MAGE-904.

## Why / approach

The pre-init branches already delegate to `RequestEnqueuer` + `IdentityStore`; the post-init paths still used the legacy `state`-projection + `defer` write-through. This collapses each action's two branches into one init-state-agnostic path, folding in the post-init-only nuances (prompt-flush, `enrichAndPublishEvent`, dedup, skip optimization, token re-association, identifier-change reset). Parity-preserving, gated by the existing reducer test suite.

## Changelog / Code Overview

- **Identity setters** (`setEmail`/`setPhoneNumber`/`setExternalId`) → new `applyIdentifierChange` helper (writes `IdentityStore`; `isNotEmptyOrSame` empty/unchanged short-circuit + developer warning preserved; token re-association gated on `state.apiKey` so pre-init/warm-start falls through to the buffered/queued path instead of dropping).
- **Push-token setters** (`setPushToken`/`setAutomaticPushToken`/`setPushEnablement`) → dedup against `IdentityStore.pushToken`; `setPushToken` **write-throughs `state.pushTokenData`** (persisted to `IdentityStore` by the reducer `defer`) so the projection stays in sync for all state readers; `setPushEnablement` reads the **canonical `IdentityStore` token**, not the stale projection. Token path gated on `state.apiKey` (matches `enqueueRequest`) so a warm-start persisted apiKey can't drop the register.
- **Events** (`enqueueEvent`/`enqueueAggregateEvent`) → `RequestEnqueuer`; `enrichAndPublishEvent` (`.fireAndForget`) + the high-priority opened-push/geofence prompt-flush kept **post-init only**.
- **`enqueueProfile`** → Core path. **Intentional behavior change:** with an existing token it now sends **two** requests — `createProfile` (attributes) + an identity-only `registerPushToken` — instead of one token request with embedded attributes. Net server state is equivalent (attributes persisted + token bound to the same identity); the identity-only registration, ordered after `createProfile`, carries no attributes so it can't overwrite them. Skip optimization + identifier-change reset (fresh anon + PII drop) preserved.
- **`enqueueSubscription`** + **`trackingLinkResolutionFailed`** → `RequestEnqueuer` (subscription channel/identifier validation preserved — invalid combos still enqueue nothing).
- **`resetProfile`** → Core path (fresh anon + PII drop; canonical push token retained and re-registered under the new identity).
- **Flush safety:** `enqueueProfileOrTokenRequest` (the `pendingProfile` drain in `flushQueue`) no longer nils `state.pushTokenData`, so the write-through `defer` can't persist nil into `IdentityStore` and wipe the canonical/persisted token mid-flush (a crash in that window previously lost the token on disk).
- Removed now-dead `KlaviyoState.updateEmail/updatePhoneNumber/updateExternalId`.
- **Out of scope (MAGE-1197/904):** `setProfileProperty`/`pendingProfile` staging, the flush/retry engine, `initialize`/`completeInitialization`, dispatch-site removal, and `KlaviyoState`/vendored-TCA deletion.

## Review feedback addressed (commits `fd5e09bc`, `4eaec236`)

- **Stale-token clobber:** `setPushEnablement` read the stale `state.pushTokenData` and could re-register/clobber the canonical token → now reads `IdentityStore`.
- **Warm-start drop (Critical):** token path gated on `SDKConfigStore.apiKey` but enqueued via the `state.apiKey`-gated `enqueueRequest` → dropped when a persisted apiKey preceded `.initialize`. Both sites now gate on `state.apiKey`.
- **Flush token-wipe:** see "Flush safety" above.
- **CodeRabbit quick wins:** `setPushToken` write-through (CR#1), `@MainActor` fix, DRY test helpers (`makeInitializedIdentifierStore`, `expectedIdentityOnlyTokenRequest`, `seedCanonicalStores`).

## Due Diligence
- [ ] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release. (iOS modularization line.)

## Test Plan

Full `KlaviyoSwiftTests` + `KlaviyoCoreTests` green (0 failures). Notable additions:
- **Payload-parity snapshots** proving the Core-built request equals the legacy builder output: `createEvent` (incl. `_openedPush` push-token branch) and `createProfile`.
- **Regression gates:** `setPushEnablement` reads the canonical token; warm-start `setEmail` (persisted apiKey, nil `state.apiKey`) enqueues rather than drops; `flushQueue` with a staged `pendingProfile` keeps the canonical push token; empty/whitespace/unchanged setters enqueue nothing; token retained after `resetProfile`.
- Existing setter/event/profile/subscription/reset tests re-pointed to the canonical-store contract (assert `IdentityStore` + spy `QueueStore`) across `StateManagementTests`, `StateManagementEdgeCaseTests`, `StateManagementEnqueueEdgeCaseTests`, `ResolveTrackingLinkTests`.

## Related Issues/Tickets

- [MAGE-1196](https://linear.app/klaviyo/issue/MAGE-1196) (sub-issue of [MAGE-904](https://linear.app/klaviyo/issue/MAGE-904))
- Builds on [MAGE-953](https://linear.app/klaviyo/issue/MAGE-953) (#720, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved handling of identity, profile, event, subscription, push-token, reset, and tracking-link requests.
  * Added reliable buffering for operations performed before SDK initialization.
  * Improved persistence, synchronization, and deduplication of identifiers and push tokens.
  * Avoided unnecessary profile updates when identifiers remain unchanged.
  * Preserved push-token registration across profile resets.
* **Tests**
  * Expanded coverage for initialization, identity persistence, request routing, token handling, and profile updates.
* **Documentation**
  * Clarified test documentation and removed obsolete issue references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->