### PR TITLE
refactor(KlaviyoCore): durable countdown backoff for RequestQueue (MAGE-1197)

### DIFF
--- a/Sources/KlaviyoCore/RequestQueue.swift
+++ b/Sources/KlaviyoCore/RequestQueue.swift
@@ -124,20 +124,10 @@ public actor RequestQueue {
         isFlushing = true
         defer { isFlushing = false }
 
-        // Durable countdown backoff: if a prior failure set a backoff, decrement it by one tick and skip
-        // the flush until it elapses. The failing request is already restored to QueueStore (below), so it
-        // stays durable during the wait. On expiry, promote to `.retry(requestCount)` and fall through to
-        // drain + send. Ports the reducer's flushQueue countdown (no TCA).
-        if case let .retryWithBackoff(requestCount, totalCount, backoff) = retryState {
-            let remaining = max(backoff - Int(flushInterval), 0)
-            if remaining > 0 {
-                retryState = .retryWithBackoff(requestCount: requestCount,
-                                               totalRetryCount: totalCount,
-                                               currentBackoff: remaining)
-                return
-            }
-            retryState = .retry(requestCount)
-        }
+        // Durable countdown backoff gate. Advances the countdown once per flush; if a backoff is still
+        // outstanding, skip this flush (the failing request stays durable in `QueueStore` during the
+        // wait). See `advanceBackoffGate`.
+        if case .wait = advanceBackoffGate() { return }
 
         // 2. Let the owner enqueue any last-minute requests before we take the snapshot.
         await willDrain?()
@@ -147,46 +137,57 @@ public actor RequestQueue {
         requestsInFlight = QueueStore.shared.drainAll()
         guard !requestsInFlight.isEmpty else { return }
 
-        // 4. Send head-first, FIFO, dequeuing each on success.
+        // 4. Send head-first, FIFO, dequeuing each on success. `sendHead` reports whether to keep
+        //    draining the batch or stop and let the run loop retry on a later tick.
         while let head = requestsInFlight.first {
-            // Source `numAttempts` from `.retry(count)` ONLY. The countdown gate above always promotes
-            // `.retryWithBackoff` to `.retry` before any send, so retryState is `.retry` here. Reading
-            // `.retryWithBackoff` is what caused the reverted `requestCount: 0` stall — do NOT.
-            var numAttempts = FlushConstants.initialAttempt
-            if case let .retry(count) = retryState {
-                numAttempts = count
-            }
-
-            let attemptInfo: RequestAttemptInfo
-            do {
-                attemptInfo = try RequestAttemptInfo(
-                    attemptNumber: numAttempts,
-                    maxAttempts: head.endpoint.maxRetries
-                )
-            } catch {
-                environment.emitDeveloperWarning("Invalid RequestAttemptInfo parameters: \(error)")
-                restoreLease()
+            switch await sendHead(head) {
+            case .continueSending:
+                continue
+            case .stopFlush:
                 return
             }
+        }
+    }
 
-            let outcome = await send(head, attemptInfo)
-            guard !requestsInFlight.isEmpty else { return }
-            switch outcome {
-            case .success:
-                if case let .registerPushToken(_, payload) = head.endpoint {
-                    IdentityStore.shared.updatePushToken(PushTokenData(payload))
-                }
-                requestsInFlight.removeFirst()
-                retryState = .retry(FlushConstants.initialAttempt)
+    /// Sends one head request with its per-attempt metadata and applies the result, reporting whether
+    /// the flush loop should continue with the next request or stop. On `.success` a registered push
+    /// token is written back to `IdentityStore` and the head is dequeued; on `.failure` the error is
+    /// classified by `handleSendFailure`. Stops early if the attempt metadata is invalid or the lease
+    /// was cleared mid-send (e.g. by `stop()`).
+    private func sendHead(_ head: KlaviyoRequest) async -> FailureOutcome {
+        // Source `numAttempts` from `.retry(count)` ONLY. The countdown gate always promotes
+        // `.retryWithBackoff` to `.retry` before any send, so retryState is `.retry` here. Reading
+        // `.retryWithBackoff` is what caused the reverted `requestCount: 0` stall — do NOT.
+        var numAttempts = FlushConstants.initialAttempt
+        if case let .retry(count) = retryState {
+            numAttempts = count
+        }
 
-            case let .failure(error):
-                switch await handleSendFailure(error, head: head) {
-                case .continueSending:
-                    continue
-                case .stopFlush:
-                    return
-                }
+        let attemptInfo: RequestAttemptInfo
+        do {
+            attemptInfo = try RequestAttemptInfo(
+                attemptNumber: numAttempts,
+                maxAttempts: head.endpoint.maxRetries
+            )
+        } catch {
+            environment.emitDeveloperWarning("Invalid RequestAttemptInfo parameters: \(error)")
+            restoreLease()
+            return .stopFlush
+        }
+
+        let outcome = await send(head, attemptInfo)
+        guard !requestsInFlight.isEmpty else { return .stopFlush }
+        switch outcome {
+        case .success:
+            if case let .registerPushToken(_, payload) = head.endpoint {
+                IdentityStore.shared.updatePushToken(PushTokenData(payload))
             }
+            requestsInFlight.removeFirst()
+            retryState = .retry(FlushConstants.initialAttempt)
+            return .continueSending
+
+        case let .failure(error):
+            return await handleSendFailure(error, head: head)
         }
     }
 
@@ -197,6 +198,36 @@ public actor RequestQueue {
         guard !requestsInFlight.isEmpty else { return }
         QueueStore.shared.prepend(requestsInFlight, persist: .synchronous)
         requestsInFlight = []
+    }
+
+    /// Result of the durable countdown backoff gate: whether this flush should wait out an
+    /// outstanding backoff or proceed to drain + send.
+    private enum BackoffGate {
+        case wait
+        case proceed
+    }
+
+    /// Advances the durable countdown backoff by one flush interval and reports whether `flush()`
+    /// should skip this pass. Called once per flush — from a scheduled run-loop tick OR an immediate
+    /// `flushNow()` — which mirrors the reducer, whose `flushQueue` decremented the backoff on every
+    /// dispatch (timer and high-priority paths alike). Timing is therefore approximate in both
+    /// directions: a backoff fires at most one interval late on the tick path, and a burst of
+    /// immediate flushes can expire it early. That imprecision is the accepted cost of reducer parity.
+    /// The failing request is already restored to the durable `QueueStore`, so it survives the wait.
+    private func advanceBackoffGate() -> BackoffGate {
+        guard case let .retryWithBackoff(requestCount, totalCount, backoff) = retryState else {
+            return .proceed
+        }
+        let remaining = max(backoff - Int(flushInterval), 0)
+        if remaining > 0 {
+            retryState = .retryWithBackoff(requestCount: requestCount,
+                                           totalRetryCount: totalCount,
+                                           currentBackoff: remaining)
+            return .wait
+        }
+        // Expired: promote to a plain retry and let the caller fall through to drain + send.
+        retryState = .retry(requestCount)
+        return .proceed
     }
 
     /// Whether the flush loop should keep sending the next request or stop (and let the run loop

--- a/Sources/KlaviyoCore/RequestQueue.swift
+++ b/Sources/KlaviyoCore/RequestQueue.swift
@@ -12,8 +12,9 @@ import Foundation
 /// loop, and implements the drain/send happy path: `flush()` leases the pending batch and sends it
 /// head-first in FIFO order, writing a registered push token back to `IdentityStore` on success.
 /// On failure it classifies the error and either dequeues + continues (non-retryable), stops and
-/// restores the lease so retries resume next tick (transient), or sleeps the backoff and retries
-/// the same head in place (rate-limit / server error).
+/// restores the lease so retries resume next tick (transient), or records a durable countdown
+/// backoff and restores the request to the queue (rate-limit / server error) — the request stays
+/// on disk while the countdown gate at the top of `flush()` waits it out over ticks, then resends.
 public actor RequestQueue {
     /// Transport seam: sends one request with its per-attempt retry metadata and reports the result.
     public typealias Send = @Sendable (KlaviyoRequest, RequestAttemptInfo)
@@ -114,13 +115,29 @@ public actor RequestQueue {
     /// leases the whole batch, and sends head-first in FIFO order. On `.success` a registered push
     /// token is written back to the canonical `IdentityStore`. On `.failure` the error is classified
     /// (`classifyFailure`) and handled: non-retryable → dequeue + continue; transient → stop + lease
-    /// restore (retries next tick); rate-limit/server → direct-sleep backoff then retry in place.
+    /// restore (retries next tick); rate-limit/server → record a durable countdown backoff + restore
+    /// the request, which the countdown gate below waits out over ticks before resending.
     private func flush() async {
         // 1. Gate: pre-init or offline. Do not flush.
         guard SDKConfigStore.shared.current.apiKey != nil, flushInterval.isFinite else { return }
         guard !isFlushing else { return }
         isFlushing = true
         defer { isFlushing = false }
+
+        // Durable countdown backoff: if a prior failure set a backoff, decrement it by one tick and skip
+        // the flush until it elapses. The failing request is already restored to QueueStore (below), so it
+        // stays durable during the wait. On expiry, promote to `.retry(requestCount)` and fall through to
+        // drain + send. Ports the reducer's flushQueue countdown (no TCA).
+        if case let .retryWithBackoff(requestCount, totalCount, backoff) = retryState {
+            let remaining = max(backoff - Int(flushInterval), 0)
+            if remaining > 0 {
+                retryState = .retryWithBackoff(requestCount: requestCount,
+                                               totalRetryCount: totalCount,
+                                               currentBackoff: remaining)
+                return
+            }
+            retryState = .retry(requestCount)
+        }
 
         // 2. Let the owner enqueue any last-minute requests before we take the snapshot.
         await willDrain?()
@@ -132,6 +149,9 @@ public actor RequestQueue {
 
         // 4. Send head-first, FIFO, dequeuing each on success.
         while let head = requestsInFlight.first {
+            // Source `numAttempts` from `.retry(count)` ONLY. The countdown gate above always promotes
+            // `.retryWithBackoff` to `.retry` before any send, so retryState is `.retry` here. Reading
+            // `.retryWithBackoff` is what caused the reverted `requestCount: 0` stall — do NOT.
             var numAttempts = FlushConstants.initialAttempt
             if case let .retry(count) = retryState {
                 numAttempts = count
@@ -190,7 +210,7 @@ public actor RequestQueue {
     /// the next request or stop. Extracted from `flush()`. Mirrors `handleRequestError` +
     /// `requestFailed`/`deQueueCompletedResults` in the legacy reducer: non-retryable errors dequeue
     /// the head and CONTINUE; retryable errors set `retryState`, drop the head if it exceeded
-    /// `maxRetries`, then STOP (network) or SLEEP + retry-in-place (backoff).
+    /// `maxRetries`, then STOP; any backoff is waited out over ticks by the countdown gate in `flush()`.
     private func handleSendFailure(_ error: KlaviyoAPIError, head: KlaviyoRequest) async -> FailureOutcome {
         switch classifyFailure(error: error, retryState: retryState) {
         case .dequeue:
@@ -232,32 +252,22 @@ public actor RequestQueue {
             restoreLease()
             return .stopFlush
 
-        case let .retryWithBackoff(newState, seconds):
-            // Rate-limit / server error. Set the new retry state; if it exceeded `maxRetries`, drop
-            // the head, reset per `requestFailed`, and STOP.
+        case let .retryWithBackoff(newState):
+            // Rate-limit / server error. Record the backoff on `retryState` and put the request back
+            // on the durable `QueueStore`; the countdown gate at the top of `flush()` waits it out
+            // over ticks, then resends. If it already exceeded `maxRetries`, drop the head and reset
+            // to a fresh `.retry(initialAttempt)`. This DELIBERATELY diverges from the reducer's
+            // `.retryWithBackoff(requestCount: 0)` reset — under the countdown gate that would promote
+            // to `.retry(0)`, which `RequestAttemptInfo` rejects → a permanent stall. Do NOT restore
+            // that parity.
             retryState = newState
-            if case let .retryWithBackoff(requestCount, totalCount, backOff) = newState,
+            if case let .retryWithBackoff(requestCount, _, _) = newState,
                requestCount > head.endpoint.maxRetries {
                 requestsInFlight.removeFirst()
-                retryState = .retryWithBackoff(
-                    requestCount: 0,
-                    totalRetryCount: totalCount,
-                    currentBackoff: backOff
-                )
-                restoreLease()
-                return .stopFlush
+                retryState = .retry(FlushConstants.initialAttempt)
             }
-            // Decision 2: sleep the backoff directly, then retry the SAME head in place (rather than
-            // restoring + waiting for the reducer's per-tick countdown). The `isFlushing` guard
-            // stays true across the sleep, so no concurrent flush runs.
-            try? await clock.sleep(Double(seconds))
-            // Promote back to `.retry(requestCount)` so the in-place retry advances `attemptNumber`
-            // (parity with the reducer's backoff-expiry: `state.retryState = .retry(requestCount)`).
-            // Without this the retried send would keep sourcing `numAttempts` as the initial attempt.
-            if case let .retryWithBackoff(requestCount, _, _) = retryState {
-                retryState = .retry(requestCount)
-            }
-            return .continueSending
+            restoreLease()
+            return .stopFlush
         }
     }
 }

--- a/Sources/KlaviyoCore/RequestQueueSupport.swift
+++ b/Sources/KlaviyoCore/RequestQueueSupport.swift
@@ -112,8 +112,9 @@ public enum FlushDecision: Equatable {
     /// A transient network error occurred; resend on the regular flush cadence.
     case retry(RetryState)
 
-    /// A rate-limit or server error occurred; wait `seconds` before resending.
-    case retryWithBackoff(RetryState, seconds: Int)
+    /// A rate-limit or server error occurred; record the backoff on the nested `RetryState`
+    /// (`currentBackoff`) and count it down over flush ticks before resending.
+    case retryWithBackoff(RetryState)
 
     /// The server rejected a field (e.g. email or phone) with a validation error.
     /// Strip the offending field(s) and remove the request from the queue.
@@ -166,8 +167,7 @@ public func classifyFailure(error: KlaviyoAPIError, retryState: RetryState) -> F
                 requestCount: requestRetryCount,
                 totalRetryCount: totalRetryCount,
                 currentBackoff: backOff
-            ),
-            seconds: backOff
+            )
         )
 
     case .internalError,

--- a/Tests/KlaviyoCoreTests/FlushDecisionTests.swift
+++ b/Tests/KlaviyoCoreTests/FlushDecisionTests.swift
@@ -107,8 +107,7 @@ final class FlushDecisionTests: XCTestCase {
         XCTAssertEqual(
             decision,
             .retryWithBackoff(
-                .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: backOff),
-                seconds: backOff
+                .retryWithBackoff(requestCount: 3, totalRetryCount: 3, currentBackoff: backOff)
             )
         )
     }
@@ -124,8 +123,7 @@ final class FlushDecisionTests: XCTestCase {
         XCTAssertEqual(
             decision,
             .retryWithBackoff(
-                .retryWithBackoff(requestCount: 3, totalRetryCount: 5, currentBackoff: backOff),
-                seconds: backOff
+                .retryWithBackoff(requestCount: 3, totalRetryCount: 5, currentBackoff: backOff)
             )
         )
     }
@@ -139,8 +137,7 @@ final class FlushDecisionTests: XCTestCase {
         XCTAssertEqual(
             decision,
             .retryWithBackoff(
-                .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: backOff),
-                seconds: backOff
+                .retryWithBackoff(requestCount: 2, totalRetryCount: 2, currentBackoff: backOff)
             )
         )
     }
@@ -155,8 +152,7 @@ final class FlushDecisionTests: XCTestCase {
         XCTAssertEqual(
             decision,
             .retryWithBackoff(
-                .retryWithBackoff(requestCount: 2, totalRetryCount: 4, currentBackoff: backOff),
-                seconds: backOff
+                .retryWithBackoff(requestCount: 2, totalRetryCount: 4, currentBackoff: backOff)
             )
         )
     }

--- a/Tests/KlaviyoCoreTests/RequestQueueTests.swift
+++ b/Tests/KlaviyoCoreTests/RequestQueueTests.swift
@@ -279,42 +279,64 @@ final class RequestQueueTests: XCTestCase {
         XCTAssertTrue(QueueStore.shared.requests.isEmpty, "request dequeued after success")
     }
 
-    /// A rate-limit error sleeps the backoff, then retries the SAME head in place within one flush
-    /// (Decision 2: direct sleep). `RecordingSleepClock` returns instantly and records the backoff.
-    func testRateLimitSleepsBackoffThenResends() async {
+    /// A rate-limit error records a durable countdown backoff and restores the request to
+    /// `QueueStore` (it stays on disk, not held in memory). It is NOT re-sent on the same tick. The
+    /// countdown gate at the top of `flush()` decrements the backoff by `flushInterval` each tick;
+    /// once it elapses the request is promoted to `.retry(requestCount)`, drained, and resent — with
+    /// `attemptNumber` advanced (`sentAttempts == [1, 2]`). Driven by repeated `flushNow()` ticks; no
+    /// run loop or recording clock is involved.
+    func testRateLimitCountsDownBackoffThenResends() async {
         QueueStore.register(makeQueueStore())
-        let recording = RecordingSleepClock()
+        // backoff 25s, wifi interval 10s → gate needs 25→15→5→0 to elapse across ticks.
         let spy = SendSpy(results: [
-            .failure(.rateLimitError(backOff: 8)),
+            .failure(.rateLimitError(backOff: 25)),
             .success(Data())
         ])
         QueueStore.shared.enqueue(makeCreateProfileRequest(id: "rate"), persist: .synchronous)
-        let queue = RequestQueue(clock: recording.clock, send: spy.send)
+        let queue = RequestQueue(clock: .immediate, send: spy.send)
 
+        // Tick 1: send fails with rate-limit; the request is restored to the durable queue, not resent.
         await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["rate"], "sent once; not resent on the same tick")
+        XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["rate"],
+                       "rate-limited request must be restored to the durable queue during the countdown")
 
-        XCTAssertTrue(recording.requested.contains(8), "backoff of 8s must be slept before resend")
-        XCTAssertEqual(spy.sentIds, ["rate", "rate"], "same head retried in place after the sleep")
+        // Ticks 2 & 3: the gate counts the backoff down (25→15→5) and skips the flush; no new send.
+        await queue.flushNow()
+        await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["rate"], "no resend while the backoff is still counting down")
+        XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["rate"],
+                       "request stays durable in the queue across the countdown ticks")
+
+        // Tick 4: backoff elapses (5→0), promotes to `.retry(2)`, drains + resends → success + dequeue.
+        await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["rate", "rate"], "resent once the backoff elapsed")
         XCTAssertEqual(spy.sentAttempts, [1, 2],
                        "attemptNumber must advance across the backoff retry, not freeze at 1")
         XCTAssertTrue(QueueStore.shared.requests.isEmpty, "request dequeued after successful resend")
     }
 
-    /// A server error behaves like a rate-limit: sleep the backoff, then retry the same head in place.
-    func testServerErrorSleepsBackoffThenResends() async {
+    /// A server error behaves like a rate-limit: record the countdown backoff, restore the request,
+    /// count it down over ticks, then resend.
+    func testServerErrorCountsDownBackoffThenResends() async {
         QueueStore.register(makeQueueStore())
-        let recording = RecordingSleepClock()
+        // backoff 5s, wifi interval 10s → one countdown tick (5→0) elapses it.
         let spy = SendSpy(results: [
             .failure(.serverError(statusCode: 503, backOff: 5)),
             .success(Data())
         ])
         QueueStore.shared.enqueue(makeCreateProfileRequest(id: "srv"), persist: .synchronous)
-        let queue = RequestQueue(clock: recording.clock, send: spy.send)
+        let queue = RequestQueue(clock: .immediate, send: spy.send)
 
+        // Tick 1: send fails; the request is restored to the durable queue, not resent.
         await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["srv"], "sent once; not resent on the same tick")
+        XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["srv"],
+                       "server-errored request must be restored to the durable queue during the backoff")
 
-        XCTAssertTrue(recording.requested.contains(5), "server-error backoff must be slept")
-        XCTAssertEqual(spy.sentIds, ["srv", "srv"], "same head retried in place after the sleep")
+        // Tick 2: backoff elapses (5→0), promotes to `.retry`, drains + resends → success + dequeue.
+        await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["srv", "srv"], "resent once the backoff elapsed")
         XCTAssertTrue(QueueStore.shared.requests.isEmpty, "request dequeued after successful resend")
     }
 
@@ -358,24 +380,33 @@ final class RequestQueueTests: XCTestCase {
     /// Exercises the `.retryWithBackoff` EXCEEDED branch. A low-retry endpoint (`maxRetries == 1`)
     /// receives a rate-limit error on its first attempt: `classifyFailure` returns
     /// `.retryWithBackoff(requestCount: 2, ...)`, which exceeds `maxRetries == 1`. The engine must
-    /// DROP the head (not restore it) without sleeping the backoff, restore the (now-empty) remaining
-    /// lease, and return — leaving the store empty and `send` called exactly once.
+    /// DROP the head (not restore it) and reset retryState to a fresh `.retry(initialAttempt)` — NOT
+    /// `.retryWithBackoff(requestCount: 0, …)`, which would make the gate later promote to `.retry(0)`
+    /// and permanently stall. To prove no stall, a subsequently-enqueued request must still send.
     func testExceedingMaxRetriesOnBackoffDropsRequest() async {
         QueueStore.register(makeQueueStore())
-        let recording = RecordingSleepClock()
         let spy = SendSpy(results: [
-            .failure(.rateLimitError(backOff: 5))
+            .failure(.rateLimitError(backOff: 5)),
+            .success(Data())
         ])
         QueueStore.shared.enqueue(makeLowRetryRequest(id: "backoff-doomed"), persist: .synchronous)
-        let queue = RequestQueue(clock: recording.clock, send: spy.send)
+        let queue = RequestQueue(clock: .immediate, send: spy.send)
 
         await queue.flushNow()
 
         XCTAssertEqual(spy.sentIds, ["backoff-doomed"], "request sent exactly once before being dropped")
         XCTAssertTrue(QueueStore.shared.requests.isEmpty,
                       "head must be dropped (not restored) when backoff retryCount exceeds maxRetries")
-        XCTAssertTrue(recording.requested.isEmpty,
-                      "backoff sleep must NOT fire when the exceeded branch exits early")
+
+        // The exceeded-reset must leave retryState at `.retry(initialAttempt)`, not `.retry(0)`. A
+        // freshly enqueued request must send validly on the next tick (no RequestAttemptInfo stall).
+        QueueStore.shared.enqueue(makeCreateProfileRequest(id: "after"), persist: .synchronous)
+        await queue.flushNow()
+        XCTAssertEqual(spy.sentIds, ["backoff-doomed", "after"],
+                       "a request enqueued after the exceeded-drop must still send (no .retry(0) stall)")
+        XCTAssertEqual(spy.sentAttempts.last, 1,
+                       "the successor sends at the initial attempt number, proving a clean reset")
+        XCTAssertTrue(QueueStore.shared.requests.isEmpty, "successor dequeued after success")
     }
 
     /// Exercises the `.dequeue` CONTINUE semantics. Two requests are seeded; the first fails with a
@@ -552,69 +583,33 @@ final class RequestQueueTests: XCTestCase {
         XCTAssertEqual(parking.sentIds, ["leased"], "the head was sent exactly once, not re-processed")
     }
 
-    /// Regression for the backoff-sleep join-point: `stop()` (from `.notReachable`) can fire while
-    /// `flush()` is parked in the backoff `clock.sleep` of the `.retryWithBackoff` not-exceeded
-    /// branch. `stop()` restores the lease and clears `requestsInFlight`; when the gated clock is
-    /// released the flush's `continue` re-evaluates `requestsInFlight.first`, finds it empty (the
-    /// lease was cleared by `stop()`), and exits cleanly — no crash and the request is preserved in
-    /// the store (restored by `stop()`, not lost and not double-sent).
-    /// Runs 3 times for stability (no wall-clock waits in assertions).
-    func testStopDuringBackoffSleepPreservesRequest() async {
-        for _ in 1...3 {
-            SDKConfigStore.shared.reset()
-            IdentityStore.shared.reset()
-            QueueStore.resetShared()
-            fileIO = FileIODouble()
-            environment = fileIO.makeEnvironment()
-            SDKConfigStore.shared.update(KlaviyoConfig(apiKey: "test-api-key"))
+    /// Durability during the countdown backoff is inherent: after a rate-limit failure the request is
+    /// restored to `QueueStore` (on disk) and only the retry bookkeeping lives in memory. There is no
+    /// backoff sleep to be interrupted, so a `stop()` mid-wait is trivially safe — the request is
+    /// already durable in the store. This asserts the synchronous restore hit disk and the store holds
+    /// the request while the backoff counts down, so nothing can be stranded in memory across shutdown.
+    func testBackoffKeepsRequestDurableInQueueStore() async {
+        let diskSpy = WriteSpyDiskIO()
+        QueueStore.register(makeQueueStore(diskIO: diskSpy))
+        let spy = SendSpy(results: [
+            .failure(.rateLimitError(backOff: 60))
+        ])
+        QueueStore.shared.enqueue(makeCreateProfileRequest(id: "durable"), persist: .synchronous)
+        let queue = RequestQueue(clock: .immediate, send: spy.send)
 
-            let diskSpy = WriteSpyDiskIO()
-            QueueStore.register(makeQueueStore(diskIO: diskSpy))
+        // Rate-limit failure: the request must be restored to the durable store synchronously.
+        await queue.flushNow()
 
-            // A gated clock parks the flush inside the backoff sleep. `flushNow()` only enters one
-            // clock.sleep — the backoff — so a gated clock parks there deterministically.
-            let gated = GatedSleepClock()
+        XCTAssertFalse(diskSpy.savedBatches.isEmpty,
+                       "the rate-limited request must be restored to QueueStore synchronously")
+        XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["durable"],
+                       "request stays durable in the store during the backoff wait, not held in memory")
+        XCTAssertEqual(spy.sentIds, ["durable"], "sent once; the backoff is counted down, not slept")
 
-            // Script: first send fails with a rate-limit error (enters backoff), second would succeed
-            // but must never be reached because stop() fires while the backoff sleep is parked.
-            let spy = SendSpy(results: [
-                .failure(.rateLimitError(backOff: 60)),
-                .success(Data())
-            ])
-
-            QueueStore.shared.enqueue(makeCreateProfileRequest(id: "backoff-parked"), persist: .synchronous)
-            let queue = RequestQueue(clock: gated.clock, send: spy.send)
-
-            // Kick off a flushNow() — it sends, gets a rate-limit error, then parks on the backoff
-            // sleep. Since flushNow doesn't run the loop, the ONLY clock.sleep is the backoff one.
-            let flushTask = Task.detached { await queue.flushNow() }
-
-            // Wait (bounded) until the flush has parked on the backoff sleep.
-            XCTAssertTrue(gated.waitForRequested(atLeast: 1, timeout: 2.0),
-                          "flush must park on the backoff sleep before we call networkConnectivityChanged")
-
-            // Going offline runs stop(): cancels the loop (no-op here since flushNow is not the
-            // loop), restores the in-flight lease to QueueStore, and clears requestsInFlight.
-            await queue.networkConnectivityChanged(.notReachable)
-
-            // The restore must have hit disk before we release the sleep.
-            XCTAssertFalse(diskSpy.savedBatches.isEmpty,
-                           "stop() must restore the in-flight lease to QueueStore synchronously")
-            XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["backoff-parked"],
-                           "request must be in the store (restored by stop()) before sleep is released")
-
-            // Release the backoff sleep. The flush's `continue` re-checks `requestsInFlight.first`,
-            // finds it empty (cleared by stop()), and exits the while loop cleanly — no crash, no
-            // second send.
-            gated.releaseOneTick()
-            await flushTask.value
-
-            // The request is preserved exactly once: restored by stop(), not dropped, not re-sent.
-            XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["backoff-parked"],
-                           "request preserved after stop-during-backoff-sleep: in store, not lost")
-            XCTAssertEqual(spy.sentIds, ["backoff-parked"],
-                           "head sent exactly once; no second send after the sleep was released")
-        }
+        // A `stop()` mid-wait is trivially safe: the request is already on disk, in-flight is empty.
+        await queue.stop()
+        XCTAssertEqual(QueueStore.shared.requests.map(\.id), ["durable"],
+                       "stop() during the backoff wait leaves the durable request untouched")
     }
 
     /// WiFi → WWAN coalesces: the old WiFi loop is cancelled and only the WWAN interval (30 s)

--- a/Tests/KlaviyoCoreTests/Support/SleepClockDoubles.swift
+++ b/Tests/KlaviyoCoreTests/Support/SleepClockDoubles.swift
@@ -6,10 +6,8 @@
 //
 //
 // Test doubles for the `SleepClock` timing seam, shared by the `RequestQueue` parity tests:
-// `.immediate` returns without waiting; `RecordingSleepClock` captures requested durations so
-// backoff/interval timing can be asserted deterministically without wall-clock delays.
-// `GatedSleepClock` parks each sleep on a continuation so the run loop advances one controlled
-// step at a time.
+// `.immediate` returns without waiting. `GatedSleepClock` parks each sleep on a continuation so the
+// run loop advances one controlled step at a time.
 //
 
 @testable import KlaviyoCore
@@ -18,24 +16,6 @@ import Foundation
 extension SleepClock {
     /// Returns immediately, ignoring the requested duration.
     static var immediate: SleepClock { SleepClock { _ in } }
-}
-
-/// Captures the durations passed to `sleep`, in order, without waiting. Thread-safe so it can be
-/// used from the actor under test.
-final class RecordingSleepClock: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _requested: [TimeInterval] = []
-
-    var requested: [TimeInterval] {
-        lock.lock(); defer { lock.unlock() }
-        return _requested
-    }
-
-    var clock: SleepClock {
-        SleepClock { [self] seconds in
-            lock.lock(); _requested.append(seconds); lock.unlock()
-        }
-    }
 }
 
 /// A clock that records each requested sleep duration and then suspends the run loop until the


### PR DESCRIPTION
# Description
Replace the `RequestQueue` actor's direct-sleep backoff with a **durable countdown** (pre-modularization parity). In #732 we introduced a direct-sleep model where in if a request is rate limited, it is only parked in-memory while waiting for the backoff time to pass, in which exactly on expiry it retries. That differs from the pre-existing behavior where we stored a rate limited request on disk during wait and flushed it on the next scheduled flush if its backoff has passed/expired. tldr;


| Model | Durable (survives crash)? | Precise timing? |
|---|---|---|
| Existing (countdown on ticks) | ✅ on disk during wait | ❌ retries on the next tick (up to +1 interval) |
| Introduced in #732 | ❌ in-memory during wait | ✅ retries at ~exactly the backoff |
| New "durable countdown" | ✅ | ❌ (same as before) |


Still **unwired** — no app behavior change.

## Due Diligence
- [x] I have tested this on a simulator or a physical device.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are compatible with all iOS and XCode versions the SDK currently supports.

## Release/Versioning Considerations
- [x] `Patch` — internal engine change, unwired (no public API or behavior change yet).
- [x] This is planned work for an upcoming release (part of `feat/modularization-2`).

## Changelog / Code Overview
The engine PR (#723) shipped a **direct-sleep** backoff: on a rate-limit/5xx it held the request in the in-memory lease and `await clock.sleep(backoff)`s in place. Review (CodeRabbit + Cursor) surfaced that this is crash-lossy (lease in memory for up to ~300s) and cancellation-fragile (a `start()` mid-backoff bypasses the wait). This PR swaps it for the reducer's proven **countdown** algorithm — ported to the actor, no TCA:

- **Failure branch:** on rate-limit/5xx, record the backoff on `retryState` and **restore the request to the durable `QueueStore`**, then stop the flush (no `clock.sleep` in the backoff path).
- **Countdown gate** at the top of `flush()`: each run-loop tick decrements the backoff by `flushInterval`; when it reaches zero it promotes to `.retry(requestCount)` and drains + sends.
- The request stays **on disk during the entire wait** (crash-safe); a `start()`/`stop()` mid-backoff just resumes the countdown on the next tick (`retryState` is actor state) — no immediate-retry bypass.
- Exceeded-`maxRetries` on backoff resets to `.retry(initialAttempt)` (NOT `requestCount: 0`) — a deliberate divergence from the reducer, whose reset would promote to `.retry(0)` and stall `RequestAttemptInfo`.
- Removed the now-dead `FlushDecision.retryWithBackoff` `seconds:` value and the `RecordingSleepClock` test double (no backoff sleep to record). `SleepClock` is now used only for the run-loop interval.

Trade-off: retry timing is tick-coarse (fires on the next tick after the backoff expires, up to one interval late) — accepted, matches the reducer.

## Test Plan
- `xcodebuild test -scheme klaviyo-swift-sdk-Package` → **KlaviyoCore suite green** (329 tests, 0 failures).
- Backoff tests rewritten to the countdown model (flushNow-as-tick): a rate-limited request is durable in `QueueStore` during the wait, skipped for N ticks, then resent with an advanced attempt number; exceeded-on-backoff drops the request and a successor still sends (no stall).

## Related Issues/Tickets
- Linear: MAGE-1197 (parent MAGE-904). Follow-up to merged #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate limits and server errors by preserving queued requests during backoff periods.
  * Requests now remain durable across processing cycles and shutdowns, then retry automatically after the backoff countdown expires.
  * Retry tracking now resets cleanly after the maximum retry limit is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->